### PR TITLE
Improved prediction prompt for prediction_offline and non-Claude models

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -5,7 +5,7 @@
         "custom/valory/openai_request/0.1.0": "bafybeigz5brshryms5awq5zscxsxibjymdofm55dw5o6ud7gtwmodm3vmq",
         "custom/valory/prediction_request_embedding/0.1.0": "bafybeihtwykqnoxluqo2n4w2ccoh4xqoc6pifevol6obho3fneg7touzj4",
         "custom/valory/resolve_market/0.1.0": "bafybeidog2vsqmezxe63jqjpf7p6qmqy3opq3rppvihqtehf6k44hzyo74",
-        "custom/valory/prediction_request/0.1.0": "bafybeignvi5ny72jinwfhksh57bqcxige2f4kigtcdlsav6bykjxzzpe4y",
+        "custom/valory/prediction_request/0.1.0": "bafybeic35rhhm56nn62wrd7hferovhunt6j7jwgjf362vrnqcxm65s2sfu",
         "custom/valory/stability_ai_request/0.1.0": "bafybeifzlmtyvvo2x43sx6y2f53gqyakoqrxk5yclembw5xc3gihf2vrxm",
         "custom/polywrap/prediction_with_research_report/0.1.0": "bafybeiebis63otzt7vy44zxk4uwfknrttfsibnas5x7sttwgh4lzuhrnna",
         "custom/jhehemann/prediction_sum_url_content/0.1.0": "bafybeih6wp7icu5apa2uyuyisg65reh6ptl5umeji7qvgoluwplufkrypy",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -5,7 +5,7 @@
         "custom/valory/openai_request/0.1.0": "bafybeigz5brshryms5awq5zscxsxibjymdofm55dw5o6ud7gtwmodm3vmq",
         "custom/valory/prediction_request_embedding/0.1.0": "bafybeihtwykqnoxluqo2n4w2ccoh4xqoc6pifevol6obho3fneg7touzj4",
         "custom/valory/resolve_market/0.1.0": "bafybeidog2vsqmezxe63jqjpf7p6qmqy3opq3rppvihqtehf6k44hzyo74",
-        "custom/valory/prediction_request/0.1.0": "bafybeigupgsneg4nsaljassdcq4mu53abrglmw42vfrss5kwxy7fybtisu",
+        "custom/valory/prediction_request/0.1.0": "bafybeiezzmhk3w4zl3i3yxjjjjosmjywl3iawzjsrni2qhvslh7yyohgyq",
         "custom/valory/stability_ai_request/0.1.0": "bafybeifzlmtyvvo2x43sx6y2f53gqyakoqrxk5yclembw5xc3gihf2vrxm",
         "custom/polywrap/prediction_with_research_report/0.1.0": "bafybeiebis63otzt7vy44zxk4uwfknrttfsibnas5x7sttwgh4lzuhrnna",
         "custom/jhehemann/prediction_sum_url_content/0.1.0": "bafybeih6wp7icu5apa2uyuyisg65reh6ptl5umeji7qvgoluwplufkrypy",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -5,7 +5,7 @@
         "custom/valory/openai_request/0.1.0": "bafybeigz5brshryms5awq5zscxsxibjymdofm55dw5o6ud7gtwmodm3vmq",
         "custom/valory/prediction_request_embedding/0.1.0": "bafybeihtwykqnoxluqo2n4w2ccoh4xqoc6pifevol6obho3fneg7touzj4",
         "custom/valory/resolve_market/0.1.0": "bafybeidog2vsqmezxe63jqjpf7p6qmqy3opq3rppvihqtehf6k44hzyo74",
-        "custom/valory/prediction_request/0.1.0": "bafybeiezzmhk3w4zl3i3yxjjjjosmjywl3iawzjsrni2qhvslh7yyohgyq",
+        "custom/valory/prediction_request/0.1.0": "bafybeignvi5ny72jinwfhksh57bqcxige2f4kigtcdlsav6bykjxzzpe4y",
         "custom/valory/stability_ai_request/0.1.0": "bafybeifzlmtyvvo2x43sx6y2f53gqyakoqrxk5yclembw5xc3gihf2vrxm",
         "custom/polywrap/prediction_with_research_report/0.1.0": "bafybeiebis63otzt7vy44zxk4uwfknrttfsibnas5x7sttwgh4lzuhrnna",
         "custom/jhehemann/prediction_sum_url_content/0.1.0": "bafybeih6wp7icu5apa2uyuyisg65reh6ptl5umeji7qvgoluwplufkrypy",

--- a/packages/valory/customs/prediction_request/component.yaml
+++ b/packages/valory/customs/prediction_request/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibbn67pnrrm4qm3n3kbelvbs3v7fjlrjniywmw2vbizarippidtvi
-  prediction_request.py: bafybeidlc4x76ywuhdg7nkze4jlydtwuwxrf65eqqlrld7d6mf2dd3q6uy
+  prediction_request.py: bafybeic4icsdabshmlebjh6d3gx2p6v6piq3rw7tiwzqaeqpo23pmmj3eu
 fingerprint_ignore_patterns: []
 entry_point: prediction_request.py
 callable: run

--- a/packages/valory/customs/prediction_request/component.yaml
+++ b/packages/valory/customs/prediction_request/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibbn67pnrrm4qm3n3kbelvbs3v7fjlrjniywmw2vbizarippidtvi
-  prediction_request.py: bafybeigs2aycielziuthuvfmlvknmhrcj5ck7hpptxopowhrdtk3lvwale
+  prediction_request.py: bafybeibcncnjeyxakphfov6bkuydlp3gbfkd5om3j43axqho3ukrao663u
 fingerprint_ignore_patterns: []
 entry_point: prediction_request.py
 callable: run

--- a/packages/valory/customs/prediction_request/component.yaml
+++ b/packages/valory/customs/prediction_request/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibbn67pnrrm4qm3n3kbelvbs3v7fjlrjniywmw2vbizarippidtvi
-  prediction_request.py: bafybeibcncnjeyxakphfov6bkuydlp3gbfkd5om3j43axqho3ukrao663u
+  prediction_request.py: bafybeidlc4x76ywuhdg7nkze4jlydtwuwxrf65eqqlrld7d6mf2dd3q6uy
 fingerprint_ignore_patterns: []
 entry_point: prediction_request.py
 callable: run

--- a/packages/valory/customs/prediction_request/prediction_request.py
+++ b/packages/valory/customs/prediction_request/prediction_request.py
@@ -310,21 +310,60 @@ COMPLETION_RETRIES = 3
 COMPLETION_DELAY = 2
 
 PREDICTION_PROMPT = """
-You are an LLM inside a multi-agent system that takes in a prompt of a user requesting a probability estimation
-for a given event. You are provided with an input under the label "USER_PROMPT". You must follow the instructions
-under the label "INSTRUCTIONS". You must provide your response in the format specified under "OUTPUT_FORMAT".
+Evaluate the given binary question under the label "USER_PROMPT" to determine the probabilities of the yes and no outcomes. 
+You need to compute the p_yes and p_no values based on the context of the question under the label "ADDITIONAL_INFORMATION" and the options provided.
 
-INSTRUCTIONS
-* Read the input under the label "USER_PROMPT" delimited by three backticks.
-* The "USER_PROMPT" specifies an event.
-* The event will only have two possible outcomes: either the event will happen or the event will not happen.
-* If the event has more than two possible outcomes, you must ignore the rest of the instructions and output the response "Error".
-* You must provide a probability estimation of the event happening, based on your training data.
-* You are provided an itemized list of information under the label "ADDITIONAL_INFORMATION" delimited by three backticks.
-* You can use any item in "ADDITIONAL_INFORMATION" in addition to your training data.
-* If an item in "ADDITIONAL_INFORMATION" is not relevant, you must ignore that item for the estimation.
-* You must provide your response in the format specified under "OUTPUT_FORMAT".
-* Do not include any other contents in your response.
+Follow these steps
+1. Analyze the Question: Understand the content and context of the given question. Identify key elements that will affect the probabilities.
+
+2. Consider Historical Data & Context: Reflect on any relevant historical data, trends, or context that could influence the outcomes.
+
+3. Statistical Analysis: Use statistical methods and models to determine the likelihood of each outcome based on the data or context if available.
+
+4. Calculate the yes and no probabilities:
+
+    * Determine p_yes (probability of the yes option).
+
+    * Determine p_no (probability of the no option).
+
+5. Verify Total Probability: Ensure that the sum of p_yes and p_no equals 1, confirming a valid probability distribution.
+6. Evaluate how confident you are in the predicted answer to the question: give a "confidence" value between 0 and 1.
+    * 0 meaning the lowest confidence value. 
+    * 1 meaning the maximum confidence value.
+7. Evaluate how relevant is the information provided in "ADDITIONAL_INFORMATION" and any historical data plus context used to answer the question: give an "info_utility" value between 0 and 1.
+    * 0 meaning the extra information was not very useful to answer the question.
+    * 1 meaning the extra information was very useful and relevant for the prediction.
+8. Build the final answer in JSON format with the four values:
+    {
+    "p_yes": [calculated_probability_of_yes],
+    "p_no": [calculated_probability_of_no],
+    "confidence": [confidence value],
+    "info_utility": [info_utility value]
+    }
+
+Examples
+Example 1:
+
+Input: 
+    * Question: "Will Red Bull win the World Constructors’ Championship in the 2024 F1 Season?"
+
+    * Yes Option: "Yes, Red Bull will win."
+
+    * No Option: "No, Red Bull will not win."
+
+Reasoning:
+
+    * Consider related news with the topic of the question, past sport reports and relevant articles on the field.
+
+Output:
+
+{
+  "p_yes": 0.3,
+  "p_no": 0.7,
+  "confidence": 0.8,
+  "info_utility": 0.8
+}
+
 
 USER_PROMPT:
 ```
@@ -335,22 +374,6 @@ ADDITIONAL_INFORMATION:
 ```
 {additional_information}
 ```
-
-OUTPUT_FORMAT
-* Your output response must be only a single JSON object to be parsed by Python's "json.loads()".
-* The JSON must contain four fields: "p_yes", "p_no", "confidence", and "info_utility".
-* Each item in the JSON must have a value between 0 and 1.
-   - "p_yes": Estimated probability that the event in the "USER_PROMPT" occurs.
-   - "p_no": Estimated probability that the event in the "USER_PROMPT" does not occur.
-   - "confidence": A value between 0 and 1 indicating the confidence in the prediction. 0 indicates lowest
-     confidence value; 1 maximum confidence value.
-   - "info_utility": Utility of the information provided in "ADDITIONAL_INFORMATION" to help you make the prediction.
-     0 indicates lowest utility; 1 maximum utility.
-* The sum of "p_yes" and "p_no" must equal 1.
-* Output only the JSON object. Do not include any other contents in your response.
-* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
-* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
-* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
 """
 
 URL_QUERY_PROMPT = """

--- a/packages/valory/customs/prediction_request/prediction_request.py
+++ b/packages/valory/customs/prediction_request/prediction_request.py
@@ -353,7 +353,7 @@ OUTPUT_FORMAT
 * This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
 """
 
-ALTERNATIVE_PREDICTION_PROMPT = """
+OFFLINE_PREDICTION_PROMPT = """
 You are a superforecasting agent specializing in predicting the probabilities of binary outcomes (yes or no). Your responses MUST be in JSON format as specified below.
 
 **INSTRUCTIONS:**
@@ -791,6 +791,7 @@ def run(**kwargs) -> Tuple[str, Optional[str], Optional[Dict[str, Any]], Any]:
             raise ValueError(f"Tool {tool} is not supported.")
 
         active_prompt = PREDICTION_PROMPT
+        additional_information = ""
         if tool.startswith("prediction-online"):
             additional_information, counter_callback = fetch_additional_information(
                 prompt,
@@ -804,11 +805,9 @@ def run(**kwargs) -> Tuple[str, Optional[str], Optional[Dict[str, Any]], Any]:
                 counter_callback=counter_callback,
                 source_links=kwargs.get("source_links", None),
             )
-        else:
-            additional_information = ""
-            if "claude" not in engine:
-                # used improved prompt in all models except the Claude ones
-                active_prompt = ALTERNATIVE_PREDICTION_PROMPT
+        elif "claude" not in engine:
+            # used improved prompt in all models except the Claude ones
+            active_prompt = OFFLINE_PREDICTION_PROMPT
 
         if additional_information and tool == "prediction-online-summarized-info":
             additional_information = summarize(


### PR DESCRIPTION
## Proposed changes

We detected bad performance of the prediction_offline tool so a new prompt was designed and tested using olas_predict_benchmark. Accuracy improvement was found for several models. No improvement with the Claude models.

## Fixes

If it fixes a bug or resolves a feature request, be sure to link to that issue.

## Types of changes

What types of changes does your code introduce? (A **breaking change** is a fix or feature that would cause existing functionality and APIs to not work as expected.)
_Put an `x` in the box that applies_

- [] Non-breaking fix (non-breaking change which fixes an issue)
- [ ] Breaking fix (breaking change which fixes an issue)
- [ ] Non-breaking feature (non-breaking change which adds functionality)
- [ ] Breaking feature (breaking change which adds functionality)
- [X] Refactor (non-breaking change which changes implementation)
- [ ] Messy (mixture of the above - requires explanation!)

## Checklist

_Put an `x` in the boxes that apply._

- [X] I have read the [CONTRIBUTING](../blob/main/CONTRIBUTING.md) doc
- [X] I am making a pull request against the `main` branch (left side). Also you should start your branch off our `main`.
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...