### PR TITLE
feat: integrate tournament data into unified report with per-version aggregation

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -30,11 +30,14 @@ on:
 
 jobs:
   # -----------------------------------------------------------------------
-  # Job 1: Production benchmark (existing, unchanged)
+  # Job 1: Production benchmark
+  # Depends on tournament-run so tournament_scored.jsonl is available for
+  # the scorer/analyze steps to merge into the unified report.
   # -----------------------------------------------------------------------
   benchmark:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    needs: [tournament-run]
 
     steps:
       - uses: actions/checkout@v4
@@ -56,6 +59,16 @@ jobs:
           if_no_artifact_found: warn
         continue-on-error: true
 
+      # Tournament-scored data from the tournament-run job. Used as input
+      # to scorer (--tournament-input) so the per-(tool, version, mode)
+      # breakdown shows up in the unified report.
+      - name: Download tournament scored data
+        uses: actions/download-artifact@v4
+        with:
+          name: tournament-predictions
+          path: benchmark/results/
+        continue-on-error: true
+
       # Discard cached scores when force_rebuild is requested
       - name: Clear cached scores (force rebuild)
         if: github.event.inputs.force_rebuild == 'true'
@@ -67,27 +80,53 @@ jobs:
           python -m benchmark.datasets.fetch_production \
             --lookback-days "${{ github.event.inputs.lookback_days || '7' }}"
 
+      # Incrementally merge tournament-scored rows into the cumulative
+      # scores.json. Dedup by row_id makes this a no-op for already-merged
+      # rows, so it's safe to run every day.
+      - name: Merge tournament into cumulative scores
+        if: hashFiles('benchmark/results/tournament_scored.jsonl') != ''
+        run: |
+          python -m benchmark.scorer \
+            --update benchmark/results/tournament_scored.jsonl
+        continue-on-error: true
+
       # Fallback: if inline scorer failed, run standalone rebuild
       - name: Score (fallback)
         run: |
+          TOURNAMENT_FLAG=""
+          if [ -f benchmark/results/tournament_scored.jsonl ]; then
+            TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
+          fi
           if [ ! -f benchmark/results/scores.json ]; then
             echo "scores.json missing — running standalone scorer rebuild"
-            python -m benchmark.scorer --rebuild --logs-dir benchmark/datasets/logs/
+            python -m benchmark.scorer --rebuild \
+              --logs-dir benchmark/datasets/logs/ \
+              $TOURNAMENT_FLAG
           fi
 
       # Score recent periods for diff reporting
       - name: Score today
         run: |
+          TOURNAMENT_FLAG=""
+          if [ -f benchmark/results/tournament_scored.jsonl ]; then
+            TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
+          fi
           python -m benchmark.scorer --period-days 1 \
             --logs-dir benchmark/datasets/logs/ \
-            --output benchmark/results/period_scores.json
+            --output benchmark/results/period_scores.json \
+            $TOURNAMENT_FLAG
         continue-on-error: true
 
       - name: Score last 7 days
         run: |
+          TOURNAMENT_FLAG=""
+          if [ -f benchmark/results/tournament_scored.jsonl ]; then
+            TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
+          fi
           python -m benchmark.scorer --period-days 7 \
             --logs-dir benchmark/datasets/logs/ \
-            --output benchmark/results/rolling_scores.json
+            --output benchmark/results/rolling_scores.json \
+            $TOURNAMENT_FLAG
         continue-on-error: true
 
       # Analyze reads scores.json + history + period scores
@@ -95,7 +134,8 @@ jobs:
         run: |
           python -m benchmark.analyze \
             --period benchmark/results/period_scores.json \
-            --rolling benchmark/results/rolling_scores.json
+            --rolling benchmark/results/rolling_scores.json \
+            --include-tournament
 
       # Upload state + scores (small, needed for next run)
       - name: Upload benchmark data

--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -70,44 +70,63 @@ jobs:
           path: benchmark/results/
         continue-on-error: true
 
-      # Discard cached scores when force_rebuild is requested
+      # force_rebuild semantics: wipe ALL derived scoring state as a set
+      # (scores.json, scores_history.jsonl, scored_row_ids.json) so the
+      # subsequent Score step rebuilds from raw logs without stale dedup
+      # state poisoning the result.
       - name: Clear cached scores (force rebuild)
         if: github.event.inputs.force_rebuild == 'true'
-        run: rm -f benchmark/results/scores.json benchmark/results/scores_history.jsonl
+        run: |
+          rm -f benchmark/results/scores.json \
+                benchmark/results/scores_history.jsonl \
+                benchmark/results/scored_row_ids.json
 
-      # Fetch writes daily log file + calls scorer.update() inline
+      # Fetch writes daily log file + calls scorer.update() inline (fast path).
+      # On force_rebuild, --no-score disables the inline scoring so the
+      # dedicated Score step below owns scores.json creation (slow path).
       # Inputs routed through env (not ${{ }} interpolation in the shell script)
       # to prevent workflow_dispatch shell injection — ${{ }} is macro-expanded
       # before the shell runs, so malicious input would become part of the script.
       - name: Fetch production data
         env:
           INPUT_LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '7' }}
+          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild }}
         run: |
+          NO_SCORE_FLAG=""
+          if [ "$FORCE_REBUILD" = "true" ]; then
+            NO_SCORE_FLAG="--no-score"
+          fi
           python -m benchmark.datasets.fetch_production \
-            --lookback-days "$INPUT_LOOKBACK_DAYS"
+            --lookback-days "$INPUT_LOOKBACK_DAYS" \
+            $NO_SCORE_FLAG
 
-      # Fallback: if inline scorer failed, run standalone rebuild.
-      # Must run BEFORE the tournament merge so --rebuild has a chance to
-      # reprocess all logs from scratch on force_rebuild / first run. If
-      # merge ran first, it would create a scores.json containing only
-      # tournament rows (plus whatever fetch_production accumulated from
-      # the last lookback_days window) and this guard would skip --rebuild.
-      - name: Score (fallback)
+      # Slow-path scoring: run --rebuild when either (a) scores.json is
+      # missing (first run, or prior run crashed before fetch's inline
+      # update), or (b) force_rebuild=true (explicit full rebuild). On
+      # normal runs the fast path in fetch_production already produced
+      # scores.json, and this step is a no-op.
+      - name: Score
+        env:
+          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild }}
         run: |
           TOURNAMENT_FLAG=""
           if [ -f benchmark/results/tournament_scored.jsonl ]; then
             TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
           fi
-          if [ ! -f benchmark/results/scores.json ]; then
-            echo "scores.json missing — running standalone scorer rebuild"
+          if [ ! -f benchmark/results/scores.json ] || [ "$FORCE_REBUILD" = "true" ]; then
+            echo "Running full rebuild (missing scores.json or force_rebuild=true)"
             python -m benchmark.scorer --rebuild \
               --logs-dir benchmark/datasets/logs/ \
               $TOURNAMENT_FLAG
+          else
+            echo "scores.json present and not force_rebuild — fast path already ran in fetch"
           fi
 
       # Incrementally merge tournament-scored rows into the cumulative
       # scores.json. Dedup by row_id (via scored_row_ids.json) makes this
-      # a no-op for already-merged rows, so it's safe to run every day.
+      # a no-op on force_rebuild (rebuild already included --tournament-input
+      # and wrote the full row_id set), and adds only genuinely new rows
+      # on normal runs.
       - name: Merge tournament into cumulative scores
         if: hashFiles('benchmark/results/tournament_scored.jsonl') != ''
         run: |

--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     needs: [tournament-run]
+    if: always() && !cancelled()
 
     steps:
       - uses: actions/checkout@v4
@@ -80,17 +81,12 @@ jobs:
           python -m benchmark.datasets.fetch_production \
             --lookback-days "${{ github.event.inputs.lookback_days || '7' }}"
 
-      # Incrementally merge tournament-scored rows into the cumulative
-      # scores.json. Dedup by row_id makes this a no-op for already-merged
-      # rows, so it's safe to run every day.
-      - name: Merge tournament into cumulative scores
-        if: hashFiles('benchmark/results/tournament_scored.jsonl') != ''
-        run: |
-          python -m benchmark.scorer \
-            --update benchmark/results/tournament_scored.jsonl
-        continue-on-error: true
-
-      # Fallback: if inline scorer failed, run standalone rebuild
+      # Fallback: if inline scorer failed, run standalone rebuild.
+      # Must run BEFORE the tournament merge so --rebuild has a chance to
+      # reprocess all logs from scratch on force_rebuild / first run. If
+      # merge ran first, it would create a scores.json containing only
+      # tournament rows (plus whatever fetch_production accumulated from
+      # the last lookback_days window) and this guard would skip --rebuild.
       - name: Score (fallback)
         run: |
           TOURNAMENT_FLAG=""
@@ -103,6 +99,16 @@ jobs:
               --logs-dir benchmark/datasets/logs/ \
               $TOURNAMENT_FLAG
           fi
+
+      # Incrementally merge tournament-scored rows into the cumulative
+      # scores.json. Dedup by row_id (via scored_row_ids.json) makes this
+      # a no-op for already-merged rows, so it's safe to run every day.
+      - name: Merge tournament into cumulative scores
+        if: hashFiles('benchmark/results/tournament_scored.jsonl') != ''
+        run: |
+          python -m benchmark.scorer \
+            --update benchmark/results/tournament_scored.jsonl
+        continue-on-error: true
 
       # Score recent periods for diff reporting
       - name: Score today
@@ -146,6 +152,7 @@ jobs:
             benchmark/datasets/.fetch_state.json
             benchmark/results/scores.json
             benchmark/results/scores_history.jsonl
+            benchmark/results/scored_row_ids.json
             benchmark/results/report.md
           retention-days: 90
 

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -852,7 +852,9 @@ def section_version_deltas(scores: dict[str, Any]) -> str:
         cells = sorted(multi[tool], key=lambda c: (c[0], c[1]))
         lines.append(f"### {tool}")
         lines.append("")
-        lines.append("| Baseline (version, mode) | Candidate (version, mode) | Brier Δ | Direction | n_b | n_c |")
+        lines.append(
+            "| Baseline (version, mode) | Candidate (version, mode) | Brier Δ | Direction | n_b | n_c |"
+        )
         lines.append("|---|---|---:|---|---:|---:|")
         for i, (v_b, m_b, s_b) in enumerate(cells):
             for v_c, m_c, s_c in cells[i + 1 :]:
@@ -861,7 +863,11 @@ def section_version_deltas(scores: dict[str, Any]) -> str:
                 delta = brier_cmp.get("delta")
                 direction = brier_cmp.get("direction") or "—"
                 delta_s = f"{delta:+.4f}" if isinstance(delta, (int, float)) else "—"
-                low = " ⚠" if min(s_b.get("n", 0), s_c.get("n", 0)) < VERSION_DELTA_LOW_SAMPLE else ""
+                low = (
+                    " ⚠"
+                    if min(s_b.get("n", 0), s_c.get("n", 0)) < VERSION_DELTA_LOW_SAMPLE
+                    else ""
+                )
                 lines.append(
                     f"| `{v_b}` / {m_b} | `{v_c}` / {m_c} | {delta_s}{low} | {direction} | {s_b.get('n', 0)} | {s_c.get('n', 0)} |"
                 )
@@ -881,16 +887,14 @@ def generate_report(
     rolling_scores: dict[str, Any] | None = None,
     include_tournament: bool = False,
 ) -> str:
-    """Generate the markdown report. ``include_tournament`` toggles the
-    Tool × Version × Mode (cumulative + 7d rolling) and Version Deltas
-    sections; the rest of the report is unchanged when off.
-    """
     """Generate a full benchmark report from scores and history.
 
     :param scores: parsed ``scores.json`` dict (all-time).
     :param history: list of monthly snapshots from ``scores_history.jsonl``.
     :param period_scores: scores from today's run (since last report).
     :param rolling_scores: scores from the last 7 days.
+    :param include_tournament: when True, render the Tool × Version × Mode
+        (cumulative + 7d rolling) and Version Deltas sections.
     :return: full markdown report string.
     """
     if history is None:

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -19,6 +19,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from benchmark.compare import compare_stats
 from benchmark.io import load_jsonl
 
 DEFAULT_SCORES = Path(__file__).parent / "results" / "scores.json"
@@ -772,6 +773,102 @@ def section_period(
     return "\n".join(lines)
 
 
+VERSION_DELTA_LOW_SAMPLE = 30
+
+
+def _parse_tvm_key(key: str) -> tuple[str, str, str]:
+    """Split a 'tool | version | mode' key. Pads if mode is missing (legacy)."""
+    parts = [p.strip() for p in key.split("|")]
+    while len(parts) < 3:
+        parts.append("unknown")
+    return parts[0], parts[1], parts[2]
+
+
+def section_tool_version_breakdown(
+    scores: dict[str, Any],
+    title: str = "Tool × Version × Mode",
+) -> str:
+    """Per (tool, version, mode) metrics table — combines prod and tournament."""
+    tvm = scores.get("by_tool_version_mode", {})
+    if not tvm:
+        return ""
+
+    rows = sorted(
+        (_parse_tvm_key(k) + (v,) for k, v in tvm.items()),
+        key=lambda r: (r[0], r[1], r[2]),
+    )
+
+    lines = [
+        f"## {title}",
+        "",
+        "| Tool | Version | Mode | n | valid | Brier | DirAcc | BSS |",
+        "|------|---------|------|---:|---:|---:|---:|---:|",
+    ]
+    has_low_sample = False
+    for tool, version, mode, stats in rows:
+        n = stats.get("n", 0)
+        valid_n = stats.get("valid_n", 0)
+        low = n < VERSION_DELTA_LOW_SAMPLE
+        if low:
+            has_low_sample = True
+        n_cell = f"{n} ⚠" if low else str(n)
+        brier = stats.get("brier")
+        brier_s = f"{brier:.4f}" if brier is not None else "—"
+        acc = stats.get("directional_accuracy")
+        acc_s = f"{acc:.0%}" if acc is not None else "—"
+        bss = stats.get("brier_skill_score")
+        bss_s = f"{bss:+.4f}" if bss is not None else "—"
+        lines.append(
+            f"| {tool} | `{version}` | {mode} | {n_cell} | {valid_n} | {brier_s} | {acc_s} | {bss_s} |"
+        )
+
+    if has_low_sample:
+        lines.extend(
+            [
+                "",
+                f"⚠ Rows marked with ⚠ have n < {VERSION_DELTA_LOW_SAMPLE}; metrics from these cells are statistically unreliable and superlatives should not be drawn from them.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def section_version_deltas(scores: dict[str, Any]) -> str:
+    """Pairwise Brier deltas across versions/modes for each tool with multiple cells."""
+    tvm = scores.get("by_tool_version_mode", {})
+    if not tvm:
+        return ""
+
+    by_tool: dict[str, list[tuple[str, str, dict[str, Any]]]] = {}
+    for key, stats in tvm.items():
+        tool, version, mode = _parse_tvm_key(key)
+        by_tool.setdefault(tool, []).append((version, mode, stats))
+
+    multi = {t: cells for t, cells in by_tool.items() if len(cells) >= 2}
+    if not multi:
+        return ""
+
+    lines = ["## Version Deltas", ""]
+    for tool in sorted(multi):
+        cells = sorted(multi[tool], key=lambda c: (c[0], c[1]))
+        lines.append(f"### {tool}")
+        lines.append("")
+        lines.append("| Baseline (version, mode) | Candidate (version, mode) | Brier Δ | Direction | n_b | n_c |")
+        lines.append("|---|---|---:|---|---:|---:|")
+        for i, (v_b, m_b, s_b) in enumerate(cells):
+            for v_c, m_c, s_c in cells[i + 1 :]:
+                cmp = compare_stats(s_b, s_c)
+                brier_cmp = cmp.get("brier", {})
+                delta = brier_cmp.get("delta")
+                direction = brier_cmp.get("direction") or "—"
+                delta_s = f"{delta:+.4f}" if isinstance(delta, (int, float)) else "—"
+                low = " ⚠" if min(s_b.get("n", 0), s_c.get("n", 0)) < VERSION_DELTA_LOW_SAMPLE else ""
+                lines.append(
+                    f"| `{v_b}` / {m_b} | `{v_c}` / {m_c} | {delta_s}{low} | {direction} | {s_b.get('n', 0)} | {s_c.get('n', 0)} |"
+                )
+        lines.append("")
+    return "\n".join(lines).rstrip()
+
+
 # ---------------------------------------------------------------------------
 # Report assembly
 # ---------------------------------------------------------------------------
@@ -782,7 +879,12 @@ def generate_report(
     history: list[dict[str, Any]] | None = None,
     period_scores: dict[str, Any] | None = None,
     rolling_scores: dict[str, Any] | None = None,
+    include_tournament: bool = False,
 ) -> str:
+    """Generate the markdown report. ``include_tournament`` toggles the
+    Tool × Version × Mode (cumulative + 7d rolling) and Version Deltas
+    sections; the rest of the report is unchanged when off.
+    """
     """Generate a full benchmark report from scores and history.
 
     :param scores: parsed ``scores.json`` dict (all-time).
@@ -798,6 +900,20 @@ def generate_report(
         "%Y-%m-%d"
     )
 
+    tournament_sections: list[str] = []
+    if include_tournament:
+        candidates = [
+            section_tool_version_breakdown(scores, "Tool × Version × Mode (All-Time)"),
+        ]
+        if rolling_scores is not None:
+            candidates.append(
+                section_tool_version_breakdown(
+                    rolling_scores, "Tool × Version × Mode (Last 7 Days)"
+                )
+            )
+        candidates.append(section_version_deltas(scores))
+        tournament_sections = [s for s in candidates if s]
+
     sections = [
         f"# Benchmark Report — {date}",
         section_period(period_scores, scores, "Since Last Report"),
@@ -805,6 +921,7 @@ def generate_report(
         section_overall(scores),
         section_base_rates(scores),
         section_tool_ranking(scores),
+        *tournament_sections,
         section_platform(scores),
         section_tool_platform(scores),
         section_edge_analysis(scores),
@@ -847,6 +964,11 @@ def main() -> None:
         default=None,
         help="Rolling 7-day scores JSON",
     )
+    parser.add_argument(
+        "--include-tournament",
+        action="store_true",
+        help="Render tournament-mode sections (Tool × Version × Mode and Version Deltas)",
+    )
     args = parser.parse_args()
 
     scores = load_scores(args.scores)
@@ -860,7 +982,11 @@ def main() -> None:
     )
 
     report = generate_report(
-        scores, history, period_scores=period, rolling_scores=rolling
+        scores,
+        history,
+        period_scores=period,
+        rolling_scores=rolling,
+        include_tournament=args.include_tournament,
     )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -2022,6 +2022,14 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         / "scores_history.jsonl",
         help="Path to scores_history.jsonl",
     )
+    parser.add_argument(
+        "--no-score",
+        action="store_true",
+        help=(
+            "Skip the inline scorer.update() call. Use when the workflow "
+            "will run `scorer --rebuild` explicitly afterwards."
+        ),
+    )
     return parser
 
 
@@ -2111,7 +2119,10 @@ def main() -> None:
         log.info("Appended %d new rows to %s", written, output_path)
 
         # Incremental scoring — update accumulators in scores.json
-        _run_scorer_update(all_rows, args.scores, args.history)
+        if args.no_score:
+            log.info("Inline scoring skipped (--no-score)")
+        else:
+            _run_scorer_update(all_rows, args.scores, args.history)
     else:
         log.info("No new rows to write")
 

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -45,6 +45,8 @@ Summarize this Olas Predict benchmark report using EXACTLY this structure (outpu
 
 *Regressions:* any tools or metrics that worsened vs prior period. Say "None" if trend data shows no worsening. "Regression" means worse over TIME, not just a bad score.
 
+*Tool versions:* if the report has a "Tool × Version × Mode" (cumulative or 7d), or "Version Deltas" section, summarize per-version observations: which tool versions changed, mode (production_replay vs tournament), Brier delta where shown. Show full hashes (no truncation) wrapped in backticks. CRITICAL: any row whose n cell ends in ⚠ or whose underlying n is below 30 is a small sample — when mentioning such a row you MUST lead with "small sample (n=X)" before stating any metric, and you MUST NOT use the words "best", "highest", "lowest", "worst", or any superlative for that row. Compare across versions only when both have n >= 30. Skip the section entirely if no Tool × Version × Mode or Version Deltas content is present.
+
 *Recommended actions:* 2-3 concrete next steps based on the data. If edge is negative for all tools, this is important — recommend specific improvements.
 
 Rules:
@@ -94,7 +96,7 @@ def summarize_report(report_text: str, api_key: str) -> str:
                 {"role": "system", "content": SUMMARY_SYSTEM_PROMPT},
                 {"role": "user", "content": user_content},
             ],
-            "max_tokens": 500,
+            "max_tokens": 1200,
             "temperature": 0.2,
         }
     ).encode()

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -693,6 +693,22 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
     # Tool × platform cross breakdown
     by_tool_platform = group_by_composite(rows, ["tool_name", "platform"])
 
+    # Tool × version (normalized: tool_version OR tool_ipfs_hash) cross breakdown
+    tv_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    tvm_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        tool = row.get("tool_name") or "unknown"
+        version = (
+            row.get("tool_version") or row.get("tool_ipfs_hash") or "unknown"
+        )
+        mode = row.get("mode") or "production_replay"
+        tv_groups[f"{tool} | {version}"].append(row)
+        tvm_groups[f"{tool} | {version} | {mode}"].append(row)
+    by_tool_version = {k: compute_group_stats(g) for k, g in tv_groups.items()}
+    by_tool_version_mode = {
+        k: compute_group_stats(g) for k, g in tvm_groups.items()
+    }
+
     # Tool × platform × horizon breakdown
     by_tool_platform_horizon = group_by_composite(
         rows,
@@ -740,6 +756,8 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "by_platform_liquidity": by_platform_liquidity,
         "by_tool_platform": by_tool_platform,
         "by_tool_platform_horizon": by_tool_platform_horizon,
+        "by_tool_version": by_tool_version,
+        "by_tool_version_mode": by_tool_version_mode,
         "trend": trend,
         "calibration": calibration,
         "ece": ece,
@@ -788,6 +806,7 @@ def _empty_scores(current_month: str) -> dict[str, Any]:
         "by_horizon": {},
         "by_tool_platform": {},
         "by_tool_version": {},
+        "by_tool_version_mode": {},
         "by_config": {},
         "by_difficulty": {},
         "by_liquidity": {},
@@ -1010,7 +1029,12 @@ def _accumulate_row(scores: dict[str, Any], row: dict[str, Any]) -> None:
     platform = row.get("platform") or "unknown"
     category = row.get("category") or "unknown"
     horizon = classify_horizon(row.get("prediction_lead_time_days"))
-    tool_version = row.get("tool_version") or "unknown"
+    # Production rows store the IPFS hash in `tool_version`; tournament rows
+    # store it in `tool_ipfs_hash`. Normalize so both populate the same key.
+    tool_version = (
+        row.get("tool_version") or row.get("tool_ipfs_hash") or "unknown"
+    )
+    mode = row.get("mode") or "production_replay"
     config_hash = row.get("config_hash") or "unknown"
 
     _ensure_and_accumulate(scores["by_tool"], tool, row)
@@ -1019,6 +1043,11 @@ def _accumulate_row(scores: dict[str, Any], row: dict[str, Any]) -> None:
     _ensure_and_accumulate(scores["by_horizon"], horizon, row)
     _ensure_and_accumulate(scores["by_tool_platform"], f"{tool} | {platform}", row)
     _ensure_and_accumulate(scores["by_tool_version"], f"{tool} | {tool_version}", row)
+    _ensure_and_accumulate(
+        scores["by_tool_version_mode"],
+        f"{tool} | {tool_version} | {mode}",
+        row,
+    )
     _ensure_and_accumulate(scores["by_config"], f"{tool} | {config_hash}", row)
 
     difficulty = classify_difficulty(row.get("market_prob_at_prediction"))
@@ -1107,6 +1136,7 @@ def _finalize_scores(scores: dict[str, Any]) -> dict[str, Any]:
         "by_horizon",
         "by_tool_platform",
         "by_tool_version",
+        "by_tool_version_mode",
         "by_config",
         "by_difficulty",
         "by_liquidity",
@@ -1263,6 +1293,7 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
         "by_horizon",
         "by_tool_platform",
         "by_tool_version",
+        "by_tool_version_mode",
         "by_config",
         "by_difficulty",
         "by_liquidity",
@@ -1378,6 +1409,7 @@ def update(
         "by_horizon",
         "by_tool_platform",
         "by_tool_version",
+        "by_tool_version_mode",
         "by_config",
         "by_difficulty",
         "by_liquidity",
@@ -1404,6 +1436,7 @@ def rebuild(
     scores_path: Path = DEFAULT_OUTPUT,
     history_path: Path = DEFAULT_HISTORY,
     dedup_path: Path | None = None,
+    tournament_input: Path | None = None,
 ) -> dict[str, Any]:
     """Rebuild scores.json from all log files in the logs directory.
 
@@ -1427,6 +1460,10 @@ def rebuild(
     all_rows: list[dict[str, Any]] = []
     for filepath in files:
         all_rows.extend(load_rows(Path(filepath)))
+
+    if tournament_input is not None and tournament_input.exists():
+        tournament_rows = load_rows(tournament_input)
+        all_rows.extend(tournament_rows)
 
     if not all_rows:
         scores = _empty_scores(datetime.now(timezone.utc).strftime("%Y-%m"))
@@ -1498,6 +1535,7 @@ def rebuild(
         "by_horizon",
         "by_tool_platform",
         "by_tool_version",
+        "by_tool_version_mode",
         "by_config",
         "by_difficulty",
         "by_liquidity",
@@ -1544,6 +1582,7 @@ def _extract_date_from_log_path(path: str) -> str:
 def score_period(
     logs_dir: Path = DEFAULT_LOGS_DIR,
     days: int = 1,
+    tournament_input: Path | None = None,
 ) -> dict[str, Any]:
     """Score rows whose ``predicted_at`` falls within the last *days* days.
 
@@ -1570,6 +1609,12 @@ def score_period(
     rows: list[dict[str, Any]] = []
     for filepath in all_files:
         for row in load_rows(Path(filepath)):
+            predicted_at = row.get("predicted_at") or ""
+            if predicted_at >= cutoff:
+                rows.append(row)
+
+    if tournament_input is not None and tournament_input.exists():
+        for row in load_rows(tournament_input):
             predicted_at = row.get("predicted_at") or ""
             if predicted_at >= cutoff:
                 rows.append(row)
@@ -1625,10 +1670,36 @@ def main() -> None:
         default=None,
         help="Score only the last N daily log files (for period reports)",
     )
+    parser.add_argument(
+        "--tournament-input",
+        type=Path,
+        default=None,
+        help="Optional path to tournament_scored.jsonl to merge into scoring",
+    )
+    parser.add_argument(
+        "--update",
+        type=Path,
+        default=None,
+        help="Incrementally merge rows from PATH into scores.json via update()",
+    )
     args = parser.parse_args()
 
+    if args.update is not None:
+        rows = load_rows(args.update)
+        result = update(rows, args.output, args.history)
+        overall = result["overall"]
+        print(
+            f"Merged {len(rows)} rows from {args.update}: Brier={overall['brier']},"
+            f" n={overall['n']}"
+        )
+        return
+
     if args.period_days is not None:
-        result = score_period(logs_dir=args.logs_dir, days=args.period_days)
+        result = score_period(
+            logs_dir=args.logs_dir,
+            days=args.period_days,
+            tournament_input=args.tournament_input,
+        )
         args.output.parent.mkdir(parents=True, exist_ok=True)
         args.output.write_text(json.dumps(result, indent=2))
         overall = result["overall"]
@@ -1644,6 +1715,7 @@ def main() -> None:
             logs_dir=args.logs_dir,
             scores_path=args.output,
             history_path=args.history,
+            tournament_input=args.tournament_input,
         )
         print(f"Scores written to {args.output}")
         overall = result["overall"]

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -698,16 +698,12 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
     tvm_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in rows:
         tool = row.get("tool_name") or "unknown"
-        version = (
-            row.get("tool_version") or row.get("tool_ipfs_hash") or "unknown"
-        )
+        version = row.get("tool_version") or row.get("tool_ipfs_hash") or "unknown"
         mode = row.get("mode") or "production_replay"
         tv_groups[f"{tool} | {version}"].append(row)
         tvm_groups[f"{tool} | {version} | {mode}"].append(row)
     by_tool_version = {k: compute_group_stats(g) for k, g in tv_groups.items()}
-    by_tool_version_mode = {
-        k: compute_group_stats(g) for k, g in tvm_groups.items()
-    }
+    by_tool_version_mode = {k: compute_group_stats(g) for k, g in tvm_groups.items()}
 
     # Tool × platform × horizon breakdown
     by_tool_platform_horizon = group_by_composite(
@@ -1031,9 +1027,7 @@ def _accumulate_row(scores: dict[str, Any], row: dict[str, Any]) -> None:
     horizon = classify_horizon(row.get("prediction_lead_time_days"))
     # Production rows store the IPFS hash in `tool_version`; tournament rows
     # store it in `tool_ipfs_hash`. Normalize so both populate the same key.
-    tool_version = (
-        row.get("tool_version") or row.get("tool_ipfs_hash") or "unknown"
-    )
+    tool_version = row.get("tool_version") or row.get("tool_ipfs_hash") or "unknown"
     mode = row.get("mode") or "production_replay"
     config_hash = row.get("config_hash") or "unknown"
 
@@ -1431,6 +1425,24 @@ def update(
     return finalized
 
 
+def _collect_rebuild_rows(
+    logs_dir: Path,
+    tournament_input: Path | None,
+) -> list[dict[str, Any]]:
+    """Load production log rows + optional tournament rows for rebuild."""
+    pattern = str(logs_dir / "production_log_*.jsonl")
+    files = sorted(glob_mod.glob(pattern))
+
+    rows: list[dict[str, Any]] = []
+    for filepath in files:
+        rows.extend(load_rows(Path(filepath)))
+
+    if tournament_input is not None and tournament_input.exists():
+        rows.extend(load_rows(tournament_input))
+
+    return rows
+
+
 def rebuild(
     logs_dir: Path = DEFAULT_LOGS_DIR,
     scores_path: Path = DEFAULT_OUTPUT,
@@ -1447,23 +1459,15 @@ def rebuild(
     :param scores_path: output path for ``scores.json``.
     :param history_path: output path for ``scores_history.jsonl``.
     :param dedup_path: path to ``scored_row_ids.json``.
+    :param tournament_input: optional path to ``tournament_scored.jsonl`` to
+        merge into the rebuild input.
     :return: finalized scores dict.
     """
 
     if dedup_path is None:
         dedup_path = scores_path.parent / "scored_row_ids.json"
 
-    # Collect all log files
-    pattern = str(logs_dir / "production_log_*.jsonl")
-    files = sorted(glob_mod.glob(pattern))
-
-    all_rows: list[dict[str, Any]] = []
-    for filepath in files:
-        all_rows.extend(load_rows(Path(filepath)))
-
-    if tournament_input is not None and tournament_input.exists():
-        tournament_rows = load_rows(tournament_input)
-        all_rows.extend(tournament_rows)
+    all_rows = _collect_rebuild_rows(logs_dir, tournament_input)
 
     if not all_rows:
         scores = _empty_scores(datetime.now(timezone.utc).strftime("%Y-%m"))
@@ -1592,6 +1596,8 @@ def score_period(
 
     :param logs_dir: directory containing daily log files.
     :param days: score rows from the last N days.
+    :param tournament_input: optional path to ``tournament_scored.jsonl`` whose
+        rows are filtered to the same window and merged into the input.
     :return: scores dict from ``score()``, or empty scores if no matching rows.
     """
     cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
@@ -1630,8 +1636,8 @@ def score_period(
 # ---------------------------------------------------------------------------
 
 
-def main() -> None:
-    """CLI entry point for scoring."""
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build the scorer CLI argument parser."""
     parser = argparse.ArgumentParser(
         description="Score production prediction data.",
     )
@@ -1682,7 +1688,12 @@ def main() -> None:
         default=None,
         help="Incrementally merge rows from PATH into scores.json via update()",
     )
-    args = parser.parse_args()
+    return parser
+
+
+def main() -> None:
+    """CLI entry point for scoring."""
+    args = _build_arg_parser().parse_args()
 
     if args.update is not None:
         rows = load_rows(args.update)

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -21,13 +21,16 @@
 from typing import Any
 
 from benchmark.analyze import (
+    _parse_tvm_key,
     generate_report,
     section_best_predictions,
     section_latency,
     section_overall,
     section_parse_breakdown,
     section_sample_size_warnings,
+    section_tool_version_breakdown,
     section_trend,
+    section_version_deltas,
     section_weak_spots,
     section_worst_predictions,
 )
@@ -375,3 +378,238 @@ class TestGenerateReport:
         report = generate_report(s, [])
         assert "# Benchmark Report" in report
         assert "No predictions to score" in report
+
+
+# ---------------------------------------------------------------------------
+# _parse_tvm_key
+# ---------------------------------------------------------------------------
+
+
+class TestParseTvmKey:
+    """Tests for _parse_tvm_key."""
+
+    def test_three_parts(self) -> None:
+        """Standard tool | version | mode key splits cleanly."""
+        assert _parse_tvm_key("tool-a | bafy_v1 | tournament") == (
+            "tool-a",
+            "bafy_v1",
+            "tournament",
+        )
+
+    def test_pads_missing_mode(self) -> None:
+        """Legacy two-part keys get unknown mode."""
+        assert _parse_tvm_key("tool-a | bafy_v1") == (
+            "tool-a",
+            "bafy_v1",
+            "unknown",
+        )
+
+    def test_strips_whitespace(self) -> None:
+        """Leading/trailing whitespace around | is stripped."""
+        tool, version, mode = _parse_tvm_key("tool-a|bafy_v1|tournament")
+        assert (tool, version, mode) == ("tool-a", "bafy_v1", "tournament")
+
+
+# ---------------------------------------------------------------------------
+# Tool × version × mode breakdown
+# ---------------------------------------------------------------------------
+
+
+class TestSectionToolVersionBreakdown:
+    """Tests for section_tool_version_breakdown."""
+
+    def test_empty_returns_blank(self) -> None:
+        """Missing/empty by_tool_version_mode returns empty string."""
+        assert section_tool_version_breakdown({}) == ""
+        assert section_tool_version_breakdown({"by_tool_version_mode": {}}) == ""
+
+    def test_renders_table_with_high_n_no_warning(self) -> None:
+        """Cells with n >= 30 render without ⚠ marker."""
+        scores = {
+            "by_tool_version_mode": {
+                "tool-a | bafy_v1 | production_replay": {
+                    "n": 500,
+                    "valid_n": 480,
+                    "brier": 0.21,
+                    "directional_accuracy": 0.7,
+                    "brier_skill_score": 0.05,
+                },
+            }
+        }
+        result = section_tool_version_breakdown(scores)
+        assert "tool-a" in result
+        assert "`bafy_v1`" in result
+        assert "production_replay" in result
+        assert "500" in result and "0.2100" in result
+        assert "⚠" not in result  # high-n row should not be flagged
+
+    def test_low_n_row_gets_warning_marker(self) -> None:
+        """Cells with n < 30 carry a ⚠ marker on the n cell and a footnote."""
+        scores = {
+            "by_tool_version_mode": {
+                "tool-a | bafy_v1 | tournament": {
+                    "n": 9,
+                    "valid_n": 9,
+                    "brier": 0.18,
+                    "directional_accuracy": 0.78,
+                    "brier_skill_score": 0.10,
+                },
+            }
+        }
+        result = section_tool_version_breakdown(scores)
+        assert "9 ⚠" in result  # per-row marker
+        assert "n < 30" in result  # footnote warning
+
+    def test_custom_title(self) -> None:
+        """Title argument controls the section heading."""
+        scores = {
+            "by_tool_version_mode": {"t | v | m": {"n": 5, "valid_n": 5, "brier": 0.2}}
+        }
+        result = section_tool_version_breakdown(scores, title="Last 7 Days")
+        assert result.startswith("## Last 7 Days")
+
+
+# ---------------------------------------------------------------------------
+# section_version_deltas
+# ---------------------------------------------------------------------------
+
+
+class TestSectionVersionDeltas:
+    """Tests for section_version_deltas."""
+
+    def test_empty_returns_blank(self) -> None:
+        """Missing data returns empty string."""
+        assert section_version_deltas({}) == ""
+
+    def test_single_version_per_tool_returns_blank(self) -> None:
+        """Tools with only one (version, mode) cell yield no delta section."""
+        scores = {
+            "by_tool_version_mode": {
+                "tool-a | v1 | production_replay": {"n": 100, "brier": 0.2},
+            }
+        }
+        assert section_version_deltas(scores) == ""
+
+    def test_renders_pairwise_delta_for_multi_version_tool(self) -> None:
+        """Tool with two versions produces a delta row with direction."""
+        scores = {
+            "by_tool_version_mode": {
+                "tool-a | v1 | production_replay": {
+                    "n": 100,
+                    "valid_n": 100,
+                    "brier": 0.30,
+                    "directional_accuracy": 0.6,
+                    "log_loss": 0.7,
+                    "sharpness": 0.3,
+                    "reliability": 1.0,
+                },
+                "tool-a | v2 | production_replay": {
+                    "n": 100,
+                    "valid_n": 100,
+                    "brier": 0.20,
+                    "directional_accuracy": 0.7,
+                    "log_loss": 0.6,
+                    "sharpness": 0.3,
+                    "reliability": 1.0,
+                },
+            }
+        }
+        result = section_version_deltas(scores)
+        assert "## Version Deltas" in result
+        assert "### tool-a" in result
+        assert "improved" in result  # v2 has lower Brier
+        assert "-0.1000" in result
+
+    def test_low_sample_marker_on_delta(self) -> None:
+        """Delta where either side has n < 30 carries the ⚠ marker."""
+        scores = {
+            "by_tool_version_mode": {
+                "tool-a | v1 | production_replay": {
+                    "n": 1000,
+                    "valid_n": 1000,
+                    "brier": 0.30,
+                    "directional_accuracy": 0.6,
+                    "log_loss": 0.7,
+                    "sharpness": 0.3,
+                    "reliability": 1.0,
+                },
+                "tool-a | v2 | tournament": {
+                    "n": 9,
+                    "valid_n": 9,
+                    "brier": 0.20,
+                    "directional_accuracy": 0.7,
+                    "log_loss": 0.6,
+                    "sharpness": 0.3,
+                    "reliability": 1.0,
+                },
+            }
+        }
+        result = section_version_deltas(scores)
+        assert "⚠" in result
+        assert "n_b" in result  # column header preserved
+
+
+# ---------------------------------------------------------------------------
+# generate_report — include_tournament toggle
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateReportTournamentToggle:
+    """Tests for the include_tournament flag on generate_report."""
+
+    def _scores_with_versions(self) -> dict[str, Any]:
+        s = _scores(
+            by_tool={"tool-a": {"brier": 0.3, "n": 50, "reliability": 1.0}},
+        )
+        s["by_tool_version_mode"] = {
+            "tool-a | v1 | production_replay": {
+                "n": 100,
+                "valid_n": 100,
+                "brier": 0.30,
+                "directional_accuracy": 0.6,
+                "log_loss": 0.7,
+                "sharpness": 0.3,
+                "reliability": 1.0,
+            },
+            "tool-a | v2 | tournament": {
+                "n": 50,
+                "valid_n": 50,
+                "brier": 0.20,
+                "directional_accuracy": 0.7,
+                "log_loss": 0.6,
+                "sharpness": 0.3,
+                "reliability": 1.0,
+            },
+        }
+        return s
+
+    def test_off_by_default_omits_tournament_sections(self) -> None:
+        """Default behavior: no tournament sections in the rendered report."""
+        s = self._scores_with_versions()
+        report = generate_report(s, [])
+        assert "Tool × Version × Mode" not in report
+        assert "Version Deltas" not in report
+
+    def test_on_renders_cumulative_breakdown_and_deltas(self) -> None:
+        """include_tournament=True renders the cumulative breakdown + deltas."""
+        s = self._scores_with_versions()
+        report = generate_report(s, [], include_tournament=True)
+        assert "Tool × Version × Mode (All-Time)" in report
+        assert "## Version Deltas" in report
+
+    def test_rolling_scores_render_separate_section(self) -> None:
+        """When rolling_scores has version cells, a 7d section appears too."""
+        s = self._scores_with_versions()
+        rolling = _scores()
+        rolling["by_tool_version_mode"] = {
+            "tool-a | v2 | tournament": {
+                "n": 35,
+                "valid_n": 35,
+                "brier": 0.18,
+                "directional_accuracy": 0.8,
+                "brier_skill_score": 0.1,
+            }
+        }
+        report = generate_report(s, [], rolling_scores=rolling, include_tournament=True)
+        assert "Tool × Version × Mode (All-Time)" in report
+        assert "Tool × Version × Mode (Last 7 Days)" in report

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -949,3 +949,118 @@ class TestPendingInState:  # pylint: disable=too-few-public-methods
         loaded_pending = loaded["omen"]["pending_deliveries"]
         assert len(loaded_pending) == 1
         assert loaded_pending[0]["deliver_id"] == "0xpending1"
+
+
+class TestNoScoreFlag:
+    """Tests for the --no-score flag that gates the inline scorer call."""
+
+    def test_flag_sets_attribute_true(self) -> None:
+        """--no-score on the CLI sets args.no_score to True."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets.fetch_production import _build_arg_parser
+
+        args = _build_arg_parser().parse_args(["--no-score"])
+        assert args.no_score is True
+
+    def test_default_is_false(self) -> None:
+        """Omitting --no-score keeps the fast path (inline scoring) enabled."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets.fetch_production import _build_arg_parser
+
+        args = _build_arg_parser().parse_args([])
+        assert args.no_score is False
+
+    def _stub_main_deps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        row: dict[str, Any],
+    ) -> list[tuple]:
+        """Stub out fetch/state deps for main() and capture scorer calls."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        calls: list[tuple] = []
+
+        monkeypatch.setattr(fp, "_migrate_legacy_log", lambda *a, **kw: None)
+        monkeypatch.setattr(fp, "load_fetch_state", lambda *a, **kw: {})
+        monkeypatch.setattr(fp, "load_existing_row_ids", lambda *a, **kw: set())
+        monkeypatch.setattr(fp, "fetch_omen_resolved", lambda *a, **kw: [])
+        monkeypatch.setattr(fp, "fetch_polymarket_resolved", lambda *a, **kw: [])
+        # Omen returns one row, polymarket returns none.
+        responses = iter([([row], [], 0, 0), ([], [], 0, 0)])
+        monkeypatch.setattr(fp, "process_platform", lambda *a, **kw: next(responses))
+        monkeypatch.setattr(fp, "append_rows", lambda *a, **kw: 1)
+        monkeypatch.setattr(fp, "_update_platform_state", lambda *a, **kw: None)
+        monkeypatch.setattr(fp, "save_fetch_state", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            fp,
+            "_run_scorer_update",
+            lambda rows, scores, history: calls.append((rows, scores, history)),
+        )
+        return calls
+
+    def test_main_skips_scorer_update_with_no_score(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """main(--no-score) must not call _run_scorer_update even when rows exist."""
+        # pylint: disable-next=import-outside-toplevel
+        import sys
+
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        calls = self._stub_main_deps(
+            monkeypatch, tmp_path, {"row_id": "r1", "prediction_parse_status": "valid"}
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "fetch_production",
+                "--no-score",
+                "--logs-dir",
+                str(tmp_path),
+                "--state-file",
+                str(tmp_path / "state.json"),
+                "--scores",
+                str(tmp_path / "scores.json"),
+                "--history",
+                str(tmp_path / "history.jsonl"),
+            ],
+        )
+        fp.main()
+        assert calls == []
+
+    def test_main_calls_scorer_update_by_default(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """main() without --no-score runs the fast-path inline scorer once."""
+        # pylint: disable-next=import-outside-toplevel
+        import sys
+
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        calls = self._stub_main_deps(
+            monkeypatch, tmp_path, {"row_id": "r1", "prediction_parse_status": "valid"}
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "fetch_production",
+                "--logs-dir",
+                str(tmp_path),
+                "--state-file",
+                str(tmp_path / "state.json"),
+                "--scores",
+                str(tmp_path / "scores.json"),
+                "--history",
+                str(tmp_path / "history.jsonl"),
+            ],
+        )
+        fp.main()
+        assert len(calls) == 1
+        rows, _scores, _history = calls[0]
+        assert rows == [{"row_id": "r1", "prediction_parse_status": "valid"}]

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -988,8 +988,10 @@ class TestNoScoreFlag:
         monkeypatch.setattr(fp, "fetch_omen_resolved", lambda *a, **kw: [])
         monkeypatch.setattr(fp, "fetch_polymarket_resolved", lambda *a, **kw: [])
         # Omen returns one row, polymarket returns none.
-        responses = iter([([row], [], 0, 0), ([], [], 0, 0)])
-        monkeypatch.setattr(fp, "process_platform", lambda *a, **kw: next(responses))
+        response_queue: list[Any] = [([row], [], 0, 0), ([], [], 0, 0)]
+        monkeypatch.setattr(
+            fp, "process_platform", lambda *a, **kw: response_queue.pop(0)
+        )
         monkeypatch.setattr(fp, "append_rows", lambda *a, **kw: 1)
         monkeypatch.setattr(fp, "_update_platform_state", lambda *a, **kw: None)
         monkeypatch.setattr(fp, "save_fetch_state", lambda *a, **kw: None)
@@ -1030,7 +1032,7 @@ class TestNoScoreFlag:
             ],
         )
         fp.main()
-        assert calls == []
+        assert not calls
 
     def test_main_calls_scorer_update_by_default(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -71,11 +71,13 @@ def _row(
     market_liquidity: float | None = None,
     market_spread: float | None = None,
     row_id: str | None = None,
+    tool_ipfs_hash: str | None = None,
+    mode: str | None = None,
 ) -> dict[str, Any]:
     """Build a minimal production_log row for testing."""
     if row_id is None:
         row_id = f"test_{uuid.uuid4().hex[:12]}"
-    return {
+    row: dict[str, Any] = {
         "row_id": row_id,
         "prediction_parse_status": status,
         "p_yes": p_yes if status == "valid" else None,
@@ -92,6 +94,11 @@ def _row(
         "market_liquidity_at_prediction": market_liquidity,
         "market_spread_at_prediction": market_spread,
     }
+    if tool_ipfs_hash is not None:
+        row["tool_ipfs_hash"] = tool_ipfs_hash
+    if mode is not None:
+        row["mode"] = mode
+    return row
 
 
 # ---------------------------------------------------------------------------
@@ -814,6 +821,82 @@ class TestToolVersionBreakdown:
 
         assert "t1 | unknown" in result["by_tool_version"]
         assert result["by_tool_version"]["t1 | unknown"]["n"] == 2
+
+
+class TestTournamentVersionNormalization:
+    """Tests that tool_ipfs_hash is treated as tool_version (tournament path)."""
+
+    def test_ipfs_hash_populates_version_when_tool_version_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """Tournament rows store the hash in tool_ipfs_hash, not tool_version."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [
+            _row(tool="t1", tool_ipfs_hash="bafy_abc"),
+            _row(tool="t1", tool_ipfs_hash="bafy_abc"),
+        ]
+        result = update(rows, scores_path, history_path)
+
+        assert "t1 | bafy_abc" in result["by_tool_version"]
+        assert result["by_tool_version"]["t1 | bafy_abc"]["n"] == 2
+
+    def test_tool_version_takes_precedence_over_ipfs_hash(self, tmp_path: Path) -> None:
+        """If both fields are set, tool_version wins (production semantics)."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [_row(tool="t1", tool_version="prod_v1", tool_ipfs_hash="bafy_other")]
+        result = update(rows, scores_path, history_path)
+
+        assert "t1 | prod_v1" in result["by_tool_version"]
+        assert "t1 | bafy_other" not in result["by_tool_version"]
+
+
+class TestToolVersionModeBreakdown:
+    """Tests for the (tool, version, mode) aggregation dimension."""
+
+    def test_splits_by_mode_when_hash_matches(self, tmp_path: Path) -> None:
+        """Same tool + same hash but different modes must yield separate cells."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [
+            _row(tool="t1", tool_version="v1", mode="production_replay"),
+            _row(tool="t1", tool_ipfs_hash="v1", mode="tournament"),
+        ]
+        result = update(rows, scores_path, history_path)
+
+        assert "t1 | v1 | production_replay" in result["by_tool_version_mode"]
+        assert "t1 | v1 | tournament" in result["by_tool_version_mode"]
+        assert result["by_tool_version_mode"]["t1 | v1 | production_replay"]["n"] == 1
+        assert result["by_tool_version_mode"]["t1 | v1 | tournament"]["n"] == 1
+
+    def test_defaults_mode_to_production_replay(self, tmp_path: Path) -> None:
+        """Rows without a mode field default to production_replay."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [_row(tool="t1", tool_version="v1")]
+        result = update(rows, scores_path, history_path)
+
+        assert "t1 | v1 | production_replay" in result["by_tool_version_mode"]
+
+    def test_distinct_versions_within_same_mode(self, tmp_path: Path) -> None:
+        """Two hashes of the same tool in the same mode produce two cells."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [
+            _row(tool="t1", tool_version="v1", mode="production_replay"),
+            _row(tool="t1", tool_version="v1", mode="production_replay"),
+            _row(tool="t1", tool_version="v2", mode="production_replay"),
+        ]
+        result = update(rows, scores_path, history_path)
+
+        assert result["by_tool_version_mode"]["t1 | v1 | production_replay"]["n"] == 2
+        assert result["by_tool_version_mode"]["t1 | v2 | production_replay"]["n"] == 1
 
 
 class TestConfigBreakdown:


### PR DESCRIPTION
**Stacked on #205 — review/merge that one first.**

## Summary

Wires `tournament_scored.jsonl` into the existing scorer/analyze pipeline so tournament results land in the same daily `report.md` and Slack post as production data. Adds a per-`(tool_name, tool_version, mode)` aggregation dimension so tool IPFS hash changes show up as distinct rows with Brier deltas — production currently averages all versions of a tool together, hiding version regressions/improvements.

The `--include-tournament` toggle on `analyze.py` controls whether the new sections are rendered. With the flag off, `report.md` is byte-identical to today's production-only output (verified via diff on real artifacts).

## What changes

| File | Change |
|---|---|
| `benchmark/scorer.py` | `--tournament-input` flag (rebuild + period); new `--update PATH` flag for incremental row merge; version field normalized at accumulation (`tool_version` OR `tool_ipfs_hash`); new `by_tool_version_mode` dimension threaded through 4 dim-list locations |
| `benchmark/analyze.py` | `--include-tournament` flag; new `section_tool_version_breakdown` rendered twice (cumulative + 7d rolling) when toggle on; new `section_version_deltas` using `compare.compare_stats`; per-row ⚠ marker on cells with n < 30 |
| `benchmark/notify_slack.py` | New `*Tool versions:*` slot in the structured prompt; explicit rule forbidding superlatives on small-sample rows; `max_tokens` 500 → 1200 to fit the new section |
| `.github/workflows/benchmark_flywheel.yaml` | benchmark job now `needs: [tournament-run]` and downloads the tournament-predictions artifact; new "Merge tournament into cumulative scores" step after fetch; `--tournament-input` threaded through rebuild + score-today + score-7d steps; `--include-tournament` on analyze |

## Design decisions taken

- **Single Slack post, single `report.md`.** Tournament is an additive section, not a parallel report.
- **Aggregation key:** `(tool_name, tool_ipfs_hash, mode)` — flat table, no collapsing across modes (production V1 and tournament V1 stay as separate rows even when the hash matches). User chose this to keep tournament's small n visible rather than blended into production averages.
- **Hash display:** full hashes, no truncation. Future work will map to release tags.
- **Toggle:** opt-in via `--include-tournament`; default off in code, on in the workflow. Disabling = remove the flag from the workflow; production output remains byte-identical.
- **Schemas left as-is.** Production rows store the hash in `tool_version`, tournament rows in `tool_ipfs_hash`. Adapter normalizes at accumulation time. Schema unification deferred to a separate initiative (per the original `benchmark/PROPOSAL.md` design).

## API call impact

Zero — this PR only changes how existing data is aggregated and displayed. Tournament scoring already runs daily; the new merge step is a fast no-op when no new tournament rows have arrived (dedup by `row_id`).

## Verification (local, with synthetic data covering the multi-version case)

1. Downloaded latest `benchmark-data` and `tournament-predictions` artifacts.
2. Ran `scorer --update tournament_scored.jsonl` → merged 117 tournament rows into cumulative `scores.json`, producing 13 `by_tool_version_mode` cells.
3. Ran `analyze --include-tournament --rolling rolling_scores.json` → report renders cumulative + 7d rolling Tool × Version × Mode tables and Version Deltas section.
4. Ran `analyze` (no flag) → diff vs production-only output is empty (byte-identical).
5. Ran `notify_slack --dry-run` with `OPENAI_API_KEY` → Slack summary correctly emits `*Tool versions:*` block; with synthetic multi-version data, regression of `prediction-offline` (`+0.0661 n=310`) and improvement of `prediction-online` V2 (`-0.0568 n=420`) both surface in `*Regressions:*` and `*Tool versions:*`.
6. Verified the small-sample suppression: with all-tournament data (n=9 cells), the Slack summary correctly says "All version × mode data have small samples (n<30); no reliable version comparisons possible" instead of inventing superlatives.

## Known caveats / follow-ups (not blocking this PR)

- **Existing cumulative `scores.json` was generated by the old scorer** (no `by_tool_version_mode`). After this lands, the first day's daily run will only have tournament cells in that dimension; production cells start populating as new prod rows are accumulated. A one-shot rebuild after merge is the cleanest way to backfill prod versions, but is optional — the dimension fills in over time regardless.
- **Tournament n is currently 9 markets per tool**; all version cells will carry ⚠ until that grows. The structure is correct; the warnings are honest about what the data supports.
- **Cross-mode deltas in the Version Deltas section** (e.g., production V1 vs tournament V2) compare different sampling distributions — same market universe (Omen + Polymarket), but production = trader's bets vs. tournament = open-market sample. Treat as suggestive when one side has small n.
- **Schema unification** between `tool_version` (prod) and `tool_ipfs_hash` (tournament) is deferred. Adapter handles it at read time.

## Test plan

- [ ] Trigger the workflow manually after merge; confirm `report.md` artifact contains both new sections and the Slack post includes `*Tool versions:*`.
- [ ] Confirm toggling `--include-tournament` off in the workflow restores production-only output byte-identically.
- [ ] Watch for cumulative `by_tool_version_mode` to start populating production cells as fresh prod rows are scored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)