### PR TITLE
ci: add All checks passed aggregate gate

### DIFF
--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -192,6 +192,7 @@ jobs:
       - linter_checks
       - scan
       - unit_tests
+      - integration_tests
     steps:
       - name: Verify all required checks succeeded
         run: |
@@ -203,7 +204,7 @@ jobs:
           echo "All required checks passed."
 
   integration_tests:
-    continue-on-error: True
+    continue-on-error: False
     needs:
       - unit_tests
     runs-on: ubuntu-22.04

--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -182,6 +182,26 @@ jobs:
         name: Unit tests windows-2025
         run: tox -e py${{ matrix.python-version }}-win
 
+  all_checks_passed:
+    name: All checks passed
+    runs-on: ubuntu-22.04
+    if: always()
+    needs:
+      - lock_check
+      - copyright_and_dependencies_check
+      - linter_checks
+      - scan
+      - unit_tests
+    steps:
+      - name: Verify all required checks succeeded
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
+            echo "One or more required checks failed, were cancelled, or were skipped."
+            echo "Results: ${{ toJSON(needs) }}"
+            exit 1
+          fi
+          echo "All required checks passed."
+
   integration_tests:
     continue-on-error: True
     needs:


### PR DESCRIPTION
## Summary
- Adds a single `All checks passed` meta job to `common_checks.yaml` that aggregates the status of all mandatory CI jobs (`lock_check`, `copyright_and_dependencies_check`, `linter_checks`, `scan`, `unit_tests`).
- Branch protection on `main` will reference this single context instead of mirroring the full matrix. To add/remove a mandatory job in the future, update this job's `needs` list — no branch-protection edit required.
- Integration tests are excluded (they run with `continue-on-error: true` and are not mandatory).

## Test plan
- [ ] CI runs on this PR and the new `All checks passed` job appears in the checks list
- [ ] The job succeeds when all upstream jobs succeed
- [ ] The job fails if any upstream mandatory job fails/cancels/skips (verified by the `contains(needs.*.result, ...)` guard)

Part of applying the standard Valory public-repo governance settings. Branch protection requiring this context will be configured after this PR merges.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
