### PR TITLE
feat: expand tournament coverage and fix scoring bugs

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -166,13 +166,13 @@ jobs:
         run: |
           python -m benchmark.datasets.fetch_open \
             --platform omen \
-            --max-markets "${{ github.event.inputs.max_markets || '10' }}"
+            --max-markets "${{ github.event.inputs.max_markets || '20' }}"
 
       - name: Fetch Polymarket open markets
         run: |
           python -m benchmark.datasets.fetch_open \
             --platform polymarket \
-            --max-markets "${{ github.event.inputs.max_markets || '10' }}" \
+            --max-markets "${{ github.event.inputs.max_markets || '20' }}" \
             --min-liquidity 1000
 
       - name: Upload tournament markets
@@ -248,8 +248,8 @@ jobs:
         run: |
           uv run python -m benchmark.tournament \
             --markets benchmark/datasets/open_markets.jsonl \
-            --tools "${{ github.event.inputs.tools || 'prediction-online,prediction-offline,claude-prediction-online,claude-prediction-offline,superforcaster,prediction-request-reasoning,prediction-request-reasoning-claude,prediction-request-rag,prediction-request-rag-claude,prediction-url-cot,prediction-url-cot-claude,prediction-offline-sme,prediction-online-sme' }}" \
-            --max-markets "${{ github.event.inputs.max_markets || '10' }}"
+            --tools "${{ github.event.inputs.tools || 'prediction-online,prediction-offline,claude-prediction-online,claude-prediction-offline,superforcaster,prediction-request-reasoning,prediction-request-reasoning-claude,prediction-request-rag,prediction-request-rag-claude,prediction-url-cot,prediction-url-cot-claude,prediction-offline-sme,prediction-online-sme,factual_research' }}" \
+            --max-markets "${{ github.event.inputs.max_markets || '20' }}"
 
       - name: Score resolved predictions
         run: uv run python -m benchmark.score_tournament

--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -12,7 +12,7 @@ on:
       max_markets:
         description: 'Max markets per platform for tournament'
         required: false
-        default: '10'
+        default: '20'
       tools:
         description: 'Comma-separated tool names for tournament'
         required: false

--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -16,7 +16,7 @@ on:
       tools:
         description: 'Comma-separated tool names for tournament'
         required: false
-        default: 'prediction-online,prediction-offline,claude-prediction-online,claude-prediction-offline,superforcaster,prediction-request-reasoning,prediction-request-reasoning-claude,prediction-request-rag,prediction-request-rag-claude,prediction-url-cot,prediction-url-cot-claude,prediction-offline-sme,prediction-online-sme'
+        default: 'prediction-online,prediction-offline,claude-prediction-online,claude-prediction-offline,superforcaster,prediction-request-reasoning,prediction-request-reasoning-claude,prediction-request-rag,prediction-request-rag-claude,prediction-url-cot,prediction-url-cot-claude,prediction-offline-sme,prediction-online-sme,factual_research'
       notify_slack:
         description: 'Post summary to Slack'
         required: false
@@ -62,10 +62,15 @@ jobs:
         run: rm -f benchmark/results/scores.json benchmark/results/scores_history.jsonl
 
       # Fetch writes daily log file + calls scorer.update() inline
+      # Inputs routed through env (not ${{ }} interpolation in the shell script)
+      # to prevent workflow_dispatch shell injection — ${{ }} is macro-expanded
+      # before the shell runs, so malicious input would become part of the script.
       - name: Fetch production data
+        env:
+          INPUT_LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '7' }}
         run: |
           python -m benchmark.datasets.fetch_production \
-            --lookback-days "${{ github.event.inputs.lookback_days || '7' }}"
+            --lookback-days "$INPUT_LOOKBACK_DAYS"
 
       # Fallback: if inline scorer failed, run standalone rebuild
       - name: Score (fallback)
@@ -162,17 +167,22 @@ jobs:
           if_no_artifact_found: warn
         continue-on-error: true
 
+      # Inputs routed via env to avoid shell injection — see note in benchmark job.
       - name: Fetch Omen open markets
+        env:
+          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '20' }}
         run: |
           python -m benchmark.datasets.fetch_open \
             --platform omen \
-            --max-markets "${{ github.event.inputs.max_markets || '20' }}"
+            --max-markets "$INPUT_MAX_MARKETS"
 
       - name: Fetch Polymarket open markets
+        env:
+          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '20' }}
         run: |
           python -m benchmark.datasets.fetch_open \
             --platform polymarket \
-            --max-markets "${{ github.event.inputs.max_markets || '20' }}" \
+            --max-markets "$INPUT_MAX_MARKETS" \
             --min-liquidity 1000
 
       - name: Upload tournament markets
@@ -236,6 +246,7 @@ jobs:
           if_no_artifact_found: warn
         continue-on-error: true
 
+      # Inputs routed via env to avoid shell injection — see note in benchmark job.
       - name: Run tournament predictions
         continue-on-error: true
         env:
@@ -245,11 +256,13 @@ jobs:
           SEARCH_PROVIDER: ${{ secrets.BENCHMARK_SEARCH_PROVIDER }}
           GOOGLE_API_KEY: ${{ secrets.BENCHMARK_GOOGLE_API_KEY }}
           GOOGLE_ENGINE_ID: ${{ secrets.BENCHMARK_GOOGLE_ENGINE_ID }}
+          INPUT_TOOLS: ${{ github.event.inputs.tools || 'prediction-online,prediction-offline,claude-prediction-online,claude-prediction-offline,superforcaster,prediction-request-reasoning,prediction-request-reasoning-claude,prediction-request-rag,prediction-request-rag-claude,prediction-url-cot,prediction-url-cot-claude,prediction-offline-sme,prediction-online-sme,factual_research' }}
+          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '20' }}
         run: |
           uv run python -m benchmark.tournament \
             --markets benchmark/datasets/open_markets.jsonl \
-            --tools "${{ github.event.inputs.tools || 'prediction-online,prediction-offline,claude-prediction-online,claude-prediction-offline,superforcaster,prediction-request-reasoning,prediction-request-reasoning-claude,prediction-request-rag,prediction-request-rag-claude,prediction-url-cot,prediction-url-cot-claude,prediction-offline-sme,prediction-online-sme,factual_research' }}" \
-            --max-markets "${{ github.event.inputs.max_markets || '20' }}"
+            --tools "$INPUT_TOOLS" \
+            --max-markets "$INPUT_MAX_MARKETS"
 
       - name: Score resolved predictions
         run: uv run python -m benchmark.score_tournament

--- a/benchmark/score_tournament.py
+++ b/benchmark/score_tournament.py
@@ -326,6 +326,16 @@ def _fetch_resolution_map(
     return resolution_map
 
 
+def _parse_iso(ts: Any) -> datetime | None:
+    """Parse an ISO-8601 timestamp, tolerating trailing `Z` on Python 3.10."""
+    if not isinstance(ts, str):
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
 def _apply_resolution(
     row: dict[str, Any],
     resolution: dict[str, Any],
@@ -335,20 +345,18 @@ def _apply_resolution(
     scored_row["final_outcome"] = resolution["outcome"]
     scored_row["resolved_at"] = resolution["resolved_at"]
 
-    predicted_at = row.get("predicted_at")
-    resolved_at = resolution["resolved_at"]
-    if predicted_at and resolved_at:
-        try:
-            pred_dt = datetime.fromisoformat(predicted_at.replace("Z", "+00:00"))
-            res_dt = datetime.fromisoformat(resolved_at.replace("Z", "+00:00"))
-            lead_days = (res_dt - pred_dt).total_seconds() / 86400
-            scored_row["prediction_lead_time_days"] = round(lead_days, 1)
-        except (ValueError, TypeError) as exc:
-            log.warning(
-                "Failed to compute lead time for row_id=%s: %s",
-                row.get("row_id"),
-                exc,
-            )
+    pred_dt = _parse_iso(row.get("predicted_at"))
+    res_dt = _parse_iso(resolution["resolved_at"])
+    if pred_dt and res_dt:
+        lead_days = (res_dt - pred_dt).total_seconds() / 86400
+        scored_row["prediction_lead_time_days"] = round(lead_days, 1)
+    elif row.get("predicted_at") and resolution["resolved_at"]:
+        log.warning(
+            "Failed to parse timestamps for row_id=%s: predicted_at=%r resolved_at=%r",
+            row.get("row_id"),
+            row.get("predicted_at"),
+            resolution["resolved_at"],
+        )
 
     scored_row.pop("source_content", None)
     return scored_row

--- a/benchmark/score_tournament.py
+++ b/benchmark/score_tournament.py
@@ -339,12 +339,16 @@ def _apply_resolution(
     resolved_at = resolution["resolved_at"]
     if predicted_at and resolved_at:
         try:
-            pred_dt = datetime.fromisoformat(predicted_at)
-            res_dt = datetime.fromisoformat(resolved_at)
+            pred_dt = datetime.fromisoformat(predicted_at.replace("Z", "+00:00"))
+            res_dt = datetime.fromisoformat(resolved_at.replace("Z", "+00:00"))
             lead_days = (res_dt - pred_dt).total_seconds() / 86400
             scored_row["prediction_lead_time_days"] = round(lead_days, 1)
-        except (ValueError, TypeError):
-            pass
+        except (ValueError, TypeError) as exc:
+            log.warning(
+                "Failed to compute lead time for row_id=%s: %s",
+                row.get("row_id"),
+                exc,
+            )
 
     scored_row.pop("source_content", None)
     return scored_row

--- a/benchmark/tournament.py
+++ b/benchmark/tournament.py
@@ -323,6 +323,13 @@ def run_tournament(
             by_platform.setdefault(m.get("platform", "unknown"), []).append(m)
         markets = []
         for plat_markets in by_platform.values():
+            missing = [m.get("id") for m in plat_markets if not m.get("fetched_at")]
+            if missing:
+                log.warning(
+                    "%d markets missing fetched_at (will sort last): %s",
+                    len(missing),
+                    missing[:5],
+                )
             plat_markets.sort(key=lambda m: m.get("fetched_at", ""), reverse=True)
             markets.extend(plat_markets[:max_markets])
 

--- a/benchmark/tournament.py
+++ b/benchmark/tournament.py
@@ -9,7 +9,7 @@ score_tournament.py when they resolve.
 Usage:
     python benchmark/tournament.py --markets benchmark/datasets/open_markets.jsonl
     python benchmark/tournament.py --markets open_markets.jsonl --tools prediction-online,superforcaster
-    python benchmark/tournament.py --markets open_markets.jsonl --max-markets 10
+    python benchmark/tournament.py --markets open_markets.jsonl --max-markets 10  # 10 per platform
 """
 
 from __future__ import annotations
@@ -447,7 +447,7 @@ def main() -> None:
         "--max-markets",
         type=int,
         default=None,
-        help="Max markets to process (default: all)",
+        help="Max markets per platform to process (default: all)",
     )
     parser.add_argument(
         "--timeout",

--- a/benchmark/tournament.py
+++ b/benchmark/tournament.py
@@ -318,7 +318,13 @@ def run_tournament(
     """Run all tool x market combos and append predictions."""
     markets = load_markets(markets_path)
     if max_markets is not None:
-        markets = markets[:max_markets]
+        by_platform: dict[str, list[dict[str, Any]]] = {}
+        for m in markets:
+            by_platform.setdefault(m.get("platform", "unknown"), []).append(m)
+        markets = []
+        for plat_markets in by_platform.values():
+            plat_markets.sort(key=lambda m: m.get("fetched_at", ""), reverse=True)
+            markets.extend(plat_markets[:max_markets])
 
     log.info(
         "Tournament: %d markets x %d tools = %d combos",


### PR DESCRIPTION
## Summary

Three changes to make tournament mode actually exercise both platforms and produce usable lead-time data:

- **Per-platform market slicing** (`benchmark/tournament.py`): the prior `markets[:max_markets]` slice was global. Because `open_markets.jsonl` is appended Omen-first, this starved Polymarket entirely after day 1 — only 1 unique Polymarket market made it into predictions across the whole accumulated artifact (vs 9 unique Omen). Now each platform gets up to `max_markets`, ordered by latest `fetched_at`.
- **Bump market count** `10 → 20` per platform and add `factual_research` to the default tools list (was registered in `benchmark/tools.py` but never invoked). **20 is a starting point — reviewers, please propose a different number if the API-cost / coverage tradeoff in the table below suggests otherwise.**
- **Fix `prediction_lead_time_days`** in `score_tournament.py`: every one of the 210 scored rows in the latest artifact has this field as `null`. Cause: workflow runs Python 3.10, on which `datetime.fromisoformat("...Z")` raises `ValueError`. The bare `except` swallowed it silently. Normalize `Z` → `+00:00` before parsing (works 3.10–3.14) and log on failure instead of swallowing.

## API call impact

Tool runs per day = `markets × platforms × tools`. Old setting was 10 markets globally with the slice bug → only Omen exercised, 13 tools (no `factual_research`).

| Markets / platform | Omen runs | Poly runs (steady) | **Total/day** | vs old (130) |
|---|---|---|---|---|
| 10 (old, slice bug, 13 tools) | 130 | 0 | **130** | 1× |
| 10 (per-platform, 14 tools) | 140 | 140 | **280** | 2.2× |
| **20 (this PR)** | 280 | 280 | **560** | **4.3×** |
| 30 | 420 | 420 | **840** | 6.5× |
| 50 | 700 | 700 | **1,400** | 10.8× |
| 100 | 1,400 | 1,400 | **2,800** | 21.5× |

Per-call cost varies by tool (offline tools ~1–3 LLM calls, RAG/reasoning/url-cot 5–20+). Multiply tool-run count by ~5–10 for an order-of-magnitude API-call estimate.

Note: Polymarket "steady" assumes the fetch accumulates ≥N markets — currently only 21 unique are in the artifact, so until coverage grows, Poly runs are bounded by available stock (see issue #5 below).

## Verification

- `_apply_resolution` re-tested on real artifact data: returns `4.6` days correctly.
- Per-platform slice tested against current `open_markets.jsonl` (122 markets): yields 30 Omen + 21 Polymarket at max=30 (Polymarket capped by available stock, not by slice).
- Cross-version `fromisoformat` test confirmed on Python 3.10/3.11/3.12/3.14.

## Known issues — not fixed in this PR

These were surfaced while investigating; flagging for separate work:

1. **`prediction-url-cot` is 100% malformed** (97 rows in latest artifact, `latency_s=0.0`, instant failure). Tool needs investigation.
2. **`prediction-online-sme` is 36% malformed.**
3. **Dedup retries malformed predictions every day** (per the docstring, only `valid` rows are dedup'd). Combined with `#1`, the workflow burns API calls daily on a tool that always fails. Worth a retry cap.
4. **Polymarket resolution detection misses closed-but-no-resolved-flag markets.** `score_tournament.check_polymarket_resolutions` checks `m.get("resolved", False)` — the Gamma API regularly returns `resolved: None` even for long-closed markets (e.g. `will-joe-biden-get-coronavirus-before-the-election`, conditionId `0xe3b423df...`, closed since 2020 with `outcomePrices=["0","0"]`). Should also use `closed` and `endDate`.
5. **Polymarket fetch concentrated** in `business`/`politics` only at `min_liquidity=1000` — 8 of 10 categories return nothing in the 30-day window.
6. **Existing scored rows have null `prediction_lead_time_days`** — the bug fix doesn't backfill, only newly-scored rows benefit.
7. **Tournament `tournament_scored.jsonl` is unconsumed.** Nothing downstream (`analyze.py`, `scorer.py`, `compare.py`, `report.md`, Slack) reads it. The dataset accumulates but never reaches the daily report.

## Design choice worth confirming

`row_id = (tool, market_id, platform, model)` makes a (tool, market) combo a **one-shot prediction**. Same market re-loaded every day, but never re-predicted unless the prior attempt was malformed. This means we can't observe how a tool's confidence on a given market evolves toward the close date. If we want time-series predictions for calibration-drift analysis, the row_id scheme would need a date or daily counter.

## Test plan

- [ ] Trigger the workflow manually after merge and confirm `tournament_scored.jsonl` has non-null `prediction_lead_time_days` on newly-scored rows.
- [ ] Confirm `tournament_predictions.jsonl` accumulates Polymarket entries beyond the existing 1 unique market.
- [ ] Confirm `factual_research` appears in the predictions for the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)