### PR TITLE
fix(superforcaster): switch to OpenAI Structured Outputs (#221)

### DIFF
--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -210,47 +210,6 @@ def _metrics_table(baseline: dict[str, Any], candidate: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _format_prefilter_section(filter_stats: dict[str, Any]) -> list[str]:
-    """Render the pre-filter stats block.
-
-    This block exists to make the upstream "drop non-valid parses" invariant
-    visible. Parse reliability reports baseline as 100% *by construction* —
-    only because the enrich step drops non-valid rows. Without this block, a
-    silent regression in that filter would re-create exactly the observability
-    gap that issue #221 fell through.
-
-    :param filter_stats: dict with ``accepted`` and ``rejected`` keys from the
-        ``filter_stats.json`` sidecar written by ``prompt_replay enrich``.
-    :return: markdown lines.
-    """
-    r = filter_stats.get("rejected", {}) or {}
-    accepted = filter_stats.get("accepted", 0)
-    total_rej = sum(r.values())
-    not_valid = r.get("not_valid_parse", 0)
-
-    # not_valid_parse is the load-bearing one: flag it loudly if nonzero.
-    if not_valid > 0:
-        valid_verdict = f"⚠️ {not_valid} row(s) rejected for not_valid_parse"
-    else:
-        valid_verdict = "✅ 0 rejected for not_valid_parse"
-
-    scoping_parts = [
-        f"wrong_tool={r.get('wrong_tool', 0)}",
-        f"no_deliver_id={r.get('no_deliver_id', 0)}",
-        f"no_outcome={r.get('no_outcome', 0)}",
-        f"older_than_cutoff={r.get('older_than_cutoff', 0)}",
-    ]
-
-    return [
-        "**Pre-filter (from enrich)**",
-        "",
-        f"- Accepted: {accepted}",
-        f"- Rejected: {total_rej} total — {valid_verdict}",
-        f"- Scoping rejections: {', '.join(scoping_parts)}",
-        "",
-    ]
-
-
 def _load_filter_stats(candidate_path: Path) -> Optional[dict[str, Any]]:
     """Load ``filter_stats.json`` written alongside candidate.jsonl, if present.
 
@@ -266,46 +225,71 @@ def _load_filter_stats(candidate_path: Path) -> Optional[dict[str, Any]]:
         return None
 
 
-def _format_reliability_section(
-    baseline: dict[str, Any],
+def _format_reliability_block(
     candidate: dict[str, Any],
     failure_rows: list[dict[str, Any]],
+    filter_stats: Optional[dict[str, Any]] = None,
 ) -> list[str]:
-    """Render the parse-reliability block + optional failure bodies.
+    """Render the Reliability section: candidate parse rate + pre-filter stats.
 
-    :param baseline: metrics dict including ``parse_reliability``.
+    Baseline parse rate is 100% by construction (the enrich step drops
+    non-valid rows), so it is not reported as part of a baseline-vs-candidate
+    comparison. The two observations here are one-sided:
+
+    - candidate parse rate: did the PR's code produce parseable responses?
+    - pre-filter: did the upstream enrich filter's "drop non-valid" invariant
+      hold? (non-zero ``not_valid_parse`` rejects = silent regression of the
+      invariant that made baseline 100% trustworthy in the first place)
+
     :param candidate: metrics dict including ``parse_reliability``.
     :param failure_rows: rows from ``candidate_failures.jsonl`` (may be empty).
+    :param filter_stats: optional dict from the filter_stats.json sidecar.
     :return: markdown lines.
     """
-    b_rel = baseline["parse_reliability"]
     c_rel = candidate["parse_reliability"]
-    b_rate = b_rel["parse_rate"] or 0.0
+    c_total = c_rel["total"]
+    c_valid = c_rel["valid"]
     c_rate = c_rel["parse_rate"] or 0.0
-    delta_pct = (c_rate - b_rate) * 100
+    c_marker = "✅" if c_valid == c_total else "⚠️"
 
-    # #221 is specifically "candidate delivers that don't parse" — so only a
-    # drop vs baseline is flagged, a rise is just ✅.
-    if delta_pct < -1e-9:
-        verdict = f"⚠️ {delta_pct:+.1f}% vs baseline"
-    elif delta_pct > 1e-9:
-        verdict = f"✅ {delta_pct:+.1f}% vs baseline"
-    else:
-        verdict = "✅ same as baseline"
-
-    bd = c_rel["breakdown"]
-    breakdown_str = ", ".join(f"{k}={bd[k]}" for k in PARSE_STATUS_BUCKETS)
-
-    lines = [
-        "**Parse reliability**",
+    lines: list[str] = [
+        "**Reliability**",
         "",
-        f"- Baseline: {b_rel['valid']}/{b_rel['total']} "
-        f"({b_rate * 100:.1f}%) [valid-only by filter]",
-        f"- Candidate: {c_rel['valid']}/{c_rel['total']} "
-        f"({c_rate * 100:.1f}%) — {verdict}",
-        f"- Candidate breakdown: {breakdown_str}",
-        "",
+        f"- Candidate parse rate: {c_valid}/{c_total} "
+        f"({c_rate * 100:.1f}%) {c_marker}",
     ]
+
+    # Breakdown only surfaces when candidate drifted — keeps the happy-path
+    # line count short.
+    if c_valid < c_total:
+        bd = c_rel["breakdown"]
+        breakdown_str = ", ".join(f"{k}={bd[k]}" for k in PARSE_STATUS_BUCKETS)
+        lines.append(f"  - Breakdown: {breakdown_str}")
+
+    if filter_stats is not None:
+        r = filter_stats.get("rejected", {}) or {}
+        accepted = filter_stats.get("accepted", 0)
+        total_rej = sum(r.values())
+        not_valid = r.get("not_valid_parse", 0)
+        pf_marker = "✅" if not_valid == 0 else "⚠️"
+        lines.append(
+            f"- Pre-filter (enrich): {accepted} accepted, {total_rej} rejected, "
+            f"not_valid_parse={not_valid} {pf_marker}"
+        )
+        # Scoping breakdown only when any rows were rejected — otherwise four
+        # zeroes just add noise to the happy path.
+        if total_rej > 0:
+            scoping = ", ".join(
+                [
+                    f"wrong_tool={r.get('wrong_tool', 0)}",
+                    f"no_deliver_id={r.get('no_deliver_id', 0)}",
+                    f"no_outcome={r.get('no_outcome', 0)}",
+                    f"older_than_cutoff={r.get('older_than_cutoff', 0)}",
+                ]
+            )
+            lines.append(f"  - Scoping: {scoping}")
+
+    lines.append("")
 
     if failure_rows:
         n_shown = min(len(failure_rows), MAX_FAILURE_BODIES_IN_COMMENT)
@@ -358,16 +342,10 @@ def format_report(
         f"<!-- benchmark-result:{tool} -->",
         f"## Benchmark: {tool}",
         "",
+        _metrics_table(baseline, candidate),
+        "",
     ]
-    if filter_stats is not None:
-        parts.extend(_format_prefilter_section(filter_stats))
-    parts.extend(_format_reliability_section(baseline, candidate, failure_rows or []))
-    parts.extend(
-        [
-            _metrics_table(baseline, candidate),
-            "",
-        ]
-    )
+    parts.extend(_format_reliability_block(candidate, failure_rows or [], filter_stats))
 
     # Per-platform breakdown
     b_platforms = baseline.get("by_platform", {})

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -29,12 +29,49 @@ from typing import Any
 
 from benchmark.io import load_jsonl
 
+# Status buckets emitted by parse_response. Listed in a fixed order so the PR
+# comment breakdown is diffable across runs.
+PARSE_STATUS_BUCKETS = ("valid", "missing_fields", "malformed", "error")
+
+# Upper bound on failure bodies to inline in the PR comment. Keeps the comment
+# within GitHub's 65k-character limit even when every market fails, and keeps
+# CI log output readable.
+MAX_FAILURE_BODIES_IN_COMMENT = 5
+MAX_FAILURE_BODY_CHARS = 600
+
+
+def _compute_parse_reliability(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarise parse reliability from ``prediction_parse_status`` values.
+
+    The on-chain mech protocol only delivers the four-field JSON; a row that
+    fails to parse is still an on-chain deliver + payment (see issue #221).
+    Reliability is therefore a first-class metric, not a subset of Brier.
+
+    :param rows: list of prediction rows with 'prediction_parse_status'.
+    :return: dict with total, valid, parse_rate, breakdown.
+    """
+    total = len(rows)
+    breakdown = {b: 0 for b in PARSE_STATUS_BUCKETS}
+    for r in rows:
+        status = r.get("prediction_parse_status") or "error"
+        if status not in breakdown:
+            status = "error"
+        breakdown[status] += 1
+    valid = breakdown["valid"]
+    return {
+        "total": total,
+        "valid": valid,
+        "parse_rate": (valid / total) if total else None,
+        "breakdown": breakdown,
+    }
+
 
 def compute_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Compute Brier score, accuracy, and overconfident-wrong count.
 
     :param rows: list of prediction rows with p_yes, final_outcome.
-    :return: dict with brier, accuracy, overconf_wrong, n, and by_platform.
+    :return: dict with brier, accuracy, overconf_wrong, n, parse_reliability,
+        and by_platform.
     """
     by_platform: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for row in rows:
@@ -86,6 +123,7 @@ def compute_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
         }
 
     overall = _metrics(rows)
+    overall["parse_reliability"] = _compute_parse_reliability(rows)
     overall["by_platform"] = {
         p: _metrics(prows) for p, prows in sorted(by_platform.items())
     }
@@ -171,26 +209,98 @@ def _metrics_table(baseline: dict[str, Any], candidate: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _format_reliability_section(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    failure_rows: list[dict[str, Any]],
+) -> list[str]:
+    """Render the parse-reliability block + optional failure bodies.
+
+    :param baseline: metrics dict including ``parse_reliability``.
+    :param candidate: metrics dict including ``parse_reliability``.
+    :param failure_rows: rows from ``candidate_failures.jsonl`` (may be empty).
+    :return: markdown lines.
+    """
+    b_rel = baseline["parse_reliability"]
+    c_rel = candidate["parse_reliability"]
+    b_rate = b_rel["parse_rate"] or 0.0
+    c_rate = c_rel["parse_rate"] or 0.0
+    delta_pct = (c_rate - b_rate) * 100
+
+    # #221 is specifically "candidate delivers that don't parse" — so only a
+    # drop vs baseline is flagged, a rise is just ✅.
+    if delta_pct < -1e-9:
+        verdict = f"⚠️ {delta_pct:+.1f}% vs baseline"
+    elif delta_pct > 1e-9:
+        verdict = f"✅ {delta_pct:+.1f}% vs baseline"
+    else:
+        verdict = "✅ same as baseline"
+
+    bd = c_rel["breakdown"]
+    breakdown_str = ", ".join(f"{k}={bd[k]}" for k in PARSE_STATUS_BUCKETS)
+
+    lines = [
+        "**Parse reliability**",
+        "",
+        f"- Baseline: {b_rel['valid']}/{b_rel['total']} "
+        f"({b_rate * 100:.1f}%) [valid-only by filter]",
+        f"- Candidate: {c_rel['valid']}/{c_rel['total']} "
+        f"({c_rate * 100:.1f}%) — {verdict}",
+        f"- Candidate breakdown: {breakdown_str}",
+        "",
+    ]
+
+    if failure_rows:
+        n_shown = min(len(failure_rows), MAX_FAILURE_BODIES_IN_COMMENT)
+        lines.append(
+            f"<details><summary>Candidate parse failures "
+            f"({len(failure_rows)} total; first {n_shown} shown)</summary>"
+        )
+        lines.append("")
+        for fr in failure_rows[:n_shown]:
+            body = (fr.get("raw_response") or "").replace("```", "ʼʼʼ")
+            if len(body) > MAX_FAILURE_BODY_CHARS:
+                body = body[:MAX_FAILURE_BODY_CHARS] + "…"
+            lines.append(f"**{fr.get('prediction_parse_status', 'error')}** — "
+                         f"{fr.get('question_text', '')[:120]}")
+            lines.append("")
+            lines.append("```")
+            lines.append(body)
+            lines.append("```")
+            lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    return lines
+
+
 def format_report(
     baseline: dict[str, Any],
     candidate: dict[str, Any],
     meta: dict[str, str],
+    failure_rows: list[dict[str, Any]] | None = None,
 ) -> str:
     """Format the full benchmark report as markdown.
 
     :param baseline: metrics dict from compute_metrics.
     :param candidate: metrics dict from compute_metrics.
     :param meta: dict with tool, phase, sample, seed, triggered_by.
+    :param failure_rows: optional parse-failure rows loaded from
+        candidate_failures.jsonl. When non-empty, bodies are inlined in a
+        collapsed <details> block.
     :return: markdown string.
     """
     tool = meta.get("tool", "unknown")
-    parts = [
+    parts: list[str] = [
         f"<!-- benchmark-result:{tool} -->",
         f"## Benchmark: {tool}",
         "",
+    ]
+    parts.extend(_format_reliability_section(baseline, candidate, failure_rows or []))
+    parts.extend([
         _metrics_table(baseline, candidate),
         "",
-    ]
+    ])
 
     # Per-platform breakdown
     b_platforms = baseline.get("by_platform", {})
@@ -312,6 +422,11 @@ def main() -> None:
         print("ERROR: No baseline rows found", file=sys.stderr)
         sys.exit(1)
 
+    # prompt_replay writes candidate_failures.jsonl next to candidate.jsonl
+    # whenever any candidate failed to parse. Missing file = zero failures.
+    failures_path = args.candidate.parent / "candidate_failures.jsonl"
+    failure_rows = load_jsonl(failures_path) if failures_path.exists() else []
+
     baseline_metrics = compute_metrics(baseline_rows)
     candidate_metrics = compute_metrics(candidate_rows)
 
@@ -323,7 +438,9 @@ def main() -> None:
         "triggered_by": args.triggered_by,
     }
 
-    report = format_report(baseline_metrics, candidate_metrics, meta)
+    report = format_report(
+        baseline_metrics, candidate_metrics, meta, failure_rows=failure_rows
+    )
 
     # Always print to stdout
     print(report)

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -21,11 +21,12 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import subprocess
 import sys
 from collections import defaultdict
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 from benchmark.io import load_jsonl
 
@@ -209,6 +210,62 @@ def _metrics_table(baseline: dict[str, Any], candidate: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _format_prefilter_section(filter_stats: dict[str, Any]) -> list[str]:
+    """Render the pre-filter stats block.
+
+    This block exists to make the upstream "drop non-valid parses" invariant
+    visible. Parse reliability reports baseline as 100% *by construction* —
+    only because the enrich step drops non-valid rows. Without this block, a
+    silent regression in that filter would re-create exactly the observability
+    gap that issue #221 fell through.
+
+    :param filter_stats: dict with ``accepted`` and ``rejected`` keys from the
+        ``filter_stats.json`` sidecar written by ``prompt_replay enrich``.
+    :return: markdown lines.
+    """
+    r = filter_stats.get("rejected", {}) or {}
+    accepted = filter_stats.get("accepted", 0)
+    total_rej = sum(r.values())
+    not_valid = r.get("not_valid_parse", 0)
+
+    # not_valid_parse is the load-bearing one: flag it loudly if nonzero.
+    if not_valid > 0:
+        valid_verdict = f"⚠️ {not_valid} row(s) rejected for not_valid_parse"
+    else:
+        valid_verdict = "✅ 0 rejected for not_valid_parse"
+
+    scoping_parts = [
+        f"wrong_tool={r.get('wrong_tool', 0)}",
+        f"no_deliver_id={r.get('no_deliver_id', 0)}",
+        f"no_outcome={r.get('no_outcome', 0)}",
+        f"older_than_cutoff={r.get('older_than_cutoff', 0)}",
+    ]
+
+    return [
+        "**Pre-filter (from enrich)**",
+        "",
+        f"- Accepted: {accepted}",
+        f"- Rejected: {total_rej} total — {valid_verdict}",
+        f"- Scoping rejections: {', '.join(scoping_parts)}",
+        "",
+    ]
+
+
+def _load_filter_stats(candidate_path: Path) -> Optional[dict[str, Any]]:
+    """Load ``filter_stats.json`` written alongside candidate.jsonl, if present.
+
+    :param candidate_path: path to candidate.jsonl.
+    :return: parsed stats dict, or None if absent / unreadable.
+    """
+    stats_path = candidate_path.parent / "filter_stats.json"
+    if not stats_path.exists():
+        return None
+    try:
+        return json.loads(stats_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
 def _format_reliability_section(
     baseline: dict[str, Any],
     candidate: dict[str, Any],
@@ -281,6 +338,7 @@ def format_report(
     candidate: dict[str, Any],
     meta: dict[str, str],
     failure_rows: list[dict[str, Any]] | None = None,
+    filter_stats: Optional[dict[str, Any]] = None,
 ) -> str:
     """Format the full benchmark report as markdown.
 
@@ -290,6 +348,9 @@ def format_report(
     :param failure_rows: optional parse-failure rows loaded from
         candidate_failures.jsonl. When non-empty, bodies are inlined in a
         collapsed <details> block.
+    :param filter_stats: optional ``{accepted, rejected}`` dict from
+        filter_stats.json sidecar. When present, a Pre-filter block is
+        rendered so an upstream filter regression would be visible.
     :return: markdown string.
     """
     tool = meta.get("tool", "unknown")
@@ -298,6 +359,8 @@ def format_report(
         f"## Benchmark: {tool}",
         "",
     ]
+    if filter_stats is not None:
+        parts.extend(_format_prefilter_section(filter_stats))
     parts.extend(_format_reliability_section(baseline, candidate, failure_rows or []))
     parts.extend(
         [
@@ -431,6 +494,10 @@ def main() -> None:
     failures_path = args.candidate.parent / "candidate_failures.jsonl"
     failure_rows = load_jsonl(failures_path) if failures_path.exists() else []
 
+    # prompt_replay copies filter_stats.json into output_dir when the sidecar
+    # was present at enrich time. Missing file = no stats (older pipelines).
+    filter_stats = _load_filter_stats(args.candidate)
+
     baseline_metrics = compute_metrics(baseline_rows)
     candidate_metrics = compute_metrics(candidate_rows)
 
@@ -443,7 +510,11 @@ def main() -> None:
     }
 
     report = format_report(
-        baseline_metrics, candidate_metrics, meta, failure_rows=failure_rows
+        baseline_metrics,
+        candidate_metrics,
+        meta,
+        failure_rows=failure_rows,
+        filter_stats=filter_stats,
     )
 
     # Always print to stdout

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -261,8 +261,10 @@ def _format_reliability_section(
             body = (fr.get("raw_response") or "").replace("```", "ʼʼʼ")
             if len(body) > MAX_FAILURE_BODY_CHARS:
                 body = body[:MAX_FAILURE_BODY_CHARS] + "…"
-            lines.append(f"**{fr.get('prediction_parse_status', 'error')}** — "
-                         f"{fr.get('question_text', '')[:120]}")
+            lines.append(
+                f"**{fr.get('prediction_parse_status', 'error')}** — "
+                f"{fr.get('question_text', '')[:120]}"
+            )
             lines.append("")
             lines.append("```")
             lines.append(body)
@@ -297,10 +299,12 @@ def format_report(
         "",
     ]
     parts.extend(_format_reliability_section(baseline, candidate, failure_rows or []))
-    parts.extend([
-        _metrics_table(baseline, candidate),
-        "",
-    ])
+    parts.extend(
+        [
+            _metrics_table(baseline, candidate),
+            "",
+        ]
+    )
 
     # Per-platform breakdown
     b_platforms = baseline.get("by_platform", {})

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -261,9 +261,9 @@ def _format_reliability_section(
             body = (fr.get("raw_response") or "").replace("```", "ʼʼʼ")
             if len(body) > MAX_FAILURE_BODY_CHARS:
                 body = body[:MAX_FAILURE_BODY_CHARS] + "…"
+            question = (fr.get("question_text", "")[:120]).replace("`", "ʼ")
             lines.append(
-                f"**{fr.get('prediction_parse_status', 'error')}** — "
-                f"{fr.get('question_text', '')[:120]}"
+                f"**{fr.get('prediction_parse_status', 'error')}** — `{question}`"
             )
             lines.append("")
             lines.append("```")

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -398,17 +398,30 @@ def _load_and_filter_rows(
     production_log: Path,
     tool_filter: str,
     last_days: Optional[int],
-) -> list[dict[str, Any]]:
+) -> Tuple[list[dict[str, Any]], Dict[str, int]]:
     """Load production log and filter for valid rows.
 
     :param production_log: path to production_log.jsonl.
     :param tool_filter: tool name to filter for.
     :param last_days: only include rows from the last N days.
-    :return: filtered list of row dicts.
+    :return: (filtered rows, rejection counts per reason).
     """
     cutoff = None
     if last_days is not None:
         cutoff = datetime.now(timezone.utc) - timedelta(days=last_days)
+
+    # Scoping rejections (wrong tool / no deliver_id / no outcome / too old) are
+    # expected sample narrowing. The "not_valid_parse" bucket is load-bearing:
+    # it is the invariant downstream Parse-reliability reporting depends on
+    # (baseline is 100% valid by construction *because* these rows are dropped
+    # here). If that invariant regresses, we want this count to make it loud.
+    rejected: Dict[str, int] = {
+        "wrong_tool": 0,
+        "no_deliver_id": 0,
+        "not_valid_parse": 0,
+        "no_outcome": 0,
+        "older_than_cutoff": 0,
+    }
 
     rows: list[dict[str, Any]] = []
     with open(production_log, encoding="utf-8") as f:
@@ -418,21 +431,26 @@ def _load_and_filter_rows(
                 continue
             row = json.loads(line)
             if row.get("tool_name") != tool_filter:
+                rejected["wrong_tool"] += 1
                 continue
             if not row.get("deliver_id"):
+                rejected["no_deliver_id"] += 1
                 continue
             if row.get("prediction_parse_status") != "valid":
+                rejected["not_valid_parse"] += 1
                 continue
             if row.get("final_outcome") is None:
+                rejected["no_outcome"] += 1
                 continue
             if cutoff is not None:
                 predicted = row.get("predicted_at")
                 if predicted:
                     dt = datetime.fromisoformat(predicted.replace("Z", "+00:00"))
                     if dt < cutoff:
+                        rejected["older_than_cutoff"] += 1
                         continue
             rows.append(row)
-    return rows
+    return rows, rejected
 
 
 # ---------------------------------------------------------------------------
@@ -460,12 +478,35 @@ def enrich(
     :param sample_per_platform: stratified sample N per platform before IPFS fetch.
     :param seed: random seed for sampling.
     """
-    rows = _load_and_filter_rows(production_log, tool_filter, last_days)
+    rows, rejected = _load_and_filter_rows(production_log, tool_filter, last_days)
     log.info(
         "Loaded %d %s rows with deliver_id + valid predictions + known outcome",
         len(rows),
         tool_filter,
     )
+    log.info(
+        "Pre-filter rejections: wrong_tool=%d no_deliver_id=%d "
+        "not_valid_parse=%d no_outcome=%d older_than_cutoff=%d",
+        rejected["wrong_tool"],
+        rejected["no_deliver_id"],
+        rejected["not_valid_parse"],
+        rejected["no_outcome"],
+        rejected["older_than_cutoff"],
+    )
+
+    # Sidecar JSON carries the rejection counts into the replay + PR-comment
+    # stages, where "baseline is 100% valid by construction" would otherwise be
+    # an invisible assumption.
+    stats_path = output.with_name(output.name + ".filter_stats.json")
+    stats_path.parent.mkdir(parents=True, exist_ok=True)
+    stats_path.write_text(
+        json.dumps(
+            {"accepted": len(rows), "rejected": rejected},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    log.info("Wrote filter stats: %s", stats_path)
 
     if not rows:
         log.warning("No rows to enrich")
@@ -934,6 +975,7 @@ def _log_replay_summary(
     n_scored: int,
     baseline_path: Path,
     status_counts: Dict[str, int],
+    filter_stats: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Compute accuracy and log the replay summary.
 
@@ -945,6 +987,9 @@ def _log_replay_summary(
     :param n_scored: number of candidate predictions scored.
     :param baseline_path: path to the baseline JSONL file.
     :param status_counts: candidate ``prediction_parse_status`` bucket counts.
+    :param filter_stats: optional ``{accepted, rejected}`` dict from the enrich
+        sidecar. When present, a Pre-filter block is rendered so a regression
+        in the "drop non-valid parses" upstream invariant is visible.
     """
     avg_baseline = baseline_brier_sum / total if total else 0
     avg_candidate = candidate_brier_sum / n_scored if n_scored else 0
@@ -1001,6 +1046,22 @@ def _log_replay_summary(
         status_counts["error"],
     )
     log.info("    Parse delta: %+.1f%% — %s", parse_delta_pct, parse_verdict)
+
+    if filter_stats is not None:
+        r = filter_stats.get("rejected", {})
+        total_rej = sum(r.values()) if r else 0
+        log.info("  Pre-filter (from enrich):")
+        log.info(
+            "    Accepted: %d   Rejected: %d (wrong_tool=%d, no_deliver_id=%d, "
+            "not_valid_parse=%d, no_outcome=%d, older_than_cutoff=%d)",
+            filter_stats.get("accepted", 0),
+            total_rej,
+            r.get("wrong_tool", 0),
+            r.get("no_deliver_id", 0),
+            r.get("not_valid_parse", 0),
+            r.get("no_outcome", 0),
+            r.get("older_than_cutoff", 0),
+        )
 
     log.info(
         "  Baseline avg Brier:  %.4f  Accuracy: %.1f%%",
@@ -1133,6 +1194,16 @@ def replay(  # pylint: disable=too-many-statements
     if not sampled:
         log.warning("No rows in dataset")
         return
+
+    # Optional sidecar: {dataset}.filter_stats.json written by enrich.
+    filter_stats: Optional[Dict[str, Any]] = None
+    stats_path = dataset.with_name(dataset.name + ".filter_stats.json")
+    if stats_path.exists():
+        try:
+            filter_stats = json.loads(stats_path.read_text(encoding="utf-8"))
+            log.info("Loaded filter stats: %s", stats_path)
+        except (json.JSONDecodeError, OSError) as exc:
+            log.warning("Could not load filter stats from %s: %s", stats_path, exc)
 
     tool_name = sampled[0]["tool_name"]
     is_reasoning_tool = tool_name.startswith("prediction-request-reasoning")
@@ -1381,7 +1452,15 @@ def replay(  # pylint: disable=too-many-statements
         n_scored,
         baseline_path,
         status_counts,
+        filter_stats=filter_stats,
     )
+
+    # Make the filter stats discoverable next to the candidate/baseline outputs
+    # so ci_replay.py can render them into the PR comment.
+    if filter_stats is not None:
+        (output_dir / "filter_stats.json").write_text(
+            json.dumps(filter_stats, indent=2), encoding="utf-8"
+        )
 
     # Write updated enriched JSONL with fresh reasoning for next iteration
     has_fresh = any(r.get("_fresh_reasoning") for r in sampled)

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -933,6 +933,7 @@ def _log_replay_summary(
     total: int,
     n_scored: int,
     baseline_path: Path,
+    status_counts: Dict[str, int],
 ) -> None:
     """Compute accuracy and log the replay summary.
 
@@ -943,6 +944,7 @@ def _log_replay_summary(
     :param total: total number of markets.
     :param n_scored: number of candidate predictions scored.
     :param baseline_path: path to the baseline JSONL file.
+    :param status_counts: candidate ``prediction_parse_status`` bucket counts.
     """
     avg_baseline = baseline_brier_sum / total if total else 0
     avg_candidate = candidate_brier_sum / n_scored if n_scored else 0
@@ -967,6 +969,43 @@ def _log_replay_summary(
 
     log.info("=" * 60)
     log.info("RESULTS: %d markets (%d candidate scored)", total, n_scored)
+
+    # Parse reliability — baseline is always 100% (valid-only by enrich filter),
+    # so this surfaces candidate drift only.
+    baseline_parse_rate = 1.0
+    candidate_parse_rate = status_counts["valid"] / total if total else 0
+    parse_delta_pct = (
+        (candidate_parse_rate - baseline_parse_rate) * 100 if total else 0
+    )
+    parse_verdict = (
+        "SAME"
+        if abs(parse_delta_pct) < 1e-9
+        else "IMPROVED"
+        if parse_delta_pct > 0
+        else "REGRESSED"
+    )
+    log.info("  Parse reliability:")
+    log.info(
+        "    Baseline:  %d/%d (%.1f%%)  [valid-only by filter]",
+        total,
+        total,
+        baseline_parse_rate * 100,
+    )
+    log.info(
+        "    Candidate: %d/%d (%.1f%%)",
+        status_counts["valid"],
+        total,
+        candidate_parse_rate * 100,
+    )
+    log.info(
+        "    Breakdown: valid=%d, missing_fields=%d, malformed=%d, error=%d",
+        status_counts["valid"],
+        status_counts["missing_fields"],
+        status_counts["malformed"],
+        status_counts["error"],
+    )
+    log.info("    Parse delta: %+.1f%% — %s", parse_delta_pct, parse_verdict)
+
     log.info(
         "  Baseline avg Brier:  %.4f  Accuracy: %.1f%%",
         avg_baseline,
@@ -1166,6 +1205,16 @@ def replay(  # pylint: disable=too-many-statements
     candidate_brier_sum = 0.0
     n_scored = 0
 
+    # Parse-reliability tracking (issue #221 — delivered, paid-for, but
+    # malformed responses that silently break downstream consumers).
+    status_counts: Dict[str, int] = {
+        "valid": 0,
+        "missing_fields": 0,
+        "malformed": 0,
+        "error": 0,
+    }
+    failure_rows: list[dict[str, Any]] = []
+
     with (
         open(baseline_path, "w", encoding="utf-8") as bf,
         open(candidate_path, "w", encoding="utf-8") as cf,
@@ -1285,6 +1334,10 @@ def replay(  # pylint: disable=too-many-statements
             b_brier = (row["p_yes"] - outcome_val) ** 2
             baseline_brier_sum += b_brier
 
+            status = parsed["prediction_parse_status"]
+            # Unknown statuses land in "error" so the breakdown never loses a row.
+            status_counts[status if status in status_counts else "error"] += 1
+
             if parsed["p_yes"] is not None:
                 c_brier = (parsed["p_yes"] - outcome_val) ** 2
                 candidate_brier_sum += c_brier
@@ -1302,9 +1355,23 @@ def replay(  # pylint: disable=too-many-statements
                     ),
                 )
             else:
-                log.warning(
-                    "  candidate parse failed: %s", parsed["prediction_parse_status"]
+                log.warning("  candidate parse failed: %s", status)
+                failure_rows.append(
+                    {
+                        "row_id": candidate_row["row_id"],
+                        "question_text": question,
+                        "prediction_parse_status": status,
+                        "raw_response": response_text,
+                    }
                 )
+
+    # Persist parse failures for forensic inspection.
+    failures_path = output_dir / "candidate_failures.jsonl"
+    if failure_rows:
+        with open(failures_path, "w", encoding="utf-8") as ff:
+            for fr in failure_rows:
+                ff.write(json.dumps(fr) + "\n")
+        log.info("Wrote %d parse failure(s) to %s", len(failure_rows), failures_path)
 
     # Summary
     total = len(sampled)
@@ -1317,6 +1384,7 @@ def replay(  # pylint: disable=too-many-statements
         total,
         n_scored,
         baseline_path,
+        status_counts,
     )
 
     # Write updated enriched JSONL with fresh reasoning for next iteration

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -458,6 +458,23 @@ def _load_and_filter_rows(
 # ---------------------------------------------------------------------------
 
 
+def _prepare_output_dir(output_dir: Path) -> None:
+    """Ensure ``output_dir`` exists and purge stale conditional sidecars.
+
+    ``candidate_failures.jsonl`` and ``filter_stats.json`` are written
+    conditionally by the replay step (only when failures / stats exist). When
+    a reused ``output_dir`` already contains one of these from a prior run, a
+    clean current run would leave the stale file in place and ci_replay would
+    surface it as if it were current. Purging on prep keeps the invariant
+    "files in output_dir correspond to this run only".
+
+    :param output_dir: directory that will hold baseline/candidate artifacts.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for stale in ("candidate_failures.jsonl", "filter_stats.json"):
+        (output_dir / stale).unlink(missing_ok=True)
+
+
 def enrich(
     production_log: Path,
     tool_filter: str,
@@ -1261,7 +1278,7 @@ def replay(  # pylint: disable=too-many-statements
     )
 
     # Prepare output
-    output_dir.mkdir(parents=True, exist_ok=True)
+    _prepare_output_dir(output_dir)
     baseline_path = output_dir / "baseline.jsonl"
     candidate_path = output_dir / "candidate.jsonl"
 

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -41,7 +41,7 @@ import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import openai
 import requests
@@ -704,6 +704,93 @@ def _call_openai(
         client.close()
 
 
+def _call_openai_structured(
+    model: str,
+    system_prompt: str,
+    user_prompt: str,
+    api_key: str,
+    response_format: type,
+    temperature: float = 0,
+    max_tokens: int = 4096,
+) -> Optional[str]:
+    """Call OpenAI Structured Outputs with a caller-supplied Pydantic schema.
+
+    The schema must expose ``p_yes``, ``p_no``, ``confidence`` and
+    ``info_utility`` attributes. Returns a JSON string of only those four
+    on-chain fields so the existing ``parse_response`` keeps working
+    unchanged regardless of how rich the schema is.
+
+    :param model: OpenAI model identifier.
+    :param system_prompt: system message content.
+    :param user_prompt: user message content.
+    :param api_key: OpenAI API key.
+    :param response_format: Pydantic model class used as the structured-output schema.
+    :param temperature: sampling temperature.
+    :param max_tokens: maximum tokens to generate.
+    :return: JSON string of {p_yes, p_no, confidence, info_utility}, or None on failure.
+    """
+    client = openai.OpenAI(api_key=api_key)
+    try:
+        response = client.beta.chat.completions.parse(
+            model=model,
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format=response_format,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            timeout=150,
+        )
+        parsed = response.choices[0].message.parsed
+        if parsed is None:
+            log.warning(
+                "Structured output parse failed: %s",
+                response.choices[0].message.refusal,
+            )
+            return None
+        return json.dumps(
+            {
+                "p_yes": parsed.p_yes,
+                "p_no": parsed.p_no,
+                "confidence": parsed.confidence,
+                "info_utility": parsed.info_utility,
+            }
+        )
+    except Exception as e:
+        log.warning("Structured LLM call failed: %s", e)
+        return None
+    finally:
+        client.close()
+
+
+# Tools that use OpenAI Structured Outputs instead of plain JSON-in-prompt.
+# Map: tool_name → (tool_module_import_path, schema_class_name).
+_STRUCTURED_OUTPUT_SCHEMAS: Dict[str, Tuple[str, str]] = {
+    "superforcaster": (
+        "packages.valory.customs.superforcaster.superforcaster",
+        "PredictionResult",
+    ),
+    "factual_research": (
+        "packages.valory.customs.factual_research.factual_research",
+        "PredictionResult",
+    ),
+}
+
+
+def _get_structured_output_schema(tool_name: str) -> Optional[type]:
+    """Return the Pydantic schema class for a structured-output tool, or None."""
+    entry = _STRUCTURED_OUTPUT_SCHEMAS.get(tool_name)
+    if entry is None:
+        return None
+    module_path, class_name = entry
+    # pylint: disable=import-outside-toplevel
+    from importlib import import_module
+
+    module = import_module(module_path)
+    return getattr(module, class_name)
+
+
 def _call_anthropic(
     model: str,
     system_prompt: str,
@@ -1146,12 +1233,26 @@ def replay(  # pylint: disable=too-many-statements
                         user_prompt=row["extracted_user_prompt"],
                         additional_information=row["extracted_additional_information"],
                     )
-                response_text = call_llm(
-                    model=model,
-                    system_prompt=system_prompt,
-                    user_prompt=formatted_prompt,
-                    api_key=api_key,
+                structured_schema = (
+                    _get_structured_output_schema(tool_name)
+                    if "claude" not in model
+                    else None
                 )
+                if structured_schema is not None:
+                    response_text = _call_openai_structured(
+                        model=model,
+                        system_prompt=system_prompt,
+                        user_prompt=formatted_prompt,
+                        api_key=api_key,
+                        response_format=structured_schema,
+                    )
+                else:
+                    response_text = call_llm(
+                        model=model,
+                        system_prompt=system_prompt,
+                        user_prompt=formatted_prompt,
+                        api_key=api_key,
+                    )
 
             # Cache fresh reasoning for later prediction-only iteration
             if fresh_reasoning is not None:

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -974,15 +974,11 @@ def _log_replay_summary(
     # so this surfaces candidate drift only.
     baseline_parse_rate = 1.0
     candidate_parse_rate = status_counts["valid"] / total if total else 0
-    parse_delta_pct = (
-        (candidate_parse_rate - baseline_parse_rate) * 100 if total else 0
-    )
+    parse_delta_pct = (candidate_parse_rate - baseline_parse_rate) * 100 if total else 0
     parse_verdict = (
         "SAME"
         if abs(parse_delta_pct) < 1e-9
-        else "IMPROVED"
-        if parse_delta_pct > 0
-        else "REGRESSED"
+        else "IMPROVED" if parse_delta_pct > 0 else "REGRESSED"
     )
     log.info("  Parse reliability:")
     log.info(

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import json
+
 from benchmark.ci_replay import (
     PARSE_STATUS_BUCKETS,
     _compute_parse_reliability,
+    _format_prefilter_section,
     _format_reliability_section,
+    _load_filter_stats,
     compute_metrics,
     format_report,
 )
@@ -164,3 +168,139 @@ class TestFormatReportLoadsFailuresFromDisk:
         )
         assert "Boom." in report
         assert "⚠️" in report
+
+
+class TestPrefilterSection:
+    """Markdown rendering of the Pre-filter block (filter_stats sidecar)."""
+
+    def _stats(
+        self,
+        *,
+        accepted: int = 100,
+        not_valid_parse: int = 0,
+        wrong_tool: int = 0,
+        no_deliver_id: int = 0,
+        no_outcome: int = 0,
+        older_than_cutoff: int = 0,
+    ) -> dict:
+        return {
+            "accepted": accepted,
+            "rejected": {
+                "wrong_tool": wrong_tool,
+                "no_deliver_id": no_deliver_id,
+                "not_valid_parse": not_valid_parse,
+                "no_outcome": no_outcome,
+                "older_than_cutoff": older_than_cutoff,
+            },
+        }
+
+    def test_zero_not_valid_parse_renders_green(self) -> None:
+        """With the filter invariant held, the block is informational only."""
+        text = "\n".join(_format_prefilter_section(self._stats()))
+        assert "✅ 0 rejected for not_valid_parse" in text
+        assert "⚠️" not in text
+
+    def test_nonzero_not_valid_parse_flagged(self) -> None:
+        """A single leaked non-valid row is flagged so it can't hide."""
+        text = "\n".join(_format_prefilter_section(self._stats(not_valid_parse=3)))
+        assert "⚠️" in text
+        assert "3 row(s) rejected for not_valid_parse" in text
+
+    def test_scoping_rejections_listed_separately(self) -> None:
+        """Wrong-tool / no-outcome / cutoff rejections are shown but not flagged."""
+        text = "\n".join(
+            _format_prefilter_section(
+                self._stats(wrong_tool=12, no_outcome=4, older_than_cutoff=7)
+            )
+        )
+        assert "wrong_tool=12" in text
+        assert "no_outcome=4" in text
+        assert "older_than_cutoff=7" in text
+        # Scoping rejections must not escalate the invariant marker.
+        assert "⚠️" not in text
+
+
+class TestLoadFilterStats:
+    """Sidecar loading alongside candidate.jsonl."""
+
+    def test_returns_none_when_absent(self, tmp_path: Path) -> None:
+        """Older pipelines without the sidecar return cleanly."""
+        candidate = tmp_path / "candidate.jsonl"
+        candidate.write_text("", encoding="utf-8")
+        assert _load_filter_stats(candidate) is None
+
+    def test_parses_sidecar_when_present(self, tmp_path: Path) -> None:
+        """filter_stats.json in the same dir as candidate.jsonl is loaded."""
+        candidate = tmp_path / "candidate.jsonl"
+        candidate.write_text("", encoding="utf-8")
+        stats = {"accepted": 5, "rejected": {"not_valid_parse": 1}}
+        (tmp_path / "filter_stats.json").write_text(
+            json.dumps(stats), encoding="utf-8"
+        )
+        assert _load_filter_stats(candidate) == stats
+
+    def test_returns_none_on_malformed_json(self, tmp_path: Path) -> None:
+        """A corrupt sidecar must not crash the whole report."""
+        candidate = tmp_path / "candidate.jsonl"
+        candidate.write_text("", encoding="utf-8")
+        (tmp_path / "filter_stats.json").write_text("{not json", encoding="utf-8")
+        assert _load_filter_stats(candidate) is None
+
+
+class TestFormatReportWithFilterStats:
+    """End-to-end: format_report wiring for the filter_stats arg."""
+
+    def test_omits_prefilter_block_when_stats_missing(self) -> None:
+        """Older datasets (no sidecar) render the original report unchanged."""
+        baseline = compute_metrics([_row("valid")] * 3)
+        candidate = compute_metrics([_row("valid")] * 3)
+        report = format_report(baseline, candidate, {"tool": "superforcaster"})
+        assert "Pre-filter" not in report
+
+    def test_renders_prefilter_block_when_stats_present(self) -> None:
+        """A provided filter_stats dict drops a Pre-filter section above reliability."""
+        baseline = compute_metrics([_row("valid")] * 3)
+        candidate = compute_metrics([_row("valid")] * 3)
+        stats = {
+            "accepted": 3,
+            "rejected": {
+                "wrong_tool": 10,
+                "no_deliver_id": 0,
+                "not_valid_parse": 0,
+                "no_outcome": 2,
+                "older_than_cutoff": 0,
+            },
+        }
+        report = format_report(
+            baseline,
+            candidate,
+            {"tool": "superforcaster"},
+            filter_stats=stats,
+        )
+        assert "Pre-filter" in report
+        # Ordering: Pre-filter block must precede Parse reliability block so a
+        # filter regression is the first thing a reviewer sees.
+        assert report.index("Pre-filter") < report.index("Parse reliability")
+
+    def test_prefilter_regression_surfaces_in_full_report(self) -> None:
+        """A not_valid_parse>0 count propagates the ⚠️ marker into the final report."""
+        baseline = compute_metrics([_row("valid")] * 3)
+        candidate = compute_metrics([_row("valid")] * 3)
+        stats = {
+            "accepted": 3,
+            "rejected": {
+                "wrong_tool": 0,
+                "no_deliver_id": 0,
+                "not_valid_parse": 2,
+                "no_outcome": 0,
+                "older_than_cutoff": 0,
+            },
+        }
+        report = format_report(
+            baseline,
+            candidate,
+            {"tool": "superforcaster"},
+            filter_stats=stats,
+        )
+        assert "⚠️" in report
+        assert "2 row(s) rejected for not_valid_parse" in report

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -1,0 +1,161 @@
+# -*- coding: utf-8 -*-
+"""Tests for parse-reliability metrics and rendering in ci_replay."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from benchmark.ci_replay import (
+    PARSE_STATUS_BUCKETS,
+    _compute_parse_reliability,
+    _format_reliability_section,
+    compute_metrics,
+    format_report,
+)
+
+
+def _row(status: str = "valid", p_yes: float | None = 0.6) -> dict:
+    return {
+        "platform": "omen",
+        "tool_name": "superforcaster",
+        "p_yes": p_yes,
+        "p_no": None if p_yes is None else 1 - p_yes,
+        "prediction_parse_status": status,
+        "final_outcome": True,
+    }
+
+
+class TestParseReliability:
+    def test_breakdown_keys_are_always_present(self) -> None:
+        """All four buckets are present even when only 'valid' has entries."""
+        rel = _compute_parse_reliability([_row("valid")])
+        assert set(rel["breakdown"]) == set(PARSE_STATUS_BUCKETS)
+
+    def test_mixed_statuses_counted(self) -> None:
+        """valid + malformed + missing_fields all land in the right buckets."""
+        rows = [
+            _row("valid"),
+            _row("valid"),
+            _row("malformed", None),
+            _row("missing_fields", None),
+        ]
+        rel = _compute_parse_reliability(rows)
+        assert rel == {
+            "total": 4,
+            "valid": 2,
+            "parse_rate": 0.5,
+            "breakdown": {
+                "valid": 2,
+                "missing_fields": 1,
+                "malformed": 1,
+                "error": 0,
+            },
+        }
+
+    def test_unknown_status_bucketed_as_error(self) -> None:
+        """An unexpected status value must not lose the row."""
+        rel = _compute_parse_reliability([_row("weird_new_status", None)])
+        assert rel["breakdown"]["error"] == 1
+        assert rel["total"] == 1
+
+    def test_compute_metrics_embeds_parse_reliability(self) -> None:
+        """compute_metrics must surface parse_reliability alongside Brier."""
+        metrics = compute_metrics([_row("valid"), _row("malformed", None)])
+        assert "parse_reliability" in metrics
+        assert metrics["parse_reliability"]["parse_rate"] == 0.5
+
+
+class TestReliabilitySection:
+    def _metrics(self, rows: list[dict]) -> dict:
+        return compute_metrics(rows)
+
+    def test_section_flags_regression_when_candidate_drops(self) -> None:
+        """A drop vs baseline carries the ⚠️ marker; zero-failure section omits <details>."""
+        baseline = self._metrics([_row("valid")] * 10)
+        candidate = self._metrics([_row("valid")] * 7 + [_row("malformed", None)] * 3)
+        lines = _format_reliability_section(baseline, candidate, failure_rows=[])
+        text = "\n".join(lines)
+        assert "⚠️" in text
+        assert "70.0%" in text
+        assert "malformed=3" in text
+        # No failure bodies passed in -> no <details> block
+        assert "<details>" not in text
+
+    def test_section_no_regression_gets_check_mark(self) -> None:
+        """Equal parse rates render ✅ and no warning."""
+        baseline = self._metrics([_row("valid")] * 5)
+        candidate = self._metrics([_row("valid")] * 5)
+        text = "\n".join(
+            _format_reliability_section(baseline, candidate, failure_rows=[])
+        )
+        assert "✅" in text
+        assert "⚠️" not in text
+
+    def test_failure_bodies_rendered_in_collapsed_details(self) -> None:
+        """Failure bodies inline under a <details> so the PR comment stays tidy."""
+        baseline = self._metrics([_row("valid")] * 2)
+        candidate = self._metrics([_row("valid"), _row("malformed", None)])
+        failures = [
+            {
+                "row_id": "c2",
+                "question_text": "Q2",
+                "prediction_parse_status": "malformed",
+                "raw_response": "<facts> leaked content here",
+            }
+        ]
+        lines = _format_reliability_section(baseline, candidate, failures)
+        text = "\n".join(lines)
+        assert "<details>" in text
+        assert "<facts> leaked content here" in text
+        assert "malformed" in text
+
+    def test_body_with_backticks_is_escaped(self) -> None:
+        """Markdown code fences in the body can't break out of the outer ``` block."""
+        baseline = self._metrics([_row("valid")])
+        candidate = self._metrics([_row("malformed", None)])
+        failures = [
+            {
+                "row_id": "c1",
+                "question_text": "Q",
+                "prediction_parse_status": "malformed",
+                "raw_response": "some ```json{\"p_yes\":0.5}``` leak",
+            }
+        ]
+        lines = _format_reliability_section(baseline, candidate, failures)
+        text = "\n".join(lines)
+        # Exactly two literal ``` fences from the template (open + close of the body block).
+        assert text.count("```") == 2
+
+
+class TestFormatReportLoadsFailuresFromDisk:
+    def test_report_includes_reliability_even_with_no_failures(
+        self, tmp_path: Path
+    ) -> None:
+        """format_report is callable without a failures file (None ≡ empty list)."""
+        baseline = compute_metrics([_row("valid")] * 3)
+        candidate = compute_metrics([_row("valid")] * 3)
+        report = format_report(baseline, candidate, {"tool": "superforcaster"})
+        assert "Parse reliability" in report
+        assert "<details>" not in report
+
+    def test_report_embeds_failure_bodies_when_provided(self, tmp_path: Path) -> None:
+        """format_report threads the failure_rows arg into the reliability section."""
+        baseline = compute_metrics([_row("valid")] * 2)
+        candidate = compute_metrics([_row("valid"), _row("error", None)])
+        failures = [
+            {
+                "row_id": "c2",
+                "question_text": "Q2",
+                "prediction_parse_status": "error",
+                "raw_response": "Boom.",
+            }
+        ]
+        report = format_report(
+            baseline,
+            candidate,
+            {"tool": "superforcaster"},
+            failure_rows=failures,
+        )
+        assert "Boom." in report
+        assert "⚠️" in report

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -3,15 +3,13 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import json
+from pathlib import Path
 
 from benchmark.ci_replay import (
     PARSE_STATUS_BUCKETS,
     _compute_parse_reliability,
-    _format_prefilter_section,
-    _format_reliability_section,
+    _format_reliability_block,
     _load_filter_stats,
     compute_metrics,
     format_report,
@@ -71,37 +69,90 @@ class TestParseReliability:
         assert metrics["parse_reliability"]["parse_rate"] == 0.5
 
 
-class TestReliabilitySection:
-    """Markdown rendering of the reliability block + failure-body <details>."""
+def _stats(
+    *,
+    accepted: int = 100,
+    not_valid_parse: int = 0,
+    wrong_tool: int = 0,
+    no_deliver_id: int = 0,
+    no_outcome: int = 0,
+    older_than_cutoff: int = 0,
+) -> dict:
+    return {
+        "accepted": accepted,
+        "rejected": {
+            "wrong_tool": wrong_tool,
+            "no_deliver_id": no_deliver_id,
+            "not_valid_parse": not_valid_parse,
+            "no_outcome": no_outcome,
+            "older_than_cutoff": older_than_cutoff,
+        },
+    }
+
+
+class TestReliabilityBlock:
+    """Markdown rendering of the Reliability section (candidate + pre-filter)."""
 
     def _metrics(self, rows: list[dict]) -> dict:
         return compute_metrics(rows)
 
-    def test_section_flags_regression_when_candidate_drops(self) -> None:
-        """A drop vs baseline carries the ⚠️ marker; zero-failure section omits <details>."""
-        baseline = self._metrics([_row("valid")] * 10)
-        candidate = self._metrics([_row("valid")] * 7 + [_row("malformed", None)] * 3)
-        lines = _format_reliability_section(baseline, candidate, failure_rows=[])
-        text = "\n".join(lines)
-        assert "⚠️" in text
-        assert "70.0%" in text
-        assert "malformed=3" in text
-        # No failure bodies passed in -> no <details> block
-        assert "<details>" not in text
-
-    def test_section_no_regression_gets_check_mark(self) -> None:
-        """Equal parse rates render ✅ and no warning."""
-        baseline = self._metrics([_row("valid")] * 5)
+    def test_green_happy_path_is_two_lines(self) -> None:
+        """All-valid candidate + clean pre-filter → two bullets, no breakdown noise."""
         candidate = self._metrics([_row("valid")] * 5)
-        text = "\n".join(
-            _format_reliability_section(baseline, candidate, failure_rows=[])
+        lines = _format_reliability_block(candidate, [], _stats(accepted=5))
+        text = "\n".join(lines)
+        assert "Candidate parse rate: 5/5 (100.0%) ✅" in text
+        assert (
+            "Pre-filter (enrich): 5 accepted, 0 rejected, not_valid_parse=0 ✅" in text
         )
-        assert "✅" in text
+        # Breakdown is hidden when candidate is at 100%.
+        assert "Breakdown:" not in text
+        # Scoping is hidden when there are no rejections.
+        assert "Scoping:" not in text
         assert "⚠️" not in text
+
+    def test_candidate_drift_flags_and_shows_breakdown(self) -> None:
+        """Candidate < 100% → ⚠️ + breakdown line exposes which buckets failed."""
+        candidate = self._metrics([_row("valid")] * 7 + [_row("malformed", None)] * 3)
+        lines = _format_reliability_block(candidate, [], _stats(accepted=10))
+        text = "\n".join(lines)
+        assert "Candidate parse rate: 7/10 (70.0%) ⚠️" in text
+        assert "malformed=3" in text
+
+    def test_prefilter_not_valid_parse_flagged(self) -> None:
+        """not_valid_parse > 0 is the load-bearing invariant — must surface ⚠️."""
+        candidate = self._metrics([_row("valid")] * 5)
+        lines = _format_reliability_block(
+            candidate, [], _stats(accepted=5, not_valid_parse=2)
+        )
+        text = "\n".join(lines)
+        assert "not_valid_parse=2 ⚠️" in text
+
+    def test_scoping_rejections_shown_but_not_flagged(self) -> None:
+        """Scoping buckets (wrong_tool etc.) are informational, not warnings."""
+        candidate = self._metrics([_row("valid")] * 5)
+        lines = _format_reliability_block(
+            candidate,
+            [],
+            _stats(accepted=5, wrong_tool=12, no_outcome=4, older_than_cutoff=7),
+        )
+        text = "\n".join(lines)
+        assert "Scoping:" in text
+        assert "wrong_tool=12" in text
+        assert "no_outcome=4" in text
+        assert "older_than_cutoff=7" in text
+        # Scoping alone must not raise the invariant marker.
+        assert "⚠️" not in text
+
+    def test_prefilter_omitted_when_stats_none(self) -> None:
+        """Older pipelines (no sidecar) render without the Pre-filter line."""
+        candidate = self._metrics([_row("valid")] * 3)
+        text = "\n".join(_format_reliability_block(candidate, [], None))
+        assert "Pre-filter" not in text
+        assert "Candidate parse rate" in text
 
     def test_failure_bodies_rendered_in_collapsed_details(self) -> None:
         """Failure bodies inline under a <details> so the PR comment stays tidy."""
-        baseline = self._metrics([_row("valid")] * 2)
         candidate = self._metrics([_row("valid"), _row("malformed", None)])
         failures = [
             {
@@ -111,15 +162,13 @@ class TestReliabilitySection:
                 "raw_response": "<facts> leaked content here",
             }
         ]
-        lines = _format_reliability_section(baseline, candidate, failures)
-        text = "\n".join(lines)
+        text = "\n".join(_format_reliability_block(candidate, failures, None))
         assert "<details>" in text
         assert "<facts> leaked content here" in text
         assert "malformed" in text
 
     def test_body_with_backticks_is_escaped(self) -> None:
         """Markdown code fences in the body can't break out of the outer ``` block."""
-        baseline = self._metrics([_row("valid")])
         candidate = self._metrics([_row("malformed", None)])
         failures = [
             {
@@ -129,26 +178,57 @@ class TestReliabilitySection:
                 "raw_response": 'some ```json{"p_yes":0.5}``` leak',
             }
         ]
-        lines = _format_reliability_section(baseline, candidate, failures)
-        text = "\n".join(lines)
-        # Exactly two literal ``` fences from the template (open + close of the body block).
+        text = "\n".join(_format_reliability_block(candidate, failures, None))
         assert text.count("```") == 2
 
 
-class TestFormatReportLoadsFailuresFromDisk:
-    """End-to-end ``format_report`` wiring, with and without failure bodies."""
+class TestLoadFilterStats:
+    """Sidecar loading alongside candidate.jsonl."""
 
-    def test_report_includes_reliability_even_with_no_failures(
-        self, tmp_path: Path
-    ) -> None:
-        """format_report is callable without a failures file (None ≡ empty list)."""
+    def test_returns_none_when_absent(self, tmp_path: Path) -> None:
+        """Older pipelines without the sidecar return cleanly."""
+        candidate = tmp_path / "candidate.jsonl"
+        candidate.write_text("", encoding="utf-8")
+        assert _load_filter_stats(candidate) is None
+
+    def test_parses_sidecar_when_present(self, tmp_path: Path) -> None:
+        """filter_stats.json in the same dir as candidate.jsonl is loaded."""
+        candidate = tmp_path / "candidate.jsonl"
+        candidate.write_text("", encoding="utf-8")
+        stats = {"accepted": 5, "rejected": {"not_valid_parse": 1}}
+        (tmp_path / "filter_stats.json").write_text(json.dumps(stats), encoding="utf-8")
+        assert _load_filter_stats(candidate) == stats
+
+    def test_returns_none_on_malformed_json(self, tmp_path: Path) -> None:
+        """A corrupt sidecar must not crash the whole report."""
+        candidate = tmp_path / "candidate.jsonl"
+        candidate.write_text("", encoding="utf-8")
+        (tmp_path / "filter_stats.json").write_text("{not json", encoding="utf-8")
+        assert _load_filter_stats(candidate) is None
+
+
+class TestFormatReportEndToEnd:
+    """End-to-end ``format_report`` shape: table first, Reliability below."""
+
+    def test_metrics_table_precedes_reliability_section(self) -> None:
+        """Primary comparison (Brier etc.) must come before reliability checks."""
         baseline = compute_metrics([_row("valid")] * 3)
         candidate = compute_metrics([_row("valid")] * 3)
         report = format_report(baseline, candidate, {"tool": "superforcaster"})
-        assert "Parse reliability" in report
-        assert "<details>" not in report
+        assert "**Reliability**" in report
+        assert "| Metric |" in report
+        assert report.index("| Metric |") < report.index("**Reliability**")
 
-    def test_report_embeds_failure_bodies_when_provided(self, tmp_path: Path) -> None:
+    def test_report_renders_without_failures_or_filter_stats(self) -> None:
+        """format_report works on its minimal arg set (older pipelines)."""
+        baseline = compute_metrics([_row("valid")] * 3)
+        candidate = compute_metrics([_row("valid")] * 3)
+        report = format_report(baseline, candidate, {"tool": "superforcaster"})
+        assert "Candidate parse rate: 3/3 (100.0%) ✅" in report
+        assert "Pre-filter" not in report
+        assert "<details><summary>Candidate parse failures" not in report
+
+    def test_report_embeds_failure_bodies_when_provided(self) -> None:
         """format_report threads the failure_rows arg into the reliability section."""
         baseline = compute_metrics([_row("valid")] * 2)
         candidate = compute_metrics([_row("valid"), _row("error", None)])
@@ -169,138 +249,28 @@ class TestFormatReportLoadsFailuresFromDisk:
         assert "Boom." in report
         assert "⚠️" in report
 
-
-class TestPrefilterSection:
-    """Markdown rendering of the Pre-filter block (filter_stats sidecar)."""
-
-    def _stats(
-        self,
-        *,
-        accepted: int = 100,
-        not_valid_parse: int = 0,
-        wrong_tool: int = 0,
-        no_deliver_id: int = 0,
-        no_outcome: int = 0,
-        older_than_cutoff: int = 0,
-    ) -> dict:
-        return {
-            "accepted": accepted,
-            "rejected": {
-                "wrong_tool": wrong_tool,
-                "no_deliver_id": no_deliver_id,
-                "not_valid_parse": not_valid_parse,
-                "no_outcome": no_outcome,
-                "older_than_cutoff": older_than_cutoff,
-            },
-        }
-
-    def test_zero_not_valid_parse_renders_green(self) -> None:
-        """With the filter invariant held, the block is informational only."""
-        text = "\n".join(_format_prefilter_section(self._stats()))
-        assert "✅ 0 rejected for not_valid_parse" in text
-        assert "⚠️" not in text
-
-    def test_nonzero_not_valid_parse_flagged(self) -> None:
-        """A single leaked non-valid row is flagged so it can't hide."""
-        text = "\n".join(_format_prefilter_section(self._stats(not_valid_parse=3)))
-        assert "⚠️" in text
-        assert "3 row(s) rejected for not_valid_parse" in text
-
-    def test_scoping_rejections_listed_separately(self) -> None:
-        """Wrong-tool / no-outcome / cutoff rejections are shown but not flagged."""
-        text = "\n".join(
-            _format_prefilter_section(
-                self._stats(wrong_tool=12, no_outcome=4, older_than_cutoff=7)
-            )
-        )
-        assert "wrong_tool=12" in text
-        assert "no_outcome=4" in text
-        assert "older_than_cutoff=7" in text
-        # Scoping rejections must not escalate the invariant marker.
-        assert "⚠️" not in text
-
-
-class TestLoadFilterStats:
-    """Sidecar loading alongside candidate.jsonl."""
-
-    def test_returns_none_when_absent(self, tmp_path: Path) -> None:
-        """Older pipelines without the sidecar return cleanly."""
-        candidate = tmp_path / "candidate.jsonl"
-        candidate.write_text("", encoding="utf-8")
-        assert _load_filter_stats(candidate) is None
-
-    def test_parses_sidecar_when_present(self, tmp_path: Path) -> None:
-        """filter_stats.json in the same dir as candidate.jsonl is loaded."""
-        candidate = tmp_path / "candidate.jsonl"
-        candidate.write_text("", encoding="utf-8")
-        stats = {"accepted": 5, "rejected": {"not_valid_parse": 1}}
-        (tmp_path / "filter_stats.json").write_text(
-            json.dumps(stats), encoding="utf-8"
-        )
-        assert _load_filter_stats(candidate) == stats
-
-    def test_returns_none_on_malformed_json(self, tmp_path: Path) -> None:
-        """A corrupt sidecar must not crash the whole report."""
-        candidate = tmp_path / "candidate.jsonl"
-        candidate.write_text("", encoding="utf-8")
-        (tmp_path / "filter_stats.json").write_text("{not json", encoding="utf-8")
-        assert _load_filter_stats(candidate) is None
-
-
-class TestFormatReportWithFilterStats:
-    """End-to-end: format_report wiring for the filter_stats arg."""
-
-    def test_omits_prefilter_block_when_stats_missing(self) -> None:
-        """Older datasets (no sidecar) render the original report unchanged."""
+    def test_report_renders_prefilter_when_stats_provided(self) -> None:
+        """A filter_stats dict adds the Pre-filter line to the reliability block."""
         baseline = compute_metrics([_row("valid")] * 3)
         candidate = compute_metrics([_row("valid")] * 3)
-        report = format_report(baseline, candidate, {"tool": "superforcaster"})
-        assert "Pre-filter" not in report
-
-    def test_renders_prefilter_block_when_stats_present(self) -> None:
-        """A provided filter_stats dict drops a Pre-filter section above reliability."""
-        baseline = compute_metrics([_row("valid")] * 3)
-        candidate = compute_metrics([_row("valid")] * 3)
-        stats = {
-            "accepted": 3,
-            "rejected": {
-                "wrong_tool": 10,
-                "no_deliver_id": 0,
-                "not_valid_parse": 0,
-                "no_outcome": 2,
-                "older_than_cutoff": 0,
-            },
-        }
         report = format_report(
             baseline,
             candidate,
             {"tool": "superforcaster"},
-            filter_stats=stats,
+            filter_stats=_stats(accepted=3, wrong_tool=10, no_outcome=2),
         )
-        assert "Pre-filter" in report
-        # Ordering: Pre-filter block must precede Parse reliability block so a
-        # filter regression is the first thing a reviewer sees.
-        assert report.index("Pre-filter") < report.index("Parse reliability")
+        assert "Pre-filter (enrich): 3 accepted, 12 rejected" in report
+        assert "⚠️" not in report  # scoping only, invariant held
 
-    def test_prefilter_regression_surfaces_in_full_report(self) -> None:
-        """A not_valid_parse>0 count propagates the ⚠️ marker into the final report."""
+    def test_filter_regression_surfaces_warning_in_full_report(self) -> None:
+        """not_valid_parse > 0 propagates the ⚠️ marker into the final report."""
         baseline = compute_metrics([_row("valid")] * 3)
         candidate = compute_metrics([_row("valid")] * 3)
-        stats = {
-            "accepted": 3,
-            "rejected": {
-                "wrong_tool": 0,
-                "no_deliver_id": 0,
-                "not_valid_parse": 2,
-                "no_outcome": 0,
-                "older_than_cutoff": 0,
-            },
-        }
         report = format_report(
             baseline,
             candidate,
             {"tool": "superforcaster"},
-            filter_stats=stats,
+            filter_stats=_stats(accepted=3, not_valid_parse=2),
         )
         assert "⚠️" in report
-        assert "2 row(s) rejected for not_valid_parse" in report
+        assert "not_valid_parse=2 ⚠️" in report

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from benchmark.ci_replay import (
@@ -27,13 +26,15 @@ def _row(status: str = "valid", p_yes: float | None = 0.6) -> dict:
 
 
 class TestParseReliability:
+    """Bucket counts and rates from ``prediction_parse_status`` values."""
+
     def test_breakdown_keys_are_always_present(self) -> None:
         """All four buckets are present even when only 'valid' has entries."""
         rel = _compute_parse_reliability([_row("valid")])
         assert set(rel["breakdown"]) == set(PARSE_STATUS_BUCKETS)
 
     def test_mixed_statuses_counted(self) -> None:
-        """valid + malformed + missing_fields all land in the right buckets."""
+        """Mixed statuses (valid, malformed, missing_fields) land in the right buckets."""
         rows = [
             _row("valid"),
             _row("valid"),
@@ -67,6 +68,8 @@ class TestParseReliability:
 
 
 class TestReliabilitySection:
+    """Markdown rendering of the reliability block + failure-body <details>."""
+
     def _metrics(self, rows: list[dict]) -> dict:
         return compute_metrics(rows)
 
@@ -119,7 +122,7 @@ class TestReliabilitySection:
                 "row_id": "c1",
                 "question_text": "Q",
                 "prediction_parse_status": "malformed",
-                "raw_response": "some ```json{\"p_yes\":0.5}``` leak",
+                "raw_response": 'some ```json{"p_yes":0.5}``` leak',
             }
         ]
         lines = _format_reliability_section(baseline, candidate, failures)
@@ -129,6 +132,8 @@ class TestReliabilitySection:
 
 
 class TestFormatReportLoadsFailuresFromDisk:
+    """End-to-end ``format_report`` wiring, with and without failure bodies."""
+
     def test_report_includes_reliability_even_with_no_failures(
         self, tmp_path: Path
     ) -> None:

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -230,11 +230,7 @@ class TestPrepareOutputDir:
         assert not stale.exists()
 
     def test_prep_preserves_unrelated_artifacts(self, tmp_path: Path) -> None:
-        """Prep must only purge known-stale sidecars, not other contents.
-
-        Users may chain runs or inspect artifacts like
-        ``enriched_with_new_reasoning.jsonl``; prep must leave those alone.
-        """
+        """Prep must only purge the two sidecars, not e.g. chained enriched output."""
         output_dir = tmp_path / "out"
         output_dir.mkdir()
         keep = output_dir / "enriched_with_new_reasoning.jsonl"

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -52,7 +52,7 @@ class TestLoadAndFilterRows:
         path = tmp_path / "log.jsonl"
         _write_jsonl(path, [_row(tool="other"), _row(tool="another")])
         rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
-        assert rows == []
+        assert not rows
         assert rejected["wrong_tool"] == 2
         assert rejected["not_valid_parse"] == 0
 
@@ -77,7 +77,7 @@ class TestLoadAndFilterRows:
         path = tmp_path / "log.jsonl"
         _write_jsonl(path, [_row(outcome=None)])
         rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
-        assert rows == []
+        assert not rows
         assert rejected["no_outcome"] == 1
         assert rejected["not_valid_parse"] == 0
 
@@ -86,7 +86,7 @@ class TestLoadAndFilterRows:
         path = tmp_path / "log.jsonl"
         _write_jsonl(path, [_row(deliver_id="")])
         rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
-        assert rows == []
+        assert not rows
         assert rejected["no_deliver_id"] == 1
 
     def test_filter_order_gives_first_failing_reason(self, tmp_path: Path) -> None:
@@ -95,6 +95,8 @@ class TestLoadAndFilterRows:
         Order: wrong_tool → no_deliver_id → not_valid_parse → no_outcome → cutoff.
         A row with wrong tool AND bad parse AND no outcome increments wrong_tool
         only — so the total rejection count matches row count exactly.
+
+        :param tmp_path: pytest tmp_path fixture.
         """
         path = tmp_path / "log.jsonl"
         _write_jsonl(
@@ -102,7 +104,7 @@ class TestLoadAndFilterRows:
             [_row(tool="other", status="malformed", outcome=None)],
         )
         rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
-        assert rows == []
+        assert not rows
         assert rejected["wrong_tool"] == 1
         assert sum(rejected.values()) == 1
 

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+"""Tests for prompt_replay filter + sidecar plumbing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from benchmark.prompt_replay import _load_and_filter_rows, _log_replay_summary
+
+
+def _row(
+    *,
+    tool: str = "superforcaster",
+    deliver_id: str = "0xabc",
+    status: str = "valid",
+    outcome: Any = True,
+    predicted_at: str | None = None,
+) -> dict:
+    r: dict = {
+        "tool_name": tool,
+        "deliver_id": deliver_id,
+        "prediction_parse_status": status,
+        "final_outcome": outcome,
+    }
+    if predicted_at is not None:
+        r["predicted_at"] = predicted_at
+    return r
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+class TestLoadAndFilterRows:
+    """Rejection counters on `_load_and_filter_rows`."""
+
+    def test_all_accepted_zero_rejections(self, tmp_path: Path) -> None:
+        """Rows matching every filter land in rows; counters stay at zero."""
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(path, [_row(), _row()])
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert len(rows) == 2
+        assert sum(rejected.values()) == 0
+
+    def test_wrong_tool_counted(self, tmp_path: Path) -> None:
+        """Rows with a different tool_name hit the wrong_tool bucket only."""
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(path, [_row(tool="other"), _row(tool="another")])
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert rows == []
+        assert rejected["wrong_tool"] == 2
+        assert rejected["not_valid_parse"] == 0
+
+    def test_not_valid_parse_counted(self, tmp_path: Path) -> None:
+        """The load-bearing bucket — a leaked non-valid row lands here."""
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _row(status="malformed"),
+                _row(status="missing_fields"),
+                _row(status="error"),
+                _row(status="valid"),
+            ],
+        )
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert len(rows) == 1
+        assert rejected["not_valid_parse"] == 3
+
+    def test_no_outcome_counted(self, tmp_path: Path) -> None:
+        """Rows without final_outcome hit no_outcome, not not_valid_parse."""
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(path, [_row(outcome=None)])
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert rows == []
+        assert rejected["no_outcome"] == 1
+        assert rejected["not_valid_parse"] == 0
+
+    def test_no_deliver_id_counted(self, tmp_path: Path) -> None:
+        """Rows without deliver_id hit no_deliver_id."""
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(path, [_row(deliver_id="")])
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert rows == []
+        assert rejected["no_deliver_id"] == 1
+
+    def test_filter_order_gives_first_failing_reason(self, tmp_path: Path) -> None:
+        """A row failing multiple predicates counts in the first one only.
+
+        Order: wrong_tool → no_deliver_id → not_valid_parse → no_outcome → cutoff.
+        A row with wrong tool AND bad parse AND no outcome increments wrong_tool
+        only — so the total rejection count matches row count exactly.
+        """
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(
+            path,
+            [_row(tool="other", status="malformed", outcome=None)],
+        )
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert rows == []
+        assert rejected["wrong_tool"] == 1
+        assert sum(rejected.values()) == 1
+
+
+class TestLogReplaySummaryFilterStats:
+    """`_log_replay_summary` renders the Pre-filter block when stats are given."""
+
+    def _sampled(self) -> list[dict]:
+        return [
+            {"p_yes": 0.7, "p_no": 0.3, "final_outcome": True, "tool_name": "x"},
+            {"p_yes": 0.4, "p_no": 0.6, "final_outcome": False, "tool_name": "x"},
+        ]
+
+    def _write_candidate(self, path: Path) -> None:
+        rows = [
+            {"p_yes": 0.8, "p_no": 0.2, "final_outcome": True},
+            {"p_yes": 0.3, "p_no": 0.7, "final_outcome": False},
+        ]
+        _write_jsonl(path, rows)
+
+    def test_block_rendered_when_filter_stats_given(
+        self, tmp_path: Path, caplog: Any
+    ) -> None:
+        """The Pre-filter line appears in the log when filter_stats is not None."""
+        candidate = tmp_path / "candidate.jsonl"
+        self._write_candidate(candidate)
+        stats = {
+            "accepted": 2,
+            "rejected": {
+                "wrong_tool": 4,
+                "no_deliver_id": 0,
+                "not_valid_parse": 1,
+                "no_outcome": 2,
+                "older_than_cutoff": 0,
+            },
+        }
+        with caplog.at_level("INFO"):
+            _log_replay_summary(
+                sampled=self._sampled(),
+                candidate_path=candidate,
+                baseline_brier_sum=0.1,
+                candidate_brier_sum=0.2,
+                total=2,
+                n_scored=2,
+                baseline_path=candidate,
+                status_counts={
+                    "valid": 2,
+                    "missing_fields": 0,
+                    "malformed": 0,
+                    "error": 0,
+                },
+                filter_stats=stats,
+            )
+        text = caplog.text
+        assert "Pre-filter" in text
+        assert "not_valid_parse=1" in text
+
+    def test_block_omitted_when_stats_none(self, tmp_path: Path, caplog: Any) -> None:
+        """When no sidecar is provided the summary logs exactly as before."""
+        candidate = tmp_path / "candidate.jsonl"
+        self._write_candidate(candidate)
+        with caplog.at_level("INFO"):
+            _log_replay_summary(
+                sampled=self._sampled(),
+                candidate_path=candidate,
+                baseline_brier_sum=0.1,
+                candidate_brier_sum=0.2,
+                total=2,
+                n_scored=2,
+                baseline_path=candidate,
+                status_counts={
+                    "valid": 2,
+                    "missing_fields": 0,
+                    "malformed": 0,
+                    "error": 0,
+                },
+            )
+        assert "Pre-filter" not in caplog.text

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -7,7 +7,11 @@ import json
 from pathlib import Path
 from typing import Any
 
-from benchmark.prompt_replay import _load_and_filter_rows, _log_replay_summary
+from benchmark.prompt_replay import (
+    _load_and_filter_rows,
+    _log_replay_summary,
+    _prepare_output_dir,
+)
 
 
 def _row(
@@ -183,3 +187,65 @@ class TestLogReplaySummaryFilterStats:
                 },
             )
         assert "Pre-filter" not in caplog.text
+
+
+class TestPrepareOutputDir:
+    """`_prepare_output_dir` must isolate runs that share an output_dir.
+
+    Regression coverage for stale-sidecar leak (see PR #231 review): both
+    `candidate_failures.jsonl` and `filter_stats.json` are written
+    conditionally (only when failures / stats exist), so a clean run in a
+    reused directory would otherwise inherit the previous run's sidecars
+    and silently mislead ci_replay.
+    """
+
+    def test_stale_candidate_failures_purged_before_fresh_run(
+        self, tmp_path: Path
+    ) -> None:
+        """A prior run's candidate_failures.jsonl must not survive prep."""
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        stale = output_dir / "candidate_failures.jsonl"
+        stale.write_text(
+            json.dumps({"row_id": "stale", "raw_response": "from prior run"}) + "\n",
+            encoding="utf-8",
+        )
+
+        _prepare_output_dir(output_dir)
+
+        assert not stale.exists()
+
+    def test_stale_filter_stats_purged_before_fresh_run(self, tmp_path: Path) -> None:
+        """A prior run's filter_stats.json must not survive prep."""
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        stale = output_dir / "filter_stats.json"
+        stale.write_text(
+            json.dumps({"accepted": 999, "rejected": {"not_valid_parse": 42}}),
+            encoding="utf-8",
+        )
+
+        _prepare_output_dir(output_dir)
+
+        assert not stale.exists()
+
+    def test_prep_preserves_unrelated_artifacts(self, tmp_path: Path) -> None:
+        """Prep must only purge known-stale sidecars, not other contents.
+
+        Users may chain runs or inspect artifacts like
+        ``enriched_with_new_reasoning.jsonl``; prep must leave those alone.
+        """
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        keep = output_dir / "enriched_with_new_reasoning.jsonl"
+        keep.write_text("keep me\n", encoding="utf-8")
+
+        _prepare_output_dir(output_dir)
+
+        assert keep.read_text(encoding="utf-8") == "keep me\n"
+
+    def test_prep_is_noop_when_sidecars_absent(self, tmp_path: Path) -> None:
+        """Fresh output_dir: prep must not error when there's nothing to purge."""
+        output_dir = tmp_path / "out"
+        _prepare_output_dir(output_dir)
+        assert output_dir.is_dir()

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,13 +11,13 @@
         "custom/valory/prediction_request/0.1.0": "bafybeidf5hlr5elgt4x7gvaxosq3hmcbb7sabwdbm6voocyrbtsyzns4yu",
         "custom/valory/prepare_tx/0.1.0": "bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya",
         "custom/valory/resolve_market/0.1.0": "bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi",
-        "custom/valory/superforcaster/0.1.0": "bafybeifvtujcbylio5dpvna4gxtxancksdveafjtqfpxp4wskh4i6k3p5q",
+        "custom/valory/superforcaster/0.1.0": "bafybeifgf3av5u6fb2bjmeu342zo4nvydioyp5qr4uunpblvap3jhlxcdy",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeibcpvtqbdpu3dbuycqhxwyoi74dtnremjkvscbtt2bt4l2puxjupi",
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiciwntuzeqnal5b3wwixquq4efv443eu4m4z3ujoy6olmulktfl3q",
-        "agent/valory/mech_predict/0.1.0": "bafybeiagbnduttizdzluz3bn2remkyti6rsj2ognoni3gyp56ov7hg323a",
-        "service/valory/mech_predict/0.1.0": "bafybeifyxlmhk3rohqciq6yqbr6cogdhqoklpc3iaromytafaxhyob7itq"
+        "agent/valory/mech_predict/0.1.0": "bafybeibqfyppjzcy2hdwn4f7jhxt2byh6ubg3zju4cvqqm6xqsy7knvfgq",
+        "service/valory/mech_predict/0.1.0": "bafybeiciyde4aupdeaauk5wqjc3wmekh3ktopxxxemxvkfq734tjsw23ky"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,13 +11,13 @@
         "custom/valory/prediction_request/0.1.0": "bafybeidf5hlr5elgt4x7gvaxosq3hmcbb7sabwdbm6voocyrbtsyzns4yu",
         "custom/valory/prepare_tx/0.1.0": "bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya",
         "custom/valory/resolve_market/0.1.0": "bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi",
-        "custom/valory/superforcaster/0.1.0": "bafybeigewmglpbdbcldvyepmpeejx3vmsocwec2fjy57pgnqg2jxmfd2oe",
+        "custom/valory/superforcaster/0.1.0": "bafybeieclhesexzyj2v57ar5jenakf6sdqhk7srleolq2bfs7ylqq23bne",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeibcpvtqbdpu3dbuycqhxwyoi74dtnremjkvscbtt2bt4l2puxjupi",
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiciwntuzeqnal5b3wwixquq4efv443eu4m4z3ujoy6olmulktfl3q",
-        "agent/valory/mech_predict/0.1.0": "bafybeihzthsfntge7wghphyvdwje2nsgwfrvuu3h3ym7lfxfvcrq6fwadq",
-        "service/valory/mech_predict/0.1.0": "bafybeiebjbdjcdr6jnn72hunmgbqwg3qokajfbbokpz4glypqfbbidmeau"
+        "agent/valory/mech_predict/0.1.0": "bafybeiakj4ekdw6gqbplpq6n7vynv3rk2hlmlp3fko2x6bd43dzbg5cb3y",
+        "service/valory/mech_predict/0.1.0": "bafybeidjfe32i3gykx4digb255d4njn5xin7vr5ifc3cnagwuo6yosp5ri"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,13 +11,13 @@
         "custom/valory/prediction_request/0.1.0": "bafybeidf5hlr5elgt4x7gvaxosq3hmcbb7sabwdbm6voocyrbtsyzns4yu",
         "custom/valory/prepare_tx/0.1.0": "bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya",
         "custom/valory/resolve_market/0.1.0": "bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi",
-        "custom/valory/superforcaster/0.1.0": "bafybeieclhesexzyj2v57ar5jenakf6sdqhk7srleolq2bfs7ylqq23bne",
+        "custom/valory/superforcaster/0.1.0": "bafybeifvtujcbylio5dpvna4gxtxancksdveafjtqfpxp4wskh4i6k3p5q",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeibcpvtqbdpu3dbuycqhxwyoi74dtnremjkvscbtt2bt4l2puxjupi",
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiciwntuzeqnal5b3wwixquq4efv443eu4m4z3ujoy6olmulktfl3q",
-        "agent/valory/mech_predict/0.1.0": "bafybeiakj4ekdw6gqbplpq6n7vynv3rk2hlmlp3fko2x6bd43dzbg5cb3y",
-        "service/valory/mech_predict/0.1.0": "bafybeidjfe32i3gykx4digb255d4njn5xin7vr5ifc3cnagwuo6yosp5ri"
+        "agent/valory/mech_predict/0.1.0": "bafybeiagbnduttizdzluz3bn2remkyti6rsj2ognoni3gyp56ov7hg323a",
+        "service/valory/mech_predict/0.1.0": "bafybeifyxlmhk3rohqciq6yqbr6cogdhqoklpc3iaromytafaxhyob7itq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -61,7 +61,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
-- valory/superforcaster:0.1.0:bafybeigewmglpbdbcldvyepmpeejx3vmsocwec2fjy57pgnqg2jxmfd2oe
+- valory/superforcaster:0.1.0:bafybeieclhesexzyj2v57ar5jenakf6sdqhk7srleolq2bfs7ylqq23bne
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -61,7 +61,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
-- valory/superforcaster:0.1.0:bafybeifvtujcbylio5dpvna4gxtxancksdveafjtqfpxp4wskh4i6k3p5q
+- valory/superforcaster:0.1.0:bafybeifgf3av5u6fb2bjmeu342zo4nvydioyp5qr4uunpblvap3jhlxcdy
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -61,7 +61,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
-- valory/superforcaster:0.1.0:bafybeieclhesexzyj2v57ar5jenakf6sdqhk7srleolq2bfs7ylqq23bne
+- valory/superforcaster:0.1.0:bafybeifvtujcbylio5dpvna4gxtxancksdveafjtqfpxp4wskh4i6k3p5q
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -7,9 +7,9 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifvbuxt54l5jsxextf6ru5yvimkfdg4gfkcsnmyvsyqcsgclg7vey
-  superforcaster.py: bafybeigc756gorf3ifsyxpohv53sdf3hrefpoveienpyxqa2sb7qahtnjm
+  superforcaster.py: bafybeibnrv3okkvvgc2hr5qiioa5jh2j3iwqoirgvqhmd7xlxyejcasliq
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
-  tests/test_superforcaster.py: bafybeigscr6ayqdkgchxxvygp25yzqlu6g6rkwg3fcbflxx2sbfpymgdqa
+  tests/test_superforcaster.py: bafybeiboaixfm4itoashxu5a4fshfe36plhnkk2tw3reznnoxz4yl7ovhm
 fingerprint_ignore_patterns: []
 entry_point: superforcaster.py
 callable: run
@@ -22,5 +22,7 @@ dependencies:
     version: ==0.25.2
   tiktoken:
     version: ==0.12.0
+  pydantic:
+    version: '>=2.0.0,<3.0.0'
   requests:
     version: ==2.32.5

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifvbuxt54l5jsxextf6ru5yvimkfdg4gfkcsnmyvsyqcsgclg7vey
-  superforcaster.py: bafybeibnrv3okkvvgc2hr5qiioa5jh2j3iwqoirgvqhmd7xlxyejcasliq
+  superforcaster.py: bafybeibkt2qey6f2hyzy3s2u6dqbbdz6i3wkxa76phcokflid7mnxjsp4q
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
   tests/test_superforcaster.py: bafybeiboaixfm4itoashxu5a4fshfe36plhnkk2tw3reznnoxz4yl7ovhm
 fingerprint_ignore_patterns: []

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifvbuxt54l5jsxextf6ru5yvimkfdg4gfkcsnmyvsyqcsgclg7vey
-  superforcaster.py: bafybeibkt2qey6f2hyzy3s2u6dqbbdz6i3wkxa76phcokflid7mnxjsp4q
+  superforcaster.py: bafybeic7vbcjcq5jomciosjaez2nnktwsdlbf2ctakdrbh5nl7cgod5z6e
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
   tests/test_superforcaster.py: bafybeiboaixfm4itoashxu5a4fshfe36plhnkk2tw3reznnoxz4yl7ovhm
 fingerprint_ignore_patterns: []

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -328,6 +328,18 @@ def _parse_completion(
     ``client.beta.chat.completions.parse()`` guarantees the response conforms
     to the supplied Pydantic schema — no prompt-side JSON format instructions
     or regex extraction required.
+
+    :param client: an initialised OpenAI client.
+    :param model: OpenAI model identifier.
+    :param messages: chat messages list (role + content dicts).
+    :param response_format: Pydantic model class used as the structured-output schema.
+    :param temperature: sampling temperature (0 = deterministic).
+    :param max_tokens: maximum tokens to generate.
+    :param retries: number of retry attempts on transient / validation failure.
+    :param delay: delay in seconds between retries.
+    :param counter_callback: optional callback tracking token usage.
+    :return: tuple of (parsed model instance, counter_callback).
+    :raises RuntimeError: if all retries exhausted without a successful parse.
     """
     attempt = 0
     while attempt < retries:

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -59,30 +59,30 @@ class PredictionResult(BaseModel):
     facts: str = Field(
         ...,
         description=(
-            "Step 1 — Core factual points compiled from the sources and "
-            "relevant background. Specific, relevant, no conclusions about "
-            "how a fact influences the forecast."
+            "Core factual points compiled from the sources and relevant "
+            "background. Specific, relevant, no conclusions about how a "
+            "fact influences the forecast."
         ),
     )
     reasons_no: str = Field(
         ...,
         description=(
-            "Step 2 — Reasons why the answer might be NO. Rate the strength "
-            "of each reason on a scale of 1-10."
+            "Reasons why the answer might be NO. Rate the strength of each "
+            "reason on a scale of 1-10."
         ),
     )
     reasons_yes: str = Field(
         ...,
         description=(
-            "Step 3 — Reasons why the answer might be YES. Rate the strength "
-            "of each reason on a scale of 1-10."
+            "Reasons why the answer might be YES. Rate the strength of each "
+            "reason on a scale of 1-10."
         ),
     )
     aggregation: str = Field(
         ...,
         description=(
-            "Step 4 — Aggregate considerations. Weigh competing factors, apply "
-            "the CALIBRATION block (state a base rate and justify, adjust using "
+            "Aggregate considerations. Weigh competing factors, apply the "
+            "CALIBRATION block (state a base rate and justify, adjust using "
             "specific evidence, treat missing expected evidence as a NO signal), "
             "adjust for news negativity / sensationalism bias. End by stating a "
             "tentative probability in [0,1]."
@@ -91,7 +91,7 @@ class PredictionResult(BaseModel):
     reflection: str = Field(
         ...,
         description=(
-            "Step 6 — Sanity checks and finalisation. Apply the three checks: "
+            "Sanity checks and finalisation. Apply the three checks: "
             "EVIDENCE BAR, CONFIDENCE COUPLING, NUMERIC QUESTIONS. Check for "
             "over/underconfidence and forecasting biases. Highlight the key "
             "factors informing the final forecast."

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -27,6 +27,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import openai
 import requests
+from openai import OpenAI
+from pydantic import BaseModel, Field, model_validator
 from tiktoken import encoding_for_model
 
 MechResponseWithKeys = Tuple[
@@ -41,6 +43,99 @@ N_MODEL_CALLS = 1
 DEFAULT_DELIVERY_RATE = 100
 
 
+# ---------------------------------------------------------------------------
+# Pydantic schema for OpenAI Structured Outputs
+# ---------------------------------------------------------------------------
+
+
+class PredictionResult(BaseModel):
+    """Superforecaster structured output.
+
+    The text fields carry the 7-step reasoning chain (facts → pros/cons →
+    aggregation + tentative → reflection → final). Only the four numeric
+    fields at the bottom are returned on-chain per the mech protocol.
+    """
+
+    facts: str = Field(
+        ...,
+        description=(
+            "Step 1 — Core factual points compiled from the sources and "
+            "relevant background. Specific, relevant, no conclusions about "
+            "how a fact influences the forecast."
+        ),
+    )
+    reasons_no: str = Field(
+        ...,
+        description=(
+            "Step 2 — Reasons why the answer might be NO. Rate the strength "
+            "of each reason on a scale of 1-10."
+        ),
+    )
+    reasons_yes: str = Field(
+        ...,
+        description=(
+            "Step 3 — Reasons why the answer might be YES. Rate the strength "
+            "of each reason on a scale of 1-10."
+        ),
+    )
+    aggregation: str = Field(
+        ...,
+        description=(
+            "Step 4 — Aggregate considerations. Weigh competing factors, apply "
+            "the CALIBRATION block (state a base rate and justify, adjust using "
+            "specific evidence, treat missing expected evidence as a NO signal), "
+            "adjust for news negativity / sensationalism bias. End by stating a "
+            "tentative probability in [0,1]."
+        ),
+    )
+    reflection: str = Field(
+        ...,
+        description=(
+            "Step 6 — Sanity checks and finalisation. Apply the three checks: "
+            "EVIDENCE BAR, CONFIDENCE COUPLING, NUMERIC QUESTIONS. Check for "
+            "over/underconfidence and forecasting biases. Highlight the key "
+            "factors informing the final forecast."
+        ),
+    )
+    p_yes: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Estimated probability that the event in the Question occurs.",
+    )
+    p_no: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Estimated probability that the event does NOT occur.",
+    )
+    confidence: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Confidence in the prediction (0 = lowest, 1 = highest).",
+    )
+    info_utility: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Utility of the information in the sources to inform the prediction "
+            "(0 = lowest, 1 = highest)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _check_p_yes_p_no_sum(self) -> "PredictionResult":
+        """Validate that p_yes + p_no ≈ 1."""
+        if abs(self.p_yes + self.p_no - 1.0) > 0.01:
+            raise ValueError(
+                f"p_yes + p_no must equal 1 (got {self.p_yes} + {self.p_no} = "
+                f"{self.p_yes + self.p_no})"
+            )
+        return self
+
+
 def with_key_rotation(func: Callable) -> Callable:
     """
     Decorator that retries a function with API key rotation on failure.
@@ -51,16 +146,22 @@ def with_key_rotation(func: Callable) -> Callable:
     """
 
     @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> MechResponseWithKeys:
+    def wrapper(
+        *args: Any, **kwargs: Any
+    ) -> Union[MaxCostResponse, MechResponseWithKeys]:
         # this is expected to be a KeyChain object,
         # although it is not explicitly typed as such
         api_keys = kwargs["api_keys"]
         retries_left: Dict[str, int] = api_keys.max_retries()
 
-        def execute() -> MechResponseWithKeys:
+        def execute() -> Union[MaxCostResponse, MechResponseWithKeys]:
             """Retry the function with a new key."""
             try:
-                result: MechResponse = func(*args, **kwargs)
+                result = func(*args, **kwargs)
+                # Max-cost path returns a float; pass through without appending
+                # api_keys (tuple concatenation would fail).
+                if isinstance(result, float):
+                    return result
                 return result + (api_keys,)
             except openai.RateLimitError as e:
                 # try with a new key again
@@ -81,86 +182,33 @@ def with_key_rotation(func: Callable) -> Callable:
 
 
 class OpenAIClientManager:
-    """Client context manager for OpenAI."""
+    """Context manager that creates and closes a local OpenAI client."""
 
     def __init__(self, api_key: str):
-        """Initializes with API keys"""
+        """Initializes with API key."""
         self.api_key = api_key
-        self._client: Optional["OpenAIClient"] = None
+        self._client: Optional[OpenAI] = None
 
-    def __enter__(self) -> "OpenAIClient":
-        """Initializes and returns LLM client."""
-        self._client = OpenAIClient(api_key=self.api_key)
+    def __enter__(self) -> OpenAI:
+        """Initializes and returns the OpenAI client."""
+        self._client = OpenAI(api_key=self.api_key)
         return self._client
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        """Closes the LLM client"""
+        """Closes the OpenAI client."""
         if self._client is not None:
-            self._client.client.close()
+            self._client.close()
             self._client = None
-
-
-class Usage:
-    """Usage class."""
-
-    def __init__(
-        self,
-        prompt_tokens: Optional[Any] = None,
-        completion_tokens: Optional[Any] = None,
-    ):
-        """Initializes with prompt tokens and completion tokens."""
-        self.prompt_tokens = prompt_tokens
-        self.completion_tokens = completion_tokens
-
-
-class OpenAIResponse:
-    """Response class."""
-
-    def __init__(self, content: Optional[str] = None, usage: Optional[Usage] = None):
-        """Initializes with content and usage class."""
-        self.content = content
-        self.usage = Usage()
-
-
-class OpenAIClient:
-    """OpenAI Client"""
-
-    def __init__(self, api_key: str):
-        """Initializes with API keys and client."""
-        self.api_key = api_key
-        self.client = openai.OpenAI(api_key=self.api_key)
-
-    def completions(
-        self,
-        model: str,
-        messages: List = [],  # noqa: B006
-        timeout: Optional[Union[float, int]] = None,
-        temperature: Optional[float] = None,
-        top_p: Optional[float] = None,
-        n: Optional[int] = None,
-        stop: Any = None,
-        max_tokens: Optional[float] = None,
-    ) -> Optional[OpenAIResponse]:
-        """Generate a completion from the specified LLM provider using the given model and messages."""
-        response_provider = self.client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            n=1,
-            timeout=150,
-            stop=None,
-        )
-        response = OpenAIResponse()
-        response.content = response_provider.choices[0].message.content
-        response.usage.prompt_tokens = response_provider.usage.prompt_tokens
-        response.usage.completion_tokens = response_provider.usage.completion_tokens
-        return response
 
 
 def count_tokens(text: str, model: str) -> int:
     """Count the number of tokens in a text."""
-    enc = encoding_for_model(model)
+    try:
+        enc = encoding_for_model(model)
+    except KeyError:
+        from tiktoken import get_encoding
+
+        enc = get_encoding("o200k_base")
     return len(enc.encode(text))
 
 
@@ -176,6 +224,8 @@ MAX_SOURCES = 5
 COMPLETION_RETRIES = 3
 COMPLETION_DELAY = 2
 
+
+SYSTEM_PROMPT = "You are a helpful assistant."
 
 PREDICTION_PROMPT = """
 You are an advanced AI system which has been finetuned to provide calibrated probabilistic
@@ -195,20 +245,21 @@ We have retrieved the following information for this question:
 Recall the question you are forecasting:
 {question}
 
-Instructions:
-1. Compress key factual information from the sources, as well as useful background information
+Return a structured PredictionResult whose fields capture the following reasoning chain:
+
+1. `facts` — Compress key factual information from the sources, as well as useful background information
 which may not be in the sources, into a list of core factual points to reference. Aim for
 information which is specific, relevant, and covers the core considerations you'll use to make
 your forecast. For this step, do not draw any conclusions about how a fact will influence your
-answer or forecast. Place this section of your response in <facts></facts> tags.
+answer or forecast.
 
-2. Provide a few reasons why the answer might be no. Rate the strength of each reason on a
-scale of 1-10. Use <no></no> tags.
+2. `reasons_no` — Provide a few reasons why the answer might be no. Rate the strength of each reason on a
+scale of 1-10.
 
-3. Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
-scale of 1-10. Use <yes></yes> tags.
+3. `reasons_yes` — Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
+scale of 1-10.
 
-4. Aggregate your considerations. Do not summarize or repeat previous points; instead,
+4. `aggregation` — Aggregate your considerations. Do not summarize or repeat previous points; instead,
 investigate how the competing factors and mechanisms interact and weigh against each other.
 Factorize your thinking across (exhaustive, mutually exclusive) cases if and only if it would be
 beneficial to your reasoning. We have detected that you overestimate world conflict, drama,
@@ -216,18 +267,17 @@ violence, and crises due to news' negativity bias, which doesn't necessarily rep
 trends or base rates. Similarly, we also have detected you overestimate dramatic, shocking,
 or emotionally charged news due to news' sensationalism bias. Therefore adjust for news'
 negativity bias and sensationalism bias by considering reasons to why your provided sources
-might be biased or exaggerated. Think like a superforecaster. Use <thinking></thinking> tags
-for this section of your response.
+might be biased or exaggerated. Think like a superforecaster.
 
 CALIBRATION (mandatory before any probability):
 - State a base-rate probability for this event category and justify it.
 - Adjust from the base rate using specific evidence only.
 - Missing expected evidence (no announcement found, no confirmation) is a NO signal.
 
-5. Output an initial probability (prediction) as a single number between 0 and 1 given steps 1-4.
-Use <tentative></tentative> tags.
+End the `aggregation` field by stating an initial tentative probability (a single number between 0 and 1)
+given steps 1-4.
 
-6. Reflect on your answer, performing sanity checks and mentioning any additional knowledge
+5. `reflection` — Reflect on your tentative answer, performing sanity checks and mentioning any additional knowledge
 or background information which may be relevant. Check for over/underconfidence, improper
 treatment of conjunctive or disjunctive conditions (only if applicable), and other forecasting
 biases when reviewing your reasoning. Consider priors/base rates, and the extent to which
@@ -235,7 +285,7 @@ case-specific information justifies the deviation between your tentative forecas
 Recall that your performance will be evaluated according to the Brier score. Be precise with tail
 probabilities. Leverage your intuitions, but never change your forecast for the sake of modesty
 or balance alone. Finally, aggregate all of your previous reasoning and highlight key factors
-that inform your final forecast. Use <thinking></thinking> tags for this portion of your response.
+that inform your final forecast.
 
 BEFORE FINAL ANSWER — apply all three checks:
 
@@ -250,57 +300,56 @@ BEFORE FINAL ANSWER — apply all three checks:
 3. NUMERIC QUESTIONS: For price/temperature/count thresholds, find the current
    value and compare to the threshold. A large gap overrides sentiment or forecasts.
 
-7. Output your final prediction (a number between 0 and 1 with an asterisk at the beginning and
-end of the decimal) in <answer></answer> tags.
-
-
-OUTPUT_FORMAT
-* Your output response must be only a single JSON object to be parsed by Python's "json.loads()".
-* The JSON must contain four fields: "p_yes", "p_no", "confidence", and "info_utility".
-* Each item in the JSON must have a value between 0 and 1.
+6. `p_yes`, `p_no`, `confidence`, `info_utility` — the four numeric fields:
    - "p_yes": Estimated probability that the event in the "Question" occurs.
    - "p_no": Estimated probability that the event in the "Question" does not occur.
    - "confidence": A value between 0 and 1 indicating the confidence in the prediction. 0 indicates lowest
      confidence value; 1 maximum confidence value.
    - "info_utility": Utility of the information provided in "sources" to help you make the prediction.
      0 indicates lowest utility; 1 maximum utility.
-* The sum of "p_yes" and "p_no" must equal 1.
-* Output only the JSON object. Do not include any other contents in your response.
-* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
-* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
-* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
+   - Each value must be between 0 and 1.
+   - The sum of "p_yes" and "p_no" must equal 1.
 """
 
 
-def generate_prediction_with_retry(
-    client: "OpenAIClient",
+def _parse_completion(
+    client: OpenAI,
     model: str,
     messages: List[Dict[str, str]],
-    temperature: float,
-    max_tokens: int,
+    response_format: Any,
+    temperature: float = 0,
+    max_tokens: int = 4096,
     retries: int = COMPLETION_RETRIES,
     delay: int = COMPLETION_DELAY,
     counter_callback: Optional[Callable] = None,
 ) -> Tuple[Any, Optional[Callable]]:
-    """Attempt to generate a prediction with retries on failure."""
+    """Call OpenAI Structured Outputs and parse into a Pydantic model.
+
+    ``client.beta.chat.completions.parse()`` guarantees the response conforms
+    to the supplied Pydantic schema — no prompt-side JSON format instructions
+    or regex extraction required.
+    """
     attempt = 0
     while attempt < retries:
         try:
-            response = client.completions(
+            response = client.beta.chat.completions.parse(
                 model=model,
                 messages=messages,
+                response_format=response_format,
                 temperature=temperature,
                 max_tokens=max_tokens,
-                n=1,
-                timeout=90,
-                stop=None,
+                timeout=150,
             )
 
-            if (
-                response
-                and response.content is not None
-                and counter_callback is not None
-            ):
+            parsed = response.choices[0].message.parsed
+
+            if parsed is None:
+                refusal = response.choices[0].message.refusal
+                raise ValueError(
+                    f"Model refused or returned unparseable output: {refusal}"
+                )
+
+            if counter_callback is not None:
                 counter_callback(
                     input_tokens=response.usage.prompt_tokens,
                     output_tokens=response.usage.completion_tokens,
@@ -308,13 +357,23 @@ def generate_prediction_with_retry(
                     token_counter=count_tokens,
                 )
 
-            content = response.content if response else None
-            return content, counter_callback
-        except Exception as e:
-            print(f"Attempt {attempt + 1} failed with error: {e}")
+            return parsed, counter_callback
+        except (
+            openai.APIConnectionError,
+            openai.RateLimitError,
+            openai.InternalServerError,
+            ValueError,
+        ) as e:
+            # Retry only transient failures and model-side issues:
+            #   - APIConnectionError (includes APITimeoutError) — network blips
+            #   - RateLimitError / InternalServerError — OpenAI-side retryable
+            #   - ValueError — covers pydantic ValidationError (e.g. p_yes+p_no
+            #     sum check) and the inline "Model refused…" raise above
+            print(f"[superforcaster] Attempt {attempt + 1} failed: {e}")
             time.sleep(delay)
             attempt += 1
-    raise Exception("Failed to generate prediction after retries")
+
+    raise RuntimeError("Failed to get structured LLM completion after retries")
 
 
 def fetch_additional_sources(question: Any, serper_api_key: Any) -> requests.Response:
@@ -453,26 +512,47 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
         )
         print(f"\n{prediction_prompt=}\n")
         messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": prediction_prompt},
         ]
         print("Getting prompt response...")
-        extracted_block, counter_callback = generate_prediction_with_retry(
+        prediction: PredictionResult
+        prediction, counter_callback = _parse_completion(
             client=llm_client,
             model=model,
             messages=messages,
+            response_format=PredictionResult,
             temperature=temperature,
             max_tokens=max_tokens,
-            retries=COMPLETION_RETRIES,
-            delay=COMPLETION_DELAY,
             counter_callback=counter_callback,
         )
 
-        used_params = {
+        print(f"[superforcaster] === FACTS ===\n{prediction.facts}")
+        print(f"[superforcaster] === REASONS_NO ===\n{prediction.reasons_no}")
+        print(f"[superforcaster] === REASONS_YES ===\n{prediction.reasons_yes}")
+        print(f"[superforcaster] === AGGREGATION ===\n{prediction.aggregation}")
+        print(f"[superforcaster] === REFLECTION ===\n{prediction.reflection}")
+        print(
+            f"[superforcaster] Result: p_yes={prediction.p_yes}, "
+            f"p_no={prediction.p_no}, confidence={prediction.confidence}, "
+            f"info_utility={prediction.info_utility}"
+        )
+
+        # On-chain result — only the four standard mech fields.
+        result = json.dumps(
+            {
+                "p_yes": prediction.p_yes,
+                "p_no": prediction.p_no,
+                "confidence": prediction.confidence,
+                "info_utility": prediction.info_utility,
+            }
+        )
+
+        used_params: Dict[str, Any] = {
             "model": model,
             "temperature": temperature,
             "max_tokens": max_tokens,
         }
         if return_source_content:
             used_params["source_content"] = captured_source_content
-        return extracted_block, prediction_prompt, None, counter_callback, used_params
+        return result, prediction_prompt, None, counter_callback, used_params

--- a/packages/valory/customs/superforcaster/tests/test_superforcaster.py
+++ b/packages/valory/customs/superforcaster/tests/test_superforcaster.py
@@ -17,7 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Unit tests for superforcaster: thread-safe client, offline tiktoken, and source_content."""
+"""Unit tests for superforcaster: thread-safe client, structured outputs, source_content."""
 
 import inspect
 import json
@@ -29,7 +29,8 @@ import pytest
 import packages.valory.customs.superforcaster.superforcaster as module
 from packages.valory.customs.superforcaster.superforcaster import (
     OpenAIClientManager,
-    generate_prediction_with_retry,
+    PredictionResult,
+    _parse_completion,
     run,
 )
 
@@ -37,20 +38,20 @@ from packages.valory.customs.superforcaster.superforcaster import (
 class TestOpenAIClientManager:
     """Verify OpenAIClientManager creates per-context clients without globals."""
 
-    def test_context_manager_returns_client_instance(self) -> None:
-        """__enter__ returns a fresh OpenAIClient, __exit__ closes it."""
+    def test_context_manager_returns_openai_client(self) -> None:
+        """__enter__ returns a fresh openai.OpenAI client, __exit__ closes it."""
         mgr = OpenAIClientManager(api_key="sk-test")
         with patch(
-            "packages.valory.customs.superforcaster.superforcaster.OpenAIClient"
-        ) as MockClient:
+            "packages.valory.customs.superforcaster.superforcaster.OpenAI"
+        ) as MockOpenAI:
             mock_instance = MagicMock()
-            MockClient.return_value = mock_instance
+            MockOpenAI.return_value = mock_instance
 
             with mgr as client:
                 assert client is mock_instance
-                MockClient.assert_called_once_with(api_key="sk-test")
+                MockOpenAI.assert_called_once_with(api_key="sk-test")
 
-            mock_instance.client.close.assert_called_once()
+            mock_instance.close.assert_called_once()
 
     def test_no_global_client_variable(self) -> None:
         """The module must not define a module-level 'client' variable."""
@@ -63,9 +64,9 @@ class TestOpenAIClientManager:
                         f"Module-level 'client' variable found at line {i}: {line}"
                     )
 
-    def test_generate_prediction_requires_client_param(self) -> None:
-        """generate_prediction_with_retry requires client as first param."""
-        params = list(inspect.signature(generate_prediction_with_retry).parameters)
+    def test_parse_completion_requires_client_param(self) -> None:
+        """_parse_completion requires client as first param."""
+        params = list(inspect.signature(_parse_completion).parameters)
         assert params[0] == "client"
 
 
@@ -86,8 +87,16 @@ FAKE_SERPER_RESPONSE = {
     ],
 }
 
-PREDICTION_JSON = json.dumps(
-    {"p_yes": 0.5, "p_no": 0.5, "confidence": 0.5, "info_utility": 0.5}
+FAKE_PREDICTION = PredictionResult(
+    facts="Fact 1. Fact 2.",
+    reasons_no="No 1 (strength 6). No 2 (strength 4).",
+    reasons_yes="Yes 1 (strength 5). Yes 2 (strength 3).",
+    aggregation="Base rate 0.5. Tentative: 0.5.",
+    reflection="Passes evidence bar.",
+    p_yes=0.5,
+    p_no=0.5,
+    confidence=0.5,
+    info_utility=0.5,
 )
 
 PREDICTION_PROMPT = (
@@ -110,6 +119,116 @@ def _make_mock_api_keys(return_source_content: str = "false") -> MagicMock:
     return mock
 
 
+def _mock_parse_response() -> MagicMock:
+    """Build a fake response object matching the beta.chat.completions.parse shape."""
+    return MagicMock(
+        choices=[MagicMock(message=MagicMock(parsed=FAKE_PREDICTION, refusal=None))],
+        usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+class TestStructuredOutputContract:
+    """Verify the tool uses OpenAI Structured Outputs and returns only the 4 on-chain fields."""
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_uses_beta_parse_with_prediction_result_schema(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """run() calls client.beta.chat.completions.parse with response_format=PredictionResult."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        run(
+            tool="superforcaster",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+
+        mock_client.beta.chat.completions.parse.assert_called_once()
+        kwargs = mock_client.beta.chat.completions.parse.call_args.kwargs
+        assert kwargs["response_format"] is PredictionResult
+        assert kwargs["model"] == "gpt-4.1-2025-04-14"
+        mock_client.chat.completions.create.assert_not_called()
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_returns_only_four_mech_fields_on_chain(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """The on-chain result JSON contains exactly p_yes/p_no/confidence/info_utility."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = run(
+            tool="superforcaster",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+
+        on_chain_json = result[0]
+        parsed = json.loads(on_chain_json)
+        assert set(parsed.keys()) == {"p_yes", "p_no", "confidence", "info_utility"}
+        assert "facts" not in parsed
+        assert "reasons_no" not in parsed
+        assert "aggregation" not in parsed
+        assert "reflection" not in parsed
+        assert parsed["p_yes"] == 0.5
+        assert parsed["p_no"] == 0.5
+
+
+class TestPredictionResultValidator:
+    """Pydantic sum validator rejects malformed probabilities."""
+
+    def test_valid_sum_accepted(self) -> None:
+        """p_yes + p_no = 1.0 is accepted."""
+        obj = PredictionResult(
+            facts="f",
+            reasons_no="n",
+            reasons_yes="y",
+            aggregation="a",
+            reflection="r",
+            p_yes=0.7,
+            p_no=0.3,
+            confidence=0.6,
+            info_utility=0.5,
+        )
+        assert obj.p_yes == 0.7
+
+    def test_sum_violation_rejected(self) -> None:
+        """p_yes + p_no outside 0.01 tolerance raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PredictionResult(
+                facts="f",
+                reasons_no="n",
+                reasons_yes="y",
+                aggregation="a",
+                reflection="r",
+                p_yes=0.7,
+                p_no=0.2,
+                confidence=0.6,
+                info_utility=0.5,
+            )
+
+
 class TestSuperforcasterSourceContent:
     """Verify superforcaster captures and replays source_content correctly."""
 
@@ -124,16 +243,13 @@ class TestSuperforcasterSourceContent:
         mock_fetch.return_value = mock_response
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         result = run(
             tool="superforcaster",
-            model="gpt-4o",
+            model="gpt-4.1-2025-04-14",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("true"),
             counter_callback=None,
@@ -151,17 +267,14 @@ class TestSuperforcasterSourceContent:
     ) -> None:
         """Replay with {'serper_response': ...} uses organic and peopleAlsoAsk."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         source_content = {"serper_response": FAKE_SERPER_RESPONSE}
         result = run(
             tool="superforcaster",
-            model="gpt-4o",
+            model="gpt-4.1-2025-04-14",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("true"),
             counter_callback=None,
@@ -185,16 +298,13 @@ class TestSuperforcasterSourceContent:
         mock_fetch.return_value = mock_response
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         result = run(
             tool="superforcaster",
-            model="gpt-4o",
+            model="gpt-4.1-2025-04-14",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("false"),
             counter_callback=None,

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeiakj4ekdw6gqbplpq6n7vynv3rk2hlmlp3fko2x6bd43dzbg5cb3y
+agent: valory/mech_predict:0.1.0:bafybeiagbnduttizdzluz3bn2remkyti6rsj2ognoni3gyp56ov7hg323a
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeihzthsfntge7wghphyvdwje2nsgwfrvuu3h3ym7lfxfvcrq6fwadq
+agent: valory/mech_predict:0.1.0:bafybeiakj4ekdw6gqbplpq6n7vynv3rk2hlmlp3fko2x6bd43dzbg5cb3y
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeiagbnduttizdzluz3bn2remkyti6rsj2ognoni3gyp56ov7hg323a
+agent: valory/mech_predict:0.1.0:bafybeibqfyppjzcy2hdwn4f7jhxt2byh6ubg3zju4cvqqm6xqsy7knvfgq
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
Closes #221.

## Summary

- `superforcaster` delivers: swap the contradictory JSON-in-prompt path (7-step XML reasoning chain + "output only JSON") for OpenAI Structured Outputs against a `PredictionResult` pydantic schema. The model physically cannot return free-form text anymore — the `<facts>`-leak mode that hit 25–30%/day on Gnosis (since 2026-04-08) is no longer representable. Superforecaster methodology (CALIBRATION base rate, EVIDENCE BAR, CONFIDENCE COUPLING, NUMERIC QUESTIONS, bias adjustments) is preserved verbatim — only the XML scaffolding and the per-step structural distinctness of steps 5 and 7 were compressed. See the commit body on `0bdce2cf` for methodology diff.
- `benchmark/prompt_replay`: add `_call_openai_structured` + a `tool_name → schema class` registry so tools using structured outputs (superforcaster now, `factual_research` already) can be replayed honestly instead of fallen-through to `chat.completions.create`.
- `benchmark/prompt_replay` + `benchmark/ci_replay`: surface **parse reliability** as a first-class metric. #221 was invisible to every existing dashboard because an on-chain deliver with a malformed `toolResponse` counted as a success — Brier and accuracy both skipped it. The replay summary and PR comment now report `valid/total` with a 4-bucket breakdown and flag any candidate drop vs baseline (⚠️); failure bodies are persisted to `candidate_failures.jsonl` and inlined in a collapsed `<details>` in the PR comment for forensic inspection.

On-chain output is unchanged — only the four standard mech fields (`p_yes`, `p_no`, `confidence`, `info_utility`) are serialised.

## Test plan
- [x] `pytest packages/valory/customs/superforcaster/tests` — 10/10 green (schema contract, on-chain shape, validator, source_content replay)
- [x] `pytest benchmark/tests` — 307/307 green, including 10 new tests for `ci_replay` reliability rendering
- [x] Local `prompt_replay` on N=11 stratified sample: 11/11 candidate parse success (vs the 25-30% leak rate in prod)
- [ ] Larger CI sweep via `/benchmark superforcaster` — see next comment