### PR TITLE
fix: rag tool embedding token limit

### DIFF
--- a/packages/napthaai/customs/prediction_request_rag/component.yaml
+++ b/packages/napthaai/customs/prediction_request_rag/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibt7f7crtwvmkg7spy3jhscmlqltvyblzp32g6gj44v7tlo5lycuq
-  prediction_request_rag.py: bafybeieju5oen4mslshprq2rjylmxvxagu6rlnxh4lq477mtf3tgg4jcna
+  prediction_request_rag.py: bafybeihrvqcgjiz5qzzmepultffocmpokhesptnrxofybsgywibijx3wzi
 fingerprint_ignore_patterns: []
 entry_point: prediction_request_rag.py
 callable: run

--- a/packages/napthaai/customs/prediction_request_rag/prediction_request_rag.py
+++ b/packages/napthaai/customs/prediction_request_rag/prediction_request_rag.py
@@ -60,6 +60,7 @@ IMAGE_RELATED_PATTERNS = [
 N_MODEL_CALLS = 2
 
 USER_AGENT_HEADER = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"
+
 GOOGLE_RATE_LIMIT_EXCEEDED_CODE = 429
 DEFAULT_DELIVERY_RATE = 100
 
@@ -333,23 +334,20 @@ DEFAULT_NUM_QUERIES = 3
 NUM_URLS_PER_QUERY = 5
 SPLITTER_CHUNK_SIZE = 1800
 SPLITTER_OVERLAP = 50
-EMBEDDING_MODEL = "text-embedding-ada-002"
-EMBEDDING_BATCH_SIZE = 1000
-EMBEDDING_SIZE = 1536
-SPLITTER_MAX_TOKENS = 1800
-SPLITTER_OVERLAP = 50
+EMBEDDING_MODEL = "text-embedding-3-large"
+EMBEDDING_SIZE = 3072
 NUM_NEIGHBORS = 4
 HTTP_TIMEOUT = 20
 HTTP_MAX_REDIRECTS = 5
 HTTP_MAX_RETIES = 2
 DOC_TOKEN_LIMIT = 7000  # Maximum tokens per document for embeddings
 RAG_PROMPT_LENGTH = 320
-DEFAULT_MAX_EMBEDDING_TOKENS = 300000
+DEFAULT_MAX_EMBEDDING_TOKENS = 8192
+MAX_PER_BATCH_TOKEN_LIMIT = 300_000  # Maximum tokens for the embeddings batch
 BUFFER = 15000  # Buffer for the total tokens in the embeddings batch
 MAX_NR_DOCS = 1000
 TOKENS_DISTANCE_TO_LIMIT = 200
-if DEFAULT_MAX_EMBEDDING_TOKENS - RAG_PROMPT_LENGTH - BUFFER <= 0:
-    raise ValueError("Wrong MAX_EMBEDDING_TOKENS configuration")
+
 
 PREDICTION_PROMPT = """
 You will be evaluating the likelihood of an event based on a user's question and additional information from search results.
@@ -433,25 +431,6 @@ def truncate_text(text: str, model: str, max_tokens: int) -> str:
     if len(token_ids) <= max_tokens:
         return text
     return enc.decode(token_ids[:max_tokens])
-
-
-def get_max_embeddings_tokens(model: str) -> int:
-    """Get the maximum number of tokens for embeddings based on the model."""
-
-    if model in LLM_SETTINGS:
-        # Maximum tokens for the embeddings batch
-        # there are models with values under 300000
-        limit_max_tokens = min(
-            LLM_SETTINGS[model]["limit_max_tokens"], DEFAULT_MAX_EMBEDDING_TOKENS
-        )
-        max_embeddings_tokens = limit_max_tokens - RAG_PROMPT_LENGTH - BUFFER
-        if max_embeddings_tokens <= 0:
-            raise ValueError(
-                f"Model {model} has a limit_max_tokens that is too low for embeddings."
-            )
-        return max_embeddings_tokens
-
-    return DEFAULT_MAX_EMBEDDING_TOKENS - RAG_PROMPT_LENGTH - BUFFER
 
 
 # Utility: count tokens using model-specific tokenizer
@@ -710,14 +689,17 @@ def extract_texts(
 
 
 def find_similar_chunks(
-    query: str, docs_with_embeddings: List[ExtendedDocument], k: int = 4
+    query: str,
+    docs_with_embeddings: List[ExtendedDocument],
+    embedding_model: str,
+    k: int = 4,
 ) -> List:
     """Similarity search to find similar chunks to a query"""
     if not client_embedding:
         raise RuntimeError("Embeddings not intialized")
     query_embedding = (
         client_embedding.embeddings(
-            model=EMBEDDING_MODEL,
+            model=embedding_model,
             input_=query,
         )
         .data[0]
@@ -736,26 +718,20 @@ def find_similar_chunks(
 
 
 def get_embeddings(
-    split_docs: List[ExtendedDocument], model: str
+    split_docs: List[ExtendedDocument], embedding_model: str
 ) -> List[ExtendedDocument]:
     """Get embeddings for the split documents: clean, truncate, then batch by token count."""
     # Preprocess each document: clean and truncate to DOC_TOKEN_LIMIT
-    # Filter out any documents that exceed the maximum token limit individually
     filtered_docs = []
     total_tokens_count = 0
-    max_embeddings_tokens = get_max_embeddings_tokens(model)
+    max_embeddings_tokens = DEFAULT_MAX_EMBEDDING_TOKENS
     for doc in split_docs:
-        # if we are very close to the limit then break the loop
-        if max_embeddings_tokens - total_tokens_count < TOKENS_DISTANCE_TO_LIMIT:
-            break
         cleaned = clean_text(doc.text)
         # TODO we could summarize instead of truncating
-        doc.text = truncate_text(cleaned, EMBEDDING_MODEL, DOC_TOKEN_LIMIT)
+        doc.text = truncate_text(cleaned, embedding_model, DOC_TOKEN_LIMIT)
         # filter empty strings
         doc.text = doc.text.strip()
-        doc.tokens = count_tokens(doc.text, EMBEDDING_MODEL)
-        if total_tokens_count + doc.tokens > max_embeddings_tokens:
-            continue
+        doc.tokens = count_tokens(doc.text, embedding_model)
         if doc.text:
             filtered_docs.append(doc)
             total_tokens_count += doc.tokens
@@ -770,7 +746,7 @@ def get_embeddings(
         while i < len(filtered_docs):
             doc = filtered_docs[i]
             if doc.tokens == 0:
-                doc.tokens = count_tokens(doc.text, EMBEDDING_MODEL)
+                doc.tokens = count_tokens(doc.text, embedding_model)
 
             if current_batch_tokens + doc.tokens > max_embeddings_tokens:
                 break
@@ -788,7 +764,7 @@ def get_embeddings(
         if not client_embedding:
             raise RuntimeError("Embeddings not intialized")
         response = client_embedding.embeddings(
-            model=EMBEDDING_MODEL,
+            model=embedding_model,
             input_=batch_texts,
         )
 
@@ -894,12 +870,13 @@ def fetch_additional_information(
         # truncate the split_docs to the first MAX_NR_DOCS documents
         split_docs = split_docs[:MAX_NR_DOCS]
     # Embed the documents
-    docs_with_embeddings = get_embeddings(split_docs, model)
+    docs_with_embeddings = get_embeddings(split_docs, EMBEDDING_MODEL)
 
     # Find similar chunks
     similar_chunks = find_similar_chunks(
         query=prompt,
         docs_with_embeddings=docs_with_embeddings,
+        embedding_model=EMBEDDING_MODEL,
         k=NUM_NEIGHBORS,
     )
     print(f"Similar Chunks: {len(similar_chunks)}")

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,7 +7,7 @@
         "custom/psouranis/optimization_by_prompting/0.1.0": "bafybeictfa5pjn4v7si3ybw5ddolqm3ho3j3655fopidnikngqcbeawbuq",
         "custom/nickcom007/prediction_request_sme/0.1.0": "bafybeiex6ckgmvps46p4xnjr27vvceiesw5skmz4nbfusqgmmcq7nxxujq",
         "custom/napthaai/resolve_market_reasoning/0.1.0": "bafybeiewvkwt5qrvvi4zocai5tq4vxldfq34z3ixupkr3udnefvxm2kkie",
-        "custom/napthaai/prediction_request_rag/0.1.0": "bafybeib2kz2sbgto5uarwyy2imrxqq7suixuz2pejvsfjq76hbbcp5wgcm",
+        "custom/napthaai/prediction_request_rag/0.1.0": "bafybeibjp3h2g232notyryfer2brlxa6zjwbh4bliy7kjk6zt527m7rn3m",
         "custom/napthaai/prediction_request_reasoning/0.1.0": "bafybeicwpsljbbfpv7qe3euxy2grkrykjy356wqghnl7m7zfkoynkf2xr4",
         "custom/valory/prepare_tx/0.1.0": "bafybeibjzexmjct6ledxezfa54usa3o4abdafm6e2u2xxjzaji3l6sw6b4",
         "custom/napthaai/prediction_url_cot/0.1.0": "bafybeihqlqtp4cgnxbrw5gazh6f7m6ejsw7zgku7snf3mw4q6y3vxxpoqe",
@@ -21,8 +21,8 @@
         "custom/valory/tee_openai_request/0.1.0": "bafybeigtbzt7qnzzcds33r6kz34jn6i57djh2mx7zrzcffq3vdkaik6uka",
         "custom/dvilela/corcel_request/0.1.0": "bafybeidk3lht6yaaasobigkyjzbjvh7mm3lqcbgzwzzngjbxnrvumigdte",
         "custom/dvilela/gemini_prediction/0.1.0": "bafybeidxq54wpslnnzymifdho323q7cpvgi7oo2vptzmycuzuhetfu57ri",
-        "agent/valory/mech/0.1.0": "bafybeiffyu3xj6cktg2muul6ovpaia5nnfyd7sqfgvkpzv57dc5h7psche",
-        "service/valory/mech/0.1.0": "bafybeihmvupzvgla7ekuqhpkg7d2uec5afntchtn3x3vtzmxn37cwm6ze4"
+        "agent/valory/mech/0.1.0": "bafybeic7fhalaquvzm5ypyp5afbyvbdmrcysu6q3k43b2na7khrozowkp4",
+        "service/valory/mech/0.1.0": "bafybeia4lenemhotaapglr6ztycitkng3ldlnafqoj6fjc7vyn6vyuflpm"
     },
     "third_party": {
         "protocol/valory/acn_data_share/0.1.0": "bafybeih5ydonnvrwvy2ygfqgfabkr47s4yw3uqxztmwyfprulwfsoe7ipq",

--- a/packages/valory/agents/mech/aea-config.yaml
+++ b/packages/valory/agents/mech/aea-config.yaml
@@ -57,7 +57,7 @@ customs:
 - jhehemann/prediction_sum_url_content:0.1.0:bafybeidqfhxg2q7wogiacc7rhwaagfzuz74uaxwheurluflfvtu2ir424q
 - psouranis/optimization_by_prompting:0.1.0:bafybeictfa5pjn4v7si3ybw5ddolqm3ho3j3655fopidnikngqcbeawbuq
 - napthaai/resolve_market_reasoning:0.1.0:bafybeiewvkwt5qrvvi4zocai5tq4vxldfq34z3ixupkr3udnefvxm2kkie
-- napthaai/prediction_request_rag:0.1.0:bafybeib2kz2sbgto5uarwyy2imrxqq7suixuz2pejvsfjq76hbbcp5wgcm
+- napthaai/prediction_request_rag:0.1.0:bafybeibjp3h2g232notyryfer2brlxa6zjwbh4bliy7kjk6zt527m7rn3m
 - napthaai/prediction_request_reasoning:0.1.0:bafybeicwpsljbbfpv7qe3euxy2grkrykjy356wqghnl7m7zfkoynkf2xr4
 - valory/prepare_tx:0.1.0:bafybeibjzexmjct6ledxezfa54usa3o4abdafm6e2u2xxjzaji3l6sw6b4
 - napthaai/prediction_url_cot:0.1.0:bafybeihqlqtp4cgnxbrw5gazh6f7m6ejsw7zgku7snf3mw4q6y3vxxpoqe

--- a/packages/valory/services/mech/service.yaml
+++ b/packages/valory/services/mech/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeif7ia4jdlazy6745ke2k2x5yoqlwsgwr6sbztbgqtwvs3ndm2p7ba
 fingerprint_ignore_patterns: []
-agent: valory/mech:0.1.0:bafybeiffyu3xj6cktg2muul6ovpaia5nnfyd7sqfgvkpzv57dc5h7psche
+agent: valory/mech:0.1.0:bafybeic7fhalaquvzm5ypyp5afbyvbdmrcysu6q3k43b2na7khrozowkp4
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
Corrected the incorrect token limit used for embeddings and updated the embedding model. Also refactored some methods to consistently use a single model throughout, instead of previously mixing tokenizers (eg. using o200k_base for token counting and text-ada for tokenization).

https://linear.app/valory-xyz/issue/PREDICT-223



### Related PRs that will give more context.
- Original PR: https://github.com/valory-xyz/mech-predict/pull/65
- PR to release to prod: https://github.com/valory-xyz/mech-predict/pull/70



**Note: Changes are already pushed to prod. This PR is just to bring the changes to `main`**