### PR TITLE
Feat/diagnostic metrics

### DIFF
--- a/benchmark/PROPOSAL.md
+++ b/benchmark/PROPOSAL.md
@@ -440,8 +440,8 @@ These metrics are not used to rank or select tools. They diagnose whether accura
 | Metric | Formula | What it diagnoses |
 |--------|---------|-------------------|
 | **ECE** | `sum(n_bin * \|gap_bin\|) / total_n` | Overall calibration quality. 0 = perfect. |
-| **Calibration intercept** | Weighted linear regression intercept (realized vs predicted) | Systematic bias direction. Positive = underestimates. |
-| **Calibration slope** | Weighted linear regression slope | Prediction dispersion. < 1 = overconfident, > 1 = underconfident. |
+| **Calibration intercept** | Row-level logistic regression (Platt scaling) on `logit(p_yes)` — intercept term | Systematic bias direction. Positive = underestimates. |
+| **Calibration slope** | Row-level logistic regression (Platt scaling) on `logit(p_yes)` — slope term | Prediction dispersion. < 1 = overconfident, > 1 = underconfident. |
 | **Sharpness** | `mean(\|p_yes - 0.5\|)` | How decisive predictions are. Only good if calibration is also good. |
 | **Directional accuracy** | `correct / n_directional` (excludes p_yes == 0.5) | Fraction correct when the tool has an opinion. |
 | **No-signal rate** | `count(p_yes == 0.5) / n_valid` | How often the tool says "I don't know." |
@@ -1266,10 +1266,11 @@ The first sprint delivers a minimal but complete pipeline: real production data 
    - Preserve missingness explicitly instead of silently dropping rows
    - Output a first `production_log.jsonl`
 
-3. **`scorer.py` with the gated baseline metrics**
-   - Reliability gate first
-   - Then Brier score
-   - Then edge-over-market where eligible
+3. **`scorer.py` with the staged pipeline**
+   - Reliability gate (80% threshold)
+   - Brier + Log Loss (primary ranking metrics)
+   - Calibration: ECE, intercept/slope via Platt scaling (min 20/bin for ECE)
+   - Edge diagnostics where market_prob available
    - Include `n_total`, `n_eligible`, `n_excluded`, exclusion reasons, and timing
 
 4. **Baseline reporting**

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -358,8 +358,8 @@ gap           = avg_predicted - realized_rate
 
 | Gap sign | Meaning |
 |----------|---------|
-| Positive | Overconfident — predicts higher than reality |
-| Negative | Underconfident — predicts lower than reality |
+| Positive | Overpredicts — predicted probability higher than realized rate |
+| Negative | Underpredicts — predicted probability lower than realized rate |
 
 A perfectly calibrated tool has gap ≈ 0 in every bin. The calibration plot (reliability diagram) shows avg_predicted vs realized_rate; the diagonal line is perfect calibration.
 
@@ -377,8 +377,8 @@ Bins with fewer than 20 samples (`MIN_CALIBRATION_BIN_SIZE`) are excluded to avo
 
 ```
 slope = 1.0 → perfectly calibrated
-slope < 1.0 → overconfident (predictions too extreme)
-slope > 1.0 → underconfident (predictions too compressed toward 0.5)
+slope < 1.0 → predictions too extreme (overconfident)
+slope > 1.0 → predictions too compressed toward 0.5 (underconfident)
 
 intercept evaluated at p_yes = 0.5 (logit midpoint)
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -232,21 +232,22 @@ python benchmark/sweep.py \
 
 ```
 ## Overall
-|                     |  B.Brier |  C.Brier |    Delta |    B.Acc |    C.Acc |    Delta |   B.N |   C.N | Direction  |
-|---------------------|----------|----------|----------|----------|----------|----------|-------|-------|------------|
-| Overall             |   0.2217 |   0.0358 |  -0.1859 |   0.6667 |   1.0000 |  +0.3333 |     3 |     3 | improved   |
+|                                     |  B.Brier |  C.Brier |    Delta |     B.LL |     C.LL |    Delta |   B.DAcc |   C.DAcc |    Delta |   B.N |   C.N | Direction  |
+|-------------------------------------|----------|----------|----------|----------|----------|----------|----------|----------|----------|-------|-------|------------|
+| Overall                             |   0.2217 |   0.0358 |  -0.1859 |   0.6931 |   0.1054 |  -0.5877 |   0.6667 |   1.0000 |  +0.3333 |     3 |     3 | improved   |
 
 ## By Tool
-|                     |  B.Brier |  C.Brier |    Delta |    B.Acc |    C.Acc |    Delta |   B.N |   C.N | Direction  |
-|---------------------|----------|----------|----------|----------|----------|----------|-------|-------|------------|
-| superforcaster      |   0.2300 |   0.2400 |  +0.0100 |   0.7300 |   0.7200 |  -0.0100 |    85 |    85 | regressed  |
+|                                     |  B.Brier |  C.Brier |    Delta |     B.LL |     C.LL |    Delta |   B.DAcc |   C.DAcc |    Delta |   B.N |   C.N | Direction  |
+|-------------------------------------|----------|----------|----------|----------|----------|----------|----------|----------|----------|-------|-------|------------|
+| superforcaster                      |   0.2300 |   0.2400 |  +0.0100 |   0.5200 |   0.5400 |  +0.0200 |   0.7300 |   0.7200 |  -0.0100 |    85 |    85 | regressed  |
 ```
 
 - **B.Brier / C.Brier**: Baseline / Candidate Brier score (lower is better, 0 = perfect)
-- **B.Acc / C.Acc**: Baseline / Candidate accuracy (higher is better)
+- **B.LL / C.LL**: Baseline / Candidate Log Loss (lower is better; punishes confident wrong predictions harder than Brier)
+- **B.DAcc / C.DAcc**: Baseline / Candidate Directional Accuracy (higher is better; excludes p_yes = 0.5)
 - **B.N / C.N**: Sample sizes (should match for fair comparison)
-- **Delta**: Candidate minus baseline (negative Brier delta = improvement)
-- **Direction**: `improved` / `regressed` / `unchanged`
+- **Delta**: Candidate minus baseline (negative Brier/LL delta = improvement)
+- **Direction**: `improved` / `regressed` / `unchanged` (based on combined Brier + LL + DAcc movement)
 
 ## Scoring metrics — formulas
 
@@ -367,10 +368,10 @@ A perfectly calibrated tool has gap ≈ 0 in every bin. The calibration plot (re
 **ECE (Expected Calibration Error)** — a single scalar summarizing calibration quality:
 
 ```
-ECE = sum(n_bin * |gap_bin|) / sum(n_bin)
+ECE = sum(n_bin * |gap_bin|) / sum(n_bin)    (bins with n < 20 excluded)
 ```
 
-ECE = 0 means perfectly calibrated. ECE = 0.10 means predictions are off by 10pp on average.
+Bins with fewer than 20 samples (`MIN_CALIBRATION_BIN_SIZE`) are excluded to avoid noisy calibration estimates dominating the score. ECE = 0 means perfectly calibrated. ECE = 0.10 means predictions are off by 10pp on average.
 
 **Calibration intercept and slope** — Platt scaling on the logit scale: `logit(P(y=1|p)) = intercept + slope * logit(p_yes)`.
 
@@ -413,10 +414,12 @@ Used in PR-comment replay comparisons. Counts predictions where the tool was con
 overconf_wrong_i = 1  if max(p_yes, 1 - p_yes) > 0.80 AND predicted direction ≠ outcome
                    0  otherwise
 Overconfident wrong count = sum(overconf_wrong_i)
-Overconfident wrong rate  = count / n
+Overconfident wrong rate  = count / n_valid
 ```
 
-These are the most expensive mistakes — high-conviction wrong predictions that would trigger large Kelly bets in the wrong direction. The rate normalizes by sample size for cross-dataset comparison.
+Where `n_valid` is the count of predictions with non-null `p_yes`. Rows with p_yes = 0.5 can never be overconfident-wrong (max(0.5, 0.5) = 0.5 < 0.80), so the numerator is unaffected; the denominator normalizes against total valid sample size.
+
+These are the most expensive mistakes — high-conviction wrong predictions that would trigger large Kelly bets in the wrong direction.
 
 ### Stratification dimensions
 

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -650,6 +650,8 @@ def _render_directional_bias(
             lines.append(
                 f"- **{cat}**: insufficient data" f" (n={c_n}, need {MIN_SAMPLE_SIZE})"
             )
+        else:
+            lines.append(f"- **{cat}**: no losses to measure")
 
 
 def section_diagnostic_metrics(scores: dict[str, Any]) -> str:

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -605,9 +605,14 @@ def section_diagnostic_metrics(scores: dict[str, Any]) -> str:
     bias = overall.get("directional_bias")
     n_losses = overall.get("n_bias_losses", 0)
     if bias is not None:
-        direction = "overestimates" if bias > 0 else "underestimates"
+        if bias > 0:
+            direction = "overestimates"
+        elif bias < 0:
+            direction = "underestimates"
+        else:
+            direction = "no bias"
         lines.append(
-            f"- **Overall**: {bias:+.4f} (tends to {direction},"
+            f"- **Overall**: {bias:+.4f} ({direction},"
             f" n={n_losses} losses)"
         )
     else:
@@ -621,7 +626,12 @@ def section_diagnostic_metrics(scores: dict[str, Any]) -> str:
         c_bias = stats.get("directional_bias")
         c_n = stats.get("n_bias_losses", 0)
         if c_bias is not None:
-            c_dir = "overestimates" if c_bias > 0 else "underestimates"
+            if c_bias > 0:
+                c_dir = "overestimates"
+            elif c_bias < 0:
+                c_dir = "underestimates"
+            else:
+                c_dir = "no bias"
             lines.append(
                 f"- **{cat}**: {c_bias:+.4f} ({c_dir}, n={c_n})"
             )

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from benchmark.io import load_jsonl
-from benchmark.scorer import MIN_SAMPLE_SIZE
+from benchmark.scorer import DISAGREE_THRESHOLD, LARGE_TRADE_THRESHOLD, MIN_SAMPLE_SIZE
 
 DEFAULT_SCORES = Path(__file__).parent / "results" / "scores.json"
 DEFAULT_HISTORY = Path(__file__).parent / "results" / "scores_history.jsonl"
@@ -550,7 +550,8 @@ def _render_conditional_accuracy(
     lines.append("")
     lines.append(
         "When the tool disagrees with the market enough to trigger a trade"
-        " (|p_yes - market_prob| > 0.03), is the tool or market closer to truth?"
+        f" (|p_yes - market_prob| > {DISAGREE_THRESHOLD}),"
+        " is the tool or market closer to truth?"
     )
     lines.append("")
 
@@ -593,9 +594,12 @@ def _render_disagreement_brier(overall: dict[str, Any], lines: list[str]) -> Non
     lines.append("")
 
     bucket_labels = [
-        ("no_trade", "No trade (|d| \u2264 0.03)"),
-        ("small_trade", "Small trade (0.03 < |d| \u2264 0.10)"),
-        ("large_trade", "Large trade (|d| > 0.10)"),
+        ("no_trade", f"No trade (|d| \u2264 {DISAGREE_THRESHOLD})"),
+        (
+            "small_trade",
+            f"Small trade ({DISAGREE_THRESHOLD} < |d| \u2264 {LARGE_TRADE_THRESHOLD})",
+        ),
+        ("large_trade", f"Large trade (|d| > {LARGE_TRADE_THRESHOLD})"),
     ]
     for bucket_key, label in bucket_labels:
         b = overall.get(f"brier_{bucket_key}")

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any
 
 from benchmark.io import load_jsonl
+from benchmark.scorer import MIN_SAMPLE_SIZE
 
 DEFAULT_SCORES = Path(__file__).parent / "results" / "scores.json"
 DEFAULT_HISTORY = Path(__file__).parent / "results" / "scores_history.jsonl"
@@ -561,7 +562,7 @@ def _render_conditional_accuracy(
     else:
         lines.append(
             f"- **Overall**: insufficient data (n={disagree_n} disagreements,"
-            f" need {30})"
+            f" need {MIN_SAMPLE_SIZE})"
         )
 
     for plat, stats in sorted(scores.get("by_platform", {}).items()):
@@ -569,6 +570,11 @@ def _render_conditional_accuracy(
         p_dn = stats.get("disagree_n", 0)
         if p_ca is not None:
             lines.append(f"- **{plat}**: {p_ca:.0%} tool-wins (n={p_dn})")
+        elif p_dn > 0:
+            lines.append(
+                f"- **{plat}**: insufficient data (n={p_dn},"
+                f" need {MIN_SAMPLE_SIZE})"
+            )
     lines.append("")
 
 
@@ -627,7 +633,8 @@ def _render_directional_bias(
         )
     else:
         lines.append(
-            f"- **Overall**: insufficient data (n={n_losses} losses," f" need {30})"
+            f"- **Overall**: insufficient data (n={n_losses} losses,"
+            f" need {MIN_SAMPLE_SIZE})"
         )
 
     for cat, stats in sorted(scores.get("by_category", {}).items()):
@@ -635,6 +642,10 @@ def _render_directional_bias(
         c_n = stats.get("n_bias_losses", 0)
         if c_bias is not None:
             lines.append(f"- **{cat}**: {c_bias:+.4f} ({_bias_label(c_bias)}, n={c_n})")
+        elif c_n > 0:
+            lines.append(
+                f"- **{cat}**: insufficient data" f" (n={c_n}, need {MIN_SAMPLE_SIZE})"
+            )
 
 
 def section_diagnostic_metrics(scores: dict[str, Any]) -> str:

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -522,26 +522,29 @@ def section_edge_analysis(scores: dict[str, Any]) -> str:
 _DIAG_SECTION_HEADER = "## Diagnostic Edge Metrics"
 
 
-def section_diagnostic_metrics(scores: dict[str, Any]) -> str:
-    """Conditional accuracy, disagreement-stratified Brier, and directional bias."""
-    overall = scores.get("overall", {})
+def _bias_label(bias: float) -> str:
+    """Return a human-readable label for a directional bias value.
+
+    :param bias: directional bias value.
+    :return: label string.
+    """
+    if bias > 0:
+        return "overestimates"
+    if bias < 0:
+        return "underestimates"
+    return "no bias"
+
+
+def _render_conditional_accuracy(
+    overall: dict[str, Any], scores: dict[str, Any], lines: list[str]
+) -> None:
+    """Render conditional accuracy subsection.
+
+    :param overall: overall stats dict.
+    :param scores: full scores dict (for by_platform).
+    :param lines: output list to append to.
+    """
     disagree_n = overall.get("disagree_n", 0)
-    if disagree_n == 0 and overall.get("edge_n", 0) == 0:
-        return (
-            f"{_DIAG_SECTION_HEADER}\n\n"
-            "No edge-eligible rows — diagnostic metrics require "
-            "market_prob_at_prediction."
-        )
-
-    lines = [
-        _DIAG_SECTION_HEADER,
-        "",
-        "These metrics diagnose whether accuracy translates to profit and"
-        " where the system loses. They are not used for tool ranking.",
-        "",
-    ]
-
-    # --- Conditional accuracy ---
     lines.append("### Conditional Accuracy When Disagreeing")
     lines.append("")
     lines.append(
@@ -561,15 +564,20 @@ def section_diagnostic_metrics(scores: dict[str, Any]) -> str:
             f" need {30})"
         )
 
-    by_plat = scores.get("by_platform", {})
-    for plat, stats in sorted(by_plat.items()):
+    for plat, stats in sorted(scores.get("by_platform", {}).items()):
         p_ca = stats.get("conditional_accuracy_rate")
         p_dn = stats.get("disagree_n", 0)
         if p_ca is not None:
             lines.append(f"- **{plat}**: {p_ca:.0%} tool-wins (n={p_dn})")
     lines.append("")
 
-    # --- Disagreement-stratified Brier ---
+
+def _render_disagreement_brier(overall: dict[str, Any], lines: list[str]) -> None:
+    """Render disagreement-stratified Brier subsection.
+
+    :param overall: overall stats dict.
+    :param lines: output list to append to.
+    """
     lines.append("### Disagreement-Stratified Brier")
     lines.append("")
     lines.append(
@@ -592,7 +600,16 @@ def section_diagnostic_metrics(scores: dict[str, Any]) -> str:
             lines.append(f"- **{label}**: insufficient data (n={n})")
     lines.append("")
 
-    # --- Directional bias ---
+
+def _render_directional_bias(
+    overall: dict[str, Any], scores: dict[str, Any], lines: list[str]
+) -> None:
+    """Render directional bias subsection.
+
+    :param overall: overall stats dict.
+    :param scores: full scores dict (for by_category).
+    :param lines: output list to append to.
+    """
     lines.append("### Directional Bias (When Tool Loses)")
     lines.append("")
     lines.append(
@@ -605,36 +622,43 @@ def section_diagnostic_metrics(scores: dict[str, Any]) -> str:
     bias = overall.get("directional_bias")
     n_losses = overall.get("n_bias_losses", 0)
     if bias is not None:
-        if bias > 0:
-            direction = "overestimates"
-        elif bias < 0:
-            direction = "underestimates"
-        else:
-            direction = "no bias"
         lines.append(
-            f"- **Overall**: {bias:+.4f} ({direction},"
-            f" n={n_losses} losses)"
+            f"- **Overall**: {bias:+.4f} ({_bias_label(bias)}," f" n={n_losses} losses)"
         )
     else:
         lines.append(
-            f"- **Overall**: insufficient data (n={n_losses} losses,"
-            f" need {30})"
+            f"- **Overall**: insufficient data (n={n_losses} losses," f" need {30})"
         )
 
-    by_cat = scores.get("by_category", {})
-    for cat, stats in sorted(by_cat.items()):
+    for cat, stats in sorted(scores.get("by_category", {}).items()):
         c_bias = stats.get("directional_bias")
         c_n = stats.get("n_bias_losses", 0)
         if c_bias is not None:
-            if c_bias > 0:
-                c_dir = "overestimates"
-            elif c_bias < 0:
-                c_dir = "underestimates"
-            else:
-                c_dir = "no bias"
-            lines.append(
-                f"- **{cat}**: {c_bias:+.4f} ({c_dir}, n={c_n})"
-            )
+            lines.append(f"- **{cat}**: {c_bias:+.4f} ({_bias_label(c_bias)}, n={c_n})")
+
+
+def section_diagnostic_metrics(scores: dict[str, Any]) -> str:
+    """Conditional accuracy, disagreement-stratified Brier, and directional bias."""
+    overall = scores.get("overall", {})
+    disagree_n = overall.get("disagree_n", 0)
+    if disagree_n == 0 and overall.get("edge_n", 0) == 0:
+        return (
+            f"{_DIAG_SECTION_HEADER}\n\n"
+            "No edge-eligible rows — diagnostic metrics require "
+            "market_prob_at_prediction."
+        )
+
+    lines = [
+        _DIAG_SECTION_HEADER,
+        "",
+        "These metrics diagnose whether accuracy translates to profit and"
+        " where the system loses. They are not used for tool ranking.",
+        "",
+    ]
+
+    _render_conditional_accuracy(overall, scores, lines)
+    _render_disagreement_brier(overall, lines)
+    _render_directional_bias(overall, scores, lines)
 
     return "\n".join(lines)
 

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -519,6 +519,116 @@ def section_edge_analysis(scores: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+_DIAG_SECTION_HEADER = "## Diagnostic Edge Metrics"
+
+
+def section_diagnostic_metrics(scores: dict[str, Any]) -> str:
+    """Conditional accuracy, disagreement-stratified Brier, and directional bias."""
+    overall = scores.get("overall", {})
+    disagree_n = overall.get("disagree_n", 0)
+    if disagree_n == 0 and overall.get("edge_n", 0) == 0:
+        return (
+            f"{_DIAG_SECTION_HEADER}\n\n"
+            "No edge-eligible rows — diagnostic metrics require "
+            "market_prob_at_prediction."
+        )
+
+    lines = [
+        _DIAG_SECTION_HEADER,
+        "",
+        "These metrics diagnose whether accuracy translates to profit and"
+        " where the system loses. They are not used for tool ranking.",
+        "",
+    ]
+
+    # --- Conditional accuracy ---
+    lines.append("### Conditional Accuracy When Disagreeing")
+    lines.append("")
+    lines.append(
+        "When the tool disagrees with the market enough to trigger a trade"
+        " (|p_yes - market_prob| > 0.03), is the tool or market closer to truth?"
+    )
+    lines.append("")
+
+    ca = overall.get("conditional_accuracy_rate")
+    if ca is not None:
+        lines.append(
+            f"- **Overall**: {ca:.0%} tool-wins (n={disagree_n} disagreements)"
+        )
+    else:
+        lines.append(
+            f"- **Overall**: insufficient data (n={disagree_n} disagreements,"
+            f" need {30})"
+        )
+
+    by_plat = scores.get("by_platform", {})
+    for plat, stats in sorted(by_plat.items()):
+        p_ca = stats.get("conditional_accuracy_rate")
+        p_dn = stats.get("disagree_n", 0)
+        if p_ca is not None:
+            lines.append(f"- **{plat}**: {p_ca:.0%} tool-wins (n={p_dn})")
+    lines.append("")
+
+    # --- Disagreement-stratified Brier ---
+    lines.append("### Disagreement-Stratified Brier")
+    lines.append("")
+    lines.append(
+        "Brier score bucketed by how much the tool disagrees with the market."
+        " Worse accuracy on large_trade = losing money where it matters."
+    )
+    lines.append("")
+
+    bucket_labels = [
+        ("no_trade", "No trade (|d| \u2264 0.03)"),
+        ("small_trade", "Small trade (0.03 < |d| \u2264 0.10)"),
+        ("large_trade", "Large trade (|d| > 0.10)"),
+    ]
+    for bucket_key, label in bucket_labels:
+        b = overall.get(f"brier_{bucket_key}")
+        n = overall.get(f"n_{bucket_key}", 0)
+        if b is not None:
+            lines.append(f"- **{label}**: Brier {b:.4f} (n={n})")
+        else:
+            lines.append(f"- **{label}**: insufficient data (n={n})")
+    lines.append("")
+
+    # --- Directional bias ---
+    lines.append("### Directional Bias (When Tool Loses)")
+    lines.append("")
+    lines.append(
+        "When the tool disagrees and the market was closer to truth,"
+        " does the tool tend to overestimate (positive) or underestimate"
+        " (negative)?"
+    )
+    lines.append("")
+
+    bias = overall.get("directional_bias")
+    n_losses = overall.get("n_bias_losses", 0)
+    if bias is not None:
+        direction = "overestimates" if bias > 0 else "underestimates"
+        lines.append(
+            f"- **Overall**: {bias:+.4f} (tends to {direction},"
+            f" n={n_losses} losses)"
+        )
+    else:
+        lines.append(
+            f"- **Overall**: insufficient data (n={n_losses} losses,"
+            f" need {30})"
+        )
+
+    by_cat = scores.get("by_category", {})
+    for cat, stats in sorted(by_cat.items()):
+        c_bias = stats.get("directional_bias")
+        c_n = stats.get("n_bias_losses", 0)
+        if c_bias is not None:
+            c_dir = "overestimates" if c_bias > 0 else "underestimates"
+            lines.append(
+                f"- **{cat}**: {c_bias:+.4f} ({c_dir}, n={c_n})"
+            )
+
+    return "\n".join(lines)
+
+
 def section_calibration(scores: dict[str, Any]) -> str:
     """Calibration analysis — are predictions overconfident or underconfident?"""
     cal = scores.get("calibration", [])
@@ -808,6 +918,7 @@ def generate_report(
         section_platform(scores),
         section_tool_platform(scores),
         section_edge_analysis(scores),
+        section_diagnostic_metrics(scores),
         section_calibration(scores),
         section_weak_spots(scores),
         section_reliability_issues(scores),

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -38,7 +38,7 @@ def compute_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """
     by_platform: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in rows:
-        by_platform[row.get("platform", "unknown")].append(row)
+        by_platform[row.get("platform") or "unknown"].append(row)
 
     def _metrics(subset: list[dict[str, Any]]) -> dict[str, Any]:
         valid = [r for r in subset if r.get("p_yes") is not None]

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -70,6 +70,11 @@ def compare_stats(
         "directional_accuracy": {"lower_is_better": False},
         "sharpness": {"lower_is_better": False},
         "reliability": {"lower_is_better": False},
+        # Diagnostic edge metrics
+        "conditional_accuracy_rate": {"lower_is_better": False},
+        "brier_no_trade": {"lower_is_better": True},
+        "brier_small_trade": {"lower_is_better": True},
+        "brier_large_trade": {"lower_is_better": True},
     }
 
     result: dict[str, Any] = {
@@ -87,6 +92,20 @@ def compare_stats(
             "delta": d,
             "direction": _direction(d, opts["lower_is_better"]),
         }
+
+    # Directional bias — closer to 0 is better (use abs comparison)
+    b_bias = baseline.get("directional_bias")
+    c_bias = candidate.get("directional_bias")
+    bias_delta = _delta(
+        abs(b_bias) if b_bias is not None else None,
+        abs(c_bias) if c_bias is not None else None,
+    )
+    result["directional_bias"] = {
+        "baseline": b_bias,
+        "candidate": c_bias,
+        "delta": bias_delta,
+        "direction": _direction(bias_delta, lower_is_better=True),
+    }
 
     return result
 
@@ -257,6 +276,38 @@ def format_markdown(comparison: dict[str, Any]) -> str:
         lines.append(separator)
         for cat in sorted(by_category):
             lines.append(_table_row(cat, by_category[cat]))
+        lines.append("")
+
+    # Diagnostic edge metrics summary (overall only)
+    overall = comparison.get("overall", {})
+    diag_metrics = [
+        ("Conditional Accuracy", "conditional_accuracy_rate", False),
+        ("Brier (no trade)", "brier_no_trade", True),
+        ("Brier (small trade)", "brier_small_trade", True),
+        ("Brier (large trade)", "brier_large_trade", True),
+        ("Directional Bias (|abs|)", "directional_bias", True),
+    ]
+    has_diag = any(overall.get(m) for _, m, _ in diag_metrics)
+    if has_diag:
+        lines.append("## Diagnostic Edge Metrics")
+        lines.append("")
+        lines.append(
+            "| Metric | Baseline | Candidate | Delta | Direction |"
+        )
+        lines.append(
+            "|--------|----------|-----------|-------|-----------|"
+        )
+        for label, key, lower_better in diag_metrics:
+            m = overall.get(key, {})
+            if not m:
+                continue
+            lines.append(
+                f"| {label} "
+                f"| {_fmt(m.get('baseline'))} "
+                f"| {_fmt(m.get('candidate'))} "
+                f"| {_fmt_delta(m.get('delta'))} "
+                f"| {m.get('direction', '—')} |"
+            )
         lines.append("")
 
     return "\n".join(lines)

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -295,13 +295,9 @@ def format_markdown(comparison: dict[str, Any]) -> str:
     if has_diag:
         lines.append("## Diagnostic Edge Metrics")
         lines.append("")
-        lines.append(
-            "| Metric | Baseline | Candidate | Delta | Direction |"
-        )
-        lines.append(
-            "|--------|----------|-----------|-------|-----------|"
-        )
-        for label, key, lower_better in diag_metrics:
+        lines.append("| Metric | Baseline | Candidate | Delta | Direction |")
+        lines.append("|--------|----------|-----------|-------|-----------|")
+        for label, key, _lower_better in diag_metrics:
             m = overall.get(key, {})
             if not m:
                 continue

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -288,47 +288,58 @@ def format_markdown(comparison: dict[str, Any]) -> str:
             lines.append(_table_row(cat, by_category[cat]))
         lines.append("")
 
-    # Diagnostic edge metrics summary (overall only)
-    overall = comparison.get("overall", {})
-    diag_metrics = [
-        ("Conditional Accuracy", "conditional_accuracy_rate", False),
-        ("Brier (no trade)", "brier_no_trade", True),
-        ("Brier (small trade)", "brier_small_trade", True),
-        ("Brier (large trade)", "brier_large_trade", True),
-        ("Directional Bias (|abs|)", "directional_bias", True),
-    ]
+    _format_diagnostic_table(comparison.get("overall", {}), lines)
+
+    return "\n".join(lines)
+
+
+_DIAG_METRICS = [
+    ("Conditional Accuracy", "conditional_accuracy_rate"),
+    ("Brier (no trade)", "brier_no_trade"),
+    ("Brier (small trade)", "brier_small_trade"),
+    ("Brier (large trade)", "brier_large_trade"),
+    ("Directional Bias (|abs|)", "directional_bias"),
+]
+
+
+def _format_diagnostic_table(overall: dict[str, Any], lines: list[str]) -> None:
+    """Append the diagnostic edge metrics comparison table to *lines*.
+
+    :param overall: overall comparison stats dict.
+    :param lines: output list to append to.
+    """
     has_diag = any(
         (overall.get(m) or {}).get("baseline") is not None
         or (overall.get(m) or {}).get("candidate") is not None
-        for _, m, _ in diag_metrics
+        for _, m in _DIAG_METRICS
     )
-    if has_diag:
-        lines.append("## Diagnostic Edge Metrics")
-        lines.append("")
-        lines.append("| Metric | Baseline | Candidate | Delta | Direction |")
-        lines.append("|--------|----------|-----------|-------|-----------|")
-        for label, key, _lower_better in diag_metrics:
-            m = overall.get(key, {})
-            if not m:
-                continue
-            b_val = m.get("baseline")
-            c_val = m.get("candidate")
-            if key == "directional_bias":
-                b_display = _fmt(abs(b_val) if b_val is not None else None)
-                c_display = _fmt(abs(c_val) if c_val is not None else None)
-            else:
-                b_display = _fmt(b_val)
-                c_display = _fmt(c_val)
-            lines.append(
-                f"| {label} "
-                f"| {b_display} "
-                f"| {c_display} "
-                f"| {_fmt_delta(m.get('delta'))} "
-                f"| {m.get('direction', '—')} |"
-            )
-        lines.append("")
+    if not has_diag:
+        return
 
-    return "\n".join(lines)
+    lines.append("## Diagnostic Edge Metrics")
+    lines.append("")
+    lines.append("| Metric | Baseline | Candidate | Delta | Direction |")
+    lines.append("|--------|----------|-----------|-------|-----------|")
+    for label, key in _DIAG_METRICS:
+        m = overall.get(key, {})
+        if not m:
+            continue
+        b_val = m.get("baseline")
+        c_val = m.get("candidate")
+        if key == "directional_bias":
+            b_display = _fmt(abs(b_val) if b_val is not None else None)
+            c_display = _fmt(abs(c_val) if c_val is not None else None)
+        else:
+            b_display = _fmt(b_val)
+            c_display = _fmt(c_val)
+        lines.append(
+            f"| {label} "
+            f"| {b_display} "
+            f"| {c_display} "
+            f"| {_fmt_delta(m.get('delta'))} "
+            f"| {m.get('direction', '—')} |"
+        )
+    lines.append("")
 
 
 # ---------------------------------------------------------------------------

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -311,10 +311,18 @@ def format_markdown(comparison: dict[str, Any]) -> str:
             m = overall.get(key, {})
             if not m:
                 continue
+            b_val = m.get("baseline")
+            c_val = m.get("candidate")
+            if key == "directional_bias":
+                b_display = _fmt(abs(b_val) if b_val is not None else None)
+                c_display = _fmt(abs(c_val) if c_val is not None else None)
+            else:
+                b_display = _fmt(b_val)
+                c_display = _fmt(c_val)
             lines.append(
                 f"| {label} "
-                f"| {_fmt(m.get('baseline'))} "
-                f"| {_fmt(m.get('candidate'))} "
+                f"| {b_display} "
+                f"| {c_display} "
                 f"| {_fmt_delta(m.get('delta'))} "
                 f"| {m.get('direction', '—')} |"
             )

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -287,7 +287,11 @@ def format_markdown(comparison: dict[str, Any]) -> str:
         ("Brier (large trade)", "brier_large_trade", True),
         ("Directional Bias (|abs|)", "directional_bias", True),
     ]
-    has_diag = any(overall.get(m) for _, m, _ in diag_metrics)
+    has_diag = any(
+        (overall.get(m) or {}).get("baseline") is not None
+        or (overall.get(m) or {}).get("candidate") is not None
+        for _, m, _ in diag_metrics
+    )
     if has_diag:
         lines.append("## Diagnostic Edge Metrics")
         lines.append("")

--- a/benchmark/compare.py
+++ b/benchmark/compare.py
@@ -93,18 +93,28 @@ def compare_stats(
             "direction": _direction(d, opts["lower_is_better"]),
         }
 
-    # Directional bias — closer to 0 is better (use abs comparison)
+    # Directional bias — closer to 0 is better (use abs comparison).
+    # A sign-flip with same magnitude (e.g. +0.05 → -0.05) yields
+    # abs-delta=0 but is qualitatively significant — flag it explicitly.
     b_bias = baseline.get("directional_bias")
     c_bias = candidate.get("directional_bias")
     bias_delta = _delta(
         abs(b_bias) if b_bias is not None else None,
         abs(c_bias) if c_bias is not None else None,
     )
+    bias_direction = _direction(bias_delta, lower_is_better=True)
+    if (
+        b_bias is not None
+        and c_bias is not None
+        and (b_bias > 0) != (c_bias > 0)
+        and bias_direction == "unchanged"
+    ):
+        bias_direction = "sign-flip"
     result["directional_bias"] = {
         "baseline": b_bias,
         "candidate": c_bias,
         "delta": bias_delta,
-        "direction": _direction(bias_delta, lower_is_better=True),
+        "direction": bias_direction,
     }
 
     return result

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -45,6 +45,13 @@ Summarize this Olas Predict benchmark report using EXACTLY this structure (outpu
 
 *Regressions:* any tools or metrics that worsened vs prior period. Say "None" if trend data shows no worsening. "Regression" means worse over TIME, not just a bad score.
 
+*Diagnostics:*
+If the report includes "Diagnostic Edge Metrics", summarize:
+• Conditional accuracy: X% tool-wins when disagreeing (n=X) — when the tool would trigger a trade, how often is it closer to truth than the market?
+• Disagreement Brier (large trade): X.XX — prediction accuracy on high-disagreement questions where PnL impact is highest
+• Directional bias: ±X.XX — positive = tool overestimates, negative = underestimates, near 0 = no systematic bias
+Only include this section if the report has diagnostic metric data. Skip if insufficient data.
+
 *Recommended actions:* 2-3 concrete next steps based on the data. If edge is negative for all tools, this is important — recommend specific improvements.
 
 Rules:

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -162,9 +162,7 @@ def _is_edge_eligible(row: dict[str, Any]) -> bool:
 # ---------------------------------------------------------------------------
 
 
-def classify_disagreement(
-    p_yes: float, market_prob: float, outcome: bool
-) -> str:
+def classify_disagreement(p_yes: float, market_prob: float, outcome: bool) -> str:
     """Classify whether tool or market was closer to the outcome.
 
     :param p_yes: tool's predicted probability.
@@ -282,7 +280,11 @@ def _compute_edge_diagnostics(
     # Diagnostic edge metrics
     tool_wins = 0
     disagree_n = 0
-    bucket_brier: dict[str, float] = {"no_trade": 0.0, "small_trade": 0.0, "large_trade": 0.0}
+    bucket_brier: dict[str, float] = {
+        "no_trade": 0.0,
+        "small_trade": 0.0,
+        "large_trade": 0.0,
+    }
     bucket_n: dict[str, int] = {"no_trade": 0, "small_trade": 0, "large_trade": 0}
     bias_sum = 0.0
     n_bias_losses = 0
@@ -1057,6 +1059,17 @@ def _derive_group(group: dict[str, Any]) -> dict[str, Any]:
         result["edge_positive_rate"] = None
 
     # Diagnostic edge metrics — conditional accuracy, disagreement Brier, bias
+    _derive_diagnostic_metrics(group, result)
+
+    return result
+
+
+def _derive_diagnostic_metrics(group: dict[str, Any], result: dict[str, Any]) -> None:
+    """Derive diagnostic edge metrics from accumulators into *result*.
+
+    :param group: accumulator dict with diagnostic keys.
+    :param result: output dict to populate (mutated in place).
+    """
     disagree_n = group.get("disagree_n", 0)
     result["disagree_n"] = disagree_n
     if disagree_n >= MIN_SAMPLE_SIZE:
@@ -1082,8 +1095,6 @@ def _derive_group(group: dict[str, Any]) -> dict[str, Any]:
         result["directional_bias"] = round(group["bias_sum"] / n_losses, 4)
     else:
         result["directional_bias"] = None
-
-    return result
 
 
 def _ensure_and_accumulate(
@@ -1419,11 +1430,16 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
         restored["edge_positive_count"] = g.get("edge_positive_count", 0)
         # Diagnostic edge metrics — default to 0 for pre-existing scores
         for key in (
-            "disagree_tool_win_count", "disagree_n",
-            "brier_sum_no_trade", "n_no_trade",
-            "brier_sum_small_trade", "n_small_trade",
-            "brier_sum_large_trade", "n_large_trade",
-            "bias_sum", "n_bias_losses",
+            "disagree_tool_win_count",
+            "disagree_n",
+            "brier_sum_no_trade",
+            "n_no_trade",
+            "brier_sum_small_trade",
+            "n_small_trade",
+            "brier_sum_large_trade",
+            "n_large_trade",
+            "bias_sum",
+            "n_bias_losses",
         ):
             restored[key] = g.get(key, restored[key])
         return restored

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -45,6 +45,11 @@ RELIABILITY_GATE = 0.80
 MIN_SAMPLE_SIZE = 30
 MIN_CALIBRATION_BIN_SIZE = 20
 
+# Diagnostic edge metric thresholds (PROPOSAL.md Stage 4).
+# Fixed for now — will version if changed.
+DISAGREE_THRESHOLD = 0.03
+LARGE_TRADE_THRESHOLD = 0.10
+
 # Keys that must be persisted in scores.json for incremental resume.
 # Used in update() and rebuild() when merging accumulators into output.
 _ACCUM_KEYS = (
@@ -58,6 +63,17 @@ _ACCUM_KEYS = (
     "edge_sum",
     "edge_n",
     "edge_positive_count",
+    # Diagnostic edge metrics (PROPOSAL.md Stage 4)
+    "disagree_tool_win_count",
+    "disagree_n",
+    "brier_sum_no_trade",
+    "n_no_trade",
+    "brier_sum_small_trade",
+    "n_small_trade",
+    "brier_sum_large_trade",
+    "n_large_trade",
+    "bias_sum",
+    "n_bias_losses",
 )
 
 
@@ -142,6 +158,46 @@ def _is_edge_eligible(row: dict[str, Any]) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Diagnostic edge metric helpers (PROPOSAL.md Stage 4)
+# ---------------------------------------------------------------------------
+
+
+def classify_disagreement(
+    p_yes: float, market_prob: float, outcome: bool
+) -> str:
+    """Classify whether tool or market was closer to the outcome.
+
+    :param p_yes: tool's predicted probability.
+    :param market_prob: market probability at prediction time.
+    :param outcome: actual outcome (True = yes).
+    :return: ``"tool_win"``, ``"market_win"``, or ``"tie"``.
+    """
+    outcome_val = 1.0 if outcome else 0.0
+    tool_dist = abs(p_yes - outcome_val)
+    market_dist = abs(market_prob - outcome_val)
+    if tool_dist < market_dist:
+        return "tool_win"
+    if tool_dist > market_dist:
+        return "market_win"
+    return "tie"
+
+
+def disagree_bucket(p_yes: float, market_prob: float) -> str:
+    """Bucket a prediction by disagreement magnitude with the market.
+
+    :param p_yes: tool's predicted probability.
+    :param market_prob: market probability at prediction time.
+    :return: ``"no_trade"``, ``"small_trade"``, or ``"large_trade"``.
+    """
+    d = round(abs(p_yes - market_prob), 10)
+    if d <= DISAGREE_THRESHOLD:
+        return "no_trade"
+    if d <= LARGE_TRADE_THRESHOLD:
+        return "small_trade"
+    return "large_trade"
+
+
+# ---------------------------------------------------------------------------
 # Difficulty and liquidity classification
 # ---------------------------------------------------------------------------
 
@@ -186,20 +242,34 @@ def classify_liquidity(liquidity_usd: float | None) -> str:
     return "high"
 
 
+_DIAGNOSTIC_NONE: dict[str, Any] = {
+    "edge": None,
+    "edge_n": 0,
+    "edge_positive_rate": None,
+    "conditional_accuracy_rate": None,
+    "disagree_n": 0,
+    "brier_no_trade": None,
+    "n_no_trade": 0,
+    "brier_small_trade": None,
+    "n_small_trade": 0,
+    "brier_large_trade": None,
+    "n_large_trade": 0,
+    "directional_bias": None,
+    "n_bias_losses": 0,
+}
+
+
 def _compute_edge_diagnostics(
     edge_rows: list[dict[str, Any]],
 ) -> dict[str, Any]:
-    """Compute edge-over-market metrics for edge-eligible rows.
+    """Compute edge-over-market and diagnostic metrics for edge-eligible rows.
 
     :param edge_rows: valid rows that have market_prob_at_prediction.
-    :return: dict with edge, edge_n, edge_positive_rate.
+    :return: dict with edge, conditional accuracy, disagreement Brier,
+        and directional bias metrics.
     """
     if not edge_rows:
-        return {
-            "edge": None,
-            "edge_n": 0,
-            "edge_positive_rate": None,
-        }
+        return dict(_DIAGNOSTIC_NONE)
 
     edges = [
         edge_score(r["p_yes"], r["market_prob_at_prediction"], r["final_outcome"])
@@ -209,11 +279,59 @@ def _compute_edge_diagnostics(
     edge_positive = sum(1 for e in edges if e > 0)
     edge_pos_rate = round(edge_positive / len(edges), 4)
 
-    return {
+    # Diagnostic edge metrics
+    tool_wins = 0
+    disagree_n = 0
+    bucket_brier: dict[str, float] = {"no_trade": 0.0, "small_trade": 0.0, "large_trade": 0.0}
+    bucket_n: dict[str, int] = {"no_trade": 0, "small_trade": 0, "large_trade": 0}
+    bias_sum = 0.0
+    n_bias_losses = 0
+
+    for r in edge_rows:
+        p_yes = r["p_yes"]
+        market_prob = r["market_prob_at_prediction"]
+        outcome = r["final_outcome"]
+        brier = brier_score(p_yes, outcome)
+
+        bucket = disagree_bucket(p_yes, market_prob)
+        bucket_brier[bucket] += brier
+        bucket_n[bucket] += 1
+
+        if bucket != "no_trade":
+            result = classify_disagreement(p_yes, market_prob, outcome)
+            if result != "tie":
+                disagree_n += 1
+                if result == "tool_win":
+                    tool_wins += 1
+                else:
+                    bias_sum += p_yes - (1.0 if outcome else 0.0)
+                    n_bias_losses += 1
+
+    diag: dict[str, Any] = {
         "edge": edge_avg,
         "edge_n": len(edge_rows),
         "edge_positive_rate": edge_pos_rate,
+        "disagree_n": disagree_n,
+        "n_bias_losses": n_bias_losses,
     }
+
+    diag["conditional_accuracy_rate"] = (
+        round(tool_wins / disagree_n, 4) if disagree_n >= MIN_SAMPLE_SIZE else None
+    )
+
+    for bucket in ("no_trade", "small_trade", "large_trade"):
+        diag[f"n_{bucket}"] = bucket_n[bucket]
+        diag[f"brier_{bucket}"] = (
+            round(bucket_brier[bucket] / bucket_n[bucket], 4)
+            if bucket_n[bucket] >= MIN_SAMPLE_SIZE
+            else None
+        )
+
+    diag["directional_bias"] = (
+        round(bias_sum / n_bias_losses, 4) if n_bias_losses >= MIN_SAMPLE_SIZE else None
+    )
+
+    return diag
 
 
 def compute_group_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
@@ -242,9 +360,7 @@ def compute_group_stats(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "outcome_yes_rate": None,
         "baseline_brier": None,
         "brier_skill_score": None,
-        "edge": None,
-        "edge_n": 0,
-        "edge_positive_rate": None,
+        **_DIAGNOSTIC_NONE,
     }
     if total == 0:
         return dict(_none_stats)
@@ -769,6 +885,17 @@ def _empty_group() -> dict[str, Any]:
         "edge_sum": 0.0,
         "edge_n": 0,
         "edge_positive_count": 0,
+        # Diagnostic edge metrics
+        "disagree_tool_win_count": 0,
+        "disagree_n": 0,
+        "brier_sum_no_trade": 0.0,
+        "n_no_trade": 0,
+        "brier_sum_small_trade": 0.0,
+        "n_small_trade": 0,
+        "brier_sum_large_trade": 0.0,
+        "n_large_trade": 0,
+        "bias_sum": 0.0,
+        "n_bias_losses": 0,
     }
 
 
@@ -836,11 +963,25 @@ def _accumulate_group(group: dict[str, Any], row: dict[str, Any]) -> None:
         # Edge over market
         market_prob = row.get("market_prob_at_prediction")
         if market_prob is not None:
+            brier = brier_score(p_yes, outcome)
             edge = edge_score(p_yes, market_prob, outcome)
             group["edge_sum"] += edge
             group["edge_n"] += 1
             if edge > 0:
                 group["edge_positive_count"] += 1
+            # Diagnostic edge metrics
+            bucket = disagree_bucket(p_yes, market_prob)
+            group[f"brier_sum_{bucket}"] += brier
+            group[f"n_{bucket}"] += 1
+            if bucket != "no_trade":
+                result = classify_disagreement(p_yes, market_prob, outcome)
+                if result != "tie":
+                    group["disagree_n"] += 1
+                    if result == "tool_win":
+                        group["disagree_tool_win_count"] += 1
+                    else:
+                        group["bias_sum"] += p_yes - (1.0 if outcome else 0.0)
+                        group["n_bias_losses"] += 1
 
 
 def _derive_group(group: dict[str, Any]) -> dict[str, Any]:
@@ -914,6 +1055,33 @@ def _derive_group(group: dict[str, Any]) -> dict[str, Any]:
     else:
         result["edge"] = None
         result["edge_positive_rate"] = None
+
+    # Diagnostic edge metrics — conditional accuracy, disagreement Brier, bias
+    disagree_n = group.get("disagree_n", 0)
+    result["disagree_n"] = disagree_n
+    if disagree_n >= MIN_SAMPLE_SIZE:
+        result["conditional_accuracy_rate"] = round(
+            group["disagree_tool_win_count"] / disagree_n, 4
+        )
+    else:
+        result["conditional_accuracy_rate"] = None
+
+    for bucket in ("no_trade", "small_trade", "large_trade"):
+        n_bucket = group.get(f"n_{bucket}", 0)
+        result[f"n_{bucket}"] = n_bucket
+        if n_bucket >= MIN_SAMPLE_SIZE:
+            result[f"brier_{bucket}"] = round(
+                group[f"brier_sum_{bucket}"] / n_bucket, 4
+            )
+        else:
+            result[f"brier_{bucket}"] = None
+
+    n_losses = group.get("n_bias_losses", 0)
+    result["n_bias_losses"] = n_losses
+    if n_losses >= MIN_SAMPLE_SIZE:
+        result["directional_bias"] = round(group["bias_sum"] / n_losses, 4)
+    else:
+        result["directional_bias"] = None
 
     return result
 
@@ -1236,20 +1404,29 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
         return None
 
     def _restore_group(g: dict[str, Any]) -> dict[str, Any]:
-        return {
-            "n": g["n"],
-            "valid_n": g["valid_n"],
-            "brier_sum": g["brier_sum"],
-            "correct_count": g["correct_count"],
-            "n_directional": g.get("n_directional", 0),
-            "no_signal_count": g.get("no_signal_count", 0),
-            "sharpness_sum": g["sharpness_sum"],
-            "outcome_yes_count": g.get("outcome_yes_count", 0),
-            "log_loss_sum": g.get("log_loss_sum", 0.0),
-            "edge_sum": g.get("edge_sum", 0.0),
-            "edge_n": g.get("edge_n", 0),
-            "edge_positive_count": g.get("edge_positive_count", 0),
-        }
+        restored = _empty_group()
+        restored["n"] = g["n"]
+        restored["valid_n"] = g["valid_n"]
+        restored["brier_sum"] = g["brier_sum"]
+        restored["correct_count"] = g["correct_count"]
+        restored["n_directional"] = g.get("n_directional", 0)
+        restored["no_signal_count"] = g.get("no_signal_count", 0)
+        restored["sharpness_sum"] = g["sharpness_sum"]
+        restored["outcome_yes_count"] = g.get("outcome_yes_count", 0)
+        restored["log_loss_sum"] = g.get("log_loss_sum", 0.0)
+        restored["edge_sum"] = g.get("edge_sum", 0.0)
+        restored["edge_n"] = g.get("edge_n", 0)
+        restored["edge_positive_count"] = g.get("edge_positive_count", 0)
+        # Diagnostic edge metrics — default to 0 for pre-existing scores
+        for key in (
+            "disagree_tool_win_count", "disagree_n",
+            "brier_sum_no_trade", "n_no_trade",
+            "brier_sum_small_trade", "n_small_trade",
+            "brier_sum_large_trade", "n_large_trade",
+            "bias_sum", "n_bias_losses",
+        ):
+            restored[key] = g.get(key, restored[key])
+        return restored
 
     scores: dict[str, Any] = {
         "current_month": data["current_month"],

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -21,7 +21,7 @@ import math
 import random
 import re
 from collections import defaultdict
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -1738,32 +1738,38 @@ def score_period(
     logs_dir: Path = DEFAULT_LOGS_DIR,
     days: int = 1,
 ) -> dict[str, Any]:
-    """Score a recent subset of daily log files.
+    """Score rows whose ``predicted_at`` falls within the last *days* days.
 
-    Finds the most recent *days* log files in *logs_dir* and runs the
-    batch ``score()`` on their combined rows. Used for "since last report"
-    (days=1) and "rolling 7-day" (days=7) sections.
+    Reads all log files in *logs_dir*, filters rows by timestamp, and
+    runs ``score()`` on the matching subset.  This works correctly even
+    when all data lands in a single file (e.g. after a force rebuild),
+    when multiple files cover the same date, or when days are missing.
 
     Handles both ``YYYY-MM-DD.jsonl`` and ``production_log_YYYY_MM_DD.jsonl``
     naming conventions (the flywheel uses the latter).
 
     :param logs_dir: directory containing daily log files.
-    :param days: how many of the most recent files to include.
-    :return: scores dict from ``score()``, or empty scores if no files.
+    :param days: score rows from the last N calendar days.
+    :return: scores dict from ``score()``, or empty scores if no matching rows.
     """
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
+
     # Both naming conventions: YYYY-MM-DD.jsonl and production_log_YYYY_MM_DD.jsonl
     daily_pattern = str(logs_dir / "????-??-??.jsonl")
     prod_pattern = str(logs_dir / "production_log_*.jsonl")
-    # Merge, deduplicate, sort by extracted date (not lexicographic filename)
     all_files = sorted(
         set(glob_mod.glob(daily_pattern) + glob_mod.glob(prod_pattern)),
         key=_extract_date_from_log_path,
     )
-    recent = all_files[-days:] if all_files else []
 
     rows: list[dict[str, Any]] = []
-    for filepath in recent:
-        rows.extend(load_rows(Path(filepath)))
+    for filepath in all_files:
+        for row in load_rows(Path(filepath)):
+            predicted_at = row.get("predicted_at") or ""
+            if predicted_at >= cutoff:
+                rows.append(row)
 
     if not rows:
         return score([])

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -368,6 +368,7 @@ class TestGenerateReport:
         assert "## Best Predictions" in report
         assert "## Trend" in report
         assert "## Sample Size Warnings" in report
+        assert "## Diagnostic Edge Metrics" in report
 
     def test_empty_data_no_crash(self) -> None:
         """Test empty data does not crash."""

--- a/benchmark/tests/test_compare.py
+++ b/benchmark/tests/test_compare.py
@@ -101,6 +101,16 @@ class TestCompareDiagnosticMetrics:
         assert db["delta"] == 0.06
         assert db["direction"] == "regressed"
 
+    def test_directional_bias_sign_flip_same_magnitude(self) -> None:
+        """Bias +0.05 → -0.05: abs-delta=0 but sign flipped."""
+        baseline = _stats(directional_bias=0.05)
+        candidate = _stats(directional_bias=-0.05)
+        result = compare_stats(baseline, candidate)
+
+        db = result["directional_bias"]
+        assert abs(db["delta"]) < 0.001
+        assert db["direction"] == "sign-flip"
+
     def test_none_values_produce_dashes(self) -> None:
         """None baseline or candidate → delta is None, direction is '—'."""
         baseline = _stats(conditional_accuracy_rate=None)

--- a/benchmark/tests/test_compare.py
+++ b/benchmark/tests/test_compare.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Tests for benchmark/compare.py — diagnostic edge metric deltas."""
+
+from typing import Any
+
+from benchmark.compare import compare_stats, format_markdown
+
+
+def _stats(**overrides: Any) -> dict[str, Any]:
+    """Build a minimal stats dict with defaults."""
+    base: dict[str, Any] = {
+        "brier": 0.25,
+        "log_loss": 0.5,
+        "directional_accuracy": 0.7,
+        "sharpness": 0.2,
+        "reliability": 0.95,
+        "n": 100,
+        "valid_n": 95,
+        "conditional_accuracy_rate": None,
+        "brier_no_trade": None,
+        "brier_small_trade": None,
+        "brier_large_trade": None,
+        "directional_bias": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCompareDiagnosticMetrics:
+    """Tests for diagnostic metric deltas in compare_stats."""
+
+    def test_conditional_accuracy_improved(self) -> None:
+        """Higher conditional accuracy → improved."""
+        baseline = _stats(conditional_accuracy_rate=0.65)
+        candidate = _stats(conditional_accuracy_rate=0.75)
+        result = compare_stats(baseline, candidate)
+
+        ca = result["conditional_accuracy_rate"]
+        assert ca["baseline"] == 0.65
+        assert ca["candidate"] == 0.75
+        assert ca["delta"] == 0.1
+        assert ca["direction"] == "improved"
+
+    def test_brier_large_trade_improved(self) -> None:
+        """Lower brier on large trades → improved."""
+        baseline = _stats(brier_large_trade=0.30)
+        candidate = _stats(brier_large_trade=0.25)
+        result = compare_stats(baseline, candidate)
+
+        bl = result["brier_large_trade"]
+        assert bl["delta"] == -0.05
+        assert bl["direction"] == "improved"
+
+    def test_directional_bias_toward_zero_improved(self) -> None:
+        """Bias moving from +0.08 toward 0 → improved."""
+        baseline = _stats(directional_bias=0.08)
+        candidate = _stats(directional_bias=0.03)
+        result = compare_stats(baseline, candidate)
+
+        db = result["directional_bias"]
+        assert db["baseline"] == 0.08
+        assert db["candidate"] == 0.03
+        # abs delta: 0.03 - 0.08 = -0.05 (lower abs = improved)
+        assert db["delta"] == -0.05
+        assert db["direction"] == "improved"
+
+    def test_directional_bias_sign_flip_improved(self) -> None:
+        """Bias from +0.08 to -0.02 → improved (closer to 0)."""
+        baseline = _stats(directional_bias=0.08)
+        candidate = _stats(directional_bias=-0.02)
+        result = compare_stats(baseline, candidate)
+
+        db = result["directional_bias"]
+        # abs: 0.02 - 0.08 = -0.06
+        assert db["delta"] == -0.06
+        assert db["direction"] == "improved"
+
+    def test_directional_bias_away_from_zero_regressed(self) -> None:
+        """Bias from +0.02 to -0.08 → regressed (further from 0)."""
+        baseline = _stats(directional_bias=0.02)
+        candidate = _stats(directional_bias=-0.08)
+        result = compare_stats(baseline, candidate)
+
+        db = result["directional_bias"]
+        # abs: 0.08 - 0.02 = +0.06
+        assert db["delta"] == 0.06
+        assert db["direction"] == "regressed"
+
+    def test_none_values_produce_dashes(self) -> None:
+        """None baseline or candidate → delta is None, direction is '—'."""
+        baseline = _stats(conditional_accuracy_rate=None)
+        candidate = _stats(conditional_accuracy_rate=0.75)
+        result = compare_stats(baseline, candidate)
+
+        ca = result["conditional_accuracy_rate"]
+        assert ca["delta"] is None
+        assert ca["direction"] == "—"
+
+    def test_format_markdown_includes_diagnostics(self) -> None:
+        """format_markdown includes diagnostic section when data present."""
+        baseline = _stats(
+            conditional_accuracy_rate=0.65,
+            brier_large_trade=0.30,
+            directional_bias=0.08,
+        )
+        candidate = _stats(
+            conditional_accuracy_rate=0.75,
+            brier_large_trade=0.25,
+            directional_bias=0.03,
+        )
+        comparison = {
+            "overall": compare_stats(baseline, candidate),
+            "by_tool": {},
+            "by_platform": {},
+            "by_category": {},
+        }
+        md = format_markdown(comparison)
+        assert "## Diagnostic Edge Metrics" in md
+        assert "Conditional Accuracy" in md
+        assert "Brier (large trade)" in md
+        assert "Directional Bias" in md

--- a/benchmark/tests/test_compare.py
+++ b/benchmark/tests/test_compare.py
@@ -88,7 +88,6 @@ class TestCompareDiagnosticMetrics:
         result = compare_stats(baseline, candidate)
 
         db = result["directional_bias"]
-        # abs: 0.02 - 0.08 = -0.06
         assert db["delta"] == -0.06
         assert db["direction"] == "improved"
 
@@ -99,7 +98,6 @@ class TestCompareDiagnosticMetrics:
         result = compare_stats(baseline, candidate)
 
         db = result["directional_bias"]
-        # abs: 0.08 - 0.02 = +0.06
         assert db["delta"] == 0.06
         assert db["direction"] == "regressed"
 

--- a/benchmark/tests/test_compare.py
+++ b/benchmark/tests/test_compare.py
@@ -136,3 +136,16 @@ class TestCompareDiagnosticMetrics:
         assert "Conditional Accuracy" in md
         assert "Brier (large trade)" in md
         assert "Directional Bias" in md
+
+    def test_format_markdown_hides_diagnostics_when_all_none(self) -> None:
+        """No diagnostic table when all values are None."""
+        baseline = _stats()  # all diagnostic keys are None
+        candidate = _stats()
+        comparison = {
+            "overall": compare_stats(baseline, candidate),
+            "by_tool": {},
+            "by_platform": {},
+            "by_category": {},
+        }
+        md = format_markdown(comparison)
+        assert "## Diagnostic Edge Metrics" not in md

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -20,7 +20,7 @@
 
 import json
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -1657,40 +1657,61 @@ class TestDeriveGroupSchema:
 
 
 class TestScorePeriod:
-    """Tests for score_period."""
+    """Tests for score_period — timestamp-based filtering."""
 
-    def test_picks_most_recent_by_date(self, tmp_path: Path) -> None:
-        """days=1 picks the most recent file regardless of naming convention."""
+    def _ts(self, days_ago: int) -> str:
+        """Return an ISO timestamp *days_ago* days in the past.
+
+        :param days_ago: how many days before now.
+        :return: ISO 8601 UTC timestamp string.
+        """
+        dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def test_filters_by_timestamp_not_file(self, tmp_path: Path) -> None:
+        """days=1 includes rows from the last 24h regardless of file name."""
         logs = tmp_path / "logs"
         logs.mkdir()
 
-        old_row = _row(p_yes=0.7, outcome=True, predicted_at="2026-04-05T10:00:00Z")
-        new_row = _row(p_yes=0.3, outcome=False, predicted_at="2026-04-07T10:00:00Z")
+        old_row = _row(p_yes=0.7, outcome=True, predicted_at=self._ts(5))
+        new_row = _row(p_yes=0.3, outcome=False, predicted_at=self._ts(0))
 
-        (logs / "production_log_2026_04_05.jsonl").write_text(
-            json.dumps(old_row) + "\n"
+        (logs / "production_log_2020_01_01.jsonl").write_text(
+            json.dumps(old_row) + "\n" + json.dumps(new_row) + "\n"
         )
-        (logs / "2026-04-07.jsonl").write_text(json.dumps(new_row) + "\n")
 
         result = score_period(logs, days=1)
         assert result["total_rows"] == 1
-        # The newest file (2026-04-07) should be selected
         assert result["overall"]["brier"] is not None
 
-    def test_mixed_naming_days2(self, tmp_path: Path) -> None:
-        """days=2 picks two most recent across both naming conventions."""
+    def test_days7_includes_recent_week(self, tmp_path: Path) -> None:
+        """days=7 includes rows from the last 7 calendar days."""
         logs = tmp_path / "logs"
         logs.mkdir()
 
-        for name, p, dt in [
-            ("production_log_2026_04_05.jsonl", 0.7, "2026-04-05T10:00:00Z"),
-            ("2026-04-06.jsonl", 0.4, "2026-04-06T10:00:00Z"),
-            ("production_log_2026_04_07.jsonl", 0.9, "2026-04-07T10:00:00Z"),
-        ]:
-            row = _row(p_yes=p, outcome=True, predicted_at=dt)
-            (logs / name).write_text(json.dumps(row) + "\n")
+        rows_data = [
+            _row(p_yes=0.7, outcome=True, predicted_at=self._ts(10)),
+            _row(p_yes=0.4, outcome=True, predicted_at=self._ts(3)),
+            _row(p_yes=0.9, outcome=True, predicted_at=self._ts(0)),
+        ]
+        content = "\n".join(json.dumps(r) for r in rows_data) + "\n"
+        (logs / "production_log_2020_01_01.jsonl").write_text(content)
 
-        result = score_period(logs, days=2)
+        result = score_period(logs, days=7)
+        assert result["total_rows"] == 2
+
+    def test_reads_both_naming_conventions(self, tmp_path: Path) -> None:
+        """Rows from both file naming conventions are included."""
+        logs = tmp_path / "logs"
+        logs.mkdir()
+
+        row_a = _row(p_yes=0.6, outcome=True, predicted_at=self._ts(0))
+        row_b = _row(p_yes=0.4, outcome=False, predicted_at=self._ts(0))
+
+        (logs / "production_log_2020_01_01.jsonl").write_text(json.dumps(row_a) + "\n")
+        (logs / "2020-01-02.jsonl").write_text(json.dumps(row_b) + "\n")
+
+        result = score_period(logs, days=1)
         assert result["total_rows"] == 2
 
     def test_empty_dir(self, tmp_path: Path) -> None:

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -29,7 +29,6 @@ from benchmark.scorer import (
     DISAGREE_THRESHOLD,
     LARGE_TRADE_THRESHOLD,
     LATENCY_RESERVOIR_SIZE,
-    MIN_SAMPLE_SIZE,
     WORST_BEST_SIZE,
     _accumulate_group,
     _derive_group,
@@ -1741,41 +1740,22 @@ class TestClassifyDisagreement:
 
     def test_tool_wins(self) -> None:
         """Tool closer to truth."""
-        # p_yes=0.8, market=0.3, outcome=True(1.0)
-        # tool_dist=0.2, market_dist=0.7
         assert classify_disagreement(0.8, 0.3, True) == "tool_win"
 
     def test_market_wins(self) -> None:
         """Market closer to truth."""
-        # p_yes=0.3, market=0.8, outcome=True(1.0)
-        # tool_dist=0.7, market_dist=0.2
         assert classify_disagreement(0.3, 0.8, True) == "market_win"
 
     def test_tie(self) -> None:
-        """Both equidistant from truth."""
-        # p_yes=0.6, market=0.4, outcome=True(1.0)
-        # tool_dist=0.4, market_dist=0.6 — NOT a tie
-        # p_yes=0.6, market=0.4, outcome=False(0.0)
-        # tool_dist=0.6, market_dist=0.4 — NOT a tie
-        # Actual tie: p_yes=0.3, market=0.7, outcome=True(1.0)
-        # tool_dist=0.7, market_dist=0.3 — NOT a tie
-        # tie: p_yes=0.7, market=0.3, outcome=False(0.0)
-        # tool_dist=0.7, market_dist=0.3 — NOT a tie
-        # Simple tie: same prediction
+        """Same prediction → both equidistant from truth."""
         assert classify_disagreement(0.5, 0.5, True) == "tie"
 
     def test_symmetric_tie(self) -> None:
-        """Symmetric around outcome — both equally wrong."""
-        # outcome=True(1.0), p_yes=0.4, market=0.6
-        # tool_dist=0.6, market_dist=0.4 → market_win
-        # For a real tie: both have same distance
-        # p_yes=0.3, market_prob=0.3, outcome=True → tie (same prediction)
+        """Identical p_yes and market_prob → tie regardless of outcome."""
         assert classify_disagreement(0.3, 0.3, True) == "tie"
 
     def test_outcome_false(self) -> None:
-        """Outcome is False (0.0)."""
-        # p_yes=0.2, market=0.7, outcome=False(0.0)
-        # tool_dist=0.2, market_dist=0.7
+        """Tool closer when outcome is False."""
         assert classify_disagreement(0.2, 0.7, False) == "tool_win"
 
     def test_extreme_values(self) -> None:
@@ -1830,32 +1810,26 @@ class TestDisagreeBucket:
 class TestDiagnosticAccumulators:
     """Test that diagnostic metrics accumulate correctly and derive properly."""
 
-    def _make_edge_rows(self, n: int = 40) -> list[dict[str, Any]]:
+    def _make_edge_rows(self) -> list[dict[str, Any]]:
         """Build rows with known diagnostic metric outcomes.
 
-        Creates rows where we can hand-calculate expected values:
-        - 20 rows: p_yes=0.8, market=0.3, outcome=True → tool_win, large_trade
-          brier = (0.8 - 1.0)² = 0.04
-        - 10 rows: p_yes=0.3, market=0.8, outcome=True → market_win, large_trade
-          brier = (0.3 - 1.0)² = 0.49, bias = 0.3 - 1.0 = -0.7
-        - 10 rows: p_yes=0.52, market=0.50, outcome=True → no_trade (|d|=0.02)
-          brier = (0.52 - 1.0)² = 0.2304
+        20 tool-win large-trade, 10 market-win large-trade,
+        10 no-trade rows.
+
+        :return: list of production log row dicts.
         """
         rows = []
         for i in range(20):
             rows.append(
-                _row(p_yes=0.8, outcome=True, market_prob=0.3,
-                     row_id=f"diag_tw_{i}")
+                _row(p_yes=0.8, outcome=True, market_prob=0.3, row_id=f"diag_tw_{i}")
             )
         for i in range(10):
             rows.append(
-                _row(p_yes=0.3, outcome=True, market_prob=0.8,
-                     row_id=f"diag_mw_{i}")
+                _row(p_yes=0.3, outcome=True, market_prob=0.8, row_id=f"diag_mw_{i}")
             )
         for i in range(10):
             rows.append(
-                _row(p_yes=0.52, outcome=True, market_prob=0.50,
-                     row_id=f"diag_nt_{i}")
+                _row(p_yes=0.52, outcome=True, market_prob=0.50, row_id=f"diag_nt_{i}")
             )
         return rows
 
@@ -1896,9 +1870,7 @@ class TestDiagnosticAccumulators:
         result = _derive_group(group)
 
         # large_trade: (20 * 0.04 + 10 * 0.49) / 30 = 5.7 / 30 = 0.19
-        assert result["brier_large_trade"] == round(
-            (20 * 0.04 + 10 * 0.49) / 30, 4
-        )
+        assert result["brier_large_trade"] == round((20 * 0.04 + 10 * 0.49) / 30, 4)
         # no_trade: 10 * 0.2304 / 10 = 0.2304
         # n=10 < MIN_SAMPLE_SIZE=30 → None
         assert result["brier_no_trade"] is None
@@ -1921,21 +1893,18 @@ class TestDiagnosticAccumulators:
         group = _empty_group()
         # Need >= 30 market_win rows
         for i in range(35):
-            row = _row(
-                p_yes=0.3, outcome=True, market_prob=0.8,
-                row_id=f"bias_{i}"
-            )
+            row = _row(p_yes=0.3, outcome=True, market_prob=0.8, row_id=f"bias_{i}")
             _accumulate_group(group, row)
         result = _derive_group(group)
 
         assert result["n_bias_losses"] == 35
-        expected_bias = round((0.3 - 1.0), 4)  # each row contributes -0.7
+        expected_bias = round((0.3 - 1.0), 4)
         assert result["directional_bias"] == expected_bias
 
     def test_no_edge_rows_all_none(self) -> None:
         """No edge-eligible rows → all diagnostic metrics are None."""
         group = _empty_group()
-        for i in range(50):
+        for _ in range(50):
             _accumulate_group(group, _row(p_yes=0.7, outcome=True))
         result = _derive_group(group)
 
@@ -1952,9 +1921,7 @@ class TestDiagnosticAccumulators:
         for i in range(50):
             # Same p_yes and market_prob → tie
             _accumulate_group(
-                group,
-                _row(p_yes=0.5, outcome=True, market_prob=0.5,
-                     row_id=f"tie_{i}")
+                group, _row(p_yes=0.5, outcome=True, market_prob=0.5, row_id=f"tie_{i}")
             )
         result = _derive_group(group)
 
@@ -1983,6 +1950,6 @@ class TestDiagnosticAccumulators:
             "n_large_trade",
             "n_bias_losses",
         ):
-            assert batch[key] == incremental[key], (
-                f"{key}: batch={batch[key]} != incremental={incremental[key]}"
-            )
+            assert (
+                batch[key] == incremental[key]
+            ), f"{key}: batch={batch[key]} != incremental={incremental[key]}"

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -26,7 +26,10 @@ from typing import Any
 from unittest.mock import patch
 
 from benchmark.scorer import (
+    DISAGREE_THRESHOLD,
+    LARGE_TRADE_THRESHOLD,
     LATENCY_RESERVOIR_SIZE,
+    MIN_SAMPLE_SIZE,
     WORST_BEST_SIZE,
     _accumulate_group,
     _derive_group,
@@ -34,11 +37,13 @@ from benchmark.scorer import (
     _is_edge_eligible,
     brier_score,
     classify_difficulty,
+    classify_disagreement,
     classify_horizon,
     classify_liquidity,
     compute_calibration_regression,
     compute_ece,
     compute_group_stats,
+    disagree_bucket,
     edge_score,
     group_by,
     group_by_horizon,
@@ -1724,3 +1729,260 @@ class TestCalibrationRegressionDegenerate:
         # May return values or None — either is acceptable, just no crash
         assert "calibration_slope" in result
         assert "calibration_intercept" in result
+
+
+# ---------------------------------------------------------------------------
+# classify_disagreement
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyDisagreement:
+    """Tests for classify_disagreement."""
+
+    def test_tool_wins(self) -> None:
+        """Tool closer to truth."""
+        # p_yes=0.8, market=0.3, outcome=True(1.0)
+        # tool_dist=0.2, market_dist=0.7
+        assert classify_disagreement(0.8, 0.3, True) == "tool_win"
+
+    def test_market_wins(self) -> None:
+        """Market closer to truth."""
+        # p_yes=0.3, market=0.8, outcome=True(1.0)
+        # tool_dist=0.7, market_dist=0.2
+        assert classify_disagreement(0.3, 0.8, True) == "market_win"
+
+    def test_tie(self) -> None:
+        """Both equidistant from truth."""
+        # p_yes=0.6, market=0.4, outcome=True(1.0)
+        # tool_dist=0.4, market_dist=0.6 — NOT a tie
+        # p_yes=0.6, market=0.4, outcome=False(0.0)
+        # tool_dist=0.6, market_dist=0.4 — NOT a tie
+        # Actual tie: p_yes=0.3, market=0.7, outcome=True(1.0)
+        # tool_dist=0.7, market_dist=0.3 — NOT a tie
+        # tie: p_yes=0.7, market=0.3, outcome=False(0.0)
+        # tool_dist=0.7, market_dist=0.3 — NOT a tie
+        # Simple tie: same prediction
+        assert classify_disagreement(0.5, 0.5, True) == "tie"
+
+    def test_symmetric_tie(self) -> None:
+        """Symmetric around outcome — both equally wrong."""
+        # outcome=True(1.0), p_yes=0.4, market=0.6
+        # tool_dist=0.6, market_dist=0.4 → market_win
+        # For a real tie: both have same distance
+        # p_yes=0.3, market_prob=0.3, outcome=True → tie (same prediction)
+        assert classify_disagreement(0.3, 0.3, True) == "tie"
+
+    def test_outcome_false(self) -> None:
+        """Outcome is False (0.0)."""
+        # p_yes=0.2, market=0.7, outcome=False(0.0)
+        # tool_dist=0.2, market_dist=0.7
+        assert classify_disagreement(0.2, 0.7, False) == "tool_win"
+
+    def test_extreme_values(self) -> None:
+        """Test with 0.0 and 1.0 predictions."""
+        assert classify_disagreement(1.0, 0.0, True) == "tool_win"
+        assert classify_disagreement(0.0, 1.0, True) == "market_win"
+        assert classify_disagreement(0.0, 1.0, False) == "tool_win"
+
+
+# ---------------------------------------------------------------------------
+# disagree_bucket
+# ---------------------------------------------------------------------------
+
+
+class TestDisagreeBucket:
+    """Tests for disagree_bucket."""
+
+    def test_no_trade_zero_disagreement(self) -> None:
+        """Identical predictions → no_trade."""
+        assert disagree_bucket(0.5, 0.5) == "no_trade"
+
+    def test_no_trade_at_threshold(self) -> None:
+        """Exactly at DISAGREE_THRESHOLD → no_trade (<=)."""
+        assert disagree_bucket(0.5, 0.5 + DISAGREE_THRESHOLD) == "no_trade"
+
+    def test_small_trade_just_above(self) -> None:
+        """Just above DISAGREE_THRESHOLD → small_trade."""
+        assert disagree_bucket(0.5, 0.5 + DISAGREE_THRESHOLD + 0.001) == "small_trade"
+
+    def test_small_trade_at_large_threshold(self) -> None:
+        """Exactly at LARGE_TRADE_THRESHOLD → small_trade (<=)."""
+        assert disagree_bucket(0.5, 0.5 + LARGE_TRADE_THRESHOLD) == "small_trade"
+
+    def test_large_trade_above(self) -> None:
+        """Above LARGE_TRADE_THRESHOLD → large_trade."""
+        assert disagree_bucket(0.5, 0.5 + LARGE_TRADE_THRESHOLD + 0.01) == "large_trade"
+
+    def test_large_trade_extreme(self) -> None:
+        """Maximum disagreement."""
+        assert disagree_bucket(0.0, 1.0) == "large_trade"
+
+    def test_sign_doesnt_matter(self) -> None:
+        """Negative disagreement (tool < market) uses absolute value."""
+        assert disagree_bucket(0.3, 0.5) == "large_trade"  # |0.3-0.5|=0.2 > 0.10
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic metrics in accumulator path
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticAccumulators:
+    """Test that diagnostic metrics accumulate correctly and derive properly."""
+
+    def _make_edge_rows(self, n: int = 40) -> list[dict[str, Any]]:
+        """Build rows with known diagnostic metric outcomes.
+
+        Creates rows where we can hand-calculate expected values:
+        - 20 rows: p_yes=0.8, market=0.3, outcome=True → tool_win, large_trade
+          brier = (0.8 - 1.0)² = 0.04
+        - 10 rows: p_yes=0.3, market=0.8, outcome=True → market_win, large_trade
+          brier = (0.3 - 1.0)² = 0.49, bias = 0.3 - 1.0 = -0.7
+        - 10 rows: p_yes=0.52, market=0.50, outcome=True → no_trade (|d|=0.02)
+          brier = (0.52 - 1.0)² = 0.2304
+        """
+        rows = []
+        for i in range(20):
+            rows.append(
+                _row(p_yes=0.8, outcome=True, market_prob=0.3,
+                     row_id=f"diag_tw_{i}")
+            )
+        for i in range(10):
+            rows.append(
+                _row(p_yes=0.3, outcome=True, market_prob=0.8,
+                     row_id=f"diag_mw_{i}")
+            )
+        for i in range(10):
+            rows.append(
+                _row(p_yes=0.52, outcome=True, market_prob=0.50,
+                     row_id=f"diag_nt_{i}")
+            )
+        return rows
+
+    def test_accumulate_group_counts(self) -> None:
+        """Verify raw accumulator values after accumulating known rows."""
+        group = _empty_group()
+        for row in self._make_edge_rows():
+            _accumulate_group(group, row)
+
+        # 30 large_trade rows (20 tool_win + 10 market_win)
+        assert group["n_large_trade"] == 30
+        # 10 no_trade rows
+        assert group["n_no_trade"] == 10
+        assert group["n_small_trade"] == 0
+        # disagree_n = 20 tool_wins + 10 market_wins (no ties)
+        assert group["disagree_n"] == 30
+        assert group["disagree_tool_win_count"] == 20
+        # bias losses = 10 market_wins
+        assert group["n_bias_losses"] == 10
+        # bias_sum = 10 * (0.3 - 1.0) = -7.0
+        assert abs(group["bias_sum"] - (-7.0)) < 1e-9
+
+    def test_derive_conditional_accuracy(self) -> None:
+        """Conditional accuracy = tool_wins / disagree_n."""
+        group = _empty_group()
+        for row in self._make_edge_rows():
+            _accumulate_group(group, row)
+        result = _derive_group(group)
+
+        # 20 tool_wins / 30 disagree = 0.6667
+        assert result["conditional_accuracy_rate"] == round(20 / 30, 4)
+
+    def test_derive_disagreement_brier(self) -> None:
+        """Brier per bucket matches hand-calculated values."""
+        group = _empty_group()
+        for row in self._make_edge_rows():
+            _accumulate_group(group, row)
+        result = _derive_group(group)
+
+        # large_trade: (20 * 0.04 + 10 * 0.49) / 30 = 5.7 / 30 = 0.19
+        assert result["brier_large_trade"] == round(
+            (20 * 0.04 + 10 * 0.49) / 30, 4
+        )
+        # no_trade: 10 * 0.2304 / 10 = 0.2304
+        # n=10 < MIN_SAMPLE_SIZE=30 → None
+        assert result["brier_no_trade"] is None
+        assert result["n_no_trade"] == 10
+
+    def test_derive_directional_bias(self) -> None:
+        """Directional bias = mean(p_yes - outcome) for losses."""
+        group = _empty_group()
+        for row in self._make_edge_rows():
+            _accumulate_group(group, row)
+        result = _derive_group(group)
+
+        # 10 losses, bias_sum = -7.0 → bias = -0.7
+        # n=10 < MIN_SAMPLE_SIZE=30 → None
+        assert result["directional_bias"] is None
+        assert result["n_bias_losses"] == 10
+
+    def test_derive_bias_with_enough_samples(self) -> None:
+        """Directional bias computed when n_bias_losses >= MIN_SAMPLE_SIZE."""
+        group = _empty_group()
+        # Need >= 30 market_win rows
+        for i in range(35):
+            row = _row(
+                p_yes=0.3, outcome=True, market_prob=0.8,
+                row_id=f"bias_{i}"
+            )
+            _accumulate_group(group, row)
+        result = _derive_group(group)
+
+        assert result["n_bias_losses"] == 35
+        expected_bias = round((0.3 - 1.0), 4)  # each row contributes -0.7
+        assert result["directional_bias"] == expected_bias
+
+    def test_no_edge_rows_all_none(self) -> None:
+        """No edge-eligible rows → all diagnostic metrics are None."""
+        group = _empty_group()
+        for i in range(50):
+            _accumulate_group(group, _row(p_yes=0.7, outcome=True))
+        result = _derive_group(group)
+
+        assert result["conditional_accuracy_rate"] is None
+        assert result["brier_no_trade"] is None
+        assert result["brier_small_trade"] is None
+        assert result["brier_large_trade"] is None
+        assert result["directional_bias"] is None
+        assert result["disagree_n"] == 0
+
+    def test_all_ties_conditional_accuracy_none(self) -> None:
+        """All ties → disagree_n=0 → conditional accuracy is None."""
+        group = _empty_group()
+        for i in range(50):
+            # Same p_yes and market_prob → tie
+            _accumulate_group(
+                group,
+                _row(p_yes=0.5, outcome=True, market_prob=0.5,
+                     row_id=f"tie_{i}")
+            )
+        result = _derive_group(group)
+
+        assert result["disagree_n"] == 0
+        assert result["conditional_accuracy_rate"] is None
+
+    def test_batch_matches_incremental(self) -> None:
+        """compute_group_stats matches _accumulate_group + _derive_group."""
+        rows = self._make_edge_rows()
+        batch = compute_group_stats(rows)
+
+        group = _empty_group()
+        for row in rows:
+            _accumulate_group(group, row)
+        incremental = _derive_group(group)
+
+        for key in (
+            "conditional_accuracy_rate",
+            "brier_large_trade",
+            "brier_small_trade",
+            "brier_no_trade",
+            "directional_bias",
+            "disagree_n",
+            "n_no_trade",
+            "n_small_trade",
+            "n_large_trade",
+            "n_bias_losses",
+        ):
+            assert batch[key] == incremental[key], (
+                f"{key}: batch={batch[key]} != incremental={incremental[key]}"
+            )

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1869,10 +1869,7 @@ class TestDiagnosticAccumulators:
             _accumulate_group(group, row)
         result = _derive_group(group)
 
-        # large_trade: (20 * 0.04 + 10 * 0.49) / 30 = 5.7 / 30 = 0.19
         assert result["brier_large_trade"] == round((20 * 0.04 + 10 * 0.49) / 30, 4)
-        # no_trade: 10 * 0.2304 / 10 = 0.2304
-        # n=10 < MIN_SAMPLE_SIZE=30 → None
         assert result["brier_no_trade"] is None
         assert result["n_no_trade"] == 10
 


### PR DESCRIPTION
# Add diagnostic edge metrics (conditional accuracy, disagreement Brier, directional bias)

## Summary

Implements the three Stage 4 diagnostic metrics defined in PROPOSAL.md that were deferred from the metrics-changes PR. These answer:

- **"When we bet, do we win?"** — Conditional accuracy when disagreeing
- **"Is accuracy good where it matters for profit?"** — Disagreement-stratified Brier
- **"When we lose, which direction?"** — Directional bias

These are **not ranking metrics** — they diagnose whether prediction accuracy translates to trading value.

## What changed

| File | Change |
|------|--------|
| `benchmark/scorer.py` | Constants (`DISAGREE_THRESHOLD=0.03`, `LARGE_TRADE_THRESHOLD=0.10`), two pure functions (`classify_disagreement`, `disagree_bucket`), 10 new accumulator keys wired into batch + incremental + rebuild paths, backward-compat defaults in `_restore_group` |
| `benchmark/analyze.py` | New `section_diagnostic_metrics()` rendering conditional accuracy (by platform), disagreement Brier (3 buckets), and directional bias (by category) |
| `benchmark/compare.py` | 5 new metrics in `compare_stats()` with directional bias using `abs()` comparison. Diagnostic summary table in `format_markdown()` |
| `benchmark/notify_slack.py` | `*Diagnostics:*` section added to LLM summary prompt |
| `benchmark/tests/test_scorer.py` | 21 new tests: pure functions, accumulators, derivation, MIN_SAMPLE_SIZE guards, ties, batch-vs-incremental equivalence |
| `benchmark/tests/test_analyze.py` | Section header assertion |
| `benchmark/tests/test_compare.py` | 7 new tests: deltas, direction classification, bias sign-flip, None handling, markdown rendering |

## Metric definitions

### Conditional accuracy when disagreeing
- **Filter:** edge-eligible rows where `|p_yes - market_prob| > 0.03`
- **Formula:** `tool_wins / n_disagreements` (ties excluded from both)
- **Output key:** `conditional_accuracy_rate`

### Disagreement-stratified Brier
- **Buckets:** `no_trade` (|d| <= 0.03), `small_trade` (0.03 < |d| <= 0.10), `large_trade` (|d| > 0.10)
- **Per bucket:** standard Brier score
- **Output keys:** `brier_no_trade`, `brier_small_trade`, `brier_large_trade`

### Directional bias
- **Filter:** edge-eligible rows where tool disagrees AND market was closer to truth (ties excluded)
- **Formula:** `mean(p_yes - outcome)` over losing rows
- **Output key:** `directional_bias` (positive = overestimates, negative = underestimates)

## Post-deploy action

After merging, run a one-time rebuild to populate diagnostic accumulators from historical data:

```bash
python -m benchmark.scorer --rebuild --logs-dir benchmark/datasets/logs/
```

Without this, diagnostic metrics will only reflect rows processed after deployment. All other metrics are unaffected.

## Test plan

- [x] 300 tests pass (136 scorer + 24 analyze + 7 compare + 133 others)
- [x] Hand-calculated expected values verified in tests
- [x] Batch path matches incremental path (equivalence test)
- [x] `update()` → `scores.json` → `_load_scores_for_resume()` round-trip proven
- [x] Old `scores.json` without diagnostic keys loads with zero defaults
- [x] `rebuild()` from daily log files matches batch computation
- [x] Empty-state (no edge-eligible rows) renders gracefully
- [x] `compare.py` directional bias uses `abs()` (closer to 0 = improved)
- [x] Float boundary handled with `round(..., 10)` in `disagree_bucket`
