### PR TITLE
feat(benchmark): CID to release-tag map computed on demand

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -41,7 +41,11 @@ jobs:
     if: always() && !cancelled()
 
     steps:
+      # fetch-depth: 0 so `git show <tag>:packages/packages.json` works for
+      # every historical release — required by benchmark/release_map.py.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v5
         with:

--- a/benchmark/release_map.py
+++ b/benchmark/release_map.py
@@ -67,8 +67,13 @@ def _run_gh_release_list(repo: str, limit: int) -> list[dict[str, str]]:
             ],
             text=True,
             stderr=subprocess.PIPE,
+            timeout=15,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ) as err:
         stderr = getattr(err, "stderr", "") or ""
         log.warning("gh release list failed: %s | stderr=%s", err, stderr.strip())
         return []
@@ -96,11 +101,16 @@ def _run_git_show_packages_json(tag: str) -> dict[str, Any] | None:
     """
     try:
         out = subprocess.check_output(
-            ["git", "show", f"{tag}:packages/packages.json"],
+            ["git", "show", f"refs/tags/{tag}:packages/packages.json"],
             text=True,
             stderr=subprocess.PIPE,
+            timeout=5,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+    ) as err:
         # Tag missing packages.json, shallow clone, or git unavailable.
         # All treated as "skip this tag". Debug-level so early tags that
         # legitimately predate packages.json don't spam WARN every run.

--- a/benchmark/release_map.py
+++ b/benchmark/release_map.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Build and query the CID -> release tag map on demand.
+
+The map is computed by shelling out to ``gh release list`` and
+``git show``, cached in memory for the process lifetime, and never
+written to disk. Downstream callers import :func:`get_release_map` or
+:func:`resolve` and the map is built lazily on first access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import subprocess
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+DEFAULT_REPO = "valory-xyz/mech-predict"
+DEFAULT_LIMIT = 200
+UNTAGGED_PREFIX = "untagged@"
+UNTAGGED_CID_CHARS = 8
+
+_CACHE: dict[str, Any] | None = None
+
+
+def _run_gh_release_list(repo: str, limit: int) -> list[dict[str, str]]:
+    """Return release descriptors sorted chronologically (oldest first).
+
+    :param repo: ``owner/name`` slug passed to ``gh release list``.
+    :param limit: ``--limit`` value (number of releases to fetch).
+    :return: list of ``{"tagName": str, "createdAt": str}`` sorted by
+        ``createdAt`` ascending. Empty list on failure.
+    """
+    try:
+        out = subprocess.check_output(
+            [
+                "gh",
+                "release",
+                "list",
+                "--repo",
+                repo,
+                "--limit",
+                str(limit),
+                "--json",
+                "tagName,createdAt",
+            ],
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
+        log.warning("gh release list failed: %s", err)
+        return []
+    try:
+        releases = json.loads(out)
+    except json.JSONDecodeError as err:
+        log.warning("gh release list returned non-JSON: %s", err)
+        return []
+    return sorted(releases, key=lambda r: r.get("createdAt", ""))
+
+
+def _run_git_show_packages_json(tag: str) -> dict[str, Any] | None:
+    """Fetch ``packages.json`` content at *tag* via ``git show``.
+
+    :param tag: a release tag (e.g. ``"v0.17.2"``).
+    :return: parsed JSON dict, or None if the file doesn't exist at
+        that tag or git/json parsing fails. Never raises.
+    """
+    try:
+        out = subprocess.check_output(
+            ["git", "show", f"{tag}:packages/packages.json"],
+            text=True,
+            stderr=subprocess.PIPE,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Tag missing packages.json, shallow clone, or git unavailable.
+        # All treated as "skip this tag".
+        return None
+    try:
+        return json.loads(out)
+    except json.JSONDecodeError:
+        return None
+
+
+def _build(repo: str = DEFAULT_REPO, limit: int = DEFAULT_LIMIT) -> dict[str, Any]:
+    """Walk every release tag and record the first tag each CID appeared in.
+
+    :param repo: ``owner/name`` slug passed to ``gh release list``.
+    :param limit: ``--limit`` value (number of releases to fetch).
+    :return: dict with keys ``generated_at``, ``tags_scanned``,
+        ``cid_to_tag``, ``cid_to_package``. Empty dicts on complete
+        failure (no raises).
+    """
+    releases = _run_gh_release_list(repo, limit)
+    tags_scanned: list[str] = []
+    cid_to_tag: dict[str, str] = {}
+    cid_to_package: dict[str, str] = {}
+
+    for rel in releases:
+        tag = rel.get("tagName")
+        if not tag:
+            continue
+        packages_json = _run_git_show_packages_json(tag)
+        if packages_json is None:
+            continue
+        tags_scanned.append(tag)
+        for key, cid in (packages_json.get("dev") or {}).items():
+            if not isinstance(key, str) or not isinstance(cid, str):
+                continue
+            if not key.startswith("custom/"):
+                continue
+            # First tag wins — reintroduced CIDs keep their origin tag.
+            if cid not in cid_to_tag:
+                cid_to_tag[cid] = tag
+                cid_to_package[cid] = key
+
+    return {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "tags_scanned": tags_scanned,
+        "cid_to_tag": cid_to_tag,
+        "cid_to_package": cid_to_package,
+    }
+
+
+def get_release_map(force_rebuild: bool = False) -> dict[str, Any]:
+    """Return the cached release map. Builds on first call; cached after.
+
+    :param force_rebuild: when True, ignore the cache and rebuild. Used
+        only by tests; no production caller should need this.
+    :return: dict with keys ``generated_at``, ``tags_scanned``,
+        ``cid_to_tag``, ``cid_to_package``. Always returns a shape-valid
+        dict, even on failure (empty inner dicts).
+    """
+    global _CACHE  # noqa: PLW0603 — single-module cache is intentional
+    if _CACHE is None or force_rebuild:
+        _CACHE = _build()
+    return _CACHE
+
+
+def _untagged_label(cid: str) -> str:
+    """Return the fallback label for a CID not present in the map."""
+    short = cid[:UNTAGGED_CID_CHARS] if cid else "unknown"
+    return f"{UNTAGGED_PREFIX}{short}"
+
+
+def resolve(cid: str, release_map: dict[str, Any] | None = None) -> str:
+    """Return the release tag for *cid*, or ``untagged@<short>`` when absent.
+
+    Never raises — callers can display whatever comes back verbatim.
+
+    :param cid: IPFS CID string (``"bafybei..."``).
+    :param release_map: optional pre-loaded map. When None, a cached
+        build is used via :func:`get_release_map`.
+    :return: release tag (e.g. ``"v0.17.2"``) or ``"untagged@<first-8>"``.
+    """
+    if not cid:
+        return _untagged_label("")
+    if release_map is None:
+        release_map = get_release_map()
+    tag = (release_map.get("cid_to_tag") or {}).get(cid)
+    if tag:
+        return tag
+    return _untagged_label(cid)
+
+
+def sort_key(
+    tag_label: str,
+    tags_scanned: list[str],
+    first_seen: str | None = None,
+) -> tuple:
+    """Return a sort key for ordering versions by release chronology.
+
+    Tagged versions sort by their index in *tags_scanned* (earliest
+    first). Untagged labels sort after all tagged ones, ordered by
+    *first_seen* timestamp (None last).
+
+    :param tag_label: label returned by :func:`resolve` — a release tag
+        or an ``untagged@...`` string.
+    :param tags_scanned: ordered tag list from the release map.
+    :param first_seen: optional ISO timestamp for fallback ordering of
+        untagged labels.
+    :return: tuple usable as a sort key.
+    """
+    is_untagged = tag_label.startswith(UNTAGGED_PREFIX)
+    if is_untagged:
+        # (1, "", first_seen_or_empty) sorts after all tagged entries.
+        return (1, "", first_seen or "~")
+    try:
+        index = tags_scanned.index(tag_label)
+    except ValueError:
+        # Tag not in the scanned list (shouldn't happen in practice) —
+        # sort at the end of the tagged group.
+        index = len(tags_scanned)
+    return (0, index, first_seen or "")
+
+
+# ---------------------------------------------------------------------------
+# CLI — inspection only. Never writes to a committed file.
+# ---------------------------------------------------------------------------
+
+
+def _cli_coverage(scores_path: str, release_map: dict[str, Any]) -> int:
+    """Print CID resolution coverage against a ``scores.json`` file.
+
+    :param scores_path: path to a scores JSON file with
+        ``by_tool_version_mode`` keys.
+    :param release_map: pre-built release map.
+    :return: process exit code (0 always; diagnostic only).
+    """
+    with open(scores_path, encoding="utf-8") as f:
+        scores = json.load(f)
+    tvm = scores.get("by_tool_version_mode", {})
+    total = 0
+    resolved = 0
+    unresolved: list[tuple[str, str]] = []
+    for key in tvm:
+        parts = [p.strip() for p in key.split("|")]
+        if len(parts) != 3:
+            continue
+        tool, cid, _mode = parts
+        if cid in ("unknown", ""):
+            continue
+        total += 1
+        tag = (release_map.get("cid_to_tag") or {}).get(cid)
+        if tag:
+            resolved += 1
+        else:
+            unresolved.append((tool, cid[:12]))
+    pct = (100.0 * resolved / total) if total else 0.0
+    print(f"Coverage: {resolved}/{total} ({pct:.0f}%)")
+    for tool, cid_short in unresolved:
+        print(f"  unresolved: tool={tool}  cid={cid_short}...")
+    return 0
+
+
+def main() -> int:
+    """CLI entry point for inspection.
+
+    :return: process exit code.
+    """
+    parser = argparse.ArgumentParser(
+        description="Inspect the CID -> release tag map for mech-predict.",
+    )
+    parser.add_argument(
+        "--cid",
+        help="Resolve a single CID and print the tag (or untagged label).",
+    )
+    parser.add_argument(
+        "--coverage",
+        help=(
+            "Path to a scores.json file. Report what fraction of "
+            "by_tool_version_mode CIDs can be resolved."
+        ),
+    )
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, help="GitHub repo slug (owner/name)."
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_LIMIT,
+        help="Number of releases to fetch.",
+    )
+    args = parser.parse_args()
+
+    # Always rebuild for the CLI — it's inspection of live state.
+    release_map = _build(repo=args.repo, limit=args.limit)
+
+    if args.cid:
+        print(resolve(args.cid, release_map))
+        return 0
+
+    if args.coverage:
+        return _cli_coverage(args.coverage, release_map)
+
+    json.dump(release_map, sys.stdout, indent=2)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/release_map.py
+++ b/benchmark/release_map.py
@@ -41,7 +41,7 @@ DEFAULT_LIMIT = 200
 UNTAGGED_PREFIX = "untagged@"
 UNTAGGED_CID_CHARS = 8
 
-_CACHE: dict[str, Any] | None = None
+_CACHE: dict[tuple[str, int], dict[str, Any]] = {}
 
 
 def _run_gh_release_list(repo: str, limit: int) -> list[dict[str, str]]:
@@ -69,13 +69,21 @@ def _run_gh_release_list(repo: str, limit: int) -> list[dict[str, str]]:
             stderr=subprocess.PIPE,
         )
     except (subprocess.CalledProcessError, FileNotFoundError) as err:
-        log.warning("gh release list failed: %s", err)
+        stderr = getattr(err, "stderr", "") or ""
+        log.warning("gh release list failed: %s | stderr=%s", err, stderr.strip())
         return []
     try:
         releases = json.loads(out)
     except json.JSONDecodeError as err:
         log.warning("gh release list returned non-JSON: %s", err)
         return []
+    if len(releases) >= limit:
+        log.warning(
+            "gh release list hit --limit=%d; older tags may be truncated and "
+            "CIDs from those tags will be misattributed to later tags. "
+            "Raise DEFAULT_LIMIT or paginate.",
+            limit,
+        )
     return sorted(releases, key=lambda r: r.get("createdAt", ""))
 
 
@@ -92,13 +100,22 @@ def _run_git_show_packages_json(tag: str) -> dict[str, Any] | None:
             text=True,
             stderr=subprocess.PIPE,
         )
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (subprocess.CalledProcessError, FileNotFoundError) as err:
         # Tag missing packages.json, shallow clone, or git unavailable.
-        # All treated as "skip this tag".
+        # All treated as "skip this tag". Debug-level so early tags that
+        # legitimately predate packages.json don't spam WARN every run.
+        stderr = getattr(err, "stderr", "") or ""
+        log.debug(
+            "git show %s:packages/packages.json failed: %s | stderr=%s",
+            tag,
+            err,
+            stderr.strip(),
+        )
         return None
     try:
         return json.loads(out)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as err:
+        log.debug("git show %s:packages/packages.json returned non-JSON: %s", tag, err)
         return None
 
 
@@ -142,19 +159,30 @@ def _build(repo: str = DEFAULT_REPO, limit: int = DEFAULT_LIMIT) -> dict[str, An
     }
 
 
-def get_release_map(force_rebuild: bool = False) -> dict[str, Any]:
+def get_release_map(
+    repo: str = DEFAULT_REPO,
+    limit: int = DEFAULT_LIMIT,
+    force_rebuild: bool = False,
+) -> dict[str, Any]:
     """Return the cached release map. Builds on first call; cached after.
 
-    :param force_rebuild: when True, ignore the cache and rebuild. Used
-        only by tests; no production caller should need this.
+    Cache is keyed on ``(repo, limit)`` so non-default callers get their
+    own entry instead of silently receiving a map built for a different
+    repo or limit.
+
+    :param repo: ``owner/name`` slug passed to ``gh release list``.
+    :param limit: ``--limit`` value (number of releases to fetch).
+    :param force_rebuild: when True, bypass the cache entry for this
+        ``(repo, limit)`` and rebuild. Used by tests; production callers
+        typically don't need this.
     :return: dict with keys ``generated_at``, ``tags_scanned``,
         ``cid_to_tag``, ``cid_to_package``. Always returns a shape-valid
         dict, even on failure (empty inner dicts).
     """
-    global _CACHE  # noqa: PLW0603 — single-module cache is intentional
-    if _CACHE is None or force_rebuild:
-        _CACHE = _build()
-    return _CACHE
+    key = (repo, limit)
+    if force_rebuild or key not in _CACHE:
+        _CACHE[key] = _build(repo=repo, limit=limit)
+    return _CACHE[key]
 
 
 def _untagged_label(cid: str) -> str:

--- a/benchmark/tests/test_release_map.py
+++ b/benchmark/tests/test_release_map.py
@@ -1,0 +1,340 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Tests for benchmark/release_map.py."""
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from benchmark import release_map
+from benchmark.release_map import (
+    UNTAGGED_PREFIX,
+    _build,
+    get_release_map,
+    resolve,
+    sort_key,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    """Wipe module-level cache between tests."""
+    release_map._CACHE = None  # pylint: disable=protected-access
+
+
+def _fake_releases(
+    *tags_in_order: tuple[str, str],
+) -> list[dict[str, str]]:
+    """Build a list of fake release descriptors in chronological order."""
+    return [{"tagName": t, "createdAt": ts} for t, ts in tags_in_order]
+
+
+def _packages_json(*entries: tuple[str, str]) -> dict[str, Any]:
+    """Build a fake packages.json body with the given custom entries."""
+    return {"dev": dict(entries)}
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuild:
+    """Tests for the private _build() function."""
+
+    def test_first_tag_wins(self) -> None:
+        """A CID seen in v1.0.0 and v1.1.0 maps to v1.0.0."""
+        releases = _fake_releases(
+            ("v1.0.0", "2026-01-01T00:00:00Z"),
+            ("v1.1.0", "2026-02-01T00:00:00Z"),
+        )
+        pkg_by_tag = {
+            "v1.0.0": _packages_json(("custom/v/tool/0.1.0", "cidA")),
+            "v1.1.0": _packages_json(("custom/v/tool/0.1.0", "cidA")),
+        }
+
+        with (
+            patch.object(release_map, "_run_gh_release_list", return_value=releases),
+            patch.object(
+                release_map,
+                "_run_git_show_packages_json",
+                side_effect=pkg_by_tag.get,
+            ),
+        ):
+            result = _build()
+
+        assert result["cid_to_tag"]["cidA"] == "v1.0.0"
+
+    def test_cid_reintroduction_preserves_origin(self) -> None:
+        """CID present in v1.0.0, absent in v1.1.0, back in v1.2.0 -> v1.0.0."""
+        releases = _fake_releases(
+            ("v1.0.0", "2026-01-01T00:00:00Z"),
+            ("v1.1.0", "2026-02-01T00:00:00Z"),
+            ("v1.2.0", "2026-03-01T00:00:00Z"),
+        )
+        pkg_by_tag = {
+            "v1.0.0": _packages_json(("custom/v/tool/0.1.0", "cidX")),
+            "v1.1.0": _packages_json(("custom/v/tool/0.1.0", "cidY")),
+            "v1.2.0": _packages_json(("custom/v/tool/0.1.0", "cidX")),
+        }
+        with (
+            patch.object(release_map, "_run_gh_release_list", return_value=releases),
+            patch.object(
+                release_map,
+                "_run_git_show_packages_json",
+                side_effect=pkg_by_tag.get,
+            ),
+        ):
+            result = _build()
+
+        assert result["cid_to_tag"]["cidX"] == "v1.0.0"
+        assert result["cid_to_tag"]["cidY"] == "v1.1.0"
+
+    def test_shared_cid_across_runtime_tools_resolves_once(self) -> None:
+        """One package CID covers many runtime tool names. Map holds one entry."""
+        releases = _fake_releases(("v1.0.0", "2026-01-01T00:00:00Z"))
+        # Only the package key matters; the map is CID-keyed.
+        pkg = _packages_json(("custom/valory/prediction_request/0.1.0", "cidShared"))
+        with (
+            patch.object(release_map, "_run_gh_release_list", return_value=releases),
+            patch.object(release_map, "_run_git_show_packages_json", return_value=pkg),
+        ):
+            result = _build()
+
+        assert list(result["cid_to_tag"].keys()) == ["cidShared"]
+        assert (
+            result["cid_to_package"]["cidShared"]
+            == "custom/valory/prediction_request/0.1.0"
+        )
+
+    def test_non_custom_keys_ignored(self) -> None:
+        """agent/service/protocol entries in packages.json are not indexed."""
+        releases = _fake_releases(("v1.0.0", "2026-01-01T00:00:00Z"))
+        pkg = _packages_json(
+            ("custom/v/tool/0.1.0", "cidCustom"),
+            ("agent/valory/mech_predict/0.1.0", "cidAgent"),
+            ("service/valory/mech_predict/0.1.0", "cidService"),
+            ("protocol/open_aea/signing/1.0.0", "cidProto"),
+        )
+        with (
+            patch.object(release_map, "_run_gh_release_list", return_value=releases),
+            patch.object(release_map, "_run_git_show_packages_json", return_value=pkg),
+        ):
+            result = _build()
+
+        assert set(result["cid_to_tag"].keys()) == {"cidCustom"}
+
+    def test_chronological_tag_order(self) -> None:
+        """Published-at timestamp (not semver) drives first-tag assignment.
+
+        In this fixture v1.2.0 was published before v1.1.0 — a hotfix
+        scenario. `_run_gh_release_list` already sorts by createdAt so
+        the caller sees v1.0.0, v1.2.0, v1.1.0 in that order, and cidNew
+        is first observed at v1.2.0.
+        """
+        releases = _fake_releases(
+            ("v1.0.0", "2026-01-01T00:00:00Z"),
+            ("v1.2.0", "2026-02-01T00:00:00Z"),
+            ("v1.1.0", "2026-03-01T00:00:00Z"),
+        )
+        pkg_by_tag = {
+            "v1.0.0": _packages_json(("custom/v/tool/0.1.0", "cidOld")),
+            "v1.2.0": _packages_json(("custom/v/tool/0.1.0", "cidNew")),
+            "v1.1.0": _packages_json(("custom/v/tool/0.1.0", "cidNew")),
+        }
+        with (
+            patch.object(release_map, "_run_gh_release_list", return_value=releases),
+            patch.object(
+                release_map,
+                "_run_git_show_packages_json",
+                side_effect=pkg_by_tag.get,
+            ),
+        ):
+            result = _build()
+
+        assert result["cid_to_tag"]["cidNew"] == "v1.2.0"
+
+    def test_missing_packages_json_at_old_tag_skipped(self) -> None:
+        """A tag without packages/packages.json is silently skipped."""
+        releases = _fake_releases(
+            ("v0.0.1", "2026-01-01T00:00:00Z"),
+            ("v1.0.0", "2026-02-01T00:00:00Z"),
+        )
+        pkg_by_tag: dict[str, Any] = {
+            "v0.0.1": None,  # missing
+            "v1.0.0": _packages_json(("custom/v/tool/0.1.0", "cid1")),
+        }
+        with (
+            patch.object(release_map, "_run_gh_release_list", return_value=releases),
+            patch.object(
+                release_map,
+                "_run_git_show_packages_json",
+                side_effect=pkg_by_tag.get,
+            ),
+        ):
+            result = _build()
+
+        assert result["cid_to_tag"]["cid1"] == "v1.0.0"
+        assert result["tags_scanned"] == ["v1.0.0"]
+
+    def test_build_failure_yields_empty_map(self) -> None:
+        """Failure of the release-list call returns an empty, shape-valid map."""
+        with patch.object(release_map, "_run_gh_release_list", return_value=[]):
+            result = _build()
+
+        assert not result["cid_to_tag"]
+        assert not result["cid_to_package"]
+        assert not result["tags_scanned"]
+
+
+# ---------------------------------------------------------------------------
+# Caching
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    """Tests for the module-level cache in get_release_map()."""
+
+    def test_cache_reuses_first_build(self) -> None:
+        """Calling get_release_map twice runs _build only once."""
+        with patch.object(
+            release_map, "_build", return_value={"cid_to_tag": {"cidA": "v1.0.0"}}
+        ) as mock_build:
+            get_release_map()
+            get_release_map()
+            get_release_map()
+        assert mock_build.call_count == 1
+
+    def test_force_rebuild_bypasses_cache(self) -> None:
+        """force_rebuild=True runs _build again."""
+        with patch.object(
+            release_map, "_build", return_value={"cid_to_tag": {}}
+        ) as mock_build:
+            get_release_map()
+            get_release_map(force_rebuild=True)
+        assert mock_build.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests for resolve
+# ---------------------------------------------------------------------------
+
+
+class TestResolve:
+    """Tests for resolve()."""
+
+    def test_returns_tag_when_present(self) -> None:
+        """A known CID returns its tag."""
+        rm = {"cid_to_tag": {"cidA": "v0.17.2"}}
+        assert resolve("cidA", rm) == "v0.17.2"
+
+    def test_returns_untagged_label_when_missing(self) -> None:
+        """An unknown CID returns 'untagged@<short>'."""
+        rm: dict[str, Any] = {"cid_to_tag": {}}
+        result = resolve("bafybei1234567890abc", rm)
+        assert result.startswith(UNTAGGED_PREFIX)
+        assert "bafybei1" in result
+
+    def test_never_raises_on_empty_map(self) -> None:
+        """An empty release_map never raises."""
+        assert resolve("anything", {}).startswith(UNTAGGED_PREFIX)
+        assert resolve("anything", {"cid_to_tag": None}).startswith(UNTAGGED_PREFIX)
+
+    def test_empty_cid_returns_untagged(self) -> None:
+        """Empty or None CID is safely handled."""
+        rm = {"cid_to_tag": {"cidA": "v1.0.0"}}
+        assert resolve("", rm).startswith(UNTAGGED_PREFIX)
+
+
+# ---------------------------------------------------------------------------
+# Tests for sort_key
+# ---------------------------------------------------------------------------
+
+
+class TestSortKey:
+    """Tests for sort_key()."""
+
+    def test_orders_by_tag_chronology(self) -> None:
+        """Tagged versions sort by their index in tags_scanned."""
+        tags = ["v1.0.0", "v1.1.0", "v1.2.0"]
+        items = [("v1.2.0", "c"), ("v1.0.0", "a"), ("v1.1.0", "b")]
+        items.sort(key=lambda x: sort_key(x[0], tags))
+        assert [x[1] for x in items] == ["a", "b", "c"]
+
+    def test_untagged_sorts_after_tagged(self) -> None:
+        """Untagged entries sort after all tagged ones."""
+        tags = ["v1.0.0", "v1.1.0"]
+        items = [
+            ("v1.1.0", "tagged_new"),
+            (f"{UNTAGGED_PREFIX}bafybei1", "dev"),
+            ("v1.0.0", "tagged_old"),
+        ]
+        items.sort(key=lambda x: sort_key(x[0], tags))
+        assert [x[1] for x in items] == ["tagged_old", "tagged_new", "dev"]
+
+    def test_untagged_fallback_to_first_seen(self) -> None:
+        """Multiple untagged entries sort by first_seen."""
+        tags: list[str] = []
+        items = [
+            (f"{UNTAGGED_PREFIX}b2", "later", "2026-03-01T00:00:00Z"),
+            (f"{UNTAGGED_PREFIX}a1", "earlier", "2026-01-01T00:00:00Z"),
+        ]
+        items.sort(key=lambda x: sort_key(x[0], tags, first_seen=x[2]))
+        assert [x[1] for x in items] == ["earlier", "later"]
+
+
+# ---------------------------------------------------------------------------
+# CLI JSON surface (smoke test)
+# ---------------------------------------------------------------------------
+
+
+class TestCliSmoke:
+    """Smoke tests for the CLI surface."""
+
+    def test_main_prints_map_as_json(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Default CLI invocation prints the map as JSON."""
+        fake_map = {
+            "generated_at": "2026-04-15T00:00:00Z",
+            "tags_scanned": ["v1.0.0"],
+            "cid_to_tag": {"cidA": "v1.0.0"},
+            "cid_to_package": {"cidA": "custom/v/tool/0.1.0"},
+        }
+        monkeypatch.setattr("sys.argv", ["release_map"])
+        with patch.object(release_map, "_build", return_value=fake_map):
+            release_map.main()
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["cid_to_tag"] == {"cidA": "v1.0.0"}
+
+    def test_main_resolve_single_cid(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--cid flag resolves and prints a single tag."""
+        monkeypatch.setattr("sys.argv", ["release_map", "--cid", "cidA"])
+        with patch.object(
+            release_map,
+            "_build",
+            return_value={"cid_to_tag": {"cidA": "v1.0.0"}},
+        ):
+            release_map.main()
+        assert capsys.readouterr().out.strip() == "v1.0.0"

--- a/benchmark/tests/test_release_map.py
+++ b/benchmark/tests/test_release_map.py
@@ -253,6 +253,58 @@ class TestRunGhReleaseList:
             run_list("owner/repo", limit=200)
         assert not any("truncated" in rec.message for rec in caplog.records)
 
+    def test_timeout_returns_empty_list(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Catches TimeoutExpired, logs it, and yields an empty list."""
+        import subprocess  # pylint: disable=import-outside-toplevel
+
+        run_list = release_map._run_gh_release_list  # pylint: disable=protected-access
+        with (
+            caplog.at_level("WARNING", logger=release_map.log.name),
+            patch.object(
+                subprocess,
+                "check_output",
+                side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=15),
+            ),
+        ):
+            result = run_list("owner/repo", limit=200)
+        assert result == []
+        assert any("gh release list failed" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _run_git_show_packages_json diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestRunGitShow:
+    """Tests for _run_git_show_packages_json() call shape and error paths."""
+
+    # pylint: disable=protected-access
+    git_show_fn = staticmethod(release_map._run_git_show_packages_json)
+
+    def test_uses_refs_tags_prefix(self) -> None:
+        """Prefixes the revision with refs/tags/ to disambiguate."""
+        import subprocess  # pylint: disable=import-outside-toplevel
+
+        with patch.object(
+            subprocess, "check_output", return_value='{"dev": {}}'
+        ) as mock_co:
+            self.git_show_fn("v1.2.3")
+        args = mock_co.call_args.args[0]
+        assert args[:2] == ["git", "show"]
+        assert args[2] == "refs/tags/v1.2.3:packages/packages.json"
+
+    def test_timeout_returns_none(self) -> None:
+        """Catches TimeoutExpired and yields None (tag skipped)."""
+        import subprocess  # pylint: disable=import-outside-toplevel
+
+        with patch.object(
+            subprocess,
+            "check_output",
+            side_effect=subprocess.TimeoutExpired(cmd="git", timeout=5),
+        ):
+            assert self.git_show_fn("v1.2.3") is None
+
 
 # ---------------------------------------------------------------------------
 # Caching

--- a/benchmark/tests/test_release_map.py
+++ b/benchmark/tests/test_release_map.py
@@ -37,7 +37,7 @@ from benchmark.release_map import (
 @pytest.fixture(autouse=True)
 def _reset_cache() -> None:
     """Wipe module-level cache between tests."""
-    release_map._CACHE = None  # pylint: disable=protected-access
+    release_map._CACHE = {}  # pylint: disable=protected-access
 
 
 def _fake_releases(
@@ -206,6 +206,55 @@ class TestBuild:
 
 
 # ---------------------------------------------------------------------------
+# _run_gh_release_list diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestRunGhReleaseList:
+    """Tests for diagnostic behavior of _run_gh_release_list()."""
+
+    def test_warns_when_result_count_hits_limit(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Logs a truncation warning when len(releases) >= limit."""
+        import subprocess  # pylint: disable=import-outside-toplevel
+
+        fake_json = json.dumps(
+            [
+                {"tagName": f"v0.0.{i}", "createdAt": f"2026-01-{i:02d}T00:00:00Z"}
+                for i in range(1, 4)
+            ]
+        )
+        run_list = release_map._run_gh_release_list  # pylint: disable=protected-access
+        with (
+            caplog.at_level("WARNING", logger=release_map.log.name),
+            patch.object(subprocess, "check_output", return_value=fake_json),
+        ):
+            run_list("owner/repo", limit=3)
+        assert any(
+            "hit --limit=3" in rec.message and "truncated" in rec.message
+            for rec in caplog.records
+        )
+
+    def test_no_truncation_warning_when_below_limit(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No truncation warning when release count is below the limit."""
+        import subprocess  # pylint: disable=import-outside-toplevel
+
+        fake_json = json.dumps(
+            [{"tagName": "v0.0.1", "createdAt": "2026-01-01T00:00:00Z"}]
+        )
+        run_list = release_map._run_gh_release_list  # pylint: disable=protected-access
+        with (
+            caplog.at_level("WARNING", logger=release_map.log.name),
+            patch.object(subprocess, "check_output", return_value=fake_json),
+        ):
+            run_list("owner/repo", limit=200)
+        assert not any("truncated" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
 # Caching
 # ---------------------------------------------------------------------------
 
@@ -231,6 +280,22 @@ class TestCache:
             get_release_map()
             get_release_map(force_rebuild=True)
         assert mock_build.call_count == 2
+
+    def test_cache_keyed_on_repo_and_limit(self) -> None:
+        """Different (repo, limit) tuples get independent cache entries."""
+        with patch.object(
+            release_map, "_build", return_value={"cid_to_tag": {}}
+        ) as mock_build:
+            get_release_map(repo="a/b", limit=50)
+            get_release_map(repo="a/b", limit=50)  # cached
+            get_release_map(repo="a/b", limit=100)  # different limit
+            get_release_map(repo="c/d", limit=50)  # different repo
+            get_release_map(repo="a/b", limit=100)  # cached
+        assert mock_build.call_count == 3
+        calls = [c.kwargs for c in mock_build.call_args_list]
+        assert {"repo": "a/b", "limit": 50} in calls
+        assert {"repo": "a/b", "limit": 100} in calls
+        assert {"repo": "c/d", "limit": 50} in calls
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

`benchmark/analyze.py` identifies tool versions by raw IPFS CID (`bafybeiczmjumnjzhma7nehgr5sfojkdge2bio2wkvbqlue7vc5uvn6bcwi`), which is opaque to read and has no temporal ordering. Every tagged mech-predict release commits `packages/packages.json`, which maps `custom/{author}/{tool}/{version} → CID`. Walking those files across release tags lets us derive a `CID → first_release_tag` map that downstream reporting code can use to:

- Render human-readable version labels (`v0.17.2` instead of a 50-char hash).
- Sort tool versions chronologically by release tag (needed for the temporal regressions work, item #5 in `BENCHMARK_REPORT_FIXES.md`).
- Support the "promote/demote" workflow: given a tournament vs production comparison, tell me which version is newer.

This PR is **pure plumbing** — it adds the module, the tests, and the one workflow line needed to make it function in CI. No existing analyze/report output changes. The follow-up PR (#5 — temporal regressions tables) is what actually consumes the helper.

## What changes

**New module `benchmark/release_map.py`** with three public functions:

```python
get_release_map(force_rebuild=False)  # lazy build + module-level cache
resolve(cid, release_map=None)        # CID → tag, or 'untagged@<short>' fallback
sort_key(label, tags_scanned, first_seen=None)  # chronological ordering key
```

Plus an inspection-only CLI:

```bash
python -m benchmark.release_map                       # dump full map as JSON
python -m benchmark.release_map --cid bafybei...wgjq  # resolve one CID
python -m benchmark.release_map --coverage scores.json
                                                      # report resolution rate
```

**No files are committed.** The map rebuilds on first access per Python process, caches in memory, and is discarded on exit. Cost per build: one `gh release list` call (~300 ms) + 74 `git show` calls (~3 s total).

**Workflow change.** `.github/workflows/benchmark_flywheel.yaml` — the benchmark job's `actions/checkout@v4` now uses `fetch-depth: 0` so `git show <tag>:…` can see historical tags. Other jobs untouched.

## Why CID-keyed (not tool-keyed)

CIDs are content-addressed and therefore globally unique. Runtime tool names are many-to-one with packages — `prediction-offline`, `prediction-online`, `claude-prediction-offline`, `claude-prediction-online` all emit from `custom/valory/prediction_request/0.1.0`. Similarly `prediction-request-reasoning-claude` maps to the same package as `prediction-request-reasoning` (different model, same code).

A tool-scoped first attempt at this map gave **29% resolution** on today's real data. CID-only gives **100%**. The tool-scoping added nothing but bugs.

## Feasibility (2026-04-15)

| Check | Result |
|---|---|
| `gh release list --limit 200` returns every tag with `createdAt` | ✅ 74 tags, from `v0.1.0` (2025-02-28) to `v0.17.3` (2026-04-15). |
| `git show {tag}:packages/packages.json` succeeds for every tag | ✅ 74/74. |
| Resolves all CIDs in today's production `scores.json:by_tool_version_mode` | ✅ 21/21 (100%). |
| Resolves all CIDs in today's `scores_tournament.json:by_tool_version_mode` | ✅ 13/13 (100%). |
| Known superforcaster CIDs map to sensible tags | ✅ `bafybeic6vai...` → `v0.17.0`, `bafybeiepzi7s...` → `v0.16.5`. |

Post-merge, the `--coverage` CLI continues to be the smoke test: < 95% resolution on production data means something is off (new package naming convention, dev-branch CID in logs, etc.).

## Tests

18 new tests in `benchmark/tests/test_release_map.py`. All `gh` / `git show` calls are mocked — no network or live-repo dependencies.

- Builder: first-tag-wins, CID reintroduction preserves origin, shared CID across runtime tools, non-custom keys ignored, chronological tag order (createdAt not semver), missing packages.json skipped silently, build-failure-yields-empty-map.
- Cache: reuses first build, `force_rebuild=True` bypasses cache.
- `resolve`: returns tag when present, returns untagged label when missing, never raises on empty map, empty CID safely handled.
- `sort_key`: orders by tag chronology, untagged sorts after tagged, untagged fallback by `first_seen`.
- CLI smoke: default invocation prints map as JSON, `--cid` prints a single tag.

**344 total tests pass locally.** `uv run tomte check-code` green.

## Test plan

- [x] `uv run --with scipy --with numpy --with pytest python -m pytest benchmark/tests/ -q` — 344 passed.
- [x] `uv run tomte check-code` — all green.
- [x] Live `python -m benchmark.release_map --coverage benchmark-data/results/scores.json` reports 21/21 (100%) against today's production scores.
- [ ] Next scheduled flywheel run completes the `Install dependencies` step after the deeper checkout — should add < 1s (deep clone).
- [ ] Once #5 lands (temporal regressions), `Tool × Version × Mode` table and Tournament Callouts in the report render with `v0.17.x` labels instead of CIDs.

## Out of scope (for follow-up PRs)

- `analyze.py` integration — swap bare CIDs for labels in every section that renders them. Covered in #5.
- Re-enabling the Version Deltas section with temporal ordering. Covered in #5.
- Any use of the `sort_key` helper. Covered in #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)