### PR TITLE
chore: Extend support for Unit tests in CI

### DIFF
--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -139,37 +139,62 @@ jobs:
 
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
-        python-version: [ "3.10" ]
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: [ "3.10", "3.11" ]
 
     timeout-minutes: 120
+    
+    env:
+      OPENAI_SECRET_KEY: ${{ secrets.OPENAI_API_KEY }}
+      STABILITY_API_KEY: ${{ secrets.STABILITY_AI_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+      GOOGLE_ENGINE_ID: ${{ vars.GOOGLE_ENGINE_ID }}
+      CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
+      REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
+      NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPEN_ROUTER_API_KEY }}
+      GNOSIS_RPC_URL: ${{ secrets.GNOSIS_RPC_URL }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GRAPH_API_KEY: ${{ secrets.GRAPH_API_KEY }}
+    
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
+      - if: matrix.os == 'ubuntu-latest'
+        name: Install dependencies (ubuntu-latest)
         run: |
           sudo apt-get update --fix-missing
           sudo apt-get autoremove
           sudo apt-get autoclean
           pip install tomte[tox,cli]==0.4.0
           pip install --user --upgrade setuptools
-      - name: Tool unit tests
-        env:
-          OPENAI_SECRET_KEY: ${{ secrets.OPENAI_API_KEY }}
-          STABILITY_API_KEY: ${{ secrets.STABILITY_AI_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GOOGLE_ENGINE_ID: ${{ vars.GOOGLE_ENGINE_ID }}
-          CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
-          REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
-          NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPEN_ROUTER_API_KEY }}
-          GNOSIS_RPC_URL: ${{ secrets.GNOSIS_RPC_URL }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GRAPH_API_KEY: ${{ secrets.GRAPH_API_KEY }}
+      - if: matrix.os == 'ubuntu-latest'
+        name: Tool unit tests ubuntu-latest
         run: |
           printenv
-          tox -e check-tools
+          tox -e py${{ matrix.python-version }}-linux
+      - if: matrix.os == 'macos-latest'
+        name: Install dependencies (macos-latest)
+        run: |
+          pip install tomte[tox,cli]==0.4.0
+          pip install --user --upgrade setuptools
+      - if: matrix.os == 'macos-latest'
+        name: Tool unit tests macos-latest
+        run: |
+          printenv
+          tox -e py${{ matrix.python-version }}-darwin
+      - if: matrix.os == 'windows-latest'
+        name: Install dependencies (windows-latest)
+        run: |
+          python -m pip install -U pip
+          pip install tomte[tox,cli]==0.4.0
+          pip install --upgrade setuptools
+      - if: matrix.os == 'windows-latest'
+        name: Tool unit tests windows-latest
+        run: |
+          printenv
+          tox -e py${{ matrix.python-version }}-win

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 ; we set the associated flag (e.g. for linting we don't need
 ; the package installation).
 [tox]
-envlist = bandit, safety, black, black-check, isort, isort-check, check-hash, check-packages, check-dependencies, flake8, mypy, pylint, darglint, check-generate-all-protocols, check-abciapp-specs, check-abci-docstrings, check-handlers, py{3.10}-{win,linux,darwin}
+envlist = bandit, safety, black, black-check, isort, isort-check, check-hash, check-packages, check-dependencies, flake8, mypy, pylint, darglint, check-generate-all-protocols, check-abciapp-specs, check-abci-docstrings, check-handlers, py{3.10,3.11}-{win,linux,darwin}
 ; when running locally we don't want to fail for no good reason
 skip_missing_interpreters = true
 isolated_build = True
@@ -83,7 +83,6 @@ deps =
 ; end-extra
 
 [testenv]
-basepython = python3.10
 whitelist_externals = /bin/sh
 deps = {[deps-packages]deps}
 passenv = *
@@ -271,6 +270,42 @@ deps = {[deps-packages]deps}
 commands =
     autonomy packages sync --update-packages
     pytest tests
+
+[testenv:py3.10-linux]
+basepython = python3.10
+platform=^linux$
+deps = {[testenv]deps}
+commands = {[testenv:check-tools]commands}
+
+[testenv:py3.11-linux]
+basepython = python3.11
+platform=^linux$
+deps = {[testenv]deps}
+commands = {[testenv:check-tools]commands}
+
+[testenv:py3.10-darwin]
+basepython = python3.10
+platform=^darwin$
+deps = {[testenv]deps}
+commands = {[testenv:check-tools]commands}
+
+[testenv:py3.11-darwin]
+basepython = python3.11
+platform=^darwin$
+deps = {[testenv]deps}
+commands = {[testenv:check-tools]commands}
+
+[testenv:py3.10-win]
+basepython = python3.10
+platform=^win32$
+deps = {[testenv]deps}
+commands = {[testenv:check-tools]commands}
+
+[testenv:py3.11-win]
+basepython = python3.11
+platform=^win32$
+deps = {[testenv]deps}
+commands = {[testenv:check-tools]commands}
 
 [testenv:fix-doc-hashes]
 skipsdist = True


### PR DESCRIPTION
## Extend support for Unit tests in CI

This PR adds support for running unit tests across multiple operating systems and Python versions in the CI workflow.

### Changes Made

#### `.github/workflows/common_checks.yaml`

- **Extended test matrix** to run on:
  - **OS**: `ubuntu-latest`, `macos-latest`, `windows-latest`
  - **Python versions**: `3.10`, `3.11`
  - **Total**: 6 test job combinations (3 OS × 2 Python versions)

- **Upgraded GitHub Actions**:
  - `actions/checkout@v2` → `actions/checkout@v3`
  - `actions/setup-python@v3` → `actions/setup-python@v4`

- **Added OS-specific installation steps**:
  - Ubuntu: Uses `apt-get` for system dependencies
  - macOS: Standard pip installation
  - Windows: Uses `python -m pip install -U pip` for compatibility

- **Abstracted environment variables**:
  - Moved all API keys and secrets to job-level `env` section
  - Eliminates duplication across all test steps
  - Environment variables are now available to all steps automatically
