### PR TITLE
[DO NOT MERGE] Fix/embedding token limit rag 2

### DIFF
--- a/packages/napthaai/customs/prediction_request_rag/component.yaml
+++ b/packages/napthaai/customs/prediction_request_rag/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibt7f7crtwvmkg7spy3jhscmlqltvyblzp32g6gj44v7tlo5lycuq
-  prediction_request_rag.py: bafybeig6mss7hfhuyt5jqhs6azgvktwovy4sx7igfuafxi6e4rjpuqivam
+  prediction_request_rag.py: bafybeiflmixsii4653mnfejrjyaxj7t647iy6roezprw6drt5ay66wp6uu
 fingerprint_ignore_patterns: []
 entry_point: prediction_request_rag.py
 callable: run

--- a/packages/napthaai/customs/prediction_request_rag/prediction_request_rag.py
+++ b/packages/napthaai/customs/prediction_request_rag/prediction_request_rag.py
@@ -331,23 +331,20 @@ DEFAULT_NUM_QUERIES = 3
 NUM_URLS_PER_QUERY = 5
 SPLITTER_CHUNK_SIZE = 1800
 SPLITTER_OVERLAP = 50
-EMBEDDING_MODEL = "text-embedding-ada-002"
-EMBEDDING_BATCH_SIZE = 1000
-EMBEDDING_SIZE = 1536
-SPLITTER_MAX_TOKENS = 1800
-SPLITTER_OVERLAP = 50
+EMBEDDING_MODEL = "text-embedding-3-large"
+EMBEDDING_SIZE = 3072
 NUM_NEIGHBORS = 4
 HTTP_TIMEOUT = 20
 HTTP_MAX_REDIRECTS = 5
 HTTP_MAX_RETIES = 2
 DOC_TOKEN_LIMIT = 7000  # Maximum tokens per document for embeddings
 RAG_PROMPT_LENGTH = 320
-DEFAULT_MAX_EMBEDDING_TOKENS = 300000
+DEFAULT_MAX_EMBEDDING_TOKENS = 8192
+MAX_PER_BATCH_TOKEN_LIMIT = 300_000  # Maximum tokens for the embeddings batch
 BUFFER = 15000  # Buffer for the total tokens in the embeddings batch
 MAX_NR_DOCS = 1000
 TOKENS_DISTANCE_TO_LIMIT = 200
-if DEFAULT_MAX_EMBEDDING_TOKENS - RAG_PROMPT_LENGTH - BUFFER <= 0:
-    raise ValueError("Wrong MAX_EMBEDDING_TOKENS configuration")
+
 
 PREDICTION_PROMPT = """
 You will be evaluating the likelihood of an event based on a user's question and additional information from search results.
@@ -431,25 +428,6 @@ def truncate_text(text: str, model: str, max_tokens: int) -> str:
     if len(token_ids) <= max_tokens:
         return text
     return enc.decode(token_ids[:max_tokens])
-
-
-def get_max_embeddings_tokens(model: str) -> int:
-    """Get the maximum number of tokens for embeddings based on the model."""
-
-    if model in LLM_SETTINGS:
-        # Maximum tokens for the embeddings batch
-        # there are models with values under 300000
-        limit_max_tokens = min(
-            LLM_SETTINGS[model]["limit_max_tokens"], DEFAULT_MAX_EMBEDDING_TOKENS
-        )
-        max_embeddings_tokens = limit_max_tokens - RAG_PROMPT_LENGTH - BUFFER
-        if max_embeddings_tokens <= 0:
-            raise ValueError(
-                f"Model {model} has a limit_max_tokens that is too low for embeddings."
-            )
-        return max_embeddings_tokens
-
-    return DEFAULT_MAX_EMBEDDING_TOKENS - RAG_PROMPT_LENGTH - BUFFER
 
 
 # Utility: count tokens using model-specific tokenizer
@@ -702,14 +680,17 @@ def extract_texts(
 
 
 def find_similar_chunks(
-    query: str, docs_with_embeddings: List[ExtendedDocument], k: int = 4
+    query: str,
+    docs_with_embeddings: List[ExtendedDocument],
+    embedding_model: str,
+    k: int = 4,
 ) -> List:
     """Similarity search to find similar chunks to a query"""
     if not client_embedding:
         raise RuntimeError("Embeddings not intialized")
     query_embedding = (
         client_embedding.embeddings(
-            model=EMBEDDING_MODEL,
+            model=embedding_model,
             input_=query,
         )
         .data[0]
@@ -728,26 +709,20 @@ def find_similar_chunks(
 
 
 def get_embeddings(
-    split_docs: List[ExtendedDocument], model: str
+    split_docs: List[ExtendedDocument], embedding_model: str
 ) -> List[ExtendedDocument]:
     """Get embeddings for the split documents: clean, truncate, then batch by token count."""
     # Preprocess each document: clean and truncate to DOC_TOKEN_LIMIT
-    # Filter out any documents that exceed the maximum token limit individually
     filtered_docs = []
     total_tokens_count = 0
-    max_embeddings_tokens = get_max_embeddings_tokens(model)
+    max_embeddings_tokens = DEFAULT_MAX_EMBEDDING_TOKENS
     for doc in split_docs:
-        # if we are very close to the limit then break the loop
-        if max_embeddings_tokens - total_tokens_count < TOKENS_DISTANCE_TO_LIMIT:
-            break
         cleaned = clean_text(doc.text)
         # TODO we could summarize instead of truncating
-        doc.text = truncate_text(cleaned, EMBEDDING_MODEL, DOC_TOKEN_LIMIT)
+        doc.text = truncate_text(cleaned, embedding_model, DOC_TOKEN_LIMIT)
         # filter empty strings
         doc.text = doc.text.strip()
-        doc.tokens = count_tokens(doc.text, EMBEDDING_MODEL)
-        if total_tokens_count + doc.tokens > max_embeddings_tokens:
-            continue
+        doc.tokens = count_tokens(doc.text, embedding_model)
         if doc.text:
             filtered_docs.append(doc)
             total_tokens_count += doc.tokens
@@ -762,7 +737,7 @@ def get_embeddings(
         while i < len(filtered_docs):
             doc = filtered_docs[i]
             if doc.tokens == 0:
-                doc.tokens = count_tokens(doc.text, EMBEDDING_MODEL)
+                doc.tokens = count_tokens(doc.text, embedding_model)
 
             if current_batch_tokens + doc.tokens > max_embeddings_tokens:
                 break
@@ -780,7 +755,7 @@ def get_embeddings(
         if not client_embedding:
             raise RuntimeError("Embeddings not intialized")
         response = client_embedding.embeddings(
-            model=EMBEDDING_MODEL,
+            model=embedding_model,
             input_=batch_texts,
         )
 
@@ -886,12 +861,13 @@ def fetch_additional_information(
         # truncate the split_docs to the first MAX_NR_DOCS documents
         split_docs = split_docs[:MAX_NR_DOCS]
     # Embed the documents
-    docs_with_embeddings = get_embeddings(split_docs, model)
+    docs_with_embeddings = get_embeddings(split_docs, EMBEDDING_MODEL)
 
     # Find similar chunks
     similar_chunks = find_similar_chunks(
         query=prompt,
         docs_with_embeddings=docs_with_embeddings,
+        embedding_model=EMBEDDING_MODEL,
         k=NUM_NEIGHBORS,
     )
     print(f"Similar Chunks: {len(similar_chunks)}")

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,7 +11,7 @@
         "custom/nickcom007/sme_generation_request/0.1.0": "bafybeic32y4wm5vmeydmndl3odw56ou5p2kefy5iep5g27oyvx4pzcf4oi",
         "custom/nickcom007/prediction_request_sme/0.1.0": "bafybeihi3zt7mxi4pqcal45l5ls4rdu7a463h445zw3xeu4b6ml3unpqgu",
         "custom/napthaai/resolve_market_reasoning/0.1.0": "bafybeidwi237cudjtn7pxtruz5gmoy52xia7uojwkevelyjjb52iyjnpea",
-        "custom/napthaai/prediction_request_rag/0.1.0": "bafybeif34kqtan72yaiseho3lhskc2kaknn6q2piubvgwizehiy5wd2tnu",
+        "custom/napthaai/prediction_request_rag/0.1.0": "bafybeif2ymldwwvzz33c3as3ixoeqk3aapcbqve6dvbb6llks3mqhmnreu",
         "custom/napthaai/prediction_request_reasoning/0.1.0": "bafybeibnnpxpuretwh3ibv2m2llmyihl3jwc5xqa5we7blj5coarnrxe5i",
         "custom/valory/prepare_tx/0.1.0": "bafybeiadkv3ufvd27e2aqxusjzh7eesvmjc672ahk54fb3hajwurrfuqpe",
         "custom/napthaai/prediction_url_cot/0.1.0": "bafybeiaigma5uzkzsnvnmiepkvo5lgpuuy5diflnfdydoc47dodnpu22dy",
@@ -29,8 +29,8 @@
         "custom/valory/tee_openai_request/0.1.0": "bafybeiew5cbr2kswtw3gvgqrjqdzkqtedjmvwjdzlllglqbq2tpofrwb4e",
         "custom/dvilela/corcel_request/0.1.0": "bafybeibt2xjjznyo3hs7zjax2fuhodu5xxybifttmhoxn253dqpdunujjq",
         "custom/dvilela/gemini_prediction/0.1.0": "bafybeifzj2sqjdkkkdxojy5th526bkxuybqfguuw3qb6x3biroy3tkjoou",
-        "agent/valory/mech/0.1.0": "bafybeifljsmwmhnlxsjri5r4rk3k2nsn272iwwyxtr7wxptgczotyj455y",
-        "service/valory/mech/0.1.0": "bafybeibpk4hntcxxqyxcquowk24n5phzbl54zxdt3dhh5zv4mryy4mpjzq"
+        "agent/valory/mech/0.1.0": "bafybeigfrt5ciail2wngdouqw7fjjzvgjqd3j4ang6tn3pvbjm4pyaiecm",
+        "service/valory/mech/0.1.0": "bafybeiancpn4fjktimdnjetvfijgnn3jzvej6f7zovr43qzwksehu6dima"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -61,7 +61,7 @@ customs:
 - nickcom007/sme_generation_request:0.1.0:bafybeic32y4wm5vmeydmndl3odw56ou5p2kefy5iep5g27oyvx4pzcf4oi
 - nickcom007/prediction_request_sme:0.1.0:bafybeihi3zt7mxi4pqcal45l5ls4rdu7a463h445zw3xeu4b6ml3unpqgu
 - napthaai/resolve_market_reasoning:0.1.0:bafybeidwi237cudjtn7pxtruz5gmoy52xia7uojwkevelyjjb52iyjnpea
-- napthaai/prediction_request_rag:0.1.0:bafybeif34kqtan72yaiseho3lhskc2kaknn6q2piubvgwizehiy5wd2tnu
+- napthaai/prediction_request_rag:0.1.0:bafybeif2ymldwwvzz33c3as3ixoeqk3aapcbqve6dvbb6llks3mqhmnreu
 - napthaai/prediction_request_reasoning:0.1.0:bafybeibnnpxpuretwh3ibv2m2llmyihl3jwc5xqa5we7blj5coarnrxe5i
 - valory/prepare_tx:0.1.0:bafybeiadkv3ufvd27e2aqxusjzh7eesvmjc672ahk54fb3hajwurrfuqpe
 - napthaai/prediction_url_cot:0.1.0:bafybeiaigma5uzkzsnvnmiepkvo5lgpuuy5diflnfdydoc47dodnpu22dy

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeifljsmwmhnlxsjri5r4rk3k2nsn272iwwyxtr7wxptgczotyj455y
+agent: valory/mech:0.1.0:bafybeigfrt5ciail2wngdouqw7fjjzvgjqd3j4ang6tn3pvbjm4pyaiecm
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
Based off of https://github.com/valory-xyz/mech-predict/pull/65. In a different branch to skip 'max cost' changes during release

Changes in this PR, not in the other one:
- `get_max_embeddings_tokens()` removed 
- Fixed logic flaw