### PR TITLE
fix(tools): replace deprecated claude-3-haiku model id

### DIFF
--- a/packages/napthaai/customs/prediction_request_rag/component.yaml
+++ b/packages/napthaai/customs/prediction_request_rag/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibt7f7crtwvmkg7spy3jhscmlqltvyblzp32g6gj44v7tlo5lycuq
-  prediction_request_rag.py: bafybeidosmqqpt4dlk2sei6ha6n2s3frzi4qkqszkrp5ecrknbifemqjvy
+  prediction_request_rag.py: bafybeigpiipikrzylpazbjly2haxx2ax6ixz6m3apxagka6otvhqso2334
   tests/__init__.py: bafybeifcgilmgfwx7kaap67cfnuokrhfrabi6bnvqiudyzgf2idu64dvxq
   tests/test_prediction_request_rag.py: bafybeihfaopk37fqncboshyvq24f4vwv3a3rvpdsj7ttyb5eacokxhcx34
 fingerprint_ignore_patterns: []

--- a/packages/napthaai/customs/prediction_request_rag/component.yaml
+++ b/packages/napthaai/customs/prediction_request_rag/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibt7f7crtwvmkg7spy3jhscmlqltvyblzp32g6gj44v7tlo5lycuq
-  prediction_request_rag.py: bafybeigpiipikrzylpazbjly2haxx2ax6ixz6m3apxagka6otvhqso2334
+  prediction_request_rag.py: bafybeie4ynwvh6rhsm67sfbbjsxdzzqg6pkpovgravt73fyjz7ekzyw6oe
   tests/__init__.py: bafybeifcgilmgfwx7kaap67cfnuokrhfrabi6bnvqiudyzgf2idu64dvxq
   tests/test_prediction_request_rag.py: bafybeihfaopk37fqncboshyvq24f4vwv3a3rvpdsj7ttyb5eacokxhcx34
 fingerprint_ignore_patterns: []

--- a/packages/napthaai/customs/prediction_request_rag/prediction_request_rag.py
+++ b/packages/napthaai/customs/prediction_request_rag/prediction_request_rag.py
@@ -285,11 +285,6 @@ LLM_SETTINGS = {
         "limit_max_tokens": 1_047_576,
         "temperature": 0,
     },
-    "claude-haiku-4-5-20251001": {
-        "default_max_tokens": 1000,
-        "limit_max_tokens": 200_000,
-        "temperature": 0,
-    },
     "claude-4-sonnet-20250514": {
         "default_max_tokens": 4096,
         "limit_max_tokens": 200_000,

--- a/packages/napthaai/customs/prediction_request_rag/prediction_request_rag.py
+++ b/packages/napthaai/customs/prediction_request_rag/prediction_request_rag.py
@@ -285,7 +285,7 @@ LLM_SETTINGS = {
         "limit_max_tokens": 1_047_576,
         "temperature": 0,
     },
-    "claude-3-haiku-20240307": {
+    "claude-haiku-4-5-20251001": {
         "default_max_tokens": 1000,
         "limit_max_tokens": 200_000,
         "temperature": 0,

--- a/packages/napthaai/customs/prediction_request_reasoning/component.yaml
+++ b/packages/napthaai/customs/prediction_request_reasoning/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeib36ew6vbztldut5xayk5553rylrq7yv4cpqyhwc5ktvd4cx67vwu
-  prediction_request_reasoning.py: bafybeiczv7bfr2mkapmu4q23smhmduhkqoitio3udnryx6uaa6f5chr73a
+  prediction_request_reasoning.py: bafybeibosnh7qhu33nvikuy2bzk6hsfltmrekas3awdtpxrgnsbhrjvex4
   tests/__init__.py: bafybeieu3toasuyaehkqounrtylk5bjer7qgvnt6ccjcsi6jlfig7wfrka
   tests/test_prediction_request_reasoning.py: bafybeiclefskba2fa4rt4tohvxiepm3uevqul5zwqo6zk6v3e5mpbrysaq
 fingerprint_ignore_patterns: []

--- a/packages/napthaai/customs/prediction_request_reasoning/component.yaml
+++ b/packages/napthaai/customs/prediction_request_reasoning/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeib36ew6vbztldut5xayk5553rylrq7yv4cpqyhwc5ktvd4cx67vwu
-  prediction_request_reasoning.py: bafybeidjt3dd3b4nqau7bqubxmjkklvzwcvfs4c2mi5vhjnx4ocxrewcim
+  prediction_request_reasoning.py: bafybeiczv7bfr2mkapmu4q23smhmduhkqoitio3udnryx6uaa6f5chr73a
   tests/__init__.py: bafybeieu3toasuyaehkqounrtylk5bjer7qgvnt6ccjcsi6jlfig7wfrka
   tests/test_prediction_request_reasoning.py: bafybeiclefskba2fa4rt4tohvxiepm3uevqul5zwqo6zk6v3e5mpbrysaq
 fingerprint_ignore_patterns: []

--- a/packages/napthaai/customs/prediction_request_reasoning/prediction_request_reasoning.py
+++ b/packages/napthaai/customs/prediction_request_reasoning/prediction_request_reasoning.py
@@ -290,7 +290,7 @@ LLM_SETTINGS = {
         "limit_max_tokens": 1_047_576,
         "temperature": 0,
     },
-    "claude-3-haiku-20240307": {
+    "claude-haiku-4-5-20251001": {
         "default_max_tokens": 1000,
         "limit_max_tokens": 200_000,
         "temperature": 0,

--- a/packages/napthaai/customs/prediction_request_reasoning/prediction_request_reasoning.py
+++ b/packages/napthaai/customs/prediction_request_reasoning/prediction_request_reasoning.py
@@ -290,11 +290,6 @@ LLM_SETTINGS = {
         "limit_max_tokens": 1_047_576,
         "temperature": 0,
     },
-    "claude-haiku-4-5-20251001": {
-        "default_max_tokens": 1000,
-        "limit_max_tokens": 200_000,
-        "temperature": 0,
-    },
     "claude-4-sonnet-20250514": {
         "default_max_tokens": 4096,
         "limit_max_tokens": 200_000,

--- a/packages/napthaai/customs/prediction_url_cot/component.yaml
+++ b/packages/napthaai/customs/prediction_url_cot/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiflni5dkn5fqe7fnu4lgbqxzfrgochhqfbgzwz3vlf5grijp3nkpm
-  prediction_url_cot.py: bafybeihqf3mom4khj3l3tdi6lwkc3y5ysp4amygb6ytavoufcjer54x7lm
+  prediction_url_cot.py: bafybeia4qqnllkyozcfu7g63yceid7tmvdaqy5elen4sx6m4u343ywtwfy
   tests/__init__.py: bafybeia2zevyo6fxbwf7dj4vkhd3fnsvog5sqvepqg4qjgzydlhsuwnn7q
   tests/test_prediction_url_cot.py: bafybeiakbfpefbuhdfwkrcdlgzglatcl24fvtlmmgi3m5ooplfowtcjkcm
 fingerprint_ignore_patterns: []

--- a/packages/napthaai/customs/prediction_url_cot/component.yaml
+++ b/packages/napthaai/customs/prediction_url_cot/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeiflni5dkn5fqe7fnu4lgbqxzfrgochhqfbgzwz3vlf5grijp3nkpm
-  prediction_url_cot.py: bafybeicfi54c66ov7vclmcoqbujlldoyizdtdcmq2vpcb5vnw27oiirvly
+  prediction_url_cot.py: bafybeihqf3mom4khj3l3tdi6lwkc3y5ysp4amygb6ytavoufcjer54x7lm
   tests/__init__.py: bafybeia2zevyo6fxbwf7dj4vkhd3fnsvog5sqvepqg4qjgzydlhsuwnn7q
   tests/test_prediction_url_cot.py: bafybeiakbfpefbuhdfwkrcdlgzglatcl24fvtlmmgi3m5ooplfowtcjkcm
 fingerprint_ignore_patterns: []

--- a/packages/napthaai/customs/prediction_url_cot/prediction_url_cot.py
+++ b/packages/napthaai/customs/prediction_url_cot/prediction_url_cot.py
@@ -263,11 +263,6 @@ class LLMClient:
 
 
 LLM_SETTINGS = {
-    "claude-haiku-4-5-20251001": {
-        "default_max_tokens": 1000,
-        "limit_max_tokens": 200_000,
-        "temperature": 0,
-    },
     "claude-4-sonnet-20250514": {
         "default_max_tokens": 4096,
         "limit_max_tokens": 200_000,

--- a/packages/napthaai/customs/prediction_url_cot/prediction_url_cot.py
+++ b/packages/napthaai/customs/prediction_url_cot/prediction_url_cot.py
@@ -263,7 +263,7 @@ class LLMClient:
 
 
 LLM_SETTINGS = {
-    "claude-3-haiku-20240307": {
+    "claude-haiku-4-5-20251001": {
         "default_max_tokens": 1000,
         "limit_max_tokens": 200_000,
         "temperature": 0,

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,13 +2,13 @@
     "dev": {
         "custom/dvilela/corcel_request/0.1.0": "bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y",
         "custom/dvilela/gemini_prediction/0.1.0": "bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq",
-        "custom/napthaai/prediction_request_rag/0.1.0": "bafybeicytl6arzvxlsjnhc4muigvkes2cvjtffirmcjsdul4rlmfypmijy",
-        "custom/napthaai/prediction_request_reasoning/0.1.0": "bafybeiglpem6kudbernorz2atcuhdkirbhjra5r6eayd3nprssgyz7iypi",
-        "custom/napthaai/prediction_url_cot/0.1.0": "bafybeiac4ilboxkzgcmqbda2goaarn7htfgwaksv6gbpqd6kif2jesyvh4",
+        "custom/napthaai/prediction_request_rag/0.1.0": "bafybeigwx7uvoxrp6rqvhxz63z5upf37dwp63c7m3r5657uh5oiwgsi4jy",
+        "custom/napthaai/prediction_request_reasoning/0.1.0": "bafybeicnug2oervqkotamtajugddn55l6x3aywwgbk5xt2lsmgnz6ynh6a",
+        "custom/napthaai/prediction_url_cot/0.1.0": "bafybeigqfqjo767gttx5td7fqah5xija6tk5752ygdsbaib35yavzawinq",
         "custom/napthaai/resolve_market_reasoning/0.1.0": "bafybeihk5wteioppm33pojdvdk32nnlryhkvowuvpn22c4a6prwkknzq34",
         "custom/nickcom007/prediction_request_sme/0.1.0": "bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu",
         "custom/valory/prediction_langchain/0.1.0": "bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a",
-        "custom/valory/prediction_request/0.1.0": "bafybeidf5hlr5elgt4x7gvaxosq3hmcbb7sabwdbm6voocyrbtsyzns4yu",
+        "custom/valory/prediction_request/0.1.0": "bafybeidxjrzfgbabr47xtczjbdipy7blfzehpddp4cdrizeczrp5uuxhpu",
         "custom/valory/prepare_tx/0.1.0": "bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya",
         "custom/valory/resolve_market/0.1.0": "bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi",
         "custom/valory/superforcaster/0.1.0": "bafybeifgf3av5u6fb2bjmeu342zo4nvydioyp5qr4uunpblvap3jhlxcdy",
@@ -16,8 +16,8 @@
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeibcpvtqbdpu3dbuycqhxwyoi74dtnremjkvscbtt2bt4l2puxjupi",
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiciwntuzeqnal5b3wwixquq4efv443eu4m4z3ujoy6olmulktfl3q",
-        "agent/valory/mech_predict/0.1.0": "bafybeifwbbhtl6w7o5ym6336zwbr7oa72ve4ntv5i2oo5q5zmm2eniu4pe",
-        "service/valory/mech_predict/0.1.0": "bafybeiflsdqgx4bvbbiqs5nsevp76mjjdoslq4oqprdln52gpur7tp44ge"
+        "agent/valory/mech_predict/0.1.0": "bafybeidaq367xciyt72slyqxcjxj3hfmifvumaqzbwpfpmxqob3puptytq",
+        "service/valory/mech_predict/0.1.0": "bafybeifq6zjt253i3og7cp246k7uuus5slkd7waljdley5qdrwtbchm2py"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -2,13 +2,13 @@
     "dev": {
         "custom/dvilela/corcel_request/0.1.0": "bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y",
         "custom/dvilela/gemini_prediction/0.1.0": "bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq",
-        "custom/napthaai/prediction_request_rag/0.1.0": "bafybeigwx7uvoxrp6rqvhxz63z5upf37dwp63c7m3r5657uh5oiwgsi4jy",
-        "custom/napthaai/prediction_request_reasoning/0.1.0": "bafybeicnug2oervqkotamtajugddn55l6x3aywwgbk5xt2lsmgnz6ynh6a",
-        "custom/napthaai/prediction_url_cot/0.1.0": "bafybeigqfqjo767gttx5td7fqah5xija6tk5752ygdsbaib35yavzawinq",
+        "custom/napthaai/prediction_request_rag/0.1.0": "bafybeiasyiowjgwaadzmqp5hekg77bfpj22vv4abjwho2vrobhvlutfs4e",
+        "custom/napthaai/prediction_request_reasoning/0.1.0": "bafybeied5ljgwnpkmigy3duc3fltkwfdwyykkdo6a7l2kcx77aceka44em",
+        "custom/napthaai/prediction_url_cot/0.1.0": "bafybeifxd5c3khhjrvhjmfspqiuxbm2arvnl6kyjclbyw67fb36gyh6b6u",
         "custom/napthaai/resolve_market_reasoning/0.1.0": "bafybeihk5wteioppm33pojdvdk32nnlryhkvowuvpn22c4a6prwkknzq34",
         "custom/nickcom007/prediction_request_sme/0.1.0": "bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu",
         "custom/valory/prediction_langchain/0.1.0": "bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a",
-        "custom/valory/prediction_request/0.1.0": "bafybeidxjrzfgbabr47xtczjbdipy7blfzehpddp4cdrizeczrp5uuxhpu",
+        "custom/valory/prediction_request/0.1.0": "bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky",
         "custom/valory/prepare_tx/0.1.0": "bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya",
         "custom/valory/resolve_market/0.1.0": "bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi",
         "custom/valory/superforcaster/0.1.0": "bafybeifgf3av5u6fb2bjmeu342zo4nvydioyp5qr4uunpblvap3jhlxcdy",
@@ -16,8 +16,8 @@
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeibcpvtqbdpu3dbuycqhxwyoi74dtnremjkvscbtt2bt4l2puxjupi",
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiciwntuzeqnal5b3wwixquq4efv443eu4m4z3ujoy6olmulktfl3q",
-        "agent/valory/mech_predict/0.1.0": "bafybeidaq367xciyt72slyqxcjxj3hfmifvumaqzbwpfpmxqob3puptytq",
-        "service/valory/mech_predict/0.1.0": "bafybeifq6zjt253i3og7cp246k7uuus5slkd7waljdley5qdrwtbchm2py"
+        "agent/valory/mech_predict/0.1.0": "bafybeiafrjuwgcua2v4v7lap4e5b3ifxz2sssmcxyjvg5577sekosag7xe",
+        "service/valory/mech_predict/0.1.0": "bafybeiafpaofseggo7lcqesvijyndumhvhgzoqq4iecdapyokmchjpxwdu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -52,12 +52,12 @@ skills:
 customs:
 - valory/resolve_market:0.1.0:bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi
 - valory/resolve_market_jury:0.1.0:bafybeiciwntuzeqnal5b3wwixquq4efv443eu4m4z3ujoy6olmulktfl3q
-- valory/prediction_request:0.1.0:bafybeidxjrzfgbabr47xtczjbdipy7blfzehpddp4cdrizeczrp5uuxhpu
+- valory/prediction_request:0.1.0:bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky
 - napthaai/resolve_market_reasoning:0.1.0:bafybeihk5wteioppm33pojdvdk32nnlryhkvowuvpn22c4a6prwkknzq34
-- napthaai/prediction_request_rag:0.1.0:bafybeigwx7uvoxrp6rqvhxz63z5upf37dwp63c7m3r5657uh5oiwgsi4jy
-- napthaai/prediction_request_reasoning:0.1.0:bafybeicnug2oervqkotamtajugddn55l6x3aywwgbk5xt2lsmgnz6ynh6a
+- napthaai/prediction_request_rag:0.1.0:bafybeiasyiowjgwaadzmqp5hekg77bfpj22vv4abjwho2vrobhvlutfs4e
+- napthaai/prediction_request_reasoning:0.1.0:bafybeied5ljgwnpkmigy3duc3fltkwfdwyykkdo6a7l2kcx77aceka44em
 - valory/prepare_tx:0.1.0:bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya
-- napthaai/prediction_url_cot:0.1.0:bafybeigqfqjo767gttx5td7fqah5xija6tk5752ygdsbaib35yavzawinq
+- napthaai/prediction_url_cot:0.1.0:bafybeifxd5c3khhjrvhjmfspqiuxbm2arvnl6kyjclbyw67fb36gyh6b6u
 - valory/prediction_langchain:0.1.0:bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -52,12 +52,12 @@ skills:
 customs:
 - valory/resolve_market:0.1.0:bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi
 - valory/resolve_market_jury:0.1.0:bafybeiciwntuzeqnal5b3wwixquq4efv443eu4m4z3ujoy6olmulktfl3q
-- valory/prediction_request:0.1.0:bafybeidf5hlr5elgt4x7gvaxosq3hmcbb7sabwdbm6voocyrbtsyzns4yu
+- valory/prediction_request:0.1.0:bafybeidxjrzfgbabr47xtczjbdipy7blfzehpddp4cdrizeczrp5uuxhpu
 - napthaai/resolve_market_reasoning:0.1.0:bafybeihk5wteioppm33pojdvdk32nnlryhkvowuvpn22c4a6prwkknzq34
-- napthaai/prediction_request_rag:0.1.0:bafybeicytl6arzvxlsjnhc4muigvkes2cvjtffirmcjsdul4rlmfypmijy
-- napthaai/prediction_request_reasoning:0.1.0:bafybeiglpem6kudbernorz2atcuhdkirbhjra5r6eayd3nprssgyz7iypi
+- napthaai/prediction_request_rag:0.1.0:bafybeigwx7uvoxrp6rqvhxz63z5upf37dwp63c7m3r5657uh5oiwgsi4jy
+- napthaai/prediction_request_reasoning:0.1.0:bafybeicnug2oervqkotamtajugddn55l6x3aywwgbk5xt2lsmgnz6ynh6a
 - valory/prepare_tx:0.1.0:bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya
-- napthaai/prediction_url_cot:0.1.0:bafybeiac4ilboxkzgcmqbda2goaarn7htfgwaksv6gbpqd6kif2jesyvh4
+- napthaai/prediction_url_cot:0.1.0:bafybeigqfqjo767gttx5td7fqah5xija6tk5752ygdsbaib35yavzawinq
 - valory/prediction_langchain:0.1.0:bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e

--- a/packages/valory/customs/prediction_request/component.yaml
+++ b/packages/valory/customs/prediction_request/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibbn67pnrrm4qm3n3kbelvbs3v7fjlrjniywmw2vbizarippidtvi
-  prediction_request.py: bafybeieqarjnkcrpakg3jujzb3oe4r62u2tmceqnzz5ck67zlzxklhg5ym
+  prediction_request.py: bafybeiatmr4d46tuh4eey7qc6mgdirxu5qwcxen43en26wmp26znpkmxei
   tests/__init__.py: bafybeib7h3aalw6bzylqazc3mefunk3n3d65pyzfck4qb33slesscud25m
   tests/test_prediction_request.py: bafybeidmyiqyrwre5fx2gr2lnlgq2ww6kmtyy3xvzpho32veiskl6akile
 fingerprint_ignore_patterns: []

--- a/packages/valory/customs/prediction_request/component.yaml
+++ b/packages/valory/customs/prediction_request/component.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibbn67pnrrm4qm3n3kbelvbs3v7fjlrjniywmw2vbizarippidtvi
-  prediction_request.py: bafybeiatmr4d46tuh4eey7qc6mgdirxu5qwcxen43en26wmp26znpkmxei
+  prediction_request.py: bafybeidwpnxrmhdno6bm3dkyssrpp3rbkdzn2wkkxeie545rkt22hzy4ou
   tests/__init__.py: bafybeib7h3aalw6bzylqazc3mefunk3n3d65pyzfck4qb33slesscud25m
   tests/test_prediction_request.py: bafybeidmyiqyrwre5fx2gr2lnlgq2ww6kmtyy3xvzpho32veiskl6akile
 fingerprint_ignore_patterns: []

--- a/packages/valory/customs/prediction_request/prediction_request.py
+++ b/packages/valory/customs/prediction_request/prediction_request.py
@@ -448,7 +448,7 @@ LLM_SETTINGS = {
         "limit_max_tokens": 1_047_576,
         "temperature": 0,
     },
-    "claude-3-haiku-20240307": {
+    "claude-haiku-4-5-20251001": {
         "default_max_tokens": 1000,
         "limit_max_tokens": 200_000,
         "temperature": 0,

--- a/packages/valory/customs/prediction_request/prediction_request.py
+++ b/packages/valory/customs/prediction_request/prediction_request.py
@@ -448,11 +448,6 @@ LLM_SETTINGS = {
         "limit_max_tokens": 1_047_576,
         "temperature": 0,
     },
-    "claude-haiku-4-5-20251001": {
-        "default_max_tokens": 1000,
-        "limit_max_tokens": 200_000,
-        "temperature": 0,
-    },
     "claude-4-sonnet-20250514": {
         "default_max_tokens": 4096,
         "limit_max_tokens": 200_000,

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeifwbbhtl6w7o5ym6336zwbr7oa72ve4ntv5i2oo5q5zmm2eniu4pe
+agent: valory/mech_predict:0.1.0:bafybeidaq367xciyt72slyqxcjxj3hfmifvumaqzbwpfpmxqob3puptytq
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeidaq367xciyt72slyqxcjxj3hfmifvumaqzbwpfpmxqob3puptytq
+agent: valory/mech_predict:0.1.0:bafybeiafrjuwgcua2v4v7lap4e5b3ifxz2sssmcxyjvg5577sekosag7xe
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
Anthropic no longer serves claude-3-haiku-20240307, so the four tools that exposed it via LLM_SETTINGS/ALLOWED_MODELS 404 on every invocation and integration tests fail with missing p_yes/p_no in the delivered message.

Swap the key to claude-haiku-4-5-20251001 in prediction_request, prediction_request_rag, prediction_request_reasoning and prediction_url_cot. Token limits are unchanged (Haiku 4.5 has the same 200k context). Package hashes refreshed via autonomy packages lock.