### PR TITLE
fix(benchmark): disable regressions section and raise tournament timeout

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -278,7 +278,7 @@ jobs:
     needs: [tournament-fetch, check-secrets]
     if: needs.check-secrets.outputs.has_keys == 'true'
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v4

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -1076,7 +1076,6 @@ def generate_report(
                     rolling_scores, "Tool × Version × Mode (Last 7 Days)"
                 )
             )
-        candidates.append(section_version_deltas(scores))
         tournament_sections = [s for s in candidates if s]
 
     sections = [

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -43,8 +43,6 @@ Summarize this Olas Predict benchmark report using EXACTLY this structure (outpu
 
 *Weak categories:* list categories with Brier > 0.40 and brief note
 
-*Tool versions:* if the report has a "Tool × Version × Mode" (cumulative or 7d) section, summarize per-version observations: which tool versions are present, mode (production_replay vs tournament), Brier per cell. Show full hashes (no truncation) wrapped in backticks. CRITICAL: any row whose n cell ends in ⚠ or whose underlying n is below 30 is a small sample — when mentioning such a row you MUST lead with "small sample (n=X)" before stating any metric, and you MUST NOT use the words "best", "highest", "lowest", "worst", or any superlative for that row. Compare across versions only when both have n >= 30. Do NOT call out regressions or per-version Brier deltas — that section is temporarily disabled pending rework. Skip this section entirely if no Tool × Version × Mode content is present.
-
 *Diagnostics:*
 If the report includes "Diagnostic Edge Metrics", summarize:
 • Conditional accuracy: X% tool-wins when disagreeing (n=X) — when the tool would trigger a trade, how often is it closer to truth than the market?

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -43,9 +43,7 @@ Summarize this Olas Predict benchmark report using EXACTLY this structure (outpu
 
 *Weak categories:* list categories with Brier > 0.40 and brief note
 
-*Regressions:* any tools or metrics that worsened vs prior period. Say "None" if trend data shows no worsening. "Regression" means worse over TIME, not just a bad score.
-
-*Tool versions:* if the report has a "Tool × Version × Mode" (cumulative or 7d), or "Version Deltas" section, summarize per-version observations: which tool versions changed, mode (production_replay vs tournament), Brier delta where shown. Show full hashes (no truncation) wrapped in backticks. CRITICAL: any row whose n cell ends in ⚠ or whose underlying n is below 30 is a small sample — when mentioning such a row you MUST lead with "small sample (n=X)" before stating any metric, and you MUST NOT use the words "best", "highest", "lowest", "worst", or any superlative for that row. Compare across versions only when both have n >= 30. Skip the section entirely if no Tool × Version × Mode or Version Deltas content is present.
+*Tool versions:* if the report has a "Tool × Version × Mode" (cumulative or 7d) section, summarize per-version observations: which tool versions are present, mode (production_replay vs tournament), Brier per cell. Show full hashes (no truncation) wrapped in backticks. CRITICAL: any row whose n cell ends in ⚠ or whose underlying n is below 30 is a small sample — when mentioning such a row you MUST lead with "small sample (n=X)" before stating any metric, and you MUST NOT use the words "best", "highest", "lowest", "worst", or any superlative for that row. Compare across versions only when both have n >= 30. Do NOT call out regressions or per-version Brier deltas — that section is temporarily disabled pending rework. Skip this section entirely if no Tool × Version × Mode content is present.
 
 *Diagnostics:*
 If the report includes "Diagnostic Edge Metrics", summarize:

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -592,11 +592,13 @@ class TestGenerateReportTournamentToggle:
         assert "Version Deltas" not in report
 
     def test_on_renders_cumulative_breakdown_and_deltas(self) -> None:
-        """include_tournament=True renders the cumulative breakdown + deltas."""
+        """include_tournament=True renders the cumulative breakdown. Version
+        Deltas is temporarily disabled pending rework (see
+        BENCHMARK_REPORT_FIXES.md §0)."""
         s = self._scores_with_versions()
         report = generate_report(s, [], include_tournament=True)
         assert "Tool × Version × Mode (All-Time)" in report
-        assert "## Version Deltas" in report
+        assert "## Version Deltas" not in report
 
     def test_rolling_scores_render_separate_section(self) -> None:
         """When rolling_scores has version cells, a 7d section appears too."""

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -592,9 +592,10 @@ class TestGenerateReportTournamentToggle:
         assert "Version Deltas" not in report
 
     def test_on_renders_cumulative_breakdown_and_deltas(self) -> None:
-        """include_tournament=True renders the cumulative breakdown. Version
-        Deltas is temporarily disabled pending rework (see
-        BENCHMARK_REPORT_FIXES.md §0)."""
+        """include_tournament=True renders the cumulative breakdown.
+
+        Version Deltas is temporarily disabled pending rework.
+        """
         s = self._scores_with_versions()
         report = generate_report(s, [], include_tournament=True)
         assert "Tool × Version × Mode (All-Time)" in report


### PR DESCRIPTION
## Summary

Three small, related changes to the daily benchmark pipeline:

- **Disable the Regressions / Version Deltas section** in the daily report. The current implementation sorts versions alphabetically by CID (semantically random) and frequently pairs a large baseline against a tiny candidate sample — producing "regressed" flags that contradict the same report's top-line numbers. Hide until reworked with temporal ordering and within-mode pooling.
- **Drop per-version content from the Slack prompt entirely** (`*Regressions:*` and `*Tool versions:*` bullets). Removes any remaining path for the LLM to narrate cross-version Brier gaps in a way that reads like a regression call-out. `report.md` still contains the `Tool × Version × Mode` tables for anyone reading the full report.
- **Raise `tournament-run` timeout from 45 → 90 minutes.** The scheduled run on 2026-04-15 was cancelled at exactly 45:16 mid-step; 14 tools × 20 markets serial reliably hits the wall-clock. Cancellation produces a report with no tournament data at all, indistinguishable from a healthy run.

## Changes

- `benchmark/analyze.py` — drop `section_version_deltas()` from the tournament block.
- `benchmark/notify_slack.py` — drop both `*Regressions:*` and `*Tool versions:*` bullets from the Slack prompt.
- `.github/workflows/benchmark_flywheel.yaml` — `tournament-run: timeout-minutes: 45` → `90`.
- `benchmark/tests/test_analyze.py` — flip the `generate_report(..., include_tournament=True)` assertion to require **no** Version Deltas header.

`section_version_deltas()` itself is preserved so the follow-up PR can re-enable it once the temporal ordering + release-map work lands.

## Test plan

- [x] `pytest benchmark/tests/test_analyze.py` — 38 passed locally.
- [ ] Tomorrow's scheduled flywheel run produces a Slack post with no `*Regressions:*` or `*Tool versions:*` section.
- [ ] `tournament-run` no longer cancels at 45 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)