### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,32 +93,25 @@ jobs:
           echo "Pushing $DOCKER_USER/oar-$AGENT:$DEFAULT_IMAGE_TAG"
           docker push $DOCKER_USER/oar-$AGENT:$VERSION
           docker push $DOCKER_USER/oar-$AGENT:$DEFAULT_IMAGE_TAG
-  deploy:
-    name: Deploy to ${{ matrix.environment }}
-    environment: ${{ matrix.environment }}
-    if: |
-      matrix.environment == 'staging' && github.event.release.prerelease == true ||
-      matrix.environment == 'production' && github.event.release.prerelease == false
+  deploy_production:
+    name: Deploy to production
+    environment: production
+    if: endsWith(github.event.release.name, '(prod)')
     needs:
-      - "publish-packages"
-      - "publish-images"
-    runs-on: ubuntu-latest
+    - "publish-packages"
+    - "publish-images"
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        include:
-          - environment: "staging"
-            dns_host: "balancer.tcp.propel.staging.autonolas.tech"
-            app_domain: "app.propel.staging.valory.xyz"
-          - environment: "production"
-            dns_host: "balancer.tcp.propel.autonolas.tech"
-            app_domain: "app.propel.valory.xyz"
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
     env:
       CMD: "propel -U ${{ vars.PROPEL_BASE_URL }}"
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-versions }}
       - name: Install dependencies
         run: |
           sudo apt-get update --fix-missing
@@ -126,20 +119,23 @@ jobs:
           sudo apt-get autoclean
           python -m pip install --upgrade pip
           pip install propel-client open-autonomy
-      - name: Make use of proxy instead of actual NLB by DNS override
+
+      - name: Make use proxy instead of actual nlb by dns override
         run: |
-          export IP_ADDR=$(dig +short ${{ matrix.dns_host }})
-          echo -e "\n$IP_ADDR\t${{ matrix.app_domain }}\n" | sudo tee -a /etc/hosts
+          export IP_ADDR=$(dig +short balancer.tcp.propel.autonolas.tech)
+          echo -e "\n$IP_ADDR\tapp.propel.valory.xyz\n"  | sudo tee -a /etc/hosts
+
       - name: Login to propel
         run: |
-          $CMD login -u '${{ vars.PROPEL_USERNAME }}' -p '${{ secrets.PROPEL_PASSWORD }}'
+          $CMD login -u  '${{ vars.PROPEL_USERNAME }}' -p  '${{ secrets.PROPEL_PASSWORD }}'
+
       - name: Do a deployment
         run: |
           # determine ipfs hash id
-          export IPFS_HASH=$(jq '.dev | to_entries[] | select(.key | startswith("service"))| .value' -r ./packages/packages.json | head -n1)
+          export IPFS_HASH=$(jq '.dev | to_entries[] | select(.key | startswith("service"))| .value' -r  ./packages/packages.json | head -n1)
           export SERVICE_PATH=service_for_propel
 
-          # fetch service file and check if published
+          # fetch service file and check it published
           autonomy init --reset --author ci --ipfs --remote
           autonomy fetch $IPFS_HASH --service --alias $SERVICE_PATH
 
@@ -148,4 +144,56 @@ jobs:
           echo >> github.vars
           echo '${{ toJSON(vars) }}' | jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")|.[]' >> github.vars
           source github.vars
-          $CMD service deploy --name '${{ vars.SERVICE_NAME }}' --service-dir $SERVICE_PATH --service-ipfs-hash $IPFS_HASH --ingress-enabled true --keys '${{ vars.SERVICE_KEYS }}' --timeout 320
+          $CMD service deploy --name  '${{ vars.SERVICE_NAME }}'  --service-dir $SERVICE_PATH --service-ipfs-hash $IPFS_HASH  --ingress-enabled true --keys '${{ vars.SERVICE_KEYS }}' --timeout 320
+  deploy_staging:
+    name: Deploy to staging
+    environment: staging
+    if: endsWith(github.event.release.name, '(staging)')
+    needs:
+    - "publish-packages"
+    - "publish-images"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ["3.10"]
+    env:
+      CMD: "propel -U ${{ vars.PROPEL_BASE_URL }}"
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-versions }}
+      - name: Install dependencies
+        run: |
+          sudo apt-get update --fix-missing
+          sudo apt-get autoremove
+          sudo apt-get autoclean
+          python -m pip install --upgrade pip
+          pip install propel-client open-autonomy
+
+      - name: Make use proxy instead of actual nlb by dns override
+        run: |
+          export IP_ADDR=$(dig +short balancer.tcp.propel.staging.autonolas.tech)
+          echo -e "\n$IP_ADDR\tapp.propel.staging.valory.xyz\n"  | sudo tee -a /etc/hosts
+
+      - name: Login to propel
+        run: |
+          $CMD login -u  '${{ vars.PROPEL_USERNAME }}' -p  '${{ secrets.PROPEL_PASSWORD }}'
+
+      - name: Do a deployment
+        run: |
+          # determine ipfs hash id
+          export IPFS_HASH=$(jq '.dev | to_entries[] | select(.key | startswith("service"))| .value' -r  ./packages/packages.json | head -n1)
+          export SERVICE_PATH=service_for_propel
+
+          # fetch service file and check it published
+          autonomy init --reset --author ci --ipfs --remote
+          autonomy fetch $IPFS_HASH --service --alias $SERVICE_PATH
+
+          # get env vars from github actions
+          echo '${{ toJSON(secrets) }}' | jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")|.[]' > github.vars
+          echo >> github.vars
+          echo '${{ toJSON(vars) }}' | jq -r 'to_entries|map("export \(.key)=\(.value|tojson)")|.[]' >> github.vars
+          source github.vars
+          $CMD service deploy --name  '${{ vars.SERVICE_NAME }}'  --service-dir $SERVICE_PATH --service-ipfs-hash $IPFS_HASH  --ingress-enabled true --keys '${{ vars.SERVICE_KEYS }}' --timeout 320


### PR DESCRIPTION
The matrix context is not available in the `if:` condition at the job level. At that point, GitHub doesn't yet have access to the matrix values, so it can't evaluate `matrix.environment`:

```
The workflow is not valid. .github/workflows/release.yaml (Line: 99, Col: 9): Unrecognized named-value: 'matrix'. Located at position 1 within expression: matrix.environment == 'staging' && github.event.release.prerelease == true ||
matrix.environment == 'production' && github.event.release.prerelease == false
```