### PR TITLE
chore(benchmark): reduce daily tournament markets to 10 per platform

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -12,7 +12,7 @@ on:
       max_markets:
         description: 'Max markets per platform for tournament'
         required: false
-        default: '20'
+        default: '10'
       tools:
         description: 'Comma-separated tool names for tournament'
         required: false
@@ -255,7 +255,7 @@ jobs:
       # Inputs routed via env to avoid shell injection — see note in benchmark job.
       - name: Fetch Omen open markets
         env:
-          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '20' }}
+          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '10' }}
         run: |
           python -m benchmark.datasets.fetch_open \
             --platform omen \
@@ -263,7 +263,7 @@ jobs:
 
       - name: Fetch Polymarket open markets
         env:
-          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '20' }}
+          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '10' }}
         run: |
           python -m benchmark.datasets.fetch_open \
             --platform polymarket \
@@ -342,7 +342,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.BENCHMARK_GOOGLE_API_KEY }}
           GOOGLE_ENGINE_ID: ${{ secrets.BENCHMARK_GOOGLE_ENGINE_ID }}
           INPUT_TOOLS: ${{ github.event.inputs.tools || 'prediction-online,prediction-offline,claude-prediction-online,claude-prediction-offline,superforcaster,prediction-request-reasoning,prediction-request-reasoning-claude,prediction-request-rag,prediction-request-rag-claude,prediction-url-cot,prediction-url-cot-claude,prediction-offline-sme,prediction-online-sme,factual_research' }}
-          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '20' }}
+          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '10' }}
         run: |
           uv run python -m benchmark.tournament \
             --markets benchmark/datasets/open_markets.jsonl \


### PR DESCRIPTION
## Summary
- Reduce `max_markets` default from 20 → 10 in `.github/workflows/benchmark_flywheel.yaml` so the daily 6am UTC cron fetches and predicts on 10 markets per platform instead of 20.
- Updated all four occurrences: workflow_dispatch input default, Omen fetch step, Polymarket fetch step, and tournament-run step.

## Test plan
- [ ] Next scheduled run (or manual `workflow_dispatch` with no override) processes 10 markets per platform.