### PR TITLE
feat: add edge-over-market metrics, dedup, and platform-specific analysis

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -248,12 +248,144 @@ python benchmark/sweep.py \
 - **Delta**: Candidate minus baseline (negative Brier delta = improvement)
 - **Direction**: `improved` / `regressed` / `unchanged`
 
-## Scoring metrics
+## Scoring metrics — formulas
 
-- **Brier score**: `(p_yes - outcome)²` averaged over all predictions. 0 = perfect, 0.25 = coin flip, 1 = always wrong.
-- **Accuracy**: Fraction of predictions where the higher-probability outcome was correct.
-- **Sharpness**: How far predictions deviate from 0.5 (decisive predictions). Higher = more decisive.
-- **Calibration**: When you say 70%, does the event happen 70% of the time?
+All formulas below match the implementations in `scorer.py` and `ci_replay.py`.
+
+### Primary metrics (used for tool ranking)
+
+**Brier score** — measures probabilistic forecast accuracy. Lower is better.
+
+```
+Per prediction:  brier_i = (p_yes - outcome)²
+Aggregate:       Brier   = mean(brier_i)  over all valid predictions
+
+outcome = 1.0 if Yes, 0.0 if No
+```
+
+| Value | Meaning |
+|-------|---------|
+| 0.0 | Perfect — predicted exactly the outcome |
+| 0.25 | No skill — equivalent to always predicting 0.5 |
+| 1.0 | Worst — maximally wrong on every prediction |
+
+**Reliability** — fraction of attempted runs that produced a valid, parseable prediction.
+
+```
+Reliability = valid_outputs / attempted_runs
+```
+
+A row is "valid" when `prediction_parse_status == "valid"`, `final_outcome` is not null, and `p_yes` is not null. Gate threshold: < 80% marks the tool as unreliable and excludes it from comparative ranking.
+
+**Accuracy** — directional correctness. Predictions at exactly 0.5 count as incorrect (no directional signal).
+
+```
+correct_i = 1  if (p_yes > 0.5) == outcome
+            0  otherwise
+Accuracy  = sum(correct_i) / n_valid
+```
+
+**Sharpness** — how decisive the predictions are. A tool that always predicts 0.5 has zero sharpness.
+
+```
+Sharpness = mean(|p_yes - 0.5|)
+```
+
+| Value | Meaning |
+|-------|---------|
+| 0.0 | All predictions at 50/50 — no conviction |
+| 0.5 | Maximally decisive — every prediction near 0 or 1 |
+
+High sharpness is only good if calibration is also good. A tool that confidently predicts 0.95 on everything is sharp but badly calibrated.
+
+**Baseline Brier** — the Brier score of a naive predictor that always outputs the observed base rate.
+
+```
+yes_rate       = count(outcome == Yes) / n_valid
+Baseline Brier = yes_rate × (1 - yes_rate)
+```
+
+If 70% of outcomes are Yes, the naive predictor always says 0.7 and gets Brier = 0.7 × 0.3 = 0.21. Any tool worth using should beat this.
+
+**Brier Skill Score (BSS)** — improvement over the baseline predictor. Positive = better than base rate.
+
+```
+BSS = 1 - (Brier / Baseline Brier)
+```
+
+| Value | Meaning |
+|-------|---------|
+| > 0 | Better than predicting the base rate |
+| 0 | Same as predicting the base rate |
+| < 0 | Worse than predicting the base rate — actively harmful |
+
+### Calibration
+
+Predictions are binned into 10 decile ranges (0.0–0.1, 0.1–0.2, ... 0.9–1.0). For each bin:
+
+```
+avg_predicted = mean(p_yes)  for predictions in this bin
+realized_rate = count(outcome == Yes) / n  for predictions in this bin
+gap           = avg_predicted - realized_rate
+```
+
+| Gap sign | Meaning |
+|----------|---------|
+| Positive | Overconfident — predicts higher than reality |
+| Negative | Underconfident — predicts lower than reality |
+
+A perfectly calibrated tool has gap ≈ 0 in every bin. The calibration plot (reliability diagram) shows avg_predicted vs realized_rate; the diagonal line is perfect calibration.
+
+### Edge over market (diagnostic — not for ranking)
+
+Edge measures whether the tool's prediction was closer to the truth than the market's price. Positive = tool beat market. This is a system diagnostic, not a ranking metric (see PROPOSAL.md for rationale).
+
+```
+Per prediction:  edge_i = (market_prob - outcome)² - (p_yes - outcome)²
+Aggregate:       Edge   = mean(edge_i)  over edge-eligible predictions
+```
+
+Expanding: `edge_i = market_brier_i - tool_brier_i`. When the tool has lower Brier than the market on a question, edge is positive for that question.
+
+**Eligibility:** A row is edge-eligible when it has a valid prediction, a resolved outcome, and `market_prob_at_prediction` is not null.
+
+**Edge positive rate** — fraction of edge-eligible predictions where the tool beat the market:
+
+```
+Edge positive rate = count(edge_i > 0) / n_edge_eligible
+```
+
+A tool can have negative aggregate edge but > 50% positive rate. This means it beats the market on most questions but loses bigger when it loses — the magnitude of losses exceeds the magnitude of wins.
+
+### Overconfident-wrong (ci_replay.py only)
+
+Used in PR-comment replay comparisons. Counts predictions where the tool was confident and wrong:
+
+```
+overconf_wrong_i = 1  if max(p_yes, 1 - p_yes) > 0.80 AND predicted direction ≠ outcome
+                   0  otherwise
+Overconfident wrong count = sum(overconf_wrong_i)
+```
+
+These are the most expensive mistakes — high-conviction wrong predictions that would trigger large Kelly bets in the wrong direction.
+
+### Stratification dimensions
+
+All primary and diagnostic metrics are computed per group across these dimensions:
+
+| Dimension | Buckets | How it's computed |
+|-----------|---------|-------------------|
+| **Tool** | One bucket per `tool_name` | Direct field grouping |
+| **Platform** | `polymarket`, `omen` | Direct field grouping |
+| **Category** | `crypto`, `politics`, `sports`, etc. | Direct field grouping |
+| **Horizon** | `short_lt_7d`, `medium_7_30d`, `long_gt_30d` | `prediction_lead_time_days`: < 7, 7–30, > 30 |
+| **Difficulty** | `hard`, `medium`, `easy` | `\|market_prob - 0.5\|`: < 0.15 = hard, 0.15–0.30 = medium, > 0.30 = easy |
+| **Liquidity** | `low`, `medium`, `high` | `market_liquidity_at_prediction` in USD: < 500 = low, 500–5000 = medium, > 5000 = high |
+| **Monthly trend** | `YYYY-MM` | Extracted from `predicted_at` |
+
+Cross-dimensions are also computed: platform × difficulty, platform × liquidity, tool × platform, tool × platform × horizon.
+
+Rows where the grouping field is null go into an `unknown` bucket.
 
 ## File locations
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -275,7 +275,7 @@ outcome = 1.0 if Yes, 0.0 if No
 Reliability = valid_outputs / attempted_runs
 ```
 
-A row is "valid" when `prediction_parse_status == "valid"`, `final_outcome` is not null, and `p_yes` is not null. Gate threshold: < 80% marks the tool as unreliable and excludes it from comparative ranking.
+A row is "valid" when `prediction_parse_status == "valid"`, `final_outcome` is not null, and `p_yes` is not null. Tools below 80% reliability are flagged with a warning in the report. Exclusion from ranking is not currently enforced — it is planned as part of the staged pipeline gates.
 
 **Accuracy** — directional correctness. Predictions at exactly 0.5 count as incorrect (no directional signal).
 

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -395,17 +395,18 @@ def section_edge_analysis(scores: dict[str, Any]) -> str:
     """Edge-over-market analysis — per platform, difficulty, and liquidity."""
     elig = scores.get("edge_eligibility", {})
     n_eligible = elig.get("n_eligible", 0)
+    n_total = elig.get("n_total", 0)
     if n_eligible == 0:
         return (
             "## Edge Over Market\n\n"
             "No edge-eligible rows (need market_prob_at_prediction)."
         )
 
+    pct = f" ({n_eligible / n_total:.1%} of total)" if n_total > 0 else ""
     lines = [
         "## Edge Over Market",
         "",
-        f"Edge-eligible rows: {n_eligible} / {elig.get('n_total', 0)}"
-        f" ({n_eligible / elig['n_total']:.1%} of total)",
+        f"Edge-eligible rows: {n_eligible} / {n_total}{pct}",
         "",
     ]
 

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -404,7 +404,10 @@ def section_edge_analysis(scores: dict[str, Any]) -> str:
 
     pct = f" ({n_eligible / n_total:.1%} of total)" if n_total > 0 else ""
     lines = [
-        "## Edge Over Market",
+        "## Edge Over Market (System Diagnostic)",
+        "",
+        "Edge measures whether prediction accuracy translates to trading"
+        " value — it is not a tool ranking metric.",
         "",
         f"Edge-eligible rows: {n_eligible} / {n_total}{pct}",
         "",

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -391,6 +391,9 @@ def section_tool_platform(scores: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+_EDGE_SECTION_HEADER = "## Edge Over Market (System Diagnostic)"
+
+
 def section_edge_analysis(scores: dict[str, Any]) -> str:
     """Edge-over-market analysis — per platform, difficulty, and liquidity."""
     elig = scores.get("edge_eligibility", {})
@@ -398,13 +401,13 @@ def section_edge_analysis(scores: dict[str, Any]) -> str:
     n_total = elig.get("n_total", 0)
     if n_eligible == 0:
         return (
-            "## Edge Over Market\n\n"
+            f"{_EDGE_SECTION_HEADER}\n\n"
             "No edge-eligible rows (need market_prob_at_prediction)."
         )
 
     pct = f" ({n_eligible / n_total:.1%} of total)" if n_total > 0 else ""
     lines = [
-        "## Edge Over Market (System Diagnostic)",
+        _EDGE_SECTION_HEADER,
         "",
         "Edge measures whether prediction accuracy translates to trading"
         " value — it is not a tool ranking metric.",

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -72,6 +72,13 @@ def section_overall(scores: dict[str, Any]) -> str:
     bss = o.get("brier_skill_score")
     bss_str = f"{bss:+.4f}" if bss is not None else "N/A"
     baseline_str = str(o.get("baseline_brier", "N/A"))
+    # Edge over market
+    edge = o.get("edge")
+    edge_n = o.get("edge_n", 0)
+    edge_str = f"{edge:+.4f}" if edge is not None else "N/A"
+    epr = o.get("edge_positive_rate")
+    epr_str = f"{epr:.0%}" if epr is not None else "N/A"
+
     lines = [
         "## Overall",
         "",
@@ -83,6 +90,10 @@ def section_overall(scores: dict[str, Any]) -> str:
         f"- Brier Skill Score: {bss_str}",
         "  - BSS > 0 = better than base rate, BSS = 0 = no skill,"
         " BSS < 0 = worse than base rate",
+        f"- Edge over market: {edge_str} (n={edge_n})",
+        "  - Positive = tool beats market consensus, negative = market wins",
+        f"  - Edge positive rate: {epr_str}"
+        " (fraction of questions where tool beat market)",
         f"- Accuracy: {acc_str}",
         f"- Sharpness: {sharp_str}",
         "  - 0.0 = all predictions at 50/50, 0.5 = maximally decisive",
@@ -121,8 +132,11 @@ def section_tool_ranking(scores: dict[str, Any]) -> str:
         )
         bss = stats.get("brier_skill_score")
         bss_str = f", BSS: {bss:+.4f}" if bss is not None else ""
+        edge = stats.get("edge")
+        edge_n = stats.get("edge_n", 0)
+        edge_str = f", Edge: {edge:+.4f} (n={edge_n})" if edge is not None else ""
         lines.append(
-            f"{i}. **{tool}** — Brier: {brier}{bss_str}, Acc: {acc},"
+            f"{i}. **{tool}** — Brier: {brier}{bss_str}{edge_str}, Acc: {acc},"
             f" Sharp: {sharp} (n={stats['n']}){flags}"
         )
 
@@ -140,11 +154,15 @@ def section_platform(scores: dict[str, Any]) -> str:
         baseline = stats.get("baseline_brier")
         bss = stats.get("brier_skill_score")
         yes_rate = stats.get("outcome_yes_rate")
+        edge = stats.get("edge")
+        edge_n = stats.get("edge_n", 0)
         parts = [f"Brier: {stats['brier']}"]
         if baseline is not None:
             parts.append(f"baseline: {baseline}")
         if bss is not None:
             parts.append(f"BSS: {bss:+.4f}")
+        if edge is not None:
+            parts.append(f"edge: {edge:+.4f} (n={edge_n})")
         if yes_rate is not None:
             parts.append(f"yes rate: {yes_rate:.0%}")
         parts.append(f"n={stats['n']}")
@@ -344,8 +362,8 @@ def section_tool_platform(scores: dict[str, Any]) -> str:
     lines = [
         "## Tool × Platform",
         "",
-        "| Tool | Platform | Brier | BSS | Accuracy | Sharpness | n |",
-        "|------|----------|-------|-----|----------|-----------|---|",
+        "| Tool | Platform | Brier | BSS | Edge | Edge n | Accuracy | Sharpness | n |",
+        "|------|----------|-------|-----|------|--------|----------|-----------|---|",
     ]
     for key, stats in sorted(
         data.items(),
@@ -357,15 +375,108 @@ def section_tool_platform(scores: dict[str, Any]) -> str:
         brier = f"{stats['brier']:.4f}" if stats.get("brier") is not None else "N/A"
         bss = stats.get("brier_skill_score")
         bss_str = f"{bss:+.4f}" if bss is not None else "N/A"
+        edge = stats.get("edge")
+        edge_str = f"{edge:+.4f}" if edge is not None else "N/A"
+        edge_n = stats.get("edge_n", 0)
         acc = f"{stats['accuracy']:.0%}" if stats.get("accuracy") is not None else "N/A"
         sharp = (
             f"{stats['sharpness']:.4f}" if stats.get("sharpness") is not None else "N/A"
         )
         label = _sample_label(stats)
         lines.append(
-            f"| {tool} | {platform} | {brier} | {bss_str} | {acc}"
-            f" | {sharp} | {stats['n']}{label} |"
+            f"| {tool} | {platform} | {brier} | {bss_str} | {edge_str}"
+            f" | {edge_n} | {acc} | {sharp} | {stats['n']}{label} |"
         )
+
+    return "\n".join(lines)
+
+
+def section_edge_analysis(scores: dict[str, Any]) -> str:
+    """Edge-over-market analysis — per platform, difficulty, and liquidity."""
+    elig = scores.get("edge_eligibility", {})
+    n_eligible = elig.get("n_eligible", 0)
+    if n_eligible == 0:
+        return (
+            "## Edge Over Market\n\n"
+            "No edge-eligible rows (need market_prob_at_prediction)."
+        )
+
+    lines = [
+        "## Edge Over Market",
+        "",
+        f"Edge-eligible rows: {n_eligible} / {elig.get('n_total', 0)}"
+        f" ({n_eligible / elig['n_total']:.1%} of total)",
+        "",
+    ]
+
+    # Per-platform edge
+    by_plat = scores.get("by_platform", {})
+    if by_plat:
+        lines.append("### By Platform")
+        lines.append("")
+        for plat, stats in sorted(by_plat.items()):
+            edge = stats.get("edge")
+            edge_n = stats.get("edge_n", 0)
+            epr = stats.get("edge_positive_rate")
+            if edge is not None:
+                lines.append(
+                    f"- **{plat}**: edge {edge:+.4f},"
+                    f" positive rate {epr:.0%}, edge_n={edge_n}"
+                )
+        lines.append("")
+
+    # Platform × difficulty
+    pd = scores.get("by_platform_difficulty", {})
+    pd_filtered = {
+        k: v for k, v in pd.items() if v.get("edge") is not None and "unknown" not in k
+    }
+    if pd_filtered:
+        lines.append("### By Platform × Difficulty")
+        lines.append("")
+        lines.append(
+            "| Platform | Difficulty | Edge | Edge +rate | Edge n | Brier | n |"
+        )
+        lines.append(
+            "|----------|-----------|------|------------|--------|-------|---|"
+        )
+        for key, stats in sorted(pd_filtered.items()):
+            parts = key.split(" | ")
+            plat, diff = parts[0], parts[1] if len(parts) > 1 else "?"
+            edge = stats["edge"]
+            epr = stats.get("edge_positive_rate", 0)
+            brier = stats.get("brier")
+            brier_str = f"{brier:.4f}" if brier is not None else "N/A"
+            lines.append(
+                f"| {plat} | {diff} | {edge:+.4f} | {epr:.0%}"
+                f" | {stats.get('edge_n', 0)} | {brier_str} | {stats['n']} |"
+            )
+        lines.append("")
+
+    # Platform × liquidity
+    pl = scores.get("by_platform_liquidity", {})
+    pl_filtered = {
+        k: v for k, v in pl.items() if v.get("edge") is not None and "unknown" not in k
+    }
+    if pl_filtered:
+        lines.append("### By Platform × Liquidity")
+        lines.append("")
+        lines.append(
+            "| Platform | Liquidity | Edge | Edge +rate | Edge n | Brier | n |"
+        )
+        lines.append(
+            "|----------|-----------|------|------------|--------|-------|---|"
+        )
+        for key, stats in sorted(pl_filtered.items()):
+            parts = key.split(" | ")
+            plat, liq = parts[0], parts[1] if len(parts) > 1 else "?"
+            edge = stats["edge"]
+            epr = stats.get("edge_positive_rate", 0)
+            brier = stats.get("brier")
+            brier_str = f"{brier:.4f}" if brier is not None else "N/A"
+            lines.append(
+                f"| {plat} | {liq} | {edge:+.4f} | {epr:.0%}"
+                f" | {stats.get('edge_n', 0)} | {brier_str} | {stats['n']} |"
+            )
 
     return "\n".join(lines)
 
@@ -552,6 +663,7 @@ def generate_report(
         section_tool_ranking(scores),
         section_platform(scores),
         section_tool_platform(scores),
+        section_edge_analysis(scores),
         section_calibration(scores),
         section_weak_spots(scores),
         section_reliability_issues(scores),

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -846,6 +846,7 @@ def _parse_request_context(content_str: str) -> dict[str, Any]:
         "market_prob": ctx.get("market_prob"),
         "market_liquidity_usd": ctx.get("market_liquidity_usd"),
         "market_close_at": ctx.get("market_close_at"),
+        "market_spread": ctx.get("market_spread"),
     }
 
 
@@ -900,6 +901,7 @@ def fetch_deliveries(
                 "market_prob": ctx.get("market_prob"),
                 "market_liquidity_usd": ctx.get("market_liquidity_usd"),
                 "market_close_at": ctx.get("market_close_at"),
+                "market_spread": ctx.get("market_spread"),
             }
         )
 
@@ -1400,6 +1402,7 @@ def build_row(
         "prediction_parse_status": parsed["prediction_parse_status"],
         "market_prob_at_prediction": delivery.get("market_prob"),
         "market_liquidity_at_prediction": delivery.get("market_liquidity_usd"),
+        "market_spread_at_prediction": delivery.get("market_spread"),
         "market_close_at": delivery.get("market_close_at"),
         "final_outcome": market["outcome"],
         "requested_at": _ts_to_iso(request_ts),

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -29,7 +29,7 @@ Summarize this Olas Predict benchmark report using EXACTLY this structure (outpu
 
 *Top tools:*
 • `tool-name` — Brier `X.XX`, Edge `±X.XX` (n=X), accuracy X%, one word on why
-(list top 3, rank by edge if available, otherwise by Brier)
+(list top 3, rank by Brier. Edge is a diagnostic shown alongside, not a ranking criterion)
 
 *Worst tools:*
 • `tool-name` — Brier `X.XX`, Edge `±X.XX` (n=X), accuracy X%, one word on why
@@ -52,7 +52,7 @@ Rules:
 - Wrap tool names, Brier scores, and Edge scores in backticks.
 - Slack mrkdwn only: *bold* (single asterisk), `code`. No **double asterisks**.
 - No greetings or preamble.
-- Edge over market: positive = tool beats market, negative = market beats tool. This is the most important metric for trading value.
+- Edge over market: positive = tool beats market, negative = market beats tool. This is a system-level diagnostic — it shows whether prediction accuracy translates to trading value, but tools are ranked by Brier (prediction quality).
 - Some tools listed below are third-party (not ours). Completely exclude them — never mention, rank, compare, or recommend actions for third-party tools anywhere in the summary."""
 
 MODEL = "gpt-4.1-mini"

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -25,31 +25,34 @@ log = logging.getLogger(__name__)
 SUMMARY_SYSTEM_PROMPT = """\
 Summarize this Olas Predict benchmark report using EXACTLY this structure (output will be posted to Slack).
 
-*Summary:* 2-3 sentence high-level takeaway — what's working, what's not, any trends.
+*Summary:* 2-3 sentence high-level takeaway — what's working, what's not, any trends. Include the overall edge-over-market if available.
 
 *Top tools:*
-• `tool-name` — Brier `X.XX`, accuracy X%, one word on why (e.g. "strong calibration")
-(list top 3)
+• `tool-name` — Brier `X.XX`, Edge `±X.XX` (n=X), accuracy X%, one word on why
+(list top 3, rank by edge if available, otherwise by Brier)
 
 *Worst tools:*
-• `tool-name` — Brier `X.XX`, accuracy X%, one word on why (e.g. "overconfident", "anti-predictive")
+• `tool-name` — Brier `X.XX`, Edge `±X.XX` (n=X), accuracy X%, one word on why
 (list bottom 3, ignore tools with 0% reliability or < 50 predictions)
 
 *Platform performance:*
-• `platform` — Brier `X.XX`, BSS `±X.XX` (interpret: >0 = skillful, <0 = worse than base rate), n=X
-(list all platforms)
+• `platform` — Brier `X.XX`, Edge `±X.XX` (n=X), BSS `±X.XX`, n=X
+(list all platforms. Edge = how much tool beats market consensus; positive = profitable signal)
+
+*Edge by difficulty:* if the report has "Platform × Difficulty" data, summarize which difficulty level has the best/worst edge per platform (1 line per platform)
 
 *Weak categories:* list categories with Brier > 0.40 and brief note
 
 *Regressions:* any tools or metrics that worsened vs prior period. Say "None" if trend data shows no worsening. "Regression" means worse over TIME, not just a bad score.
 
-*Recommended actions:* 2-3 concrete next steps based on the data
+*Recommended actions:* 2-3 concrete next steps based on the data. If edge is negative for all tools, this is important — recommend specific improvements.
 
 Rules:
 - Tool names with hyphens vs underscores are DIFFERENT tools — use exact names.
-- Wrap tool names and Brier scores in backticks.
+- Wrap tool names, Brier scores, and Edge scores in backticks.
 - Slack mrkdwn only: *bold* (single asterisk), `code`. No **double asterisks**.
 - No greetings or preamble.
+- Edge over market: positive = tool beats market, negative = market beats tool. This is the most important metric for trading value.
 - Some tools listed below are third-party (not ours). Completely exclude them — never mention, rank, compare, or recommend actions for third-party tools anywhere in the summary."""
 
 MODEL = "gpt-4.1-mini"

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -105,7 +105,7 @@ def classify_difficulty(market_prob: float | None) -> str:
     """
     if market_prob is None:
         return "unknown"
-    distance = abs(market_prob - 0.5)
+    distance = round(abs(market_prob - 0.5), 10)
     lo, hi = DIFFICULTY_THRESHOLDS
     if distance < lo:
         return "hard"

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -1136,6 +1136,8 @@ def rebuild(
         finalized = _finalize_scores(scores)
         scores_path.parent.mkdir(parents=True, exist_ok=True)
         scores_path.write_text(json.dumps(finalized, indent=2))
+        # Clear dedup file — empty rebuild means fresh start
+        _save_dedup_ids(dedup_path, set())
         return finalized
 
     # Sort rows by predicted_at to process chronologically
@@ -1165,8 +1167,10 @@ def rebuild(
     for month in sorted_months[:-1]:
         scores = _empty_scores(month)
         for row in months[month]:
-            _accumulate_row(scores, row)
             row_id = row.get("row_id")
+            if row_id and row_id in all_row_ids:
+                continue  # skip duplicate across log files
+            _accumulate_row(scores, row)
             if row_id:
                 all_row_ids.add(row_id)
         _snapshot_month(scores, history_path)
@@ -1174,8 +1178,10 @@ def rebuild(
     # The last month becomes the current scores.json
     scores = _empty_scores(last_month)
     for row in months[last_month]:
-        _accumulate_row(scores, row)
         row_id = row.get("row_id")
+        if row_id and row_id in all_row_ids:
+            continue  # skip duplicate across log files
+        _accumulate_row(scores, row)
         if row_id:
             all_row_ids.add(row_id)
     # Save dedup state to its own file — persists across month rollovers

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -829,11 +829,16 @@ def _finalize_scores(scores: dict[str, Any]) -> dict[str, Any]:
 
     # Edge eligibility from accumulators
     overall_n = scores["overall"]["n"]
+    overall_valid_n = scores["overall"]["valid_n"]
     overall_edge_n = scores["overall"].get("edge_n", 0)
     result["edge_eligibility"] = {
         "n_total": overall_n,
         "n_eligible": overall_edge_n,
         "n_excluded": overall_n - overall_edge_n,
+        "exclusion_reasons": {
+            "invalid_or_incomplete": overall_n - overall_valid_n,
+            "missing_market_prob": overall_valid_n - overall_edge_n,
+        },
     }
 
     # Calibration — derive avg_predicted, realized_rate, gap

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -27,6 +27,7 @@ from benchmark.io import load_jsonl as load_rows
 DEFAULT_INPUT = Path(__file__).parent / "datasets" / "production_log.jsonl"
 DEFAULT_OUTPUT = Path(__file__).parent / "results" / "scores.json"
 DEFAULT_HISTORY = Path(__file__).parent / "results" / "scores_history.jsonl"
+DEFAULT_DEDUP = Path(__file__).parent / "results" / "scored_row_ids.json"
 DEFAULT_LOGS_DIR = Path(__file__).parent / "datasets" / "logs"
 
 LATENCY_RESERVOIR_SIZE = 200
@@ -51,6 +52,33 @@ _ACCUM_KEYS = (
 # ---------------------------------------------------------------------------
 # Brier score computation
 # ---------------------------------------------------------------------------
+
+
+def _load_dedup_ids(dedup_path: Path) -> set[str]:
+    """Load scored row IDs from the dedup file.
+
+    Persists across month rollovers so replayed historical rows
+    are still skipped.
+
+    :param dedup_path: path to ``scored_row_ids.json``.
+    :return: set of row IDs.
+    """
+    if not dedup_path.exists():
+        return set()
+    try:
+        return set(json.loads(dedup_path.read_text()))
+    except (json.JSONDecodeError, OSError):
+        return set()
+
+
+def _save_dedup_ids(dedup_path: Path, ids: set[str]) -> None:
+    """Save scored row IDs to the dedup file.
+
+    :param dedup_path: path to ``scored_row_ids.json``.
+    :param ids: set of row IDs to persist.
+    """
+    dedup_path.parent.mkdir(parents=True, exist_ok=True)
+    dedup_path.write_text(json.dumps(sorted(ids)))
 
 
 def brier_score(p_yes: float, outcome: bool) -> float:
@@ -545,7 +573,6 @@ def _empty_scores(current_month: str) -> dict[str, Any]:
         "latency_reservoir": {},
         "worst_10": [],
         "best_10": [],
-        "scored_row_ids": set(),
     }
 
 
@@ -969,7 +996,6 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
     scores["latency_reservoir"] = data.get("latency_reservoir", {})
     scores["worst_10"] = data.get("worst_10", [])
     scores["best_10"] = data.get("best_10", [])
-    scores["scored_row_ids"] = set(data.get("scored_row_ids", []))
 
     return scores
 
@@ -978,6 +1004,7 @@ def update(
     new_rows: list[dict[str, Any]],
     scores_path: Path = DEFAULT_OUTPUT,
     history_path: Path = DEFAULT_HISTORY,
+    dedup_path: Path | None = None,
 ) -> dict[str, Any]:
     """Incrementally merge new rows into the scores accumulators.
 
@@ -986,13 +1013,18 @@ def update(
 
     Handles month boundaries: if the stored ``current_month`` differs from
     today's month, snapshots the completed month to ``scores_history.jsonl``
-    and resets accumulators.
+    and resets accumulators. Dedup state is stored in a separate file
+    (``scored_row_ids.json``) so it persists across month rollovers.
 
     :param new_rows: list of production log row dicts.
     :param scores_path: path to ``scores.json``.
     :param history_path: path to ``scores_history.jsonl``.
+    :param dedup_path: path to ``scored_row_ids.json``.
     :return: finalized scores dict (also written to disk).
     """
+    if dedup_path is None:
+        dedup_path = scores_path.parent / "scored_row_ids.json"
+
     today_month = datetime.now(timezone.utc).strftime("%Y-%m")
 
     existing = _load_scores_for_resume(scores_path)
@@ -1005,7 +1037,11 @@ def update(
     else:
         scores = _empty_scores(today_month)
 
-    scored_ids: set[str] = scores.get("scored_row_ids", set())
+    # Dedup state lives in its own file — survives month rollover
+    scored_ids = _load_dedup_ids(dedup_path)
+    # Migrate: if old scores.json had scored_row_ids, merge them
+    scored_ids.update(scores.pop("scored_row_ids", set()))
+
     skipped = 0
     no_id = 0
     for row in new_rows:
@@ -1019,7 +1055,8 @@ def update(
             continue
         _accumulate_row(scores, row)
         scored_ids.add(row_id)
-    scores["scored_row_ids"] = scored_ids
+
+    _save_dedup_ids(dedup_path, scored_ids)
 
     if skipped:
         logging.getLogger(__name__).warning(
@@ -1058,7 +1095,6 @@ def update(
             }
     # Preserve raw calibration accumulators alongside derived
     output["_calibration_accum"] = scores["calibration"]
-    output["scored_row_ids"] = sorted(scores.get("scored_row_ids", set()))
 
     scores_path.parent.mkdir(parents=True, exist_ok=True)
     scores_path.write_text(json.dumps(output, indent=2))
@@ -1070,6 +1106,7 @@ def rebuild(
     logs_dir: Path = DEFAULT_LOGS_DIR,
     scores_path: Path = DEFAULT_OUTPUT,
     history_path: Path = DEFAULT_HISTORY,
+    dedup_path: Path | None = None,
 ) -> dict[str, Any]:
     """Rebuild scores.json from all log files in the logs directory.
 
@@ -1079,8 +1116,12 @@ def rebuild(
     :param logs_dir: directory containing daily log files.
     :param scores_path: output path for ``scores.json``.
     :param history_path: output path for ``scores_history.jsonl``.
+    :param dedup_path: path to ``scored_row_ids.json``.
     :return: finalized scores dict.
     """
+
+    if dedup_path is None:
+        dedup_path = scores_path.parent / "scored_row_ids.json"
 
     # Collect all log files
     pattern = str(logs_dir / "production_log_*.jsonl")
@@ -1137,12 +1178,8 @@ def rebuild(
         row_id = row.get("row_id")
         if row_id:
             all_row_ids.add(row_id)
-    # scored_row_ids includes all months so subsequent update() calls
-    # can dedup against rows already scored during rebuild. This grows
-    # with total row count (~2MB for 74K rows). For normal update() runs,
-    # month rollover resets the set via _empty_scores(). If this becomes
-    # a concern, consider moving scored_row_ids to a separate file.
-    scores["scored_row_ids"] = all_row_ids
+    # Save dedup state to its own file — persists across month rollovers
+    _save_dedup_ids(dedup_path, all_row_ids)
 
     finalized = _finalize_scores(scores)
     # Write with accumulators for future incremental use
@@ -1170,7 +1207,6 @@ def rebuild(
                 **{k: group[k] for k in _ACCUM_KEYS},
             }
     output["_calibration_accum"] = scores["calibration"]
-    output["scored_row_ids"] = sorted(scores.get("scored_row_ids", set()))
 
     scores_path.parent.mkdir(parents=True, exist_ok=True)
     scores_path.write_text(json.dumps(output, indent=2))

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -526,6 +526,7 @@ def _empty_scores(current_month: str) -> dict[str, Any]:
         "latency_reservoir": {},
         "worst_10": [],
         "best_10": [],
+        "scored_row_ids": set(),
     }
 
 
@@ -935,6 +936,7 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
     scores["latency_reservoir"] = data.get("latency_reservoir", {})
     scores["worst_10"] = data.get("worst_10", [])
     scores["best_10"] = data.get("best_10", [])
+    scores["scored_row_ids"] = set(data.get("scored_row_ids", []))
 
     return scores
 
@@ -970,8 +972,24 @@ def update(
     else:
         scores = _empty_scores(today_month)
 
+    scored_ids: set[str] = scores.get("scored_row_ids", set())
+    skipped = 0
     for row in new_rows:
+        row_id = row.get("row_id")
+        if row_id and row_id in scored_ids:
+            skipped += 1
+            continue
         _accumulate_row(scores, row)
+        if row_id:
+            scored_ids.add(row_id)
+    scores["scored_row_ids"] = scored_ids
+
+    if skipped:
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Skipped %d duplicate rows (already scored)", skipped
+        )
 
     # Write raw accumulators (for future incremental loads)
     finalized = _finalize_scores(scores)
@@ -1008,6 +1026,7 @@ def update(
             }
     # Preserve raw calibration accumulators alongside derived
     output["_calibration_accum"] = scores["calibration"]
+    output["scored_row_ids"] = sorted(scores.get("scored_row_ids", set()))
 
     scores_path.parent.mkdir(parents=True, exist_ok=True)
     scores_path.write_text(json.dumps(output, indent=2))
@@ -1077,6 +1096,9 @@ def rebuild(
     scores = _empty_scores(last_month)
     for row in months[last_month]:
         _accumulate_row(scores, row)
+        row_id = row.get("row_id")
+        if row_id:
+            scores["scored_row_ids"].add(row_id)
 
     finalized = _finalize_scores(scores)
     # Write with accumulators for future incremental use
@@ -1111,6 +1133,7 @@ def rebuild(
                 **{k: group[k] for k in _accum_keys},
             }
     output["_calibration_accum"] = scores["calibration"]
+    output["scored_row_ids"] = sorted(scores.get("scored_row_ids", set()))
 
     scores_path.parent.mkdir(parents=True, exist_ok=True)
     scores_path.write_text(json.dumps(output, indent=2))

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -1032,19 +1032,27 @@ def update(
 
     scored_ids: set[str] = scores.get("scored_row_ids", set())
     skipped = 0
+    no_id = 0
     for row in new_rows:
         row_id = row.get("row_id")
-        if row_id and row_id in scored_ids:
+        if not row_id:
+            no_id += 1
+            _accumulate_row(scores, row)
+            continue
+        if row_id in scored_ids:
             skipped += 1
             continue
         _accumulate_row(scores, row)
-        if row_id:
-            scored_ids.add(row_id)
+        scored_ids.add(row_id)
     scores["scored_row_ids"] = scored_ids
 
     if skipped:
         logging.getLogger(__name__).warning(
             "Skipped %d duplicate rows (already scored)", skipped
+        )
+    if no_id:
+        logging.getLogger(__name__).warning(
+            "%d rows without row_id cannot be deduplicated", no_id
         )
 
     # Write raw accumulators (for future incremental loads)

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -412,6 +412,26 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         liquidity_groups[liq].append(row)
     by_liquidity = {k: compute_group_stats(g) for k, g in liquidity_groups.items()}
 
+    # Platform × difficulty cross breakdown
+    pd_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        plat = row.get("platform", "unknown")
+        diff = classify_difficulty(row.get("market_prob_at_prediction"))
+        pd_groups[f"{plat} | {diff}"].append(row)
+    by_platform_difficulty = {
+        k: compute_group_stats(g) for k, g in pd_groups.items()
+    }
+
+    # Platform × liquidity cross breakdown
+    pl_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        plat = row.get("platform", "unknown")
+        liq = classify_liquidity(row.get("market_liquidity_at_prediction"))
+        pl_groups[f"{plat} | {liq}"].append(row)
+    by_platform_liquidity = {
+        k: compute_group_stats(g) for k, g in pl_groups.items()
+    }
+
     # Tool × platform cross breakdown
     by_tool_platform = group_by_composite(rows, ["tool_name", "platform"])
 
@@ -470,6 +490,8 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "by_horizon": by_horizon,
         "by_difficulty": by_difficulty,
         "by_liquidity": by_liquidity,
+        "by_platform_difficulty": by_platform_difficulty,
+        "by_platform_liquidity": by_platform_liquidity,
         "by_tool_platform": by_tool_platform,
         "by_tool_platform_horizon": by_tool_platform_horizon,
         "trend": trend,
@@ -518,6 +540,8 @@ def _empty_scores(current_month: str) -> dict[str, Any]:
         "by_config": {},
         "by_difficulty": {},
         "by_liquidity": {},
+        "by_platform_difficulty": {},
+        "by_platform_liquidity": {},
         "calibration": {
             _bin_label(lo, hi): {"count": 0, "outcome_sum": 0, "predicted_sum": 0.0}
             for lo, hi in CALIBRATION_BINS
@@ -701,6 +725,13 @@ def _accumulate_row(scores: dict[str, Any], row: dict[str, Any]) -> None:
     liquidity = classify_liquidity(row.get("market_liquidity_at_prediction"))
     _ensure_and_accumulate(scores["by_liquidity"], liquidity, row)
 
+    _ensure_and_accumulate(
+        scores["by_platform_difficulty"], f"{platform} | {difficulty}", row
+    )
+    _ensure_and_accumulate(
+        scores["by_platform_liquidity"], f"{platform} | {liquidity}", row
+    )
+
     # Calibration buckets
     is_valid = (
         row.get("prediction_parse_status") == "valid"
@@ -785,6 +816,8 @@ def _finalize_scores(scores: dict[str, Any]) -> dict[str, Any]:
         "by_config",
         "by_difficulty",
         "by_liquidity",
+        "by_platform_difficulty",
+        "by_platform_liquidity",
     ):
         result[dim] = {k: _derive_group(v) for k, v in scores[dim].items()}
 
@@ -918,6 +951,8 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
         "by_config",
         "by_difficulty",
         "by_liquidity",
+        "by_platform_difficulty",
+        "by_platform_liquidity",
     ):
         scores[dim] = {}
         for key, group in data.get(dim, {}).items():
@@ -1018,6 +1053,8 @@ def update(
         "by_config",
         "by_difficulty",
         "by_liquidity",
+        "by_platform_difficulty",
+        "by_platform_liquidity",
     ):
         for key, group in scores[dim].items():
             output[dim][key] = {
@@ -1126,6 +1163,8 @@ def rebuild(
         "by_config",
         "by_difficulty",
         "by_liquidity",
+        "by_platform_difficulty",
+        "by_platform_liquidity",
     ):
         for key, group in scores[dim].items():
             output[dim][key] = {

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -1162,6 +1162,11 @@ def rebuild(
         row_id = row.get("row_id")
         if row_id:
             all_row_ids.add(row_id)
+    # scored_row_ids includes all months so subsequent update() calls
+    # can dedup against rows already scored during rebuild. This grows
+    # with total row count (~2MB for 74K rows). For normal update() runs,
+    # month rollover resets the set via _empty_scores(). If this becomes
+    # a concern, consider moving scored_row_ids to a separate file.
     scores["scored_row_ids"] = all_row_ids
 
     finalized = _finalize_scores(scores)

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -997,6 +997,11 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
     scores["worst_10"] = data.get("worst_10", [])
     scores["best_10"] = data.get("best_10", [])
 
+    # Preserve legacy scored_row_ids so update() can migrate them
+    # to the separate dedup file on first run after upgrade.
+    if "scored_row_ids" in data:
+        scores["scored_row_ids"] = set(data["scored_row_ids"])
+
     return scores
 
 

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import glob as glob_mod
 import json
+import logging
 from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
@@ -418,9 +419,7 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         plat = row.get("platform", "unknown")
         diff = classify_difficulty(row.get("market_prob_at_prediction"))
         pd_groups[f"{plat} | {diff}"].append(row)
-    by_platform_difficulty = {
-        k: compute_group_stats(g) for k, g in pd_groups.items()
-    }
+    by_platform_difficulty = {k: compute_group_stats(g) for k, g in pd_groups.items()}
 
     # Platform × liquidity cross breakdown
     pl_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -428,9 +427,7 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         plat = row.get("platform", "unknown")
         liq = classify_liquidity(row.get("market_liquidity_at_prediction"))
         pl_groups[f"{plat} | {liq}"].append(row)
-    by_platform_liquidity = {
-        k: compute_group_stats(g) for k, g in pl_groups.items()
-    }
+    by_platform_liquidity = {k: compute_group_stats(g) for k, g in pl_groups.items()}
 
     # Tool × platform cross breakdown
     by_tool_platform = group_by_composite(rows, ["tool_name", "platform"])
@@ -646,9 +643,7 @@ def _derive_group(group: dict[str, Any]) -> dict[str, Any]:
     result["edge_n"] = edge_n
     if edge_n > 0:
         result["edge"] = round(group["edge_sum"] / edge_n, 4)
-        result["edge_positive_rate"] = round(
-            group["edge_positive_count"] / edge_n, 4
-        )
+        result["edge_positive_rate"] = round(group["edge_positive_count"] / edge_n, 4)
     else:
         result["edge"] = None
         result["edge_positive_rate"] = None
@@ -1031,8 +1026,6 @@ def update(
     scores["scored_row_ids"] = scored_ids
 
     if skipped:
-        import logging
-
         logging.getLogger(__name__).warning(
             "Skipped %d duplicate rows (already scored)", skipped
         )

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -452,8 +452,24 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         for tool, group in group_by(rows, "tool_name").items()
     }
 
-    # Edge eligibility reporting
+    # Edge eligibility reporting — mutually exclusive exclusion reasons
     n_edge_eligible = sum(1 for r in rows if _is_edge_eligible(r))
+    n_invalid_parse = sum(
+        1 for r in rows if r.get("prediction_parse_status") != "valid"
+    )
+    n_missing_outcome = sum(
+        1
+        for r in rows
+        if r.get("prediction_parse_status") == "valid"
+        and r.get("final_outcome") is None
+    )
+    n_missing_p_yes = sum(
+        1
+        for r in rows
+        if r.get("prediction_parse_status") == "valid"
+        and r.get("final_outcome") is not None
+        and r.get("p_yes") is None
+    )
     n_missing_market_prob = sum(
         1
         for r in rows
@@ -462,20 +478,15 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         and r.get("p_yes") is not None
         and r.get("market_prob_at_prediction") is None
     )
-    n_invalid_parse = total - sum(
-        1
-        for r in rows
-        if r.get("prediction_parse_status") == "valid"
-        and r.get("final_outcome") is not None
-        and r.get("p_yes") is not None
-    )
     edge_eligibility = {
         "n_total": total,
         "n_eligible": n_edge_eligible,
         "n_excluded": total - n_edge_eligible,
         "exclusion_reasons": {
+            "invalid_parse": n_invalid_parse,
+            "missing_outcome": n_missing_outcome,
+            "missing_p_yes": n_missing_p_yes,
             "missing_market_prob": n_missing_market_prob,
-            "invalid_prediction": n_invalid_parse,
         },
     }
 
@@ -1122,11 +1133,17 @@ def rebuild(
     sorted_months = sorted(months.keys())
     last_month = sorted_months[-1]
 
+    # Collect all row_ids across all months for dedup on subsequent update() calls
+    all_row_ids: set[str] = set()
+
     # Process all months except the last one as snapshots
     for month in sorted_months[:-1]:
         scores = _empty_scores(month)
         for row in months[month]:
             _accumulate_row(scores, row)
+            row_id = row.get("row_id")
+            if row_id:
+                all_row_ids.add(row_id)
         _snapshot_month(scores, history_path)
 
     # The last month becomes the current scores.json
@@ -1135,7 +1152,8 @@ def rebuild(
         _accumulate_row(scores, row)
         row_id = row.get("row_id")
         if row_id:
-            scores["scored_row_ids"].add(row_id)
+            all_row_ids.add(row_id)
+    scores["scored_row_ids"] = all_row_ids
 
     finalized = _finalize_scores(scores)
     # Write with accumulators for future incremental use

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -35,6 +35,18 @@ WORST_BEST_SIZE = 10
 RELIABILITY_GATE = 0.80
 MIN_SAMPLE_SIZE = 30
 
+# Keys that must be persisted in scores.json for incremental resume.
+# Used in update() and rebuild() when merging accumulators into output.
+_ACCUM_KEYS = (
+    "brier_sum",
+    "correct_count",
+    "sharpness_sum",
+    "outcome_yes_count",
+    "edge_sum",
+    "edge_n",
+    "edge_positive_count",
+)
+
 
 # ---------------------------------------------------------------------------
 # Brier score computation
@@ -1039,18 +1051,9 @@ def update(
     finalized = _finalize_scores(scores)
     # Merge accumulators into the output so next load can resume
     output = dict(finalized)
-    _accum_keys = (
-        "brier_sum",
-        "correct_count",
-        "sharpness_sum",
-        "outcome_yes_count",
-        "edge_sum",
-        "edge_n",
-        "edge_positive_count",
-    )
     output["overall"] = {
         **finalized["overall"],
-        **{k: scores["overall"][k] for k in _accum_keys},
+        **{k: scores["overall"][k] for k in _ACCUM_KEYS},
     }
     for dim in (
         "by_tool",
@@ -1068,7 +1071,7 @@ def update(
         for key, group in scores[dim].items():
             output[dim][key] = {
                 **finalized[dim][key],
-                **{k: group[k] for k in _accum_keys},
+                **{k: group[k] for k in _ACCUM_KEYS},
             }
     # Preserve raw calibration accumulators alongside derived
     output["_calibration_accum"] = scores["calibration"]
@@ -1156,18 +1159,9 @@ def rebuild(
     finalized = _finalize_scores(scores)
     # Write with accumulators for future incremental use
     output = dict(finalized)
-    _accum_keys = (
-        "brier_sum",
-        "correct_count",
-        "sharpness_sum",
-        "outcome_yes_count",
-        "edge_sum",
-        "edge_n",
-        "edge_positive_count",
-    )
     output["overall"] = {
         **finalized["overall"],
-        **{k: scores["overall"][k] for k in _accum_keys},
+        **{k: scores["overall"][k] for k in _ACCUM_KEYS},
     }
     for dim in (
         "by_tool",
@@ -1185,7 +1179,7 @@ def rebuild(
         for key, group in scores[dim].items():
             output[dim][key] = {
                 **finalized[dim][key],
-                **{k: group[k] for k in _accum_keys},
+                **{k: group[k] for k in _ACCUM_KEYS},
             }
     output["_calibration_accum"] = scores["calibration"]
     output["scored_row_ids"] = sorted(scores.get("scored_row_ids", set()))

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -461,41 +461,16 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         for tool, group in group_by(rows, "tool_name").items()
     }
 
-    # Edge eligibility reporting — mutually exclusive exclusion reasons
+    # Edge eligibility reporting — same schema as _finalize_scores()
     n_edge_eligible = sum(1 for r in rows if _is_edge_eligible(r))
-    n_invalid_parse = sum(
-        1 for r in rows if r.get("prediction_parse_status") != "valid"
-    )
-    n_missing_outcome = sum(
-        1
-        for r in rows
-        if r.get("prediction_parse_status") == "valid"
-        and r.get("final_outcome") is None
-    )
-    n_missing_p_yes = sum(
-        1
-        for r in rows
-        if r.get("prediction_parse_status") == "valid"
-        and r.get("final_outcome") is not None
-        and r.get("p_yes") is None
-    )
-    n_missing_market_prob = sum(
-        1
-        for r in rows
-        if r.get("prediction_parse_status") == "valid"
-        and r.get("final_outcome") is not None
-        and r.get("p_yes") is not None
-        and r.get("market_prob_at_prediction") is None
-    )
+    valid_n = overall["valid_n"]
     edge_eligibility = {
         "n_total": total,
         "n_eligible": n_edge_eligible,
         "n_excluded": total - n_edge_eligible,
         "exclusion_reasons": {
-            "invalid_parse": n_invalid_parse,
-            "missing_outcome": n_missing_outcome,
-            "missing_p_yes": n_missing_p_yes,
-            "missing_market_prob": n_missing_market_prob,
+            "invalid_or_incomplete": total - valid_n,
+            "missing_market_prob": valid_n - n_edge_eligible,
         },
     }
 

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -45,6 +45,78 @@ def brier_score(p_yes: float, outcome: bool) -> float:
     return (p_yes - (1.0 if outcome else 0.0)) ** 2
 
 
+def edge_score(p_yes: float, market_prob: float, outcome: bool) -> float:
+    """Compute edge over market for a single prediction.
+
+    Edge = market_brier - tool_brier. Positive means the tool's prediction
+    was closer to the outcome than the market's price.
+
+    :param p_yes: tool's predicted probability.
+    :param market_prob: market probability at prediction time.
+    :param outcome: actual outcome (True = yes).
+    :return: edge score (positive = tool beat market).
+    """
+    outcome_val = 1.0 if outcome else 0.0
+    market_brier = (market_prob - outcome_val) ** 2
+    tool_brier = (p_yes - outcome_val) ** 2
+    return market_brier - tool_brier
+
+
+def _is_edge_eligible(row: dict[str, Any]) -> bool:
+    """Check if a row has all fields needed for edge-over-market calculation."""
+    return (
+        row.get("prediction_parse_status") == "valid"
+        and row.get("final_outcome") is not None
+        and row.get("p_yes") is not None
+        and row.get("market_prob_at_prediction") is not None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Difficulty and liquidity classification
+# ---------------------------------------------------------------------------
+
+# Thresholds are initial values from PROPOSAL.md. Adjust after inspecting
+# the actual data distribution from the first scorer run.
+DIFFICULTY_THRESHOLDS = (0.15, 0.3)
+LIQUIDITY_THRESHOLDS = (500.0, 5000.0)
+
+
+def classify_difficulty(market_prob: float | None) -> str:
+    """Classify market difficulty based on distance from 0.5.
+
+    Uses market_prob_at_prediction (not final market price).
+
+    :param market_prob: market probability at prediction time.
+    :return: difficulty bucket name.
+    """
+    if market_prob is None:
+        return "unknown"
+    distance = abs(market_prob - 0.5)
+    lo, hi = DIFFICULTY_THRESHOLDS
+    if distance < lo:
+        return "hard"
+    if distance <= hi:
+        return "medium"
+    return "easy"
+
+
+def classify_liquidity(liquidity_usd: float | None) -> str:
+    """Classify market liquidity into buckets.
+
+    :param liquidity_usd: market liquidity in USD at prediction time.
+    :return: liquidity bucket name.
+    """
+    if liquidity_usd is None:
+        return "unknown"
+    lo, hi = LIQUIDITY_THRESHOLDS
+    if liquidity_usd < lo:
+        return "low"
+    if liquidity_usd <= hi:
+        return "medium"
+    return "high"
+
+
 def compute_group_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Compute Brier score and reliability for a group of rows.
 
@@ -97,6 +169,20 @@ def compute_group_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
 
     sharpness = sum(abs(r["p_yes"] - 0.5) for r in valid) / len(valid)
 
+    # Edge over market — only for rows with market_prob_at_prediction
+    edge_rows = [r for r in valid if r.get("market_prob_at_prediction") is not None]
+    if edge_rows:
+        edges = [
+            edge_score(r["p_yes"], r["market_prob_at_prediction"], r["final_outcome"])
+            for r in edge_rows
+        ]
+        edge_avg = round(sum(edges) / len(edges), 4)
+        edge_positive = sum(1 for e in edges if e > 0)
+        edge_pos_rate = round(edge_positive / len(edges), 4)
+    else:
+        edge_avg = None
+        edge_pos_rate = None
+
     return {
         "brier": round(avg_brier, 4),
         "accuracy": round(accuracy, 4),
@@ -105,6 +191,9 @@ def compute_group_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "n": total,
         "valid_n": len(valid),
         "decision_worthy": worthy,
+        "edge": edge_avg,
+        "edge_n": len(edge_rows),
+        "edge_positive_rate": edge_pos_rate,
     }
 
 
@@ -309,6 +398,20 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
     # Per-horizon
     by_horizon = group_by_horizon(rows)
 
+    # Per-difficulty (requires market_prob_at_prediction)
+    difficulty_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        d = classify_difficulty(row.get("market_prob_at_prediction"))
+        difficulty_groups[d].append(row)
+    by_difficulty = {k: compute_group_stats(g) for k, g in difficulty_groups.items()}
+
+    # Per-liquidity (requires market_liquidity_at_prediction)
+    liquidity_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        liq = classify_liquidity(row.get("market_liquidity_at_prediction"))
+        liquidity_groups[liq].append(row)
+    by_liquidity = {k: compute_group_stats(g) for k, g in liquidity_groups.items()}
+
     # Tool × platform cross breakdown
     by_tool_platform = group_by_composite(rows, ["tool_name", "platform"])
 
@@ -329,6 +432,33 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         for tool, group in group_by(rows, "tool_name").items()
     }
 
+    # Edge eligibility reporting
+    n_edge_eligible = sum(1 for r in rows if _is_edge_eligible(r))
+    n_missing_market_prob = sum(
+        1
+        for r in rows
+        if r.get("prediction_parse_status") == "valid"
+        and r.get("final_outcome") is not None
+        and r.get("p_yes") is not None
+        and r.get("market_prob_at_prediction") is None
+    )
+    n_invalid_parse = total - sum(
+        1
+        for r in rows
+        if r.get("prediction_parse_status") == "valid"
+        and r.get("final_outcome") is not None
+        and r.get("p_yes") is not None
+    )
+    edge_eligibility = {
+        "n_total": total,
+        "n_eligible": n_edge_eligible,
+        "n_excluded": total - n_edge_eligible,
+        "exclusion_reasons": {
+            "missing_market_prob": n_missing_market_prob,
+            "invalid_prediction": n_invalid_parse,
+        },
+    }
+
     return {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "total_rows": total,
@@ -338,11 +468,14 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "by_platform": by_platform,
         "by_category": by_category,
         "by_horizon": by_horizon,
+        "by_difficulty": by_difficulty,
+        "by_liquidity": by_liquidity,
         "by_tool_platform": by_tool_platform,
         "by_tool_platform_horizon": by_tool_platform_horizon,
         "trend": trend,
         "calibration": calibration,
         "calibration_by_tool": calibration_by_tool,
+        "edge_eligibility": edge_eligibility,
     }
 
 
@@ -360,6 +493,9 @@ def _empty_group() -> dict[str, Any]:
         "correct_count": 0,
         "sharpness_sum": 0.0,
         "outcome_yes_count": 0,
+        "edge_sum": 0.0,
+        "edge_n": 0,
+        "edge_positive_count": 0,
     }
 
 
@@ -380,6 +516,8 @@ def _empty_scores(current_month: str) -> dict[str, Any]:
         "by_tool_platform": {},
         "by_tool_version": {},
         "by_config": {},
+        "by_difficulty": {},
+        "by_liquidity": {},
         "calibration": {
             _bin_label(lo, hi): {"count": 0, "outcome_sum": 0, "predicted_sum": 0.0}
             for lo, hi in CALIBRATION_BINS
@@ -413,6 +551,14 @@ def _accumulate_group(group: dict[str, Any], row: dict[str, Any]) -> None:
         group["sharpness_sum"] += abs(p_yes - 0.5)
         if outcome:
             group["outcome_yes_count"] += 1
+        # Edge over market
+        market_prob = row.get("market_prob_at_prediction")
+        if market_prob is not None:
+            edge = edge_score(p_yes, market_prob, outcome)
+            group["edge_sum"] += edge
+            group["edge_n"] += 1
+            if edge > 0:
+                group["edge_positive_count"] += 1
 
 
 def _derive_group(group: dict[str, Any]) -> dict[str, Any]:
@@ -458,6 +604,18 @@ def _derive_group(group: dict[str, Any]) -> dict[str, Any]:
             result["brier_skill_score"] = round(1 - (brier / baseline_brier), 4)
         else:
             result["brier_skill_score"] = None
+
+    # Edge over market — derived from edge accumulators
+    edge_n = group.get("edge_n", 0)
+    result["edge_n"] = edge_n
+    if edge_n > 0:
+        result["edge"] = round(group["edge_sum"] / edge_n, 4)
+        result["edge_positive_rate"] = round(
+            group["edge_positive_count"] / edge_n, 4
+        )
+    else:
+        result["edge"] = None
+        result["edge_positive_rate"] = None
     return result
 
 
@@ -535,6 +693,12 @@ def _accumulate_row(scores: dict[str, Any], row: dict[str, Any]) -> None:
     _ensure_and_accumulate(scores["by_tool_platform"], f"{tool} | {platform}", row)
     _ensure_and_accumulate(scores["by_tool_version"], f"{tool} | {tool_version}", row)
     _ensure_and_accumulate(scores["by_config"], f"{tool} | {config_hash}", row)
+
+    difficulty = classify_difficulty(row.get("market_prob_at_prediction"))
+    _ensure_and_accumulate(scores["by_difficulty"], difficulty, row)
+
+    liquidity = classify_liquidity(row.get("market_liquidity_at_prediction"))
+    _ensure_and_accumulate(scores["by_liquidity"], liquidity, row)
 
     # Calibration buckets
     is_valid = (
@@ -618,8 +782,19 @@ def _finalize_scores(scores: dict[str, Any]) -> dict[str, Any]:
         "by_tool_platform",
         "by_tool_version",
         "by_config",
+        "by_difficulty",
+        "by_liquidity",
     ):
         result[dim] = {k: _derive_group(v) for k, v in scores[dim].items()}
+
+    # Edge eligibility from accumulators
+    overall_n = scores["overall"]["n"]
+    overall_edge_n = scores["overall"].get("edge_n", 0)
+    result["edge_eligibility"] = {
+        "n_total": overall_n,
+        "n_eligible": overall_edge_n,
+        "n_excluded": overall_n - overall_edge_n,
+    }
 
     # Calibration — derive avg_predicted, realized_rate, gap
     cal_result = []
@@ -714,17 +889,23 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
     if "current_month" not in data or "brier_sum" not in data.get("overall", {}):
         return None
 
+    def _restore_group(g: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "n": g["n"],
+            "valid_n": g["valid_n"],
+            "brier_sum": g["brier_sum"],
+            "correct_count": g["correct_count"],
+            "sharpness_sum": g["sharpness_sum"],
+            "outcome_yes_count": g.get("outcome_yes_count", 0),
+            "edge_sum": g.get("edge_sum", 0.0),
+            "edge_n": g.get("edge_n", 0),
+            "edge_positive_count": g.get("edge_positive_count", 0),
+        }
+
     scores: dict[str, Any] = {
         "current_month": data["current_month"],
         "generated_at": data.get("generated_at", ""),
-        "overall": {
-            "n": data["overall"]["n"],
-            "valid_n": data["overall"]["valid_n"],
-            "brier_sum": data["overall"]["brier_sum"],
-            "correct_count": data["overall"]["correct_count"],
-            "sharpness_sum": data["overall"]["sharpness_sum"],
-            "outcome_yes_count": data["overall"].get("outcome_yes_count", 0),
-        },
+        "overall": _restore_group(data["overall"]),
     }
     for dim in (
         "by_tool",
@@ -734,17 +915,12 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
         "by_tool_platform",
         "by_tool_version",
         "by_config",
+        "by_difficulty",
+        "by_liquidity",
     ):
         scores[dim] = {}
         for key, group in data.get(dim, {}).items():
-            scores[dim][key] = {
-                "n": group["n"],
-                "valid_n": group["valid_n"],
-                "brier_sum": group["brier_sum"],
-                "correct_count": group["correct_count"],
-                "sharpness_sum": group["sharpness_sum"],
-                "outcome_yes_count": group.get("outcome_yes_count", 0),
-            }
+            scores[dim][key] = _restore_group(group)
 
     # Restore calibration accumulators
     if "_calibration_accum" in data:
@@ -801,17 +977,18 @@ def update(
     finalized = _finalize_scores(scores)
     # Merge accumulators into the output so next load can resume
     output = dict(finalized)
+    _accum_keys = (
+        "brier_sum",
+        "correct_count",
+        "sharpness_sum",
+        "outcome_yes_count",
+        "edge_sum",
+        "edge_n",
+        "edge_positive_count",
+    )
     output["overall"] = {
         **finalized["overall"],
-        **{
-            k: scores["overall"][k]
-            for k in (
-                "brier_sum",
-                "correct_count",
-                "sharpness_sum",
-                "outcome_yes_count",
-            )
-        },
+        **{k: scores["overall"][k] for k in _accum_keys},
     }
     for dim in (
         "by_tool",
@@ -821,19 +998,13 @@ def update(
         "by_tool_platform",
         "by_tool_version",
         "by_config",
+        "by_difficulty",
+        "by_liquidity",
     ):
         for key, group in scores[dim].items():
             output[dim][key] = {
                 **finalized[dim][key],
-                **{
-                    k: group[k]
-                    for k in (
-                        "brier_sum",
-                        "correct_count",
-                        "sharpness_sum",
-                        "outcome_yes_count",
-                    )
-                },
+                **{k: group[k] for k in _accum_keys},
             }
     # Preserve raw calibration accumulators alongside derived
     output["_calibration_accum"] = scores["calibration"]
@@ -910,17 +1081,18 @@ def rebuild(
     finalized = _finalize_scores(scores)
     # Write with accumulators for future incremental use
     output = dict(finalized)
+    _accum_keys = (
+        "brier_sum",
+        "correct_count",
+        "sharpness_sum",
+        "outcome_yes_count",
+        "edge_sum",
+        "edge_n",
+        "edge_positive_count",
+    )
     output["overall"] = {
         **finalized["overall"],
-        **{
-            k: scores["overall"][k]
-            for k in (
-                "brier_sum",
-                "correct_count",
-                "sharpness_sum",
-                "outcome_yes_count",
-            )
-        },
+        **{k: scores["overall"][k] for k in _accum_keys},
     }
     for dim in (
         "by_tool",
@@ -930,19 +1102,13 @@ def rebuild(
         "by_tool_platform",
         "by_tool_version",
         "by_config",
+        "by_difficulty",
+        "by_liquidity",
     ):
         for key, group in scores[dim].items():
             output[dim][key] = {
                 **finalized[dim][key],
-                **{
-                    k: group[k]
-                    for k in (
-                        "brier_sum",
-                        "correct_count",
-                        "sharpness_sum",
-                        "outcome_yes_count",
-                    )
-                },
+                **{k: group[k] for k in _accum_keys},
             }
     output["_calibration_accum"] = scores["calibration"]
 

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1171,6 +1171,7 @@ class TestUpdateDedup:
         """Same rows passed twice produce same result as single pass."""
         scores_path = tmp_path / "scores.json"
         history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "dedup.json"
 
         rows = [
             _row(p_yes=0.7, outcome=True, row_id="r1"),
@@ -1178,11 +1179,11 @@ class TestUpdateDedup:
         ]
 
         # First pass
-        result1 = update(rows, scores_path, history_path)
+        result1 = update(rows, scores_path, history_path, dedup_path)
         assert result1["overall"]["n"] == 2
 
         # Second pass with same rows — should be skipped
-        result2 = update(rows, scores_path, history_path)
+        result2 = update(rows, scores_path, history_path, dedup_path)
         assert (
             result2["overall"]["n"] == 2
         ), f"Expected 2 after dedup, got {result2['overall']['n']}"
@@ -1192,6 +1193,7 @@ class TestUpdateDedup:
         """New rows are added, duplicates are skipped."""
         scores_path = tmp_path / "scores.json"
         history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "dedup.json"
 
         batch1 = [_row(p_yes=0.7, outcome=True, row_id="r1")]
         batch2 = [
@@ -1199,36 +1201,42 @@ class TestUpdateDedup:
             _row(p_yes=0.4, outcome=False, row_id="r3"),  # new
         ]
 
-        update(batch1, scores_path, history_path)
-        result = update(batch2, scores_path, history_path)
+        update(batch1, scores_path, history_path, dedup_path)
+        result = update(batch2, scores_path, history_path, dedup_path)
 
         assert (
             result["overall"]["n"] == 2
         ), f"Expected 2 (r1 + r3), got {result['overall']['n']}"
 
     def test_scored_row_ids_persisted(self, tmp_path: Path) -> None:
-        """scored_row_ids are saved to scores.json and loaded on resume."""
+        """scored_row_ids are saved to separate dedup file."""
         scores_path = tmp_path / "scores.json"
         history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "dedup.json"
 
         rows = [_row(p_yes=0.7, outcome=True, row_id="r1")]
-        update(rows, scores_path, history_path)
+        update(rows, scores_path, history_path, dedup_path)
 
-        # Check the saved file
-        saved = json.loads(scores_path.read_text())
-        assert "scored_row_ids" in saved
-        assert "r1" in saved["scored_row_ids"]
+        # Check the dedup file (not scores.json)
+        assert dedup_path.exists()
+        saved_ids = json.loads(dedup_path.read_text())
+        assert "r1" in saved_ids
+
+        # scores.json should NOT contain scored_row_ids
+        saved_scores = json.loads(scores_path.read_text())
+        assert "scored_row_ids" not in saved_scores
 
     def test_rows_without_row_id_always_counted(self, tmp_path: Path) -> None:
         """Rows without row_id are always accumulated (no dedup possible)."""
         scores_path = tmp_path / "scores.json"
         history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "dedup.json"
 
         row_no_id = _row(p_yes=0.7, outcome=True)
         row_no_id.pop("row_id")
 
-        update([row_no_id], scores_path, history_path)
-        result = update([row_no_id], scores_path, history_path)
+        update([row_no_id], scores_path, history_path, dedup_path)
+        result = update([row_no_id], scores_path, history_path, dedup_path)
         # Without row_id, can't dedup — both passes count
         assert result["overall"]["n"] == 2
 
@@ -1236,6 +1244,7 @@ class TestUpdateDedup:
         """Rows scored during rebuild() are not double-counted by update()."""
         scores_path = tmp_path / "scores.json"
         history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "dedup.json"
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir()
 
@@ -1260,18 +1269,48 @@ class TestUpdateDedup:
                 f.write(json.dumps(r) + "\n")
 
         # Rebuild from log files
-        rebuild(logs_dir=logs_dir, scores_path=scores_path, history_path=history_path)
+        rebuild(
+            logs_dir=logs_dir,
+            scores_path=scores_path,
+            history_path=history_path,
+            dedup_path=dedup_path,
+        )
 
-        # Verify rebuild tracked both row_ids
-        saved = json.loads(scores_path.read_text())
-        assert "march_r1" in saved["scored_row_ids"]
-        assert "april_r1" in saved["scored_row_ids"]
+        # Verify rebuild tracked both row_ids in the dedup file
+        saved_ids = json.loads(dedup_path.read_text())
+        assert "march_r1" in saved_ids
+        assert "april_r1" in saved_ids
 
         # Now call update() with the same rows — should all be skipped
-        result = update(rows, scores_path, history_path)
+        result = update(rows, scores_path, history_path, dedup_path)
         # n should still be 1 (only april_r1 in current month accumulators)
         # because rebuild() only accumulates the last month into scores.json
-        # but scored_row_ids contains both months' IDs
+        # but dedup file contains both months' IDs
         assert (
             result["overall"]["n"] == 1
         ), f"Expected 1 (only last month in accumulators), got {result['overall']['n']}"
+
+    def test_dedup_survives_month_rollover(self, tmp_path: Path) -> None:
+        """Dedup state persists across month rollover."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "dedup.json"
+
+        rows = [_row(p_yes=0.7, outcome=True, row_id="r1")]
+
+        # Score in "March"
+        with patch("benchmark.scorer.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 3, 15, tzinfo=timezone.utc)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            update(rows, scores_path, history_path, dedup_path)
+
+        # Rollover to "April" — accumulators reset, but dedup file stays
+        with patch("benchmark.scorer.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 4, 1, tzinfo=timezone.utc)
+            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            result = update(rows, scores_path, history_path, dedup_path)
+
+        # Row should be skipped even after rollover
+        assert (
+            result["overall"]["n"] == 0
+        ), f"Expected 0 (r1 deduped across month rollover), got {result['overall']['n']}"

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1225,8 +1225,8 @@ class TestUpdateDedup:
         scores_path = tmp_path / "scores.json"
         history_path = tmp_path / "history.jsonl"
 
-        row_no_id = _row(p_yes=0.7, outcome=True, row_id="")
-        row_no_id.pop("row_id")  # remove the key entirely
+        row_no_id = _row(p_yes=0.7, outcome=True)
+        row_no_id.pop("row_id")
 
         update([row_no_id], scores_path, history_path)
         result = update([row_no_id], scores_path, history_path)

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -19,6 +19,7 @@
 """Tests for benchmark/scorer.py."""
 
 import json
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -48,9 +49,6 @@ from benchmark.scorer import (
 # ---------------------------------------------------------------------------
 
 
-_ROW_COUNTER = 0
-
-
 def _row(
     p_yes: float = 0.5,
     outcome: bool = True,
@@ -68,10 +66,8 @@ def _row(
     row_id: str | None = None,
 ) -> dict[str, Any]:
     """Build a minimal production_log row for testing."""
-    global _ROW_COUNTER
     if row_id is None:
-        _ROW_COUNTER += 1
-        row_id = f"test_row_{_ROW_COUNTER}"
+        row_id = f"test_{uuid.uuid4().hex[:12]}"
     return {
         "row_id": row_id,
         "prediction_parse_status": status,
@@ -1301,13 +1297,13 @@ class TestUpdateDedup:
         # Score in "March"
         with patch("benchmark.scorer.datetime") as mock_dt:
             mock_dt.now.return_value = datetime(2026, 3, 15, tzinfo=timezone.utc)
-            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            mock_dt.side_effect = datetime
             update(rows, scores_path, history_path, dedup_path)
 
         # Rollover to "April" — accumulators reset, but dedup file stays
         with patch("benchmark.scorer.datetime") as mock_dt:
             mock_dt.now.return_value = datetime(2026, 4, 1, tzinfo=timezone.utc)
-            mock_dt.side_effect = lambda *a, **kw: datetime(*a, **kw)
+            mock_dt.side_effect = datetime
             result = update(rows, scores_path, history_path, dedup_path)
 
         # Row should be skipped even after rollover

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1145,8 +1145,7 @@ class TestEdgeBatchScore:
         assert elig["n_excluded"] == 1
         reasons = elig["exclusion_reasons"]
         assert reasons["missing_market_prob"] == 1
-        assert reasons["invalid_parse"] == 0
-        assert reasons["missing_outcome"] == 0
+        assert reasons["invalid_or_incomplete"] == 0
 
     def test_score_includes_difficulty_and_liquidity(self) -> None:
         """score() output includes by_difficulty and by_liquidity."""

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -48,6 +48,9 @@ from benchmark.scorer import (
 # ---------------------------------------------------------------------------
 
 
+_ROW_COUNTER = 0
+
+
 def _row(
     p_yes: float = 0.5,
     outcome: bool = True,
@@ -62,9 +65,15 @@ def _row(
     market_prob: float | None = None,
     market_liquidity: float | None = None,
     market_spread: float | None = None,
+    row_id: str | None = None,
 ) -> dict[str, Any]:
     """Build a minimal production_log row for testing."""
+    global _ROW_COUNTER
+    if row_id is None:
+        _ROW_COUNTER += 1
+        row_id = f"test_row_{_ROW_COUNTER}"
     return {
+        "row_id": row_id,
         "prediction_parse_status": status,
         "p_yes": p_yes if status == "valid" else None,
         "p_no": (1 - p_yes) if status == "valid" else None,
@@ -1148,3 +1157,77 @@ class TestEdgeBatchScore:
         assert "by_liquidity" in result
         assert "hard" in result["by_difficulty"]
         assert "low" in result["by_liquidity"]
+
+
+# ---------------------------------------------------------------------------
+# Dedup in update()
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateDedup:
+    """Tests for row_id deduplication in update()."""
+
+    def test_duplicate_rows_not_double_counted(self, tmp_path: Path) -> None:
+        """Same rows passed twice produce same result as single pass."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [
+            _row(p_yes=0.7, outcome=True, row_id="r1"),
+            _row(p_yes=0.3, outcome=False, row_id="r2"),
+        ]
+
+        # First pass
+        result1 = update(rows, scores_path, history_path)
+        assert result1["overall"]["n"] == 2
+
+        # Second pass with same rows — should be skipped
+        result2 = update(rows, scores_path, history_path)
+        assert result2["overall"]["n"] == 2, (
+            f"Expected 2 after dedup, got {result2['overall']['n']}"
+        )
+        assert result2["overall"]["brier"] == result1["overall"]["brier"]
+
+    def test_new_rows_added_after_dedup(self, tmp_path: Path) -> None:
+        """New rows are added, duplicates are skipped."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        batch1 = [_row(p_yes=0.7, outcome=True, row_id="r1")]
+        batch2 = [
+            _row(p_yes=0.7, outcome=True, row_id="r1"),   # duplicate
+            _row(p_yes=0.4, outcome=False, row_id="r3"),   # new
+        ]
+
+        update(batch1, scores_path, history_path)
+        result = update(batch2, scores_path, history_path)
+
+        assert result["overall"]["n"] == 2, (
+            f"Expected 2 (r1 + r3), got {result['overall']['n']}"
+        )
+
+    def test_scored_row_ids_persisted(self, tmp_path: Path) -> None:
+        """scored_row_ids are saved to scores.json and loaded on resume."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [_row(p_yes=0.7, outcome=True, row_id="r1")]
+        update(rows, scores_path, history_path)
+
+        # Check the saved file
+        saved = json.loads(scores_path.read_text())
+        assert "scored_row_ids" in saved
+        assert "r1" in saved["scored_row_ids"]
+
+    def test_rows_without_row_id_always_counted(self, tmp_path: Path) -> None:
+        """Rows without row_id are always accumulated (no dedup possible)."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        row_no_id = _row(p_yes=0.7, outcome=True, row_id="")
+        row_no_id.pop("row_id")  # remove the key entirely
+
+        update([row_no_id], scores_path, history_path)
+        result = update([row_no_id], scores_path, history_path)
+        # Without row_id, can't dedup — both passes count
+        assert result["overall"]["n"] == 2

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1363,3 +1363,31 @@ class TestUpdateDedup:
         assert (
             result["overall"]["n"] == 1
         ), f"Expected 1 (not stale-skipped), got {result['overall']['n']}"
+
+    def test_legacy_scored_row_ids_migrated_from_scores_json(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy scored_row_ids in scores.json are migrated to dedup file."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "dedup.json"
+
+        # Simulate a legacy scores.json that contains scored_row_ids
+        rows = [_row(p_yes=0.7, outcome=True, row_id="legacy1")]
+        update(rows, scores_path, history_path, dedup_path)
+
+        # Inject legacy scored_row_ids into scores.json and remove dedup file
+        data = json.loads(scores_path.read_text())
+        data["scored_row_ids"] = ["legacy1"]
+        scores_path.write_text(json.dumps(data))
+        dedup_path.unlink()
+
+        # Update with the same row — should be skipped via migration
+        result = update(rows, scores_path, history_path, dedup_path)
+        assert (
+            result["overall"]["n"] == 1
+        ), f"Expected 1 (resumed accumulators), got {result['overall']['n']}"
+
+        # The dedup file should now contain the migrated ID
+        dedup_ids = json.loads(dedup_path.read_text())
+        assert "legacy1" in dedup_ids

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1232,3 +1232,47 @@ class TestUpdateDedup:
         result = update([row_no_id], scores_path, history_path)
         # Without row_id, can't dedup — both passes count
         assert result["overall"]["n"] == 2
+
+    def test_rebuild_then_update_deduplicates(self, tmp_path: Path) -> None:
+        """Rows scored during rebuild() are not double-counted by update()."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+
+        # Write rows spanning two months to a log file
+        rows = [
+            _row(
+                p_yes=0.7,
+                outcome=True,
+                row_id="march_r1",
+                predicted_at="2026-03-15T10:00:00Z",
+            ),
+            _row(
+                p_yes=0.4,
+                outcome=False,
+                row_id="april_r1",
+                predicted_at="2026-04-05T10:00:00Z",
+            ),
+        ]
+        log_file = logs_dir / "production_log_test.jsonl"
+        with open(log_file, "w") as f:
+            for r in rows:
+                f.write(json.dumps(r) + "\n")
+
+        # Rebuild from log files
+        rebuild(logs_dir=logs_dir, scores_path=scores_path, history_path=history_path)
+
+        # Verify rebuild tracked both row_ids
+        saved = json.loads(scores_path.read_text())
+        assert "march_r1" in saved["scored_row_ids"]
+        assert "april_r1" in saved["scored_row_ids"]
+
+        # Now call update() with the same rows — should all be skipped
+        result = update(rows, scores_path, history_path)
+        # n should still be 1 (only april_r1 in current month accumulators)
+        # because rebuild() only accumulates the last month into scores.json
+        # but scored_row_ids contains both months' IDs
+        assert result["overall"]["n"] == 1, (
+            f"Expected 1 (only last month in accumulators), got {result['overall']['n']}"
+        )

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -28,8 +28,11 @@ from benchmark.scorer import (
     LATENCY_RESERVOIR_SIZE,
     WORST_BEST_SIZE,
     brier_score,
+    classify_difficulty,
     classify_horizon,
+    classify_liquidity,
     compute_group_stats,
+    edge_score,
     group_by,
     group_by_horizon,
     group_by_month,
@@ -37,6 +40,7 @@ from benchmark.scorer import (
     rebuild,
     score,
     update,
+    _is_edge_eligible,
 )
 
 # ---------------------------------------------------------------------------
@@ -55,6 +59,9 @@ def _row(
     predicted_at: str = "2026-03-15T10:00:00Z",
     tool_version: str | None = None,
     config_hash: str | None = None,
+    market_prob: float | None = None,
+    market_liquidity: float | None = None,
+    market_spread: float | None = None,
 ) -> dict[str, Any]:
     """Build a minimal production_log row for testing."""
     return {
@@ -69,6 +76,9 @@ def _row(
         "predicted_at": predicted_at,
         "tool_version": tool_version,
         "config_hash": config_hash,
+        "market_prob_at_prediction": market_prob,
+        "market_liquidity_at_prediction": market_liquidity,
+        "market_spread_at_prediction": market_spread,
     }
 
 
@@ -820,3 +830,321 @@ class TestConfigBreakdown:
         result = update(rows, scores_path, history_path)
 
         assert "t1 | unknown" in result["by_config"]
+
+
+# ---------------------------------------------------------------------------
+# edge_score
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeScore:
+    """Tests for edge_score."""
+
+    def test_tool_beats_market(self) -> None:
+        """Positive edge when tool is closer to outcome than market."""
+        # Outcome=True, tool says 0.9, market says 0.6
+        # market_brier = (0.6-1)^2 = 0.16, tool_brier = (0.9-1)^2 = 0.01
+        edge = edge_score(0.9, 0.6, True)
+        assert round(edge, 4) == 0.15
+
+    def test_market_beats_tool(self) -> None:
+        """Negative edge when market is closer to outcome than tool."""
+        # Outcome=False, tool says 0.7, market says 0.4
+        # market_brier = (0.4-0)^2 = 0.16, tool_brier = (0.7-0)^2 = 0.49
+        edge = edge_score(0.7, 0.4, False)
+        assert round(edge, 4) == -0.33
+
+    def test_tool_equals_market(self) -> None:
+        """Zero edge when tool and market agree."""
+        edge = edge_score(0.6, 0.6, True)
+        assert edge == 0.0
+
+    def test_both_wrong_outcome_true(self) -> None:
+        """Both predict low but outcome is True — less wrong tool wins."""
+        # market=0.3, tool=0.4, outcome=True
+        # market_brier = (0.3-1)^2 = 0.49, tool_brier = (0.4-1)^2 = 0.36
+        edge = edge_score(0.4, 0.3, True)
+        assert round(edge, 4) == 0.13
+
+    def test_both_wrong_outcome_false(self) -> None:
+        """Both predict high but outcome is False — less wrong tool wins."""
+        # market=0.8, tool=0.6, outcome=False
+        # market_brier = 0.64, tool_brier = 0.36
+        edge = edge_score(0.6, 0.8, False)
+        assert round(edge, 4) == 0.28
+
+
+# ---------------------------------------------------------------------------
+# _is_edge_eligible
+# ---------------------------------------------------------------------------
+
+
+class TestIsEdgeEligible:
+    """Tests for _is_edge_eligible."""
+
+    def test_eligible_row(self) -> None:
+        """Row with all required fields is eligible."""
+        row = _row(p_yes=0.7, outcome=True, market_prob=0.6)
+        assert _is_edge_eligible(row)
+
+    def test_missing_market_prob(self) -> None:
+        """Row without market_prob is not eligible."""
+        row = _row(p_yes=0.7, outcome=True)
+        assert not _is_edge_eligible(row)
+
+    def test_invalid_parse(self) -> None:
+        """Malformed prediction is not eligible."""
+        row = _row(status="malformed", market_prob=0.6)
+        assert not _is_edge_eligible(row)
+
+    def test_no_outcome(self) -> None:
+        """Row without outcome is not eligible."""
+        row = _row(p_yes=0.7, market_prob=0.6)
+        row["final_outcome"] = None
+        assert not _is_edge_eligible(row)
+
+
+# ---------------------------------------------------------------------------
+# classify_difficulty
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyDifficulty:
+    """Tests for classify_difficulty."""
+
+    def test_hard(self) -> None:
+        """Market near 50/50 is hard."""
+        assert classify_difficulty(0.55) == "hard"
+        assert classify_difficulty(0.45) == "hard"
+
+    def test_medium(self) -> None:
+        """Market between thresholds is medium."""
+        assert classify_difficulty(0.75) == "medium"
+        assert classify_difficulty(0.25) == "medium"
+
+    def test_easy(self) -> None:
+        """Market far from 50/50 is easy."""
+        assert classify_difficulty(0.9) == "easy"
+        assert classify_difficulty(0.1) == "easy"
+
+    def test_none(self) -> None:
+        """None returns unknown."""
+        assert classify_difficulty(None) == "unknown"
+
+    def test_boundary_hard_medium(self) -> None:
+        """Exact boundary: |0.65-0.5|=0.15 is medium (>= lo)."""
+        assert classify_difficulty(0.65) == "medium"
+        assert classify_difficulty(0.35) == "medium"
+
+    def test_boundary_medium_easy(self) -> None:
+        """Near boundary: |0.8-0.5|≈0.3 falls to easy due to float precision."""
+        # abs(0.8 - 0.5) = 0.30000000000000004 > 0.3 → easy
+        assert classify_difficulty(0.8) == "easy"
+        # 0.79 is clearly medium
+        assert classify_difficulty(0.79) == "medium"
+
+
+# ---------------------------------------------------------------------------
+# classify_liquidity
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyLiquidity:
+    """Tests for classify_liquidity."""
+
+    def test_low(self) -> None:
+        """Below threshold is low."""
+        assert classify_liquidity(6.0) == "low"
+        assert classify_liquidity(499.99) == "low"
+
+    def test_medium(self) -> None:
+        """Between thresholds is medium."""
+        assert classify_liquidity(500.0) == "medium"
+        assert classify_liquidity(3000.0) == "medium"
+
+    def test_high(self) -> None:
+        """Above threshold is high."""
+        assert classify_liquidity(5001.0) == "high"
+
+    def test_none(self) -> None:
+        """None returns unknown."""
+        assert classify_liquidity(None) == "unknown"
+
+    def test_boundary(self) -> None:
+        """Exact boundary: 5000 is medium (<= hi)."""
+        assert classify_liquidity(5000.0) == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Edge in compute_group_stats (batch path)
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeInGroupStats:
+    """Tests for edge metrics in compute_group_stats."""
+
+    def test_edge_with_market_prob(self) -> None:
+        """Edge is computed when market_prob is available."""
+        rows = [
+            _row(p_yes=0.9, outcome=True, market_prob=0.6),   # edge > 0
+            _row(p_yes=0.3, outcome=False, market_prob=0.4),   # edge > 0
+        ]
+        result = compute_group_stats(rows)
+        assert result["edge_n"] == 2
+        assert result["edge"] is not None
+        assert result["edge"] > 0
+        assert result["edge_positive_rate"] == 1.0
+
+    def test_edge_without_market_prob(self) -> None:
+        """Edge is null when no rows have market_prob."""
+        rows = [_row(p_yes=0.7, outcome=True)]
+        result = compute_group_stats(rows)
+        assert result["edge_n"] == 0
+        assert result["edge"] is None
+        assert result["edge_positive_rate"] is None
+
+    def test_edge_mixed(self) -> None:
+        """Edge computed only from rows that have market_prob."""
+        rows = [
+            _row(p_yes=0.9, outcome=True, market_prob=0.6),  # eligible
+            _row(p_yes=0.7, outcome=True),                    # not eligible
+        ]
+        result = compute_group_stats(rows)
+        assert result["edge_n"] == 1
+        assert result["valid_n"] == 2  # both valid for Brier
+        assert result["edge"] is not None
+
+    def test_brier_unchanged_by_edge(self) -> None:
+        """Adding market_prob doesn't change Brier computation."""
+        rows_without = [_row(p_yes=0.7, outcome=True)]
+        rows_with = [_row(p_yes=0.7, outcome=True, market_prob=0.5)]
+        stats_without = compute_group_stats(rows_without)
+        stats_with = compute_group_stats(rows_with)
+        assert stats_without["brier"] == stats_with["brier"]
+        assert stats_without["accuracy"] == stats_with["accuracy"]
+
+
+# ---------------------------------------------------------------------------
+# Edge in incremental path
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeIncremental:
+    """Tests for edge metrics in incremental update path."""
+
+    def test_incremental_edge(self, tmp_path: Path) -> None:
+        """Edge accumulators work through update()."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [
+            _row(p_yes=0.9, outcome=True, market_prob=0.6),
+            _row(p_yes=0.3, outcome=True, market_prob=0.7),
+        ]
+        result = update(rows, scores_path, history_path)
+        assert result["overall"]["edge_n"] == 2
+        assert result["overall"]["edge"] is not None
+
+    def test_incremental_no_edge(self, tmp_path: Path) -> None:
+        """No edge when no market_prob."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [_row(p_yes=0.7, outcome=True)]
+        result = update(rows, scores_path, history_path)
+        assert result["overall"]["edge_n"] == 0
+        assert result["overall"]["edge"] is None
+
+    def test_resume_with_old_scores(self, tmp_path: Path) -> None:
+        """Old scores.json without edge fields loads gracefully."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        # Write old-format scores.json (no edge fields)
+        old_scores = {
+            "current_month": "2026-04",
+            "generated_at": "2026-04-08T00:00:00Z",
+            "overall": {
+                "n": 10,
+                "valid_n": 9,
+                "brier_sum": 2.0,
+                "correct_count": 6,
+                "sharpness_sum": 1.5,
+                "outcome_yes_count": 5,
+                "brier": 0.22,
+                "accuracy": 0.67,
+                "sharpness": 0.17,
+                "reliability": 0.9,
+                "decision_worthy": False,
+            },
+            "by_tool": {},
+            "by_platform": {},
+            "by_category": {},
+            "by_horizon": {},
+            "by_tool_platform": {},
+            "by_tool_version": {},
+            "by_config": {},
+            "calibration": {},
+            "parse_breakdown": {},
+            "latency_reservoir": {},
+            "worst_10": [],
+            "best_10": [],
+        }
+        scores_path.write_text(json.dumps(old_scores))
+
+        # Add a new row with market_prob
+        rows = [_row(p_yes=0.8, outcome=True, market_prob=0.5)]
+        result = update(rows, scores_path, history_path)
+
+        # Old rows didn't have edge, new one does
+        assert result["overall"]["edge_n"] == 1
+        assert result["overall"]["n"] == 11
+
+    def test_difficulty_and_liquidity_dimensions(self, tmp_path: Path) -> None:
+        """by_difficulty and by_liquidity dimensions are populated."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [
+            _row(p_yes=0.7, outcome=True, market_prob=0.55, market_liquidity=6.0),
+            _row(p_yes=0.8, outcome=True, market_prob=0.85, market_liquidity=1000.0),
+        ]
+        result = update(rows, scores_path, history_path)
+
+        assert "hard" in result["by_difficulty"]
+        assert "easy" in result["by_difficulty"]
+        assert "low" in result["by_liquidity"]
+        assert "medium" in result["by_liquidity"]
+
+
+# ---------------------------------------------------------------------------
+# Edge in batch score()
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeBatchScore:
+    """Tests for edge metrics in batch score()."""
+
+    def test_score_includes_edge_eligibility(self) -> None:
+        """score() output includes edge_eligibility section."""
+        rows = [
+            _row(p_yes=0.7, outcome=True, market_prob=0.5),
+            _row(p_yes=0.6, outcome=False),
+        ]
+        result = score(rows)
+        elig = result["edge_eligibility"]
+        assert elig["n_total"] == 2
+        assert elig["n_eligible"] == 1
+        assert elig["n_excluded"] == 1
+        assert elig["exclusion_reasons"]["missing_market_prob"] == 1
+
+    def test_score_includes_difficulty_and_liquidity(self) -> None:
+        """score() output includes by_difficulty and by_liquidity."""
+        rows = [
+            _row(p_yes=0.7, outcome=True, market_prob=0.55, market_liquidity=6.0),
+        ]
+        result = score(rows)
+        assert "by_difficulty" in result
+        assert "by_liquidity" in result
+        assert "hard" in result["by_difficulty"]
+        assert "low" in result["by_liquidity"]

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1310,3 +1310,56 @@ class TestUpdateDedup:
         assert (
             result["overall"]["n"] == 0
         ), f"Expected 0 (r1 deduped across month rollover), got {result['overall']['n']}"
+
+    def test_rebuild_deduplicates_across_log_files(self, tmp_path: Path) -> None:
+        """Same row_id in two log files is only counted once during rebuild."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "dedup.json"
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+
+        row = _row(p_yes=0.7, outcome=True, row_id="dup1")
+
+        # Write same row to two different log files
+        for name in ["production_log_a.jsonl", "production_log_b.jsonl"]:
+            with open(logs_dir / name, "w", encoding="utf-8") as f:
+                f.write(json.dumps(row) + "\n")
+
+        result = rebuild(
+            logs_dir=logs_dir,
+            scores_path=scores_path,
+            history_path=history_path,
+            dedup_path=dedup_path,
+        )
+        assert (
+            result["overall"]["n"] == 1
+        ), f"Expected 1 (deduped), got {result['overall']['n']}"
+
+    def test_empty_rebuild_clears_dedup(self, tmp_path: Path) -> None:
+        """Empty rebuild clears stale dedup state so rows aren't falsely skipped."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "dedup.json"
+        empty_logs = tmp_path / "empty_logs"
+        empty_logs.mkdir()
+
+        # Seed dedup via update
+        rows = [_row(p_yes=0.7, outcome=True, row_id="r1")]
+        update(rows, scores_path, history_path, dedup_path)
+        assert json.loads(dedup_path.read_text()) == ["r1"]
+
+        # Rebuild on empty logs — should clear dedup
+        rebuild(
+            logs_dir=empty_logs,
+            scores_path=scores_path,
+            history_path=history_path,
+            dedup_path=dedup_path,
+        )
+        assert json.loads(dedup_path.read_text()) == []
+
+        # Now update with the same row — should be accepted (not stale-skipped)
+        result = update(rows, scores_path, history_path, dedup_path)
+        assert (
+            result["overall"]["n"] == 1
+        ), f"Expected 1 (not stale-skipped), got {result['overall']['n']}"

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -27,6 +27,7 @@ from unittest.mock import patch
 from benchmark.scorer import (
     LATENCY_RESERVOIR_SIZE,
     WORST_BEST_SIZE,
+    _is_edge_eligible,
     brier_score,
     classify_difficulty,
     classify_horizon,
@@ -40,7 +41,6 @@ from benchmark.scorer import (
     rebuild,
     score,
     update,
-    _is_edge_eligible,
 )
 
 # ---------------------------------------------------------------------------

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -946,11 +946,9 @@ class TestClassifyDifficulty:
         assert classify_difficulty(0.35) == "medium"
 
     def test_boundary_medium_easy(self) -> None:
-        """Near boundary: |0.8-0.5|≈0.3 falls to easy due to float precision."""
-        # abs(0.8 - 0.5) = 0.30000000000000004 > 0.3 → easy
-        assert classify_difficulty(0.8) == "easy"
-        # 0.79 is clearly medium
-        assert classify_difficulty(0.79) == "medium"
+        """Exact boundary: |0.8-0.5|=0.3 is medium (<= hi)."""
+        assert classify_difficulty(0.8) == "medium"
+        assert classify_difficulty(0.2) == "medium"
 
 
 # ---------------------------------------------------------------------------

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1273,6 +1273,6 @@ class TestUpdateDedup:
         # n should still be 1 (only april_r1 in current month accumulators)
         # because rebuild() only accumulates the last month into scores.json
         # but scored_row_ids contains both months' IDs
-        assert result["overall"]["n"] == 1, (
-            f"Expected 1 (only last month in accumulators), got {result['overall']['n']}"
-        )
+        assert (
+            result["overall"]["n"] == 1
+        ), f"Expected 1 (only last month in accumulators), got {result['overall']['n']}"

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -995,8 +995,8 @@ class TestEdgeInGroupStats:
     def test_edge_with_market_prob(self) -> None:
         """Edge is computed when market_prob is available."""
         rows = [
-            _row(p_yes=0.9, outcome=True, market_prob=0.6),   # edge > 0
-            _row(p_yes=0.3, outcome=False, market_prob=0.4),   # edge > 0
+            _row(p_yes=0.9, outcome=True, market_prob=0.6),  # edge > 0
+            _row(p_yes=0.3, outcome=False, market_prob=0.4),  # edge > 0
         ]
         result = compute_group_stats(rows)
         assert result["edge_n"] == 2
@@ -1016,7 +1016,7 @@ class TestEdgeInGroupStats:
         """Edge computed only from rows that have market_prob."""
         rows = [
             _row(p_yes=0.9, outcome=True, market_prob=0.6),  # eligible
-            _row(p_yes=0.7, outcome=True),                    # not eligible
+            _row(p_yes=0.7, outcome=True),  # not eligible
         ]
         result = compute_group_stats(rows)
         assert result["edge_n"] == 1
@@ -1163,7 +1163,7 @@ class TestEdgeBatchScore:
 
 
 # ---------------------------------------------------------------------------
-# Dedup in update()
+# Row-ID deduplication
 # ---------------------------------------------------------------------------
 
 
@@ -1186,9 +1186,9 @@ class TestUpdateDedup:
 
         # Second pass with same rows — should be skipped
         result2 = update(rows, scores_path, history_path)
-        assert result2["overall"]["n"] == 2, (
-            f"Expected 2 after dedup, got {result2['overall']['n']}"
-        )
+        assert (
+            result2["overall"]["n"] == 2
+        ), f"Expected 2 after dedup, got {result2['overall']['n']}"
         assert result2["overall"]["brier"] == result1["overall"]["brier"]
 
     def test_new_rows_added_after_dedup(self, tmp_path: Path) -> None:
@@ -1198,16 +1198,16 @@ class TestUpdateDedup:
 
         batch1 = [_row(p_yes=0.7, outcome=True, row_id="r1")]
         batch2 = [
-            _row(p_yes=0.7, outcome=True, row_id="r1"),   # duplicate
-            _row(p_yes=0.4, outcome=False, row_id="r3"),   # new
+            _row(p_yes=0.7, outcome=True, row_id="r1"),  # duplicate
+            _row(p_yes=0.4, outcome=False, row_id="r3"),  # new
         ]
 
         update(batch1, scores_path, history_path)
         result = update(batch2, scores_path, history_path)
 
-        assert result["overall"]["n"] == 2, (
-            f"Expected 2 (r1 + r3), got {result['overall']['n']}"
-        )
+        assert (
+            result["overall"]["n"] == 2
+        ), f"Expected 2 (r1 + r3), got {result['overall']['n']}"
 
     def test_scored_row_ids_persisted(self, tmp_path: Path) -> None:
         """scored_row_ids are saved to scores.json and loaded on resume."""

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1145,7 +1145,10 @@ class TestEdgeBatchScore:
         assert elig["n_total"] == 2
         assert elig["n_eligible"] == 1
         assert elig["n_excluded"] == 1
-        assert elig["exclusion_reasons"]["missing_market_prob"] == 1
+        reasons = elig["exclusion_reasons"]
+        assert reasons["missing_market_prob"] == 1
+        assert reasons["invalid_parse"] == 0
+        assert reasons["missing_outcome"] == 0
 
     def test_score_includes_difficulty_and_liquidity(self) -> None:
         """score() output includes by_difficulty and by_liquidity."""

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1256,7 +1256,7 @@ class TestUpdateDedup:
             ),
         ]
         log_file = logs_dir / "production_log_test.jsonl"
-        with open(log_file, "w") as f:
+        with open(log_file, "w", encoding="utf-8") as f:
             for r in rows:
                 f.write(json.dumps(r) + "\n")
 


### PR DESCRIPTION
## Summary

Adds **edge-over-market** as the primary trading-value metric to the benchmark pipeline. Edge measures whether our tool predictions are closer to outcomes than the market consensus — a tool with good Brier but zero edge generates no trading profit.

### What's new

**Scorer (`scorer.py`):**
- `edge_score()` — per-row: `(market_prob - outcome)² - (p_yes - outcome)²`. Positive = tool beats market.
- Edge metrics (`edge`, `edge_n`, `edge_positive_rate`) in every grouping dimension: overall, by_tool, by_platform, by_category, by_horizon, by_tool_platform
- New dimensions: `by_difficulty`, `by_liquidity`, `by_platform_difficulty`, `by_platform_liquidity`
- `edge_eligibility` section with mutually exclusive exclusion reasons
- **Row-ID dedup in `update()`** — fixes a pre-existing bug where overlapping lookback windows caused double-counting. Tracks `scored_row_ids` in scores.json.
- `rebuild()` now tracks row_ids across all months (not just the last)
- Backward compat: old `scores.json` without edge fields loads gracefully (defaults to 0)

**Fetcher (`fetch_production.py`):**
- Extracts `market_spread` from `request_context` — Polymarket bid-ask spread was on-chain but silently dropped. Stored as `market_spread_at_prediction` for future PnL work.

**Report (`analyze.py`):**
- Edge in overall summary, tool ranking, platform comparison, tool×platform table
- New "Edge Over Market" section with per-platform difficulty and liquidity breakdowns

**Slack (`notify_slack.py`):**
- Summary prompt ranks tools by edge, shows edge per platform, includes difficulty breakdown

### Production run results (74,059 rows, 6,021 edge-eligible)

| Platform | Edge | +rate | Edge n |
|----------|------|-------|--------|
| omen | -0.082 | 57% | 2,673 |
| polymarket | -0.052 | 58% | 3,348 |

All tools currently have negative edge — market consensus outperforms our predictions. Superforcaster is closest to breakeven (edge -0.028, positive rate 64%).

### Not included (deferred)

- PnL simulation — need to decide Kelly vs fixed-fraction first. `market_spread` is now captured for when we're ready.
- Difficulty/liquidity thresholds are initial values from PROPOSAL.md — adjust after reviewing data distribution.

## Test plan

- [x] 239 benchmark tests pass (82 scorer tests, including 30 new)
- [x] Edge math hand-verified against real production row
- [x] Incremental and batch paths produce identical edge values
- [x] Old scores.json without edge fields loads gracefully
- [x] Dedup: same rows passed twice → no double-counting
- [x] Production CI run with `force_rebuild: true` — all dimensions populated
- [x] Bug-hunter audit: 3 bugs found and fixed (exclusion reasons overlap, rebuild dedup, schema consistency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)