### PR TITLE
perf/fix: superforcaster page scraping, source format, cutoff date

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,11 +11,11 @@
         "custom/valory/prediction_request/0.1.0": "bafybeihatfaalkmuavus2qzozjyjiqgjkzz7q56tv3sx6qzhvozwneuyli",
         "custom/valory/prepare_tx/0.1.0": "bafybeifhfervmgwtoiiyzvqc2wdetzvp4bmlwys5bk3vuef6ggclhbvwua",
         "custom/valory/resolve_market/0.1.0": "bafybeifefym253bznqivjk3ailiuxyzm5dqyfcwcr6ytmfybmbw2w6ttpm",
-        "custom/valory/superforcaster/0.1.0": "bafybeietk7fb2ds3apzrgamf4beqxcdyqkandqirjnxd64x4is6hpxgeky",
+        "custom/valory/superforcaster/0.1.0": "bafybeihhwwl3wvg3niz5d3hqbs67vqhcicq4rp4slkeftlezaldcg5mgni",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeienobnlvdrnot5trsz5r6xnryxrveajkjkzpxckn3gweswdakwaiu",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiarvmrz7674nmsvcf6lkbw4rvmhorckq5wvydmw3zczvvd5uomlyy",
-        "agent/valory/mech_predict/0.1.0": "bafybeidrjhjzeyzhgcq4cgw7mqom73lbizhexawjysjxvcfijh2u4tlxou",
-        "service/valory/mech_predict/0.1.0": "bafybeidon4eposl42vt2oh3m2oggxvjkydvoi2f77bysvmj2zvfiapxyzu"
+        "agent/valory/mech_predict/0.1.0": "bafybeiahktylyfmzjjh6tifks7yj5vcidzsc2xwx774k2ibbib73afgrby",
+        "service/valory/mech_predict/0.1.0": "bafybeiczfwhnswffnwnzzfwukjfbu2znsn3allafxyloljylfvf7dnlm3u"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,11 +11,11 @@
         "custom/valory/prediction_request/0.1.0": "bafybeihatfaalkmuavus2qzozjyjiqgjkzz7q56tv3sx6qzhvozwneuyli",
         "custom/valory/prepare_tx/0.1.0": "bafybeifhfervmgwtoiiyzvqc2wdetzvp4bmlwys5bk3vuef6ggclhbvwua",
         "custom/valory/resolve_market/0.1.0": "bafybeifefym253bznqivjk3ailiuxyzm5dqyfcwcr6ytmfybmbw2w6ttpm",
-        "custom/valory/superforcaster/0.1.0": "bafybeictt5uin75nzdvmapr6lp7tat5wwiz6mg7xvzicz2sxsinwil6zpm",
+        "custom/valory/superforcaster/0.1.0": "bafybeietk7fb2ds3apzrgamf4beqxcdyqkandqirjnxd64x4is6hpxgeky",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeienobnlvdrnot5trsz5r6xnryxrveajkjkzpxckn3gweswdakwaiu",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiarvmrz7674nmsvcf6lkbw4rvmhorckq5wvydmw3zczvvd5uomlyy",
-        "agent/valory/mech_predict/0.1.0": "bafybeighq4fmezahctkmv3xkro6ndumaxuf43mflpotm6hqcc6ttpdhkxy",
-        "service/valory/mech_predict/0.1.0": "bafybeiaznth3jcldmss5agwppdcdzg5uou3yiujr3n3x2dtgsksd25fzcm"
+        "agent/valory/mech_predict/0.1.0": "bafybeidrjhjzeyzhgcq4cgw7mqom73lbizhexawjysjxvcfijh2u4tlxou",
+        "service/valory/mech_predict/0.1.0": "bafybeidon4eposl42vt2oh3m2oggxvjkydvoi2f77bysvmj2zvfiapxyzu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,11 +11,11 @@
         "custom/valory/prediction_request/0.1.0": "bafybeihatfaalkmuavus2qzozjyjiqgjkzz7q56tv3sx6qzhvozwneuyli",
         "custom/valory/prepare_tx/0.1.0": "bafybeifhfervmgwtoiiyzvqc2wdetzvp4bmlwys5bk3vuef6ggclhbvwua",
         "custom/valory/resolve_market/0.1.0": "bafybeifefym253bznqivjk3ailiuxyzm5dqyfcwcr6ytmfybmbw2w6ttpm",
-        "custom/valory/superforcaster/0.1.0": "bafybeic4zhpu3f4gu6cevpvntl77bshdn2qa4sy6ddogsnmqoefnfzjyxy",
+        "custom/valory/superforcaster/0.1.0": "bafybeictt5uin75nzdvmapr6lp7tat5wwiz6mg7xvzicz2sxsinwil6zpm",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeienobnlvdrnot5trsz5r6xnryxrveajkjkzpxckn3gweswdakwaiu",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiarvmrz7674nmsvcf6lkbw4rvmhorckq5wvydmw3zczvvd5uomlyy",
-        "agent/valory/mech_predict/0.1.0": "bafybeidcba3qatc43kypdyhcbvjvumel2hvkfefohycb3ncfhbxrkhzm6i",
-        "service/valory/mech_predict/0.1.0": "bafybeigqmaue4hi552j24pnr4jbb6xz2yz7i74wu7ahxjm37vz7c7nikg4"
+        "agent/valory/mech_predict/0.1.0": "bafybeighq4fmezahctkmv3xkro6ndumaxuf43mflpotm6hqcc6ttpdhkxy",
+        "service/valory/mech_predict/0.1.0": "bafybeiaznth3jcldmss5agwppdcdzg5uou3yiujr3n3x2dtgsksd25fzcm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -60,7 +60,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifiw6rdeigls4pbaqwd3hbb3tq5y6psoacnezydjz2udioxullk4e
 - victorpolisetty/gemini_request:0.1.0:bafybeiarvmrz7674nmsvcf6lkbw4rvmhorckq5wvydmw3zczvvd5uomlyy
 - victorpolisetty/dalle_request:0.1.0:bafybeienobnlvdrnot5trsz5r6xnryxrveajkjkzpxckn3gweswdakwaiu
-- valory/superforcaster:0.1.0:bafybeictt5uin75nzdvmapr6lp7tat5wwiz6mg7xvzicz2sxsinwil6zpm
+- valory/superforcaster:0.1.0:bafybeietk7fb2ds3apzrgamf4beqxcdyqkandqirjnxd64x4is6hpxgeky
 - dvilela/corcel_request:0.1.0:bafybeifpareiesif37wt4gxe2e5ojplegskfemnb3nmcsj4qph74tyfcqy
 - dvilela/gemini_prediction:0.1.0:bafybeifd5rfdp73qwibjcmgf732yryefa7aukse3ql3iunty3ho5ojuhnu
 - nickcom007/prediction_request_sme:0.1.0:bafybeicvhedq6jvluraeee5374j42hwqgzznq5lzrza7iyxunkd7shwuvi

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -60,7 +60,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifiw6rdeigls4pbaqwd3hbb3tq5y6psoacnezydjz2udioxullk4e
 - victorpolisetty/gemini_request:0.1.0:bafybeiarvmrz7674nmsvcf6lkbw4rvmhorckq5wvydmw3zczvvd5uomlyy
 - victorpolisetty/dalle_request:0.1.0:bafybeienobnlvdrnot5trsz5r6xnryxrveajkjkzpxckn3gweswdakwaiu
-- valory/superforcaster:0.1.0:bafybeic4zhpu3f4gu6cevpvntl77bshdn2qa4sy6ddogsnmqoefnfzjyxy
+- valory/superforcaster:0.1.0:bafybeictt5uin75nzdvmapr6lp7tat5wwiz6mg7xvzicz2sxsinwil6zpm
 - dvilela/corcel_request:0.1.0:bafybeifpareiesif37wt4gxe2e5ojplegskfemnb3nmcsj4qph74tyfcqy
 - dvilela/gemini_prediction:0.1.0:bafybeifd5rfdp73qwibjcmgf732yryefa7aukse3ql3iunty3ho5ojuhnu
 - nickcom007/prediction_request_sme:0.1.0:bafybeicvhedq6jvluraeee5374j42hwqgzznq5lzrza7iyxunkd7shwuvi

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -60,7 +60,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifiw6rdeigls4pbaqwd3hbb3tq5y6psoacnezydjz2udioxullk4e
 - victorpolisetty/gemini_request:0.1.0:bafybeiarvmrz7674nmsvcf6lkbw4rvmhorckq5wvydmw3zczvvd5uomlyy
 - victorpolisetty/dalle_request:0.1.0:bafybeienobnlvdrnot5trsz5r6xnryxrveajkjkzpxckn3gweswdakwaiu
-- valory/superforcaster:0.1.0:bafybeietk7fb2ds3apzrgamf4beqxcdyqkandqirjnxd64x4is6hpxgeky
+- valory/superforcaster:0.1.0:bafybeihhwwl3wvg3niz5d3hqbs67vqhcicq4rp4slkeftlezaldcg5mgni
 - dvilela/corcel_request:0.1.0:bafybeifpareiesif37wt4gxe2e5ojplegskfemnb3nmcsj4qph74tyfcqy
 - dvilela/gemini_prediction:0.1.0:bafybeifd5rfdp73qwibjcmgf732yryefa7aukse3ql3iunty3ho5ojuhnu
 - nickcom007/prediction_request_sme:0.1.0:bafybeicvhedq6jvluraeee5374j42hwqgzznq5lzrza7iyxunkd7shwuvi

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifvbuxt54l5jsxextf6ru5yvimkfdg4gfkcsnmyvsyqcsgclg7vey
-  superforcaster.py: bafybeibnc4epxzokmdnjztebffowe6w3zlhwcvk5zaqifikf7pi4rnbfm4
+  superforcaster.py: bafybeic6gzt3pveaxizvdoexnbdjwrlr52ditc4orfnhgazrrlcmhgdeoy
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
   tests/test_superforcaster.py: bafybeidioqrlw4berbk4xeie6qqtpqxwdzdbub3w27okx6uebnszg3fn7y
 fingerprint_ignore_patterns: []

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -24,3 +24,7 @@ dependencies:
     version: ==0.12.0
   requests:
     version: ==2.32.5
+  readability-lxml:
+    version: ==0.8.1
+  markdownify:
+    version: ==0.11.6

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifvbuxt54l5jsxextf6ru5yvimkfdg4gfkcsnmyvsyqcsgclg7vey
-  superforcaster.py: bafybeic6gzt3pveaxizvdoexnbdjwrlr52ditc4orfnhgazrrlcmhgdeoy
+  superforcaster.py: bafybeicgqcuuuxfi4bwltpmqovegs3si2l2jtj3j4uolfloqiezyg2sryq
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
   tests/test_superforcaster.py: bafybeidioqrlw4berbk4xeie6qqtpqxwdzdbub3w27okx6uebnszg3fn7y
 fingerprint_ignore_patterns: []
@@ -26,5 +26,7 @@ dependencies:
     version: ==2.32.5
   readability-lxml:
     version: ==0.8.1
+  lxml_html_clean:
+    version: ==0.4.4
   markdownify:
     version: ==0.11.6

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifvbuxt54l5jsxextf6ru5yvimkfdg4gfkcsnmyvsyqcsgclg7vey
-  superforcaster.py: bafybeicgqcuuuxfi4bwltpmqovegs3si2l2jtj3j4uolfloqiezyg2sryq
+  superforcaster.py: bafybeidffylroywvrdlmdww4jywjpg24s72hcszooajey5nqjihstqai4a
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
   tests/test_superforcaster.py: bafybeidioqrlw4berbk4xeie6qqtpqxwdzdbub3w27okx6uebnszg3fn7y
 fingerprint_ignore_patterns: []

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -22,11 +22,14 @@ import functools
 import json
 import re
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import openai
 import requests
+from markdownify import markdownify as md
+from readability import Document as ReadabilityDocument
 from tiktoken import encoding_for_model
 
 MechResponseWithKeys = Tuple[str, Optional[str], Optional[Dict[str, Any]], Any, Any]
@@ -168,8 +171,15 @@ DEFAULT_OPENAI_SETTINGS = {
 DEFAULT_OPENAI_MODEL = "gpt-4.1-2025-04-14"
 ALLOWED_TOOLS = ["superforcaster"]
 ALLOWED_MODELS = [DEFAULT_OPENAI_MODEL]
+MAX_SOURCES = 5
 COMPLETION_RETRIES = 3
 COMPLETION_DELAY = 2
+
+_MAX_PAGE_WORDS = 400
+_SCRIPT_STYLE_PATTERN = re.compile(
+    r"<(script|style|noscript)[^>]*>.*?</\1>", re.IGNORECASE | re.DOTALL
+)
+_IMG_TAG_PATTERN = re.compile(r"<img[^>]*>", re.IGNORECASE)
 
 
 PREDICTION_PROMPT = """
@@ -183,7 +193,7 @@ Question:
 {question}
 
 Today's date: {today}
-Your pretraining knowledge cutoff: October 2023
+Your pretraining knowledge cutoff: June 2024
 
 We have retrieved the following information for this question:
 <background>{sources}</background>
@@ -309,37 +319,66 @@ def fetch_additional_sources(question: Any, serper_api_key: Any) -> requests.Res
     return response
 
 
-def format_sources_data(organic_data: Any, misc_data: Any) -> str:
-    """Formats organic search results and "People Also Ask" data into a human-readable string."""
-    sources = ""
+def _fetch_page_content(
+    url: str, max_words: int = _MAX_PAGE_WORDS, timeout: int = 10
+) -> Optional[str]:
+    """Fetch a URL and extract its main text content as clean Markdown.
 
-    if len(organic_data) > 0:
-        print("Adding organic data...")
+    :param url: The URL to fetch.
+    :type url: str
+    :param max_words: Maximum number of words to keep.
+    :type max_words: int
+    :param timeout: Request timeout in seconds.
+    :type timeout: int
 
-        sources = """
-        Organic Results:
-        """
+    :return: Extracted text content, or None on failure.
+    :rtype: Optional[str]
+    """
+    try:
+        resp = requests.get(
+            url,
+            timeout=timeout,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; MechBot/1.0)"},
+        )
+        if resp.status_code != 200:
+            return None
+        content_type = resp.headers.get("Content-Type", "")
+        if "text/html" not in content_type:
+            return None
 
-        for item in organic_data:
-            sources += f"""{item.get('position', 'N/A')}. **Title:** {item.get("title", 'N/A')}
-            - **Link:** [{item.get("link", '#')}]({item.get("link", '#')})
-            - **Snippet:** {item.get("snippet", 'N/A')}
-            """
+        html = resp.text
+        html = _SCRIPT_STYLE_PATTERN.sub("", html)
+        html = _IMG_TAG_PATTERN.sub("", html)
 
-    if len(misc_data) > 0:
-        print("Adding misc data...")
+        article_html = ReadabilityDocument(html).summary()
+        text = md(article_html, heading_style="ATX", strip=["img", "figure"])
+        if not text or not text.strip():
+            return None
 
-        sources += "People Also Ask:\n"
+        words = text.split()
+        if len(words) > max_words:
+            text = " ".join(words[:max_words]) + " […]"
 
-        counter = 1
-        for item in misc_data:
-            sources += f"""{counter}. **Question:** {item.get("question", 'N/A')}
-            - **Link:** [{item.get("link", '#')}]({item.get("link", '#')})
-            - **Snippet:** {item.get("snippet", 'N/A')}
-            """
-            counter += 1
+        return text.strip()
+    except Exception as e:
+        print(f"[superforcaster] Failed to fetch {url}: {e}")
+        return None
 
-    return sources
+
+def _format_sources(items: List[Dict[str, Any]]) -> str:
+    """Format source dicts into ARTICLE-style blocks for the prompt.
+
+    :param items: List of dicts with at least 'link' and one of 'content'/'snippet'.
+    :type items: List[Dict[str, Any]]
+
+    :return: Formatted sources string.
+    :rtype: str
+    """
+    lines = []
+    for i, item in enumerate(items):
+        content = item.get("content") or item.get("snippet", "")
+        lines.append(f"ARTICLE {i}, URL: {item.get('link', '')}, CONTENT: {content}")
+    return "\n\n".join(lines)
 
 
 def extract_question(prompt: str) -> str:
@@ -393,15 +432,27 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
 
         question = extract_question(prompt)
 
-        print("Fetching additional sources...")
+        print("[superforcaster] Fetching additional sources...")
         serper_response = fetch_additional_sources(question, serper_api_key)
         sources_data = serper_response.json()
-        print(f"Additional sources fetched: {sources_data}")
-        # choose top 5 results
-        organic_data = sources_data.get("organic", [])[:5]
-        misc_data = sources_data.get("peopleAlsoAsk", [])
-        print("Formating sources...")
-        sources = format_sources_data(organic_data, misc_data)
+        organic_data = sources_data.get("organic", [])[:MAX_SOURCES]
+        print(f"[superforcaster] Scraping {len(organic_data)} pages...")
+        with ThreadPoolExecutor(max_workers=MAX_SOURCES) as pool:
+            future_to_item = {
+                pool.submit(_fetch_page_content, item["link"]): item
+                for item in organic_data
+            }
+            for fut in as_completed(future_to_item):
+                item = future_to_item[fut]
+                try:
+                    content = fut.result()
+                    if content:
+                        item["content"] = content
+                except Exception as e:
+                    print(
+                        f"[superforcaster] Scrape failed for '{item['link']}': {e}"
+                    )
+        sources = _format_sources(organic_data)
 
         print("Updating prompt...")
         prediction_prompt = PREDICTION_PROMPT.format(

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -180,6 +180,13 @@ _SCRIPT_STYLE_PATTERN = re.compile(
     r"<(script|style|noscript)[^>]*>.*?</\1>", re.IGNORECASE | re.DOTALL
 )
 _IMG_TAG_PATTERN = re.compile(r"<img[^>]*>", re.IGNORECASE)
+_DATA_URI_IMG_PATTERN = re.compile(r'data:image/[^;]*;base64,[^"]*')
+_MARKDOWN_IMG_PATTERN = re.compile(
+    r"!\[.*?\]\((?:data:image/[^;]*;base64,[^)]*|.*?)\)"
+)
+_MARKDOWN_LINK_PATTERN = re.compile(r"\[.*?\]\(.*?\)")
+_PHOTO_CREDIT_PATTERN = re.compile(r"Photo:.*?\n")
+_IMAGE_CREDIT_PATTERN = re.compile(r"Image:.*?\n")
 
 
 PREDICTION_PROMPT = """
@@ -348,12 +355,19 @@ def _fetch_page_content(
 
         html = resp.text
         html = _SCRIPT_STYLE_PATTERN.sub("", html)
+        html = _DATA_URI_IMG_PATTERN.sub("", html)
+        html = _MARKDOWN_IMG_PATTERN.sub("", html)
         html = _IMG_TAG_PATTERN.sub("", html)
 
         article_html = ReadabilityDocument(html).summary()
         text = md(article_html, heading_style="ATX", strip=["img", "figure"])
         if not text or not text.strip():
             return None
+
+        text = _MARKDOWN_IMG_PATTERN.sub("", text)
+        text = _MARKDOWN_LINK_PATTERN.sub("", text)
+        text = _PHOTO_CREDIT_PATTERN.sub("", text)
+        text = _IMAGE_CREDIT_PATTERN.sub("", text)
 
         words = text.split()
         if len(words) > max_words:

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -181,9 +181,7 @@ _SCRIPT_STYLE_PATTERN = re.compile(
 )
 _IMG_TAG_PATTERN = re.compile(r"<img[^>]*>", re.IGNORECASE)
 _DATA_URI_IMG_PATTERN = re.compile(r'data:image/[^;]*;base64,[^"]*')
-_MARKDOWN_IMG_PATTERN = re.compile(
-    r"!\[.*?\]\((?:data:image/[^;]*;base64,[^)]*|.*?)\)"
-)
+_MARKDOWN_IMG_PATTERN = re.compile(r"!\[.*?\]\((?:data:image/[^;]*;base64,[^)]*|.*?)\)")
 _MARKDOWN_LINK_PATTERN = re.compile(r"\[.*?\]\(.*?\)")
 _PHOTO_CREDIT_PATTERN = re.compile(r"Photo:.*?\n")
 _IMAGE_CREDIT_PATTERN = re.compile(r"Image:.*?\n")

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -421,7 +421,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
         return max_cost
 
     openai_api_key = kwargs["api_keys"]["openai"]
-    serper_api_key = kwargs["api_keys"]["serperapi"]
+    source_content: Optional[Dict[str, str]] = kwargs.get("source_content", None)
     with OpenAIClientManager(openai_api_key) as llm_client:
         max_tokens = kwargs.get("max_tokens", DEFAULT_OPENAI_SETTINGS["max_tokens"])
         temperature = kwargs.get("temperature", DEFAULT_OPENAI_SETTINGS["temperature"])
@@ -432,26 +432,34 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
 
         question = extract_question(prompt)
 
-        print("[superforcaster] Fetching additional sources...")
-        serper_response = fetch_additional_sources(question, serper_api_key)
-        sources_data = serper_response.json()
-        organic_data = sources_data.get("organic", [])[:MAX_SOURCES]
-        print(f"[superforcaster] Scraping {len(organic_data)} pages...")
-        with ThreadPoolExecutor(max_workers=MAX_SOURCES) as pool:
-            future_to_item = {
-                pool.submit(_fetch_page_content, item["link"]): item
-                for item in organic_data
-            }
-            for fut in as_completed(future_to_item):
-                item = future_to_item[fut]
-                try:
-                    content = fut.result()
-                    if content:
-                        item["content"] = content
-                except Exception as e:
-                    print(
-                        f"[superforcaster] Scrape failed for '{item['link']}': {e}"
-                    )
+        if source_content:
+            print("[superforcaster] Using provided source_content (cached replay).")
+            organic_data: List[Dict[str, Any]] = [
+                {"link": url, "content": content}
+                for url, content in source_content.items()
+            ][:MAX_SOURCES]
+        else:
+            serper_api_key = kwargs["api_keys"]["serperapi"]
+            print("[superforcaster] Fetching additional sources...")
+            serper_response = fetch_additional_sources(question, serper_api_key)
+            sources_data = serper_response.json()
+            organic_data = sources_data.get("organic", [])[:MAX_SOURCES]
+            print(f"[superforcaster] Scraping {len(organic_data)} pages...")
+            with ThreadPoolExecutor(max_workers=MAX_SOURCES) as pool:
+                future_to_item = {
+                    pool.submit(_fetch_page_content, item["link"]): item
+                    for item in organic_data
+                }
+                for fut in as_completed(future_to_item):
+                    item = future_to_item[fut]
+                    try:
+                        content = fut.result()
+                        if content:
+                            item["content"] = content
+                    except Exception as e:
+                        print(
+                            f"[superforcaster] Scrape failed for '{item['link']}': {e}"
+                        )
         sources = _format_sources(organic_data)
 
         print("Updating prompt...")

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeidcba3qatc43kypdyhcbvjvumel2hvkfefohycb3ncfhbxrkhzm6i
+agent: valory/mech_predict:0.1.0:bafybeighq4fmezahctkmv3xkro6ndumaxuf43mflpotm6hqcc6ttpdhkxy
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeighq4fmezahctkmv3xkro6ndumaxuf43mflpotm6hqcc6ttpdhkxy
+agent: valory/mech_predict:0.1.0:bafybeidrjhjzeyzhgcq4cgw7mqom73lbizhexawjysjxvcfijh2u4tlxou
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeidrjhjzeyzhgcq4cgw7mqom73lbizhexawjysjxvcfijh2u4tlxou
+agent: valory/mech_predict:0.1.0:bafybeiahktylyfmzjjh6tifks7yj5vcidzsc2xwx774k2ibbib73afgrby
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

Improves `superforcaster` prediction quality and fixes CI:

- **Page scraping**: Live search path now scrapes full page content in parallel (`ThreadPoolExecutor`) instead of relying on Serper ~150-char snippets. Links that fail to scrape retain their original Serper snippet.
- **Source format**: Replaced verbose markdown `format_sources_data` with clean `ARTICLE N, URL: ..., CONTENT: ...` format — consistent with `prediction_request` tools and easier for the model to parse.
- **Knowledge cutoff**: Fixed hardcoded `October 2023` → `June 2024` (actual `gpt-4.1` cutoff).
- **Content cleanup**: Strip data-URI images, markdown images/links, and photo/image credit lines from scraped pages — aligned with other tools' extraction logic.
- **Cached replay**: Support `source_content` kwarg to skip Serper fetch and replay from cached sources.
- **Missing dependency**: Add `lxml_html_clean==0.4.4` — fixes `ImportError` on Python 3.14 (macOS CI).

## Test plan

- [ ] CI passes on all platforms (macOS/Python 3.14 was failing)
- [ ] Run with live search — confirm scraped content in prompt
- [ ] Confirm JSON output contains `p_yes`, `p_no`, `confidence`, `info_utility`

🤖 Generated with [Claude Code](https://claude.com/claude-code)