### PR TITLE
chore(benchmark): move flywheel cron to 02:30 UTC

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -2,7 +2,7 @@ name: benchmark-flywheel
 
 on:
   schedule:
-    - cron: '0 6 * * *'  # daily at 6am UTC
+    - cron: '30 2 * * *'  # daily at 02:30 UTC (aims for Slack post before 11:00 IST)
   workflow_dispatch:
     inputs:
       lookback_days:


### PR DESCRIPTION
## Summary

Move `benchmark-flywheel` scheduled cron from `0 6 * * *` (06:00 UTC) to `30 2 * * *` (02:30 UTC) so the Slack summary lands before 11:00 IST.

## Why

Observed end-to-end timing from a recent run:
- Cron fires at 06:00 UTC, actual job start ~06:40 UTC (GH scheduled-cron drift, typically 20–60 min).
- Pipeline: `tournament-fetch` → `tournament-run` (up to 90 min) → `benchmark` (up to 30 min). Slack post happens at the end of the `benchmark` job.
- Slack summary arriving ~07:45 UTC = ~13:15 IST.

Target is Slack post before 11:00 IST (05:30 UTC). Working backwards with ~1h45m typical pipeline + ~30–60 min cron drift, 02:30 UTC gives a landing window of ~10:00–10:30 IST with roughly an hour of buffer before the 11:00 IST cutoff.

## Change

One line in `.github/workflows/benchmark_flywheel.yaml`:

```yaml
# before
- cron: '0 6 * * *'  # daily at 6am UTC
# after
- cron: '30 2 * * *'  # daily at 02:30 UTC (aims for Slack post before 11:00 IST)
