### PR TITLE
feat(benchmark): split production and tournament scoring artifacts

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -159,12 +159,15 @@ jobs:
             $TOURNAMENT_FLAG
         continue-on-error: true
 
-      # Analyze reads scores.json + history + period scores
+      # Analyze reads scores.json + tournament scores + history + period scores
       - name: Analyze
         run: |
           python -m benchmark.analyze \
             --period benchmark/results/period_scores.json \
             --rolling benchmark/results/rolling_scores.json \
+            --scores-tournament benchmark/results/scores_tournament.json \
+            --period-tournament benchmark/results/period_scores_tournament.json \
+            --rolling-tournament benchmark/results/rolling_scores_tournament.json \
             --include-tournament
 
       # Upload state + scores (small, needed for next run)
@@ -175,6 +178,7 @@ jobs:
           path: |
             benchmark/datasets/.fetch_state.json
             benchmark/results/scores.json
+            benchmark/results/scores_tournament.json
             benchmark/results/scores_history.jsonl
             benchmark/results/scored_row_ids.json
             benchmark/results/report.md

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -1213,7 +1213,7 @@ def generate_report(
 
     # Since Last Report
     sections.append(section_period(period_scores, scores, "Since Last Report"))
-    if render_tournament and period_scores_tournament is not None:
+    if render_tournament and _has_tournament_data(period_scores_tournament):
         sections.append(
             _relabel_heading(
                 section_period(
@@ -1227,7 +1227,7 @@ def generate_report(
 
     # Last 7 Days Rolling
     sections.append(section_period(rolling_scores, scores, "Last 7 Days Rolling"))
-    if render_tournament and rolling_scores_tournament is not None:
+    if render_tournament and _has_tournament_data(rolling_scores_tournament):
         sections.append(
             _relabel_heading(
                 section_period(

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -1041,21 +1041,161 @@ def section_version_deltas(scores: dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
+CALLOUT_DELTA = 0.03
+CALLOUT_MIN_N = 30
+
+
+def _relabel_heading(section_md: str, suffix: str) -> str:
+    """Append *suffix* to the first ``## Heading`` line in *section_md*.
+
+    Used to dup-render production sections with a "— Tournament" label
+    without duplicating every section function.
+
+    :param section_md: rendered markdown for a single section.
+    :param suffix: string appended to the first ``## Heading`` line.
+    :return: the section markdown with the heading relabelled.
+    """
+    lines = section_md.split("\n")
+    if lines and lines[0].startswith("## "):
+        lines[0] = lines[0] + suffix
+    return "\n".join(lines)
+
+
+def _has_tournament_data(scores_tournament: dict[str, Any] | None) -> bool:
+    """Return True when a tournament scores dict has any rows to report."""
+    return bool(scores_tournament and scores_tournament.get("total_rows", 0) > 0)
+
+
+def _merged_tvm_scores(
+    scores_prod: dict[str, Any],
+    scores_tournament: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Return a scores-shaped dict whose ``by_tool_version_mode`` holds both modes.
+
+    Keys are already of the form ``tool | version | mode`` so there is no
+    risk of collision between the two files.
+
+    :param scores_prod: production scores dict.
+    :param scores_tournament: tournament scores dict, or None.
+    :return: minimal scores dict with merged ``by_tool_version_mode``.
+    """
+    merged: dict[str, Any] = {"by_tool_version_mode": {}}
+    merged["by_tool_version_mode"].update(scores_prod.get("by_tool_version_mode", {}))
+    if scores_tournament:
+        merged["by_tool_version_mode"].update(
+            scores_tournament.get("by_tool_version_mode", {})
+        )
+    return merged
+
+
+def section_tournament_callouts(
+    scores_prod: dict[str, Any],
+    scores_tournament: dict[str, Any] | None,
+) -> str:
+    """Flag tool versions whose tournament Brier diverges from prod.
+
+    A row qualifies when tournament sample size is at least
+    ``CALLOUT_MIN_N`` and the absolute Brier delta exceeds
+    ``CALLOUT_DELTA``. Negative deltas become promotion candidates
+    (tournament better); positive deltas become tournament regressions
+    (tournament worse — a warning before the version reaches production).
+
+    :param scores_prod: production scores dict (provides tool-level baselines).
+    :param scores_tournament: tournament scores dict (candidate cells), or None.
+    :return: markdown section, or empty string when no callouts qualify.
+    """
+    if not _has_tournament_data(scores_tournament):
+        return ""
+
+    prod_by_tool = scores_prod.get("by_tool", {}) if scores_prod else {}
+    assert scores_tournament is not None  # narrowed by _has_tournament_data
+    tournament_tvm = scores_tournament.get("by_tool_version_mode", {})
+
+    promotions: list[tuple[str, str, dict[str, Any], dict[str, Any]]] = []
+    regressions: list[tuple[str, str, dict[str, Any], dict[str, Any]]] = []
+
+    for key, t_stats in tournament_tvm.items():
+        tool, version, mode = _parse_tvm_key(key)
+        if mode != "tournament":
+            continue
+        if t_stats.get("n", 0) < CALLOUT_MIN_N:
+            continue
+        t_brier = t_stats.get("brier")
+        if t_brier is None:
+            continue
+
+        p_stats = prod_by_tool.get(tool)
+        if not p_stats:
+            continue
+        p_brier = p_stats.get("brier")
+        if p_brier is None:
+            continue
+
+        delta = t_brier - p_brier
+        if delta <= -CALLOUT_DELTA:
+            promotions.append((tool, version, t_stats, p_stats))
+        elif delta >= CALLOUT_DELTA:
+            regressions.append((tool, version, t_stats, p_stats))
+
+    if not promotions and not regressions:
+        return ""
+
+    lines = ["## Tournament Callouts", ""]
+    if promotions:
+        lines.append("**Promotion candidates:**")
+        lines.append("")
+        for tool, version, t_stats, p_stats in promotions:
+            delta = t_stats["brier"] - p_stats["brier"]
+            lines.append(
+                f"- `{tool}` version `{version}` — tournament Brier"
+                f" {t_stats['brier']:.4f} (n={t_stats['n']}) vs production Brier"
+                f" {p_stats['brier']:.4f} (n={p_stats['n']}). Δ {delta:+.4f}."
+            )
+        lines.append("")
+    if regressions:
+        lines.append("**Tournament regressions:**")
+        lines.append("")
+        for tool, version, t_stats, p_stats in regressions:
+            delta = t_stats["brier"] - p_stats["brier"]
+            lines.append(
+                f"- `{tool}` version `{version}` — tournament Brier"
+                f" {t_stats['brier']:.4f} (n={t_stats['n']}) vs production Brier"
+                f" {p_stats['brier']:.4f} (n={p_stats['n']}). Δ {delta:+.4f}."
+            )
+    return "\n".join(lines).rstrip()
+
+
 def generate_report(
     scores: dict[str, Any],
     history: list[dict[str, Any]] | None = None,
     period_scores: dict[str, Any] | None = None,
     rolling_scores: dict[str, Any] | None = None,
     include_tournament: bool = False,
+    scores_tournament: dict[str, Any] | None = None,
+    period_scores_tournament: dict[str, Any] | None = None,
+    rolling_scores_tournament: dict[str, Any] | None = None,
 ) -> str:
     """Generate a full benchmark report from scores and history.
 
-    :param scores: parsed ``scores.json`` dict (all-time).
+    Production-mode sections are rendered from ``scores`` /
+    ``period_scores`` / ``rolling_scores``. When tournament scores are
+    supplied and contain rows, a duplicate set of the mode-sensitive
+    sections (Since Last Report, Last 7 Days Rolling, Overall, Tool
+    Ranking) is rendered with a ``— Tournament`` suffix. The Tool ×
+    Version × Mode breakdown merges both modes. A final "Tournament
+    Callouts" section flags tool versions whose tournament Brier
+    diverges materially from the same tool's production baseline.
+
+    :param scores: parsed production ``scores.json`` dict (all-time).
     :param history: list of monthly snapshots from ``scores_history.jsonl``.
-    :param period_scores: scores from today's run (since last report).
-    :param rolling_scores: scores from the last 7 days.
-    :param include_tournament: when True, render the Tool × Version × Mode
-        (cumulative + 7d rolling) and Version Deltas sections.
+    :param period_scores: production scores since last report.
+    :param rolling_scores: production scores from the last 7 days.
+    :param include_tournament: master switch for rendering the Tool ×
+        Version × Mode breakdown. When False, tournament inputs are
+        ignored entirely.
+    :param scores_tournament: parsed ``scores_tournament.json`` dict.
+    :param period_scores_tournament: tournament since last report.
+    :param rolling_scores_tournament: tournament last 7 days.
     :return: full markdown report string.
     """
     if history is None:
@@ -1065,41 +1205,99 @@ def generate_report(
         "%Y-%m-%d"
     )
 
-    tournament_sections: list[str] = []
-    if include_tournament:
-        candidates = [
-            section_tool_version_breakdown(scores, "Tool × Version × Mode (All-Time)"),
-        ]
-        if rolling_scores is not None:
-            candidates.append(
-                section_tool_version_breakdown(
-                    rolling_scores, "Tool × Version × Mode (Last 7 Days)"
-                )
-            )
-        tournament_sections = [s for s in candidates if s]
+    render_tournament = include_tournament and _has_tournament_data(scores_tournament)
+    # Local non-optional alias for mypy once _has_tournament_data has narrowed.
+    tournament_scores: dict[str, Any] = scores_tournament or {}
 
-    sections = [
-        f"# Benchmark Report — {date}",
-        section_period(period_scores, scores, "Since Last Report"),
-        section_period(rolling_scores, scores, "Last 7 Days Rolling"),
-        section_overall(scores),
-        section_base_rates(scores),
-        section_tool_ranking(scores),
-        *tournament_sections,
-        section_platform(scores),
-        section_tool_platform(scores),
-        section_edge_analysis(scores),
-        section_diagnostic_metrics(scores),
-        section_calibration(scores),
-        section_weak_spots(scores),
-        section_reliability_issues(scores),
-        section_parse_breakdown(scores),
-        section_latency(scores),
-        section_worst_predictions(scores),
-        section_best_predictions(scores),
-        section_trend(history, scores),
-        section_sample_size_warnings(scores),
-    ]
+    sections: list[str] = [f"# Benchmark Report — {date}"]
+
+    # Since Last Report
+    sections.append(section_period(period_scores, scores, "Since Last Report"))
+    if render_tournament and period_scores_tournament is not None:
+        sections.append(
+            _relabel_heading(
+                section_period(
+                    period_scores_tournament,
+                    tournament_scores,
+                    "Since Last Report",
+                ),
+                " — Tournament",
+            )
+        )
+
+    # Last 7 Days Rolling
+    sections.append(section_period(rolling_scores, scores, "Last 7 Days Rolling"))
+    if render_tournament and rolling_scores_tournament is not None:
+        sections.append(
+            _relabel_heading(
+                section_period(
+                    rolling_scores_tournament,
+                    tournament_scores,
+                    "Last 7 Days Rolling",
+                ),
+                " — Tournament",
+            )
+        )
+
+    # Overall
+    sections.append(section_overall(scores))
+    if render_tournament:
+        sections.append(
+            _relabel_heading(section_overall(tournament_scores), " — Tournament")
+        )
+
+    # Base Rates — production only
+    sections.append(section_base_rates(scores))
+
+    # Tool Ranking
+    sections.append(section_tool_ranking(scores))
+    if render_tournament:
+        sections.append(
+            _relabel_heading(section_tool_ranking(tournament_scores), " — Tournament")
+        )
+
+    # Tool × Version × Mode — merged
+    if include_tournament:
+        merged = _merged_tvm_scores(scores, scores_tournament)
+        tvm_section = section_tool_version_breakdown(
+            merged, "Tool × Version × Mode (All-Time)"
+        )
+        if tvm_section:
+            sections.append(tvm_section)
+        if rolling_scores is not None:
+            merged_rolling = _merged_tvm_scores(
+                rolling_scores, rolling_scores_tournament
+            )
+            tvm_rolling = section_tool_version_breakdown(
+                merged_rolling, "Tool × Version × Mode (Last 7 Days)"
+            )
+            if tvm_rolling:
+                sections.append(tvm_rolling)
+
+    # Remaining production-only sections
+    sections.extend(
+        [
+            section_platform(scores),
+            section_tool_platform(scores),
+            section_edge_analysis(scores),
+            section_diagnostic_metrics(scores),
+            section_calibration(scores),
+            section_weak_spots(scores),
+            section_reliability_issues(scores),
+            section_parse_breakdown(scores),
+            section_latency(scores),
+            section_worst_predictions(scores),
+            section_best_predictions(scores),
+            section_trend(history, scores),
+            section_sample_size_warnings(scores),
+        ]
+    )
+
+    # Tournament Callouts — cross-mode
+    if render_tournament:
+        callouts = section_tournament_callouts(scores, scores_tournament)
+        if callouts:
+            sections.append(callouts)
 
     return "\n\n".join(sections) + "\n"
 
@@ -1121,29 +1319,56 @@ def main() -> None:
         "--period",
         type=Path,
         default=None,
-        help="Period scores JSON (since last report)",
+        help="Period scores JSON (since last report, production)",
     )
     parser.add_argument(
         "--rolling",
         type=Path,
         default=None,
-        help="Rolling 7-day scores JSON",
+        help="Rolling 7-day scores JSON (production)",
+    )
+    parser.add_argument(
+        "--scores-tournament",
+        type=Path,
+        default=None,
+        help="Tournament scores JSON (all-time)",
+    )
+    parser.add_argument(
+        "--period-tournament",
+        type=Path,
+        default=None,
+        help="Tournament period scores JSON (since last report)",
+    )
+    parser.add_argument(
+        "--rolling-tournament",
+        type=Path,
+        default=None,
+        help="Tournament rolling 7-day scores JSON",
     )
     parser.add_argument(
         "--include-tournament",
         action="store_true",
-        help="Render tournament-mode sections (Tool × Version × Mode and Version Deltas)",
+        help=(
+            "Render tournament-mode sections (duplicated per-mode blocks, "
+            "merged Tool × Version × Mode, and Tournament Callouts)"
+        ),
     )
     args = parser.parse_args()
 
+    def _maybe_load(path: Path | None) -> dict[str, Any] | None:
+        return load_scores(path) if path and path.exists() else None
+
     scores = load_scores(args.scores)
     history = load_history(args.history)
-    period = load_scores(args.period) if args.period and args.period.exists() else None
-    rolling = (
-        load_scores(args.rolling) if args.rolling and args.rolling.exists() else None
-    )
+    period = _maybe_load(args.period)
+    rolling = _maybe_load(args.rolling)
+    scores_tournament = _maybe_load(args.scores_tournament)
+    period_tournament = _maybe_load(args.period_tournament)
+    rolling_tournament = _maybe_load(args.rolling_tournament)
+
     print(
-        f"Loaded scores ({scores.get('total_rows', 0)} rows), {len(history)} months of history"
+        f"Loaded scores ({scores.get('total_rows', 0)} rows), "
+        f"{len(history)} months of history"
     )
 
     report = generate_report(
@@ -1152,6 +1377,9 @@ def main() -> None:
         period_scores=period,
         rolling_scores=rolling,
         include_tournament=args.include_tournament,
+        scores_tournament=scores_tournament,
+        period_scores_tournament=period_tournament,
+        rolling_scores_tournament=rolling_tournament,
     )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -43,6 +43,8 @@ Summarize this Olas Predict benchmark report using EXACTLY this structure (outpu
 
 *Weak categories:* list categories with Brier > 0.40 and brief note
 
+*Tournament callouts:* If the report has a "Tournament Callouts" section, list each callout as a single bullet: tool name, full version hash in backticks, tournament Brier + n, production Brier + n, Brier delta. Lead promotion candidates with "promotion candidate:" and tournament regressions with "watch:". Skip this section entirely if no Tournament Callouts section is present in the report.
+
 *Diagnostics:*
 If the report includes "Diagnostic Edge Metrics", summarize:
 • Conditional accuracy: X% tool-wins when disagreeing (n=X) — when the tool would trigger a trade, how often is it closer to truth than the market?

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -32,9 +32,48 @@ from benchmark.io import load_jsonl as load_rows
 
 DEFAULT_INPUT = Path(__file__).parent / "datasets" / "production_log.jsonl"
 DEFAULT_OUTPUT = Path(__file__).parent / "results" / "scores.json"
+DEFAULT_OUTPUT_TOURNAMENT = Path(__file__).parent / "results" / "scores_tournament.json"
 DEFAULT_HISTORY = Path(__file__).parent / "results" / "scores_history.jsonl"
 DEFAULT_DEDUP = Path(__file__).parent / "results" / "scored_row_ids.json"
 DEFAULT_LOGS_DIR = Path(__file__).parent / "datasets" / "logs"
+
+PRODUCTION_MODE = "production_replay"
+TOURNAMENT_MODE = "tournament"
+
+
+def _derive_tournament_path(scores_path: Path) -> Path:
+    """Return the tournament scores path paired with *scores_path*.
+
+    Convention: ``<stem>.json`` -> ``<stem>_tournament.json`` in the same dir.
+    Used so a single ``--output`` flag (or default) implies both files.
+
+    :param scores_path: production scores path.
+    :return: paired tournament scores path.
+    """
+    return scores_path.with_name(f"{scores_path.stem}_tournament{scores_path.suffix}")
+
+
+def _partition_rows_by_mode(
+    rows: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Split rows into (production, tournament) lists.
+
+    Rows are routed by ``row["mode"]``. Missing mode defaults to
+    production — matches the historical default in ``_accumulate_row``.
+
+    :param rows: input rows (any mode).
+    :return: tuple of (production_rows, tournament_rows).
+    """
+    prod: list[dict[str, Any]] = []
+    tourn: list[dict[str, Any]] = []
+    for row in rows:
+        mode = row.get("mode") or PRODUCTION_MODE
+        if mode == TOURNAMENT_MODE:
+            tourn.append(row)
+        else:
+            prod.append(row)
+    return prod, tourn
+
 
 LATENCY_RESERVOIR_SIZE = 200
 CALIBRATION_PAIRS_RESERVOIR_SIZE = 50_000
@@ -1514,76 +1553,50 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
     return scores
 
 
-def update(
-    new_rows: list[dict[str, Any]],
-    scores_path: Path = DEFAULT_OUTPUT,
-    history_path: Path = DEFAULT_HISTORY,
-    dedup_path: Path | None = None,
+def _accumulate_and_write(
+    rows: list[dict[str, Any]],
+    scores_path: Path,
+    history_path: Path | None,
+    emit_history: bool,
 ) -> dict[str, Any]:
-    """Incrementally merge new rows into the scores accumulators.
+    """Load existing scores (if any), accumulate *rows*, write output.
 
-    If ``scores.json`` exists with valid accumulators, loads and extends.
-    Otherwise initializes fresh accumulators.
+    Shared post-dedup implementation of update(). Callers pass an
+    already-deduplicated, single-mode slice of rows. When
+    ``emit_history`` is False (tournament path), the month-boundary
+    snapshot step is skipped and ``history_path`` may be None.
 
-    Handles month boundaries: if the stored ``current_month`` differs from
-    today's month, snapshots the completed month to ``scores_history.jsonl``
-    and resets accumulators. Dedup state is stored in a separate file
-    (``scored_row_ids.json``) so it persists across month rollovers.
-
-    :param new_rows: list of production log row dicts.
-    :param scores_path: path to ``scores.json``.
-    :param history_path: path to ``scores_history.jsonl``.
-    :param dedup_path: path to ``scored_row_ids.json``.
+    :param rows: pre-deduplicated rows for a single mode.
+    :param scores_path: output path for the accumulator dict.
+    :param history_path: optional history file for monthly snapshots.
+    :param emit_history: when False, skip the snapshot step entirely.
     :return: finalized scores dict (also written to disk).
     """
-    if dedup_path is None:
-        dedup_path = scores_path.parent / "scored_row_ids.json"
-
     today_month = datetime.now(timezone.utc).strftime("%Y-%m")
 
     existing = _load_scores_for_resume(scores_path)
     if existing is not None:
         scores = existing
-        # Month boundary check
         if scores["current_month"] != today_month:
-            _snapshot_month(scores, history_path)
-            scores = _empty_scores(today_month)
+            if emit_history and history_path is not None:
+                _snapshot_month(scores, history_path)
+                scores = _empty_scores(today_month)
+            else:
+                # Tournament path: keep accumulating across month boundaries
+                # so cross-mode comparisons (and callout thresholds) don't
+                # reset to zero on the 1st of every month. Only advance the
+                # stored month label.
+                scores["current_month"] = today_month
     else:
         scores = _empty_scores(today_month)
 
-    # Dedup state lives in its own file — survives month rollover
-    scored_ids = _load_dedup_ids(dedup_path)
-    # Migrate: if old scores.json had scored_row_ids, merge them
-    scored_ids.update(scores.pop("scored_row_ids", set()))
+    # Drop any migrated dedup set — dedup is owned by the caller now.
+    scores.pop("scored_row_ids", None)
 
-    skipped = 0
-    no_id = 0
-    for row in new_rows:
-        row_id = row.get("row_id")
-        if not row_id:
-            no_id += 1
-            _accumulate_row(scores, row)
-            continue
-        if row_id in scored_ids:
-            skipped += 1
-            continue
+    for row in rows:
         _accumulate_row(scores, row)
-        scored_ids.add(row_id)
 
-    _save_dedup_ids(dedup_path, scored_ids)
-
-    if skipped:
-        logging.getLogger(__name__).warning(
-            "Skipped %d duplicate rows (already scored)", skipped
-        )
-    if no_id:
-        logging.getLogger(__name__).warning(
-            "%d rows without row_id cannot be deduplicated", no_id
-        )
-
-    # Write raw accumulators (for future incremental loads)
     finalized = _finalize_scores(scores)
-    # Merge accumulators into the output so next load can resume
     output = dict(finalized)
     output["overall"] = {
         **finalized["overall"],
@@ -1608,7 +1621,6 @@ def update(
                 **finalized[dim][key],
                 **{k: group[k] for k in _ACCUM_KEYS},
             }
-    # Preserve raw calibration accumulators alongside derived
     output["_calibration_accum"] = scores["calibration"]
     output["_calibration_pairs"] = scores["calibration_pairs"]
 
@@ -1616,6 +1628,85 @@ def update(
     scores_path.write_text(json.dumps(output, indent=2))
 
     return finalized
+
+
+def update(
+    new_rows: list[dict[str, Any]],
+    scores_path: Path = DEFAULT_OUTPUT,
+    history_path: Path = DEFAULT_HISTORY,
+    dedup_path: Path | None = None,
+    tournament_scores_path: Path | None = None,
+) -> dict[str, Any]:
+    """Incrementally merge new rows into the scores accumulators.
+
+    Splits rows by ``row["mode"]``: production rows land in
+    ``scores_path``; tournament rows land in ``tournament_scores_path``
+    (derived from ``scores_path`` when omitted). Dedup is global across
+    both modes. Monthly history snapshots are emitted for the production
+    file only.
+
+    :param new_rows: list of log row dicts (any mode).
+    :param scores_path: path to production ``scores.json``.
+    :param history_path: path to ``scores_history.jsonl`` (production only).
+    :param dedup_path: path to ``scored_row_ids.json`` (shared).
+    :param tournament_scores_path: path to ``scores_tournament.json``.
+        Derived from ``scores_path`` when None.
+    :return: finalized production scores dict. Tournament result is
+        written to disk but not returned (backward compat).
+    """
+    if dedup_path is None:
+        dedup_path = scores_path.parent / "scored_row_ids.json"
+    if tournament_scores_path is None:
+        tournament_scores_path = _derive_tournament_path(scores_path)
+
+    scored_ids = _load_dedup_ids(dedup_path)
+    # Legacy migration: if an older scores.json still carries scored_row_ids
+    # inline (pre-dedup-file format), fold it into the shared dedup set now
+    # so the downstream partitioned accumulators start from a clean slate.
+    for legacy_path in (scores_path, tournament_scores_path):
+        if legacy_path.exists():
+            try:
+                legacy = json.loads(legacy_path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+            legacy_ids = legacy.get("scored_row_ids")
+            if legacy_ids:
+                scored_ids.update(legacy_ids)
+
+    deduped_rows: list[dict[str, Any]] = []
+    skipped = 0
+    no_id = 0
+    for row in new_rows:
+        row_id = row.get("row_id")
+        if not row_id:
+            no_id += 1
+            deduped_rows.append(row)
+            continue
+        if row_id in scored_ids:
+            skipped += 1
+            continue
+        deduped_rows.append(row)
+        scored_ids.add(row_id)
+
+    _save_dedup_ids(dedup_path, scored_ids)
+
+    if skipped:
+        logging.getLogger(__name__).warning(
+            "Skipped %d duplicate rows (already scored)", skipped
+        )
+    if no_id:
+        logging.getLogger(__name__).warning(
+            "%d rows without row_id cannot be deduplicated", no_id
+        )
+
+    prod_rows, tourn_rows = _partition_rows_by_mode(deduped_rows)
+
+    prod_result = _accumulate_and_write(
+        prod_rows, scores_path, history_path, emit_history=True
+    )
+    _accumulate_and_write(tourn_rows, tournament_scores_path, None, emit_history=False)
+
+    return prod_result
 
 
 def _collect_rebuild_rows(
@@ -1636,90 +1727,68 @@ def _collect_rebuild_rows(
     return rows
 
 
-def rebuild(
-    logs_dir: Path = DEFAULT_LOGS_DIR,
-    scores_path: Path = DEFAULT_OUTPUT,
-    history_path: Path = DEFAULT_HISTORY,
-    dedup_path: Path | None = None,
-    tournament_input: Path | None = None,
-) -> dict[str, Any]:
-    """Rebuild scores.json from all log files in the logs directory.
+def _rebuild_single_mode(
+    mode_rows: list[dict[str, Any]],
+    scores_path: Path,
+    history_path: Path | None,
+    emit_history: bool,
+) -> tuple[dict[str, Any], set[str]]:
+    """Rebuild one mode's scores from a pre-filtered row list.
 
-    Reads all ``production_log_*.jsonl`` files (including legacy), processes
-    rows month by month, and writes snapshots + final scores.
+    Returns the finalized scores plus the set of row_ids seen (for
+    dedup-file regeneration at the caller level).
 
-    :param logs_dir: directory containing daily log files.
-    :param scores_path: output path for ``scores.json``.
-    :param history_path: output path for ``scores_history.jsonl``.
-    :param dedup_path: path to ``scored_row_ids.json``.
-    :param tournament_input: optional path to ``tournament_scored.jsonl`` to
-        merge into the rebuild input.
-    :return: finalized scores dict.
+    :param mode_rows: rows already filtered to a single mode.
+    :param scores_path: output path for the accumulator dict.
+    :param history_path: optional history file for monthly snapshots.
+    :param emit_history: when False, snapshots are skipped and
+        ``history_path`` is ignored.
+    :return: tuple of (finalized scores dict, set of row_ids consumed).
     """
-
-    if dedup_path is None:
-        dedup_path = scores_path.parent / "scored_row_ids.json"
-
-    all_rows = _collect_rebuild_rows(logs_dir, tournament_input)
-
-    if not all_rows:
+    if not mode_rows:
         scores = _empty_scores(datetime.now(timezone.utc).strftime("%Y-%m"))
         finalized = _finalize_scores(scores)
         scores_path.parent.mkdir(parents=True, exist_ok=True)
         scores_path.write_text(json.dumps(finalized, indent=2))
-        # Clear dedup file — empty rebuild means fresh start
-        _save_dedup_ids(dedup_path, set())
-        return finalized
+        return finalized, set()
 
-    # Sort rows by predicted_at to process chronologically
-    all_rows.sort(key=lambda r: r.get("predicted_at") or "")
+    mode_rows.sort(key=lambda r: r.get("predicted_at") or "")
 
-    # Group by month and process
     months: dict[str, list[dict[str, Any]]] = defaultdict(list)
-    for row in all_rows:
+    for row in mode_rows:
         predicted_at = row.get("predicted_at")
-        if predicted_at:
-            month = predicted_at[:7]
-        else:
-            month = "unknown"
+        month = predicted_at[:7] if predicted_at else "unknown"
         months[month].append(row)
 
-    # Clear history file for rebuild
-    if history_path.exists():
+    if emit_history and history_path is not None and history_path.exists():
         history_path.unlink()
 
     sorted_months = sorted(months.keys())
     last_month = sorted_months[-1]
-
-    # Collect all row_ids across all months for dedup on subsequent update() calls
     all_row_ids: set[str] = set()
 
-    # Process all months except the last one as snapshots
     for month in sorted_months[:-1]:
         scores = _empty_scores(month)
         for row in months[month]:
             row_id = row.get("row_id")
             if row_id and row_id in all_row_ids:
-                continue  # skip duplicate across log files
+                continue
             _accumulate_row(scores, row)
             if row_id:
                 all_row_ids.add(row_id)
-        _snapshot_month(scores, history_path)
+        if emit_history and history_path is not None:
+            _snapshot_month(scores, history_path)
 
-    # The last month becomes the current scores.json
     scores = _empty_scores(last_month)
     for row in months[last_month]:
         row_id = row.get("row_id")
         if row_id and row_id in all_row_ids:
-            continue  # skip duplicate across log files
+            continue
         _accumulate_row(scores, row)
         if row_id:
             all_row_ids.add(row_id)
-    # Save dedup state to its own file — persists across month rollovers
-    _save_dedup_ids(dedup_path, all_row_ids)
 
     finalized = _finalize_scores(scores)
-    # Write with accumulators for future incremental use
     output = dict(finalized)
     output["overall"] = {
         **finalized["overall"],
@@ -1750,7 +1819,68 @@ def rebuild(
     scores_path.parent.mkdir(parents=True, exist_ok=True)
     scores_path.write_text(json.dumps(output, indent=2))
 
-    return finalized
+    return finalized, all_row_ids
+
+
+def rebuild(
+    logs_dir: Path = DEFAULT_LOGS_DIR,
+    scores_path: Path = DEFAULT_OUTPUT,
+    history_path: Path = DEFAULT_HISTORY,
+    dedup_path: Path | None = None,
+    tournament_input: Path | None = None,
+    tournament_scores_path: Path | None = None,
+) -> dict[str, Any]:
+    """Rebuild both production and tournament scores from all log files.
+
+    Production rows land in ``scores_path`` (default ``scores.json``)
+    and emit monthly history snapshots. Tournament rows (from
+    ``tournament_input`` and/or ``mode=tournament`` entries in the logs)
+    land in ``tournament_scores_path`` (default
+    ``scores_tournament.json``) and do **not** emit history.
+
+    Dedup is global across both modes: the combined set of row_ids is
+    written to ``dedup_path``.
+
+    :param logs_dir: directory containing daily log files.
+    :param scores_path: output path for production ``scores.json``.
+    :param history_path: output path for ``scores_history.jsonl``
+        (production only).
+    :param dedup_path: path to ``scored_row_ids.json``.
+    :param tournament_input: optional path to ``tournament_scored.jsonl``
+        to merge into the rebuild input.
+    :param tournament_scores_path: path to ``scores_tournament.json``.
+        Derived from ``scores_path`` when None.
+    :return: finalized production scores dict.
+    """
+    if dedup_path is None:
+        dedup_path = scores_path.parent / "scored_row_ids.json"
+    if tournament_scores_path is None:
+        tournament_scores_path = _derive_tournament_path(scores_path)
+
+    all_rows = _collect_rebuild_rows(logs_dir, tournament_input)
+
+    if not all_rows:
+        scores = _empty_scores(datetime.now(timezone.utc).strftime("%Y-%m"))
+        finalized = _finalize_scores(scores)
+        scores_path.parent.mkdir(parents=True, exist_ok=True)
+        scores_path.write_text(json.dumps(finalized, indent=2))
+        tournament_scores_path.parent.mkdir(parents=True, exist_ok=True)
+        tournament_scores_path.write_text(json.dumps(finalized, indent=2))
+        _save_dedup_ids(dedup_path, set())
+        return finalized
+
+    prod_rows, tourn_rows = _partition_rows_by_mode(all_rows)
+
+    prod_finalized, prod_ids = _rebuild_single_mode(
+        prod_rows, scores_path, history_path, emit_history=True
+    )
+    _, tourn_ids = _rebuild_single_mode(
+        tourn_rows, tournament_scores_path, None, emit_history=False
+    )
+
+    _save_dedup_ids(dedup_path, prod_ids | tourn_ids)
+
+    return prod_finalized
 
 
 # ---------------------------------------------------------------------------
@@ -1776,32 +1906,26 @@ def _extract_date_from_log_path(path: str) -> str:
     return ""
 
 
-def score_period(
+def score_period_split(
     logs_dir: Path = DEFAULT_LOGS_DIR,
     days: int = 1,
     tournament_input: Path | None = None,
-) -> dict[str, Any]:
-    """Score rows whose ``predicted_at`` falls within the last *days* days.
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Score the last *days* days, returning (production, tournament).
 
-    Reads all log files in *logs_dir*, filters rows by timestamp, and
-    runs ``score()`` on the matching subset.  This works correctly even
-    when all data lands in a single file (e.g. after a force rebuild),
-    when multiple files cover the same date, or when days are missing.
-
-    Handles both ``YYYY-MM-DD.jsonl`` and ``production_log_YYYY_MM_DD.jsonl``
-    naming conventions (the flywheel uses the latter).
+    Same collection rules as ``score_period`` but returns a tuple so
+    callers can write both files separately.
 
     :param logs_dir: directory containing daily log files.
     :param days: score rows from the last N calendar days.
-    :param tournament_input: optional path to ``tournament_scored.jsonl`` whose
-        rows are filtered to the same window and merged into the input.
-    :return: scores dict from ``score()``, or empty scores if no matching rows.
+    :param tournament_input: optional path to ``tournament_scored.jsonl``
+        whose rows are filtered to the same window and merged.
+    :return: tuple of (production_scores, tournament_scores).
     """
     cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
         "%Y-%m-%dT%H:%M:%SZ"
     )
 
-    # Both naming conventions: YYYY-MM-DD.jsonl and production_log_YYYY_MM_DD.jsonl
     daily_pattern = str(logs_dir / "????-??-??.jsonl")
     prod_pattern = str(logs_dir / "production_log_*.jsonl")
     all_files = sorted(
@@ -1822,10 +1946,29 @@ def score_period(
             if predicted_at >= cutoff:
                 rows.append(row)
 
-    if not rows:
-        return score([])
+    prod_rows, tourn_rows = _partition_rows_by_mode(rows)
+    return score(prod_rows), score(tourn_rows)
 
-    return score(rows)
+
+def score_period(
+    logs_dir: Path = DEFAULT_LOGS_DIR,
+    days: int = 1,
+    tournament_input: Path | None = None,
+) -> dict[str, Any]:
+    """Score production rows in the last *days* days (backward-compat).
+
+    Backward-compat wrapper around ``score_period_split``; returns the
+    production partition only. Callers that need the tournament scores
+    should use ``score_period_split`` directly.
+
+    :param logs_dir: directory containing daily log files.
+    :param days: score rows from the last N calendar days.
+    :param tournament_input: optional path to ``tournament_scored.jsonl``
+        whose rows are filtered to the same window and merged.
+    :return: production scores dict.
+    """
+    prod, _ = score_period_split(logs_dir, days, tournament_input)
+    return prod
 
 
 # ---------------------------------------------------------------------------
@@ -1848,7 +1991,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         "--output",
         type=Path,
         default=DEFAULT_OUTPUT,
-        help="Output JSON file path",
+        help="Production scores JSON output path",
+    )
+    parser.add_argument(
+        "--output-tournament",
+        type=Path,
+        default=None,
+        help=(
+            "Tournament scores JSON output path. If omitted, derived from "
+            "--output by appending '_tournament' to the stem."
+        ),
     )
     parser.add_argument(
         "--rebuild",
@@ -1888,60 +2040,106 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _cli_update(args: argparse.Namespace, output_tournament: Path) -> None:
+    """Handle the ``--update`` CLI mode."""
+    rows = load_rows(args.update)
+    result = update(
+        rows,
+        args.output,
+        args.history,
+        tournament_scores_path=output_tournament,
+    )
+    overall = result["overall"]
+    print(
+        f"Merged {len(rows)} rows from {args.update}: Brier={overall['brier']},"
+        f" n={overall['n']}"
+    )
+
+
+def _cli_period(args: argparse.Namespace, output_tournament: Path) -> None:
+    """Handle the ``--period-days`` CLI mode."""
+    prod_result, tourn_result = score_period_split(
+        logs_dir=args.logs_dir,
+        days=args.period_days,
+        tournament_input=args.tournament_input,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(prod_result, indent=2))
+    output_tournament.parent.mkdir(parents=True, exist_ok=True)
+    output_tournament.write_text(json.dumps(tourn_result, indent=2))
+    overall = prod_result["overall"]
+    t_overall = tourn_result["overall"]
+    print(
+        f"Period ({args.period_days}d) production: Brier={overall['brier']},"
+        f" n={overall['n']} | tournament: Brier={t_overall['brier']},"
+        f" n={t_overall['n']}"
+    )
+
+
+def _cli_rebuild(args: argparse.Namespace, output_tournament: Path) -> None:
+    """Handle the ``--rebuild`` CLI mode."""
+    print(f"Rebuilding scores from {args.logs_dir}")
+    result = rebuild(
+        logs_dir=args.logs_dir,
+        scores_path=args.output,
+        history_path=args.history,
+        tournament_input=args.tournament_input,
+        tournament_scores_path=output_tournament,
+    )
+    print(
+        f"Scores written to {args.output} (production) and "
+        f"{output_tournament} (tournament)"
+    )
+    overall = result["overall"]
+    print(
+        f"Production: Brier={overall['brier']},"
+        f" DirAcc={overall.get('directional_accuracy')}, n={overall['n']}"
+    )
+
+
+def _cli_legacy_full_recompute(
+    args: argparse.Namespace, output_tournament: Path
+) -> dict[str, Any]:
+    """Legacy full-recompute path; returns the production scores dict."""
+    rows = load_rows(args.input)
+    print(f"Loaded {len(rows)} rows from {args.input}")
+
+    prod_rows, tourn_rows = _partition_rows_by_mode(rows)
+    result = score(prod_rows)
+    tourn_result = score(tourn_rows)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2))
+    output_tournament.parent.mkdir(parents=True, exist_ok=True)
+    output_tournament.write_text(json.dumps(tourn_result, indent=2))
+    print(
+        f"Scores written to {args.output} (production, n={result['overall']['n']}) "
+        f"and {output_tournament} (tournament, n={tourn_result['overall']['n']})"
+    )
+    return result
+
+
 def main() -> None:
     """CLI entry point for scoring."""
     args = _build_arg_parser().parse_args()
 
+    output_tournament: Path = args.output_tournament or _derive_tournament_path(
+        args.output
+    )
+
     if args.update is not None:
-        rows = load_rows(args.update)
-        result = update(rows, args.output, args.history)
-        overall = result["overall"]
-        print(
-            f"Merged {len(rows)} rows from {args.update}: Brier={overall['brier']},"
-            f" n={overall['n']}"
-        )
+        _cli_update(args, output_tournament)
         return
 
     if args.period_days is not None:
-        result = score_period(
-            logs_dir=args.logs_dir,
-            days=args.period_days,
-            tournament_input=args.tournament_input,
-        )
-        args.output.parent.mkdir(parents=True, exist_ok=True)
-        args.output.write_text(json.dumps(result, indent=2))
-        overall = result["overall"]
-        print(
-            f"Period ({args.period_days}d): Brier={overall['brier']},"
-            f" n={overall['n']}"
-        )
+        _cli_period(args, output_tournament)
         return
 
     if args.rebuild:
-        print(f"Rebuilding scores from {args.logs_dir}")
-        result = rebuild(
-            logs_dir=args.logs_dir,
-            scores_path=args.output,
-            history_path=args.history,
-            tournament_input=args.tournament_input,
-        )
-        print(f"Scores written to {args.output}")
-        overall = result["overall"]
-        print(
-            f"Overall: Brier={overall['brier']}, DirAcc={overall.get('directional_accuracy')},"
-            f" n={overall['n']}"
-        )
+        _cli_rebuild(args, output_tournament)
         return
 
-    # Legacy full-recompute mode
-    rows = load_rows(args.input)
-    print(f"Loaded {len(rows)} rows from {args.input}")
-
-    result = score(rows)
-
-    args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(result, indent=2))
-    print(f"Scores written to {args.output}")
+    result = _cli_legacy_full_recompute(args, output_tournament)
 
     # Print summary
     overall = result["overall"]

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -39,6 +39,10 @@ DEFAULT_LOGS_DIR = Path(__file__).parent / "datasets" / "logs"
 
 PRODUCTION_MODE = "production_replay"
 TOURNAMENT_MODE = "tournament"
+_KNOWN_MODES = frozenset({PRODUCTION_MODE, TOURNAMENT_MODE})
+# Modes we've already logged a warning for, so a bad-data jsonl with 10k
+# identical unknown-mode rows doesn't spam the log 10k times.
+_WARNED_UNKNOWN_MODES: set[str] = set()
 
 
 def _derive_tournament_path(scores_path: Path) -> Path:
@@ -68,6 +72,13 @@ def _partition_rows_by_mode(
     tourn: list[dict[str, Any]] = []
     for row in rows:
         mode = row.get("mode") or PRODUCTION_MODE
+        if mode not in _KNOWN_MODES and mode not in _WARNED_UNKNOWN_MODES:
+            _WARNED_UNKNOWN_MODES.add(mode)
+            logging.getLogger(__name__).warning(
+                "Unknown mode %r — routing to production. If this is a new"
+                " mode, add it to _KNOWN_MODES and route it explicitly.",
+                mode,
+            )
         if mode == TOURNAMENT_MODE:
             tourn.append(row)
         else:

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -760,6 +760,29 @@ class TestGenerateReportWithTournamentFiles:
         assert "## Overall — Tournament" in report
         assert "## Tool Ranking — Tournament" in report
 
+    def test_empty_period_tournament_does_not_render_section(self) -> None:
+        """Tournament period files with zero rows don't emit empty sections.
+
+        scorer.score_period_split writes tournament period files on every
+        run; days with zero tournament rows in the window must not add a
+        dangling '## Since Last Report — Tournament' header.
+        """
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        all_time_tourn = _tournament_scores_with_version("tool-a", "v2", 0.18, 100)
+        empty_period_tourn = {"total_rows": 0, "overall": {}}
+        report = generate_report(
+            prod,
+            [],
+            period_scores=None,
+            rolling_scores=None,
+            include_tournament=True,
+            scores_tournament=all_time_tourn,
+            period_scores_tournament=empty_period_tourn,
+            rolling_scores_tournament=empty_period_tourn,
+        )
+        assert "## Since Last Report — Tournament" not in report
+        assert "## Last 7 Days Rolling — Tournament" not in report
+
     def test_merged_tool_version_mode_includes_both_modes(self) -> None:
         """Tool × Version × Mode table shows both production and tournament cells."""
         prod = _scores_with_tool("tool-a", 0.20, 1000)

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -617,3 +617,191 @@ class TestGenerateReportTournamentToggle:
         report = generate_report(s, [], rolling_scores=rolling, include_tournament=True)
         assert "Tool × Version × Mode (All-Time)" in report
         assert "Tool × Version × Mode (Last 7 Days)" in report
+
+
+# ---------------------------------------------------------------------------
+# Mode split: tournament sections and callouts (BENCHMARK_MODE_SPLIT_SPEC)
+# ---------------------------------------------------------------------------
+
+
+def _scores_with_tool(
+    tool: str,
+    brier: float,
+    n: int,
+    valid: int | None = None,
+    baseline: float = 0.25,
+) -> dict[str, Any]:
+    """Build a production scores dict with one by_tool entry."""
+    valid_n = n if valid is None else valid
+    return {
+        "generated_at": "2026-03-31T06:00:00Z",
+        "total_rows": n,
+        "valid_rows": valid_n,
+        "overall": {"brier": brier, "reliability": 0.95, "n": n},
+        "by_tool": {
+            tool: {
+                "brier": brier,
+                "baseline_brier": baseline,
+                "n": n,
+                "valid_n": valid_n,
+                "reliability": 0.95,
+                "directional_accuracy": 0.7,
+                "brier_skill_score": 0.0,
+            }
+        },
+        "by_platform": {},
+        "by_category": {},
+        "by_horizon": {},
+        "by_tool_platform": {},
+        "by_tool_version_mode": {},
+        "calibration": [],
+        "worst_10": [],
+        "best_10": [],
+        "parse_breakdown": {},
+        "latency_reservoir": {},
+    }
+
+
+def _tournament_scores_with_version(
+    tool: str,
+    version: str,
+    brier: float,
+    n: int,
+) -> dict[str, Any]:
+    """Build a tournament scores dict with one by_tool_version_mode cell."""
+    s = _scores_with_tool(tool, brier, n)
+    s["by_tool_version_mode"] = {
+        f"{tool} | {version} | tournament": {
+            "brier": brier,
+            "n": n,
+            "valid_n": n,
+            "directional_accuracy": 0.75,
+            "brier_skill_score": 0.1,
+        }
+    }
+    return s
+
+
+class TestTournamentCallouts:
+    """Tests for section_tournament_callouts."""
+
+    def test_empty_when_no_tournament_data(self) -> None:
+        """Missing tournament scores returns empty string."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark.analyze import section_tournament_callouts
+
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        assert section_tournament_callouts(prod, None) == ""
+        assert section_tournament_callouts(prod, {"total_rows": 0}) == ""
+
+    def test_promotion_candidate_flagged(self) -> None:
+        """Tournament Brier meaningfully lower than production triggers a promotion bullet."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark.analyze import section_tournament_callouts
+
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.10, 50)
+        result = section_tournament_callouts(prod, tourn)
+        assert "Promotion candidates:" in result
+        assert "tool-a" in result
+        assert "v2" in result
+        assert "Tournament regressions:" not in result
+
+    def test_tournament_regression_flagged(self) -> None:
+        """Tournament Brier meaningfully higher than production triggers a regression bullet."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark.analyze import section_tournament_callouts
+
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.40, 50)
+        result = section_tournament_callouts(prod, tourn)
+        assert "Tournament regressions:" in result
+        assert "Promotion candidates:" not in result
+
+    def test_suppressed_below_min_n(self) -> None:
+        """Tournament cells with n below CALLOUT_MIN_N are ignored."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark.analyze import section_tournament_callouts
+
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.05, 10)
+        assert section_tournament_callouts(prod, tourn) == ""
+
+    def test_suppressed_within_delta_band(self) -> None:
+        """Tournament vs production deltas within CALLOUT_DELTA are not flagged."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark.analyze import section_tournament_callouts
+
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.21, 100)
+        assert section_tournament_callouts(prod, tourn) == ""
+
+
+class TestGenerateReportWithTournamentFiles:
+    """Tests for generate_report dual-mode rendering."""
+
+    def test_tournament_sections_omitted_when_file_absent(self) -> None:
+        """No tournament inputs -> no '— Tournament' headings, no callouts."""
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        report = generate_report(prod, [], include_tournament=True)
+        assert "— Tournament" not in report
+        assert "## Tournament Callouts" not in report
+
+    def test_tournament_sections_rendered_when_data_present(self) -> None:
+        """Tournament inputs with rows -> duplicated per-mode headings render."""
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.18, 100)
+        report = generate_report(
+            prod,
+            [],
+            include_tournament=True,
+            scores_tournament=tourn,
+        )
+        assert "## Overall — Tournament" in report
+        assert "## Tool Ranking — Tournament" in report
+
+    def test_merged_tool_version_mode_includes_both_modes(self) -> None:
+        """Tool × Version × Mode table shows both production and tournament cells."""
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        prod["by_tool_version_mode"] = {
+            "tool-a | v1 | production_replay": {
+                "n": 500,
+                "valid_n": 500,
+                "brier": 0.20,
+                "directional_accuracy": 0.7,
+                "brier_skill_score": 0.0,
+            }
+        }
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.18, 100)
+        report = generate_report(
+            prod,
+            [],
+            include_tournament=True,
+            scores_tournament=tourn,
+        )
+        assert "v1" in report
+        assert "v2" in report
+
+    def test_callout_section_included_when_triggered(self) -> None:
+        """Promotion-worthy tournament data causes the callouts section to render."""
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.10, 50)
+        report = generate_report(
+            prod,
+            [],
+            include_tournament=True,
+            scores_tournament=tourn,
+        )
+        assert "## Tournament Callouts" in report
+
+    def test_callout_section_omitted_when_empty(self) -> None:
+        """Tournament data present but within delta band -> no callout section."""
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.21, 100)
+        report = generate_report(
+            prod,
+            [],
+            include_tournament=True,
+            scores_tournament=tourn,
+        )
+        assert "## Tournament Callouts" not in report

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -862,20 +862,29 @@ class TestToolVersionModeBreakdown:
     """Tests for the (tool, version, mode) aggregation dimension."""
 
     def test_splits_by_mode_when_hash_matches(self, tmp_path: Path) -> None:
-        """Same tool + same hash but different modes must yield separate cells."""
+        """Same tool + same hash, different modes, land in separate files.
+
+        :param tmp_path: pytest tmpdir fixture.
+        """
         scores_path = tmp_path / "scores.json"
         history_path = tmp_path / "history.jsonl"
+        tournament_path = tmp_path / "scores_tournament.json"
 
         rows = [
             _row(tool="t1", tool_version="v1", mode="production_replay"),
             _row(tool="t1", tool_ipfs_hash="v1", mode="tournament"),
         ]
-        result = update(rows, scores_path, history_path)
+        prod_result = update(
+            rows, scores_path, history_path, tournament_scores_path=tournament_path
+        )
+        tourn_result = json.loads(tournament_path.read_text())
 
-        assert "t1 | v1 | production_replay" in result["by_tool_version_mode"]
-        assert "t1 | v1 | tournament" in result["by_tool_version_mode"]
-        assert result["by_tool_version_mode"]["t1 | v1 | production_replay"]["n"] == 1
-        assert result["by_tool_version_mode"]["t1 | v1 | tournament"]["n"] == 1
+        assert "t1 | v1 | production_replay" in prod_result["by_tool_version_mode"]
+        assert (
+            prod_result["by_tool_version_mode"]["t1 | v1 | production_replay"]["n"] == 1
+        )
+        assert "t1 | v1 | tournament" in tourn_result["by_tool_version_mode"]
+        assert tourn_result["by_tool_version_mode"]["t1 | v1 | tournament"]["n"] == 1
 
     def test_defaults_mode_to_production_replay(self, tmp_path: Path) -> None:
         """Rows without a mode field default to production_replay."""
@@ -2054,3 +2063,201 @@ class TestDiagnosticAccumulators:
             assert (
                 batch[key] == incremental[key]
             ), f"{key}: batch={batch[key]} != incremental={incremental[key]}"
+
+
+# ---------------------------------------------------------------------------
+# Mode split: scores.json vs scores_tournament.json (BENCHMARK_MODE_SPLIT_SPEC)
+# ---------------------------------------------------------------------------
+
+
+class TestModeSplit:
+    """Tests for production/tournament scoring split."""
+
+    def test_partition_rows_by_mode(self) -> None:
+        """_partition_rows_by_mode routes rows by the mode field; missing mode defaults to production."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark.scorer import _partition_rows_by_mode
+
+        rows = [
+            _row(mode="tournament", row_id="t1"),
+            _row(mode="production_replay", row_id="p1"),
+            _row(mode=None, row_id="p2"),  # missing mode -> production
+            _row(mode="tournament", row_id="t2"),
+        ]
+        prod, tourn = _partition_rows_by_mode(rows)
+        prod_ids = {r["row_id"] for r in prod}
+        tourn_ids = {r["row_id"] for r in tourn}
+        assert prod_ids == {"p1", "p2"}
+        assert tourn_ids == {"t1", "t2"}
+
+    def test_derive_tournament_path(self) -> None:
+        """_derive_tournament_path appends _tournament to the stem."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark.scorer import _derive_tournament_path
+
+        assert _derive_tournament_path(Path("/tmp/results/scores.json")) == Path(
+            "/tmp/results/scores_tournament.json"
+        )
+
+    def test_update_writes_both_files_and_preserves_split(self, tmp_path: Path) -> None:
+        """update() splits rows by mode and writes two score files; modes don't cross-contaminate."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+        tournament_path = tmp_path / "scores_tournament.json"
+
+        rows = [
+            _row(mode="production_replay", tool="prod-tool", row_id="p1"),
+            _row(mode="production_replay", tool="prod-tool", row_id="p2"),
+            _row(mode="tournament", tool="tourn-tool", row_id="t1"),
+        ]
+        update(rows, scores_path, history_path, tournament_scores_path=tournament_path)
+
+        prod = json.loads(scores_path.read_text())
+        tourn = json.loads(tournament_path.read_text())
+
+        assert "prod-tool" in prod["by_tool"]
+        assert "tourn-tool" not in prod["by_tool"]
+        assert "tourn-tool" in tourn["by_tool"]
+        assert "prod-tool" not in tourn["by_tool"]
+
+    def test_update_shares_dedup_across_modes(self, tmp_path: Path) -> None:
+        """Both modes write to a single dedup file; re-feeding same rows is a no-op."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+        dedup_path = tmp_path / "ids.json"
+        tournament_path = tmp_path / "scores_tournament.json"
+
+        rows = [
+            _row(mode="production_replay", row_id="p1"),
+            _row(mode="tournament", row_id="t1"),
+        ]
+        update(
+            rows,
+            scores_path,
+            history_path,
+            dedup_path=dedup_path,
+            tournament_scores_path=tournament_path,
+        )
+        ids_after_first = set(json.loads(dedup_path.read_text()))
+        assert ids_after_first == {"p1", "t1"}
+
+        # Second call with the same rows should skip both
+        update(
+            rows,
+            scores_path,
+            history_path,
+            dedup_path=dedup_path,
+            tournament_scores_path=tournament_path,
+        )
+        prod = json.loads(scores_path.read_text())
+        tourn = json.loads(tournament_path.read_text())
+        # Sample size unchanged after no-op second update
+        assert prod["overall"]["n"] == 1
+        assert tourn["overall"]["n"] == 1
+
+    def test_tournament_accumulates_across_month_rollover(self, tmp_path: Path) -> None:
+        """Tournament scores must not reset on calendar month rollover.
+
+        Spec requires tournament cells to accumulate cumulatively so the
+        CALLOUT_MIN_N threshold holds across month boundaries. Production
+        still snapshots + resets; tournament only updates the month label.
+
+        :param tmp_path: pytest tmpdir fixture.
+        """
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+        tournament_path = tmp_path / "scores_tournament.json"
+
+        # Seed tournament scores with "previous month" rows
+        with patch("benchmark.scorer.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 3, 20, tzinfo=timezone.utc)
+            mock_dt.side_effect = datetime
+            update(
+                [
+                    _row(
+                        row_id="prev_m_1",
+                        predicted_at="2026-03-20T10:00:00Z",
+                        mode="tournament",
+                    )
+                ],
+                scores_path,
+                history_path,
+                tournament_scores_path=tournament_path,
+            )
+
+        seeded = json.loads(tournament_path.read_text())
+        assert seeded["overall"]["n"] == 1
+
+        # Now run again under "current month" — tournament must keep the
+        # seeded accumulator, not reset to zero.
+        with patch("benchmark.scorer.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 4, 5, tzinfo=timezone.utc)
+            mock_dt.side_effect = datetime
+            update(
+                [
+                    _row(
+                        row_id="curr_m_1",
+                        predicted_at="2026-04-05T10:00:00Z",
+                        mode="tournament",
+                    )
+                ],
+                scores_path,
+                history_path,
+                tournament_scores_path=tournament_path,
+            )
+
+        final = json.loads(tournament_path.read_text())
+        assert (
+            final["overall"]["n"] == 2
+        ), "tournament accumulator reset on month rollover"
+
+    def test_rebuild_history_production_only(self, tmp_path: Path) -> None:
+        """rebuild() emits monthly history snapshots only for production rows."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+        tournament_path = tmp_path / "scores_tournament.json"
+
+        # Two months of production + tournament rows each
+        log_file = logs_dir / "production_log_2026_01.jsonl"
+        rows = [
+            _row(
+                mode="production_replay",
+                predicted_at="2026-01-15T10:00:00Z",
+                row_id="p_jan",
+            ),
+            _row(
+                mode="production_replay",
+                predicted_at="2026-02-15T10:00:00Z",
+                row_id="p_feb",
+            ),
+            _row(
+                mode="tournament",
+                predicted_at="2026-01-15T10:00:00Z",
+                row_id="t_jan",
+            ),
+            _row(
+                mode="tournament",
+                predicted_at="2026-02-15T10:00:00Z",
+                row_id="t_feb",
+            ),
+        ]
+        log_file.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+        rebuild(
+            logs_dir=logs_dir,
+            scores_path=scores_path,
+            history_path=history_path,
+            tournament_scores_path=tournament_path,
+        )
+
+        # History exists and contains at most production months (1 snapshot for Jan).
+        assert history_path.exists()
+        history_lines = [
+            json.loads(ln) for ln in history_path.read_text().splitlines() if ln.strip()
+        ]
+        # One closed prior month (January); current month doesn't snapshot.
+        # Verify the snapshot reflects production (n=1, not n=2 from pooled modes).
+        assert len(history_lines) == 1
+        assert history_lines[0]["overall"]["n"] == 1

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -19,6 +19,7 @@
 """Tests for benchmark/scorer.py."""
 
 import json
+import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -2089,6 +2090,31 @@ class TestModeSplit:
         tourn_ids = {r["row_id"] for r in tourn}
         assert prod_ids == {"p1", "p2"}
         assert tourn_ids == {"t1", "t2"}
+
+    def test_unknown_mode_routes_to_production_with_warning(self, caplog: Any) -> None:
+        """Unknown modes route to production but log a warning (once per mode).
+
+        :param caplog: pytest log capture fixture.
+        """
+        # pylint: disable=import-outside-toplevel
+        from benchmark import scorer as _scorer_mod
+        from benchmark.scorer import _partition_rows_by_mode
+
+        _scorer_mod._WARNED_UNKNOWN_MODES.clear()  # pylint: disable=protected-access
+        rows = [
+            _row(mode="shadow", row_id="s1"),
+            _row(mode="shadow", row_id="s2"),
+            _row(mode="staging", row_id="g1"),
+        ]
+        with caplog.at_level(logging.WARNING, logger="benchmark.scorer"):
+            prod, tourn = _partition_rows_by_mode(rows)
+
+        assert {r["row_id"] for r in prod} == {"s1", "s2", "g1"}
+        assert not tourn
+        # One warning per distinct unknown mode, not per row
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        modes_warned = {w.args[0] for w in warnings if w.args}
+        assert modes_warned == {"shadow", "staging"}
 
     def test_derive_tournament_path(self) -> None:
         """_derive_tournament_path appends _tournament to the stem."""


### PR DESCRIPTION
## Why

While investigating why the 2026-04-15 Slack report's "Regressions" section didn't reconcile with its top-line numbers, we found that `benchmark/scorer.py` accumulates rows into mode-blind buckets (`by_tool`, `by_platform`, `by_category`, `by_tool_version`, `overall`, `trend`, `calibration`, etc.) — only `by_tool_version_mode` is correctly mode-keyed. The Slack summary reads from the mode-blind buckets, so any tournament rows merged into `scores.json` silently pool with production in the headline numbers (top tools, worst tools, platforms, weak categories, diagnostics, etc.).

This is latent today only because **`tournament-run` has been hitting the old 45-min job timeout and cancelling** (every scheduled run since the tournament integration landed on 2026-04-13). Cancellation aborts the upload of `tournament-predictions`, so the benchmark job silently merges zero tournament rows into `scores.json`. Today's Slack post reads clean only because of this failure — not because the pipeline is correct.

PR #215 raised the timeout to 90 min; tournament-run will start actually producing data on the next scheduled run. This PR is preventive: when tournament data does land, it goes into a dedicated artifact and the Slack headline stays production-only.

## Summary

Split the scorer into two independent artifacts, add a dedicated "Tournament Callouts" block for cross-mode anomaly detection (the promote/demote workflow).

**Stacked on #215 (now merged to main).** This branch sits on top of the PR #215 commits; since they're now in `main`, the GitHub diff shows only the mode-split commit.

## What changes

| File | Now |
|---|---|
| `scores.json` | Production rows only. Schema unchanged. |
| `scores_tournament.json` | New. Tournament rows only. Same schema. |
| `scores_history.jsonl` | Production trend only. Unchanged. |
| `scored_row_ids.json` | Global dedup across both modes. Unchanged. |

Slack post is **production-only** except when tournament performance diverges materially from the same tool's production baseline — then a `*Tournament callouts:*` block surfaces the tool version as a promotion candidate or watch item. Threshold: Brier Δ ≥ 0.03 at n ≥ 30.

Tournament accumulator does **not** reset on calendar-month rollover (production still does, with a history snapshot). Keeps callout thresholds stable across month boundaries so the promote/demote signal doesn't disappear on the 1st of each month.

## Dry-run artifacts

Ran the new pipeline end-to-end using today's production `scores.json` + yesterday's `tournament_scored.jsonl` (210 scored tournament rows from run 24384814603 — the last run where tournament-run ran partially before cancellation).

### report.md structure

```
# Benchmark Report — 2026-04-15

## Since Last Report
## Last 7 Days Rolling
## Overall                                 <-- production (n=197334, Brier 0.2345)
## Overall — Tournament                    [NEW: n=210, Brier 0.3821, clearly labelled]
## Base Rates                              production only
## Tool Ranking                            production only (15 tools)
## Tool Ranking — Tournament               [NEW: 13 tools, all n=9 ⚠]
## Tool × Version × Mode (All-Time)        [MERGED: both modes in one table]
## Platform Comparison ... Trend           production only
## Tournament Callouts                     [NOT rendered today — no cell crosses n=30]
```

The Tournament Callouts section is absent today because every tournament cell is n=9 per day. With the month-rollover accumulation fix, these will hit n=30 after ~3 daily runs and callouts will begin firing.

### Slack post (gpt-4.1-mini dry-run)

Production numbers unchanged from today's post; no tournament data leaks into Summary/Top tools/Worst tools/Platforms/Categories/Diagnostics — and this would remain true when tournament-run starts succeeding on the next scheduled run:

```
*Summary:* No new period data is available since the last report. Overall,
prediction quality remains below baseline with an all-time Brier of 0.2345
and a negative BSS of -0.4308. Directional accuracy 70%; edge -0.0614.

*Top tools:*
• prediction-request-reasoning-claude — Brier 0.1834, ... (n=2099)
• prediction-offline — Brier 0.2172, ... (n=1373)
• superforcaster — Brier 0.2212, ... (n=22601)

*Worst tools:*
• prediction-online-sme — Brier 0.3309, ... (n=158)
• prediction-request-rag — Brier 0.3289, ... (n=630)
• claude-prediction-online — Brier 0.306, ... (n=272)

*Platform performance:* omen (Brier 0.2296, n=175489) / polymarket (Brier 0.2734, n=21845)
*Edge by difficulty:* omen best on easy, polymarket worst on hard
*Weak categories:* politics, international, business, travel, sports, ...
*Diagnostics:* conditional accuracy 62%, disagreement Brier 0.2708, ...
*Recommended actions:* calibrate overconfidence, improve weak categories, platform tuning

(no *Regressions:*, no *Tool versions:*, no *Tournament callouts:* today)
```

## Migration

The production `scores.json` on disk is mode-blind (pooled with whatever stale tournament rows made it in before 2026-04-14). After merge, trigger `workflow_dispatch` with `force_rebuild=true` once to regenerate both artifacts from raw logs under the new split. Subsequent scheduled runs are clean.

## Tests

- Scorer: 5 new (`TestModeSplit`) covering partition routing, dual-file output, global dedup, production-only history, cross-month accumulation.
- Analyze: 9 new covering callout thresholds (promotion / regression / min-n / delta-band) and dual-mode `generate_report` rendering.
- 1 existing test updated to assert the new per-file layout.
- **342 total tests pass locally.** `uv run tomte check-code` green.

## Test plan

- [x] `uv run --with scipy --with numpy --with pytest python -m pytest benchmark/tests/ -q` — 342 passed
- [x] `uv run tomte check-code` — all green
- [x] End-to-end dry-run with real `scores.json` + `tournament_scored.jsonl` produces expected `report.md` and Slack summary
- [ ] After merge: `workflow_dispatch` with `force_rebuild=true` to regenerate under split
- [ ] Next scheduled run's Slack post has no per-category / top-tool tournament pollution
- [ ] Tournament callouts start appearing ~3–4 days after deploy once per-tool tournament n crosses 30

🤖 Generated with [Claude Code](https://claude.com/claude-code)