### PR TITLE
fix(benchmark): filter weak-spots to active Omen and Polymarket categories

### DIFF
--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -41,6 +41,54 @@ CAL_SLOPE_OVERCONFIDENT = 0.7
 CAL_SLOPE_UNDERCONFIDENT = 1.3
 CAL_INTERCEPT_NOTABLE = 0.3
 
+# Categories currently emitted by the two upstream platforms.
+# Keep these in sync with:
+#   Omen:       valory-xyz/market-creator — DEFAULT_TOPICS in
+#               packages/valory/skills/market_creation_manager_abci/propose_questions.py
+#   Polymarket: valory-xyz/trader — POLYMARKET_CATEGORY_TAGS in
+#               packages/valory/connections/polymarket_client/connection.py
+# Historical labels not in either set (e.g. "travel", "crypto", "tech") are
+# treated as legacy and skipped by weak-spot reporting.
+OMEN_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "business",
+        "cryptocurrency",
+        "politics",
+        "science",
+        "technology",
+        "trending",
+        "social",
+        "health",
+        "sustainability",
+        "internet",
+        "food",
+        "pets",
+        "animals",
+        "curiosities",
+        "economy",
+        "arts",
+        "entertainment",
+        "weather",
+        "sports",
+        "finance",
+        "international",
+    }
+)
+POLYMARKET_ACTIVE_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "business",
+        "politics",
+        "science",
+        "technology",
+        "health",
+        "entertainment",
+        "weather",
+        "finance",
+        "international",
+    }
+)
+ACTIVE_CATEGORIES: frozenset[str] = OMEN_CATEGORIES | POLYMARKET_ACTIVE_CATEGORIES
+
 
 # ---------------------------------------------------------------------------
 # Data loading
@@ -201,6 +249,7 @@ def section_weak_spots(scores: dict[str, Any]) -> str:
     """Generate the weak spots section."""
     lines = ["## Weak Spots", ""]
     found = False
+    skipped_legacy: list[str] = []
 
     for section_name, section_key in [
         ("category", "by_category"),
@@ -208,6 +257,9 @@ def section_weak_spots(scores: dict[str, Any]) -> str:
         ("tool", "by_tool"),
     ]:
         for name, stats in (scores.get(section_key) or {}).items():
+            if section_key == "by_category" and name not in ACTIVE_CATEGORIES:
+                skipped_legacy.append(name)
+                continue
             brier = stats.get("brier")
             bss = stats.get("brier_skill_score")
             if brier is not None and brier > BRIER_WEAK_THRESHOLD:
@@ -234,6 +286,14 @@ def section_weak_spots(scores: dict[str, Any]) -> str:
 
     if not found:
         lines.append("No weak spots detected.")
+
+    if skipped_legacy:
+        lines.append("")
+        lines.append(
+            f"_Skipped {len(skipped_legacy)} legacy category label(s) not in the"
+            f" current Omen or Polymarket taxonomy: "
+            f"{', '.join(sorted(set(skipped_legacy)))}._"
+        )
 
     return "\n".join(lines)
 

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -21,6 +21,9 @@
 from typing import Any
 
 from benchmark.analyze import (
+    ACTIVE_CATEGORIES,
+    OMEN_CATEGORIES,
+    POLYMARKET_ACTIVE_CATEGORIES,
     _parse_tvm_key,
     generate_report,
     section_best_predictions,
@@ -161,6 +164,44 @@ class TestSectionWeakSpots:
         assert "Skipped 2 legacy category label(s)" in result
         assert "crypto" in result
         assert "travel" in result
+
+
+class TestActiveCategoriesInvariants:
+    """Pin the contents of ACTIVE_CATEGORIES so accidental edits don't silently
+    shrink the filter set.
+
+    These assertions guard against the mutation: "remove a single label from
+    OMEN_CATEGORIES or POLYMARKET_ACTIVE_CATEGORIES" which the behavioural
+    weak-spots tests would not catch on its own.
+    """
+
+    def test_shared_categories_are_active(self) -> None:
+        """Categories emitted by both platforms must pass the filter."""
+        shared = {
+            "business",
+            "politics",
+            "science",
+            "technology",
+            "health",
+            "entertainment",
+            "weather",
+            "finance",
+            "international",
+        }
+        assert shared.issubset(ACTIVE_CATEGORIES)
+        assert shared.issubset(OMEN_CATEGORIES)
+        assert shared.issubset(POLYMARKET_ACTIVE_CATEGORIES)
+
+    def test_omen_only_categories_are_active(self) -> None:
+        """Categories emitted only by Omen's market creator must pass."""
+        omen_only = {"cryptocurrency", "sports", "sustainability", "pets"}
+        assert omen_only.issubset(ACTIVE_CATEGORIES)
+        assert omen_only.isdisjoint(POLYMARKET_ACTIVE_CATEGORIES)
+
+    def test_removed_labels_are_not_active(self) -> None:
+        """Labels removed from either upstream taxonomy must not be active."""
+        removed = {"travel", "crypto", "tech", "other", "economics", "fashion"}
+        assert removed.isdisjoint(ACTIVE_CATEGORIES)
 
 
 # ---------------------------------------------------------------------------

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -147,7 +147,7 @@ class TestSectionWeakSpots:
             by_category={"travel": {"brier": 0.80, "n": 100, "reliability": 0.9}}
         )
         result = section_weak_spots(s)
-        assert "travel" not in result.split("_Skipped")[0]
+        assert "travel" not in result.split("_Skipped", maxsplit=1)[0]
         assert "No weak spots detected" in result
 
     def test_legacy_category_footnote_listed(self) -> None:
@@ -167,12 +167,12 @@ class TestSectionWeakSpots:
 
 
 class TestActiveCategoriesInvariants:
-    """Pin the contents of ACTIVE_CATEGORIES so accidental edits don't silently
-    shrink the filter set.
+    """Pin the contents of ACTIVE_CATEGORIES.
 
-    These assertions guard against the mutation: "remove a single label from
-    OMEN_CATEGORIES or POLYMARKET_ACTIVE_CATEGORIES" which the behavioural
-    weak-spots tests would not catch on its own.
+    Guards against accidental edits that silently shrink the filter set.
+    The behavioural weak-spots tests would not catch the mutation "remove a
+    single label from OMEN_CATEGORIES or POLYMARKET_ACTIVE_CATEGORIES" on
+    their own.
     """
 
     def test_shared_categories_are_active(self) -> None:

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -117,7 +117,9 @@ class TestSectionWeakSpots:
 
     def test_weak_performance_label(self) -> None:
         """Brier between 0.4 and 0.5 should say 'weak performance'."""
-        s = _scores(by_category={"tech": {"brier": 0.45, "n": 100, "reliability": 0.9}})
+        s = _scores(
+            by_category={"technology": {"brier": 0.45, "n": 100, "reliability": 0.9}}
+        )
         result = section_weak_spots(s)
         assert "weak performance" in result
         assert "anti-predictive" not in result
@@ -125,7 +127,7 @@ class TestSectionWeakSpots:
     def test_no_weak_spots(self) -> None:
         """Test no weak spots detected."""
         s = _scores(
-            by_category={"crypto": {"brier": 0.2, "n": 100, "reliability": 0.9}}
+            by_category={"finance": {"brier": 0.2, "n": 100, "reliability": 0.9}}
         )
         result = section_weak_spots(s)
         assert "No weak spots" in result
@@ -135,6 +137,30 @@ class TestSectionWeakSpots:
         s = _scores(by_tool={"test": {"brier": 0.40, "n": 50, "reliability": 1.0}})
         result = section_weak_spots(s)
         assert "No weak spots" in result
+
+    def test_legacy_category_not_flagged(self) -> None:
+        """Categories no longer emitted by either platform are skipped."""
+        s = _scores(
+            by_category={"travel": {"brier": 0.80, "n": 100, "reliability": 0.9}}
+        )
+        result = section_weak_spots(s)
+        assert "travel" not in result.split("_Skipped")[0]
+        assert "No weak spots detected" in result
+
+    def test_legacy_category_footnote_listed(self) -> None:
+        """Skipped legacy categories are surfaced in a footnote."""
+        s = _scores(
+            by_category={
+                "travel": {"brier": 0.80, "n": 100, "reliability": 0.9},
+                "crypto": {"brier": 0.75, "n": 50, "reliability": 0.9},
+                "politics": {"brier": 0.45, "n": 100, "reliability": 0.9},
+            }
+        )
+        result = section_weak_spots(s)
+        assert "politics" in result
+        assert "Skipped 2 legacy category label(s)" in result
+        assert "crypto" in result
+        assert "travel" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The daily benchmark's `## Weak Spots` section flags any category with a high Brier score, with no awareness of whether that category is still emitted by our upstream taxonomies. Old scores.json files (and the current one, to a smaller extent) carry labels that were removed or merged months ago — `travel`, `crypto`, `tech`, `economics`, `fashion`, `music`, `trending`, etc. — and each one shows up as a weak-spot candidate even though we can't act on them.

This PR adds a taxonomy filter to `section_weak_spots`.

## What changed

- Added `OMEN_CATEGORIES` (21) and `POLYMARKET_ACTIVE_CATEGORIES` (9) constants in `benchmark/analyze.py`, mirroring the two upstream sources:
  - Omen: `DEFAULT_TOPICS` in [valory-xyz/market-creator](https://github.com/valory-xyz/market-creator/blob/main/packages/valory/skills/market_creation_manager_abci/propose_questions.py)
  - Polymarket: `POLYMARKET_CATEGORY_TAGS` in valory-xyz/trader (travel is excluded — it is commented out upstream)
- `ACTIVE_CATEGORIES` is their union (21 labels).
- `section_weak_spots` now skips any `by_category` entry not in `ACTIVE_CATEGORIES` and lists the skipped labels in a footnote so the omission is not silent.
- Pinned the expected membership of the frozensets in a new `TestActiveCategoriesInvariants` class so accidentally deleting a label from either set fails a test.

## Before / after on the current scores.json

Before:
\`\`\`
- **politics** (category): Brier 0.4527 — weak performance
- **other** (category): ...                  ← classifier fallback, not actionable
\`\`\`

After:
\`\`\`
- **politics** (category): Brier 0.4527 — weak performance

_Skipped 1 legacy category label(s) not in the current Omen or Polymarket
 taxonomy: other._
\`\`\`

## Scope

Deliberately narrow. Out of scope for this PR but worth a follow-up:
- \`benchmark/datasets/fetch_open.py\` still fetches Polymarket \`travel\` markets — those rows now land in scores.json then get filtered here. Not wrong, just wasteful.
- No mapping between \`cryptocurrency\` (Omen) and \`finance\` (Polymarket); they remain two rows in the report.

## Tests

- \`benchmark/tests/test_analyze.py\`: existing weak-spot tests updated (legacy labels \`tech\`/\`crypto\` swapped for active ones), two new tests for filter + footnote, three new invariant tests.
- All 43 tests in the file pass; mypy and pylint (errors only) clean.

## Test plan

- [ ] Render the daily report against both a fresh and a legacy scores.json, confirm legacy labels appear only in the footnote.
- [ ] Confirm no existing downstream consumer (slack summary prompt) breaks from the new footnote line.