### PR TITLE
feat(benchmark): wire factual_research through prompt_replay pipeline

### DIFF
--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -86,9 +86,9 @@ jobs:
             TRIGGERED_BY="$COMMENT_USER"
           fi
 
-          # Whitelist: tool name must be lowercase alphanumeric + hyphens only
-          if ! echo "$TOOL" | grep -qP '^[a-z0-9-]+$'; then
-            echo "::error::Invalid tool name: '$TOOL'. Must match [a-z0-9-]+"
+          # Whitelist: tool name must be lowercase alphanumeric + hyphens/underscores
+          if ! echo "$TOOL" | grep -qP '^[a-z0-9_-]+$'; then
+            echo "::error::Invalid tool name: '$TOOL'. Must match [a-z0-9_-]+"
             exit 1
           fi
 

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -315,9 +315,15 @@ def _extract_factual_research_prompt_components(
         messages = json.loads(reframe_match.group(1))
     except json.JSONDecodeError:
         return None
+    if not isinstance(messages, list):
+        return None
 
     user_content = next(
-        (m.get("content", "") for m in messages if m.get("role") == "user"),
+        (
+            m.get("content", "")
+            for m in messages
+            if isinstance(m, dict) and m.get("role") == "user"
+        ),
         "",
     )
     q_match = FR_QUESTION_TODAY_RE.search(user_content)

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -120,6 +120,19 @@ SF_QUESTION_RE = re.compile(r"Question:\n(.*?)\n\nToday's date:", re.DOTALL)
 SF_TODAY_RE = re.compile(r"Today's date:\s*(.*)")
 SF_SOURCES_RE = re.compile(r"<background>(.*?)</background>", re.DOTALL)
 
+# Extraction from factual_research audit-dump prompts. The prod tool writes a
+# multi-section trail (see factual_research.py `full_prompt_used`); we recover
+# the original question + today from the REFRAME chat-messages JSON, and the
+# factual briefing verbatim from the BRIEFING section.
+FR_BRIEFING_RE = re.compile(r"--- BRIEFING ---\n(.*?)\n\n--- ESTIMATE ---", re.DOTALL)
+FR_REFRAME_RE = re.compile(
+    r"--- REFRAME ---\n(.*?)\n\n--- SUB-QUESTIONS ---", re.DOTALL
+)
+FR_QUESTION_TODAY_RE = re.compile(
+    r'INPUT QUESTION:\s*"""(.*?)"""\s*\n\s*Today\'s date:\s*(.*?)(?:\n|$)',
+    re.DOTALL,
+)
+
 
 # ---------------------------------------------------------------------------
 # IPFS helpers (adapted from sweep.py / fetch_production.py)
@@ -279,6 +292,45 @@ def _extract_superforcaster_prompt_components(
     return result
 
 
+def _extract_factual_research_prompt_components(
+    formatted_prompt: str,
+) -> Optional[dict[str, str]]:
+    """Extract (question, briefing, today) from a factual_research IPFS dump.
+
+    The prod tool stores a multi-section audit trail (factual_research.py
+    `full_prompt_used`). Replay only re-runs the ESTIMATE step, so we need the
+    original question + today (embedded in the REFRAME chat-messages JSON via
+    REFRAME_USER) and the factual briefing body from the BRIEFING section.
+
+    :param formatted_prompt: the full IPFS prompt string.
+    :return: dict with user_prompt/additional_information/today, or None if
+        any required section is missing or malformed.
+    """
+    reframe_match = FR_REFRAME_RE.search(formatted_prompt)
+    briefing_match = FR_BRIEFING_RE.search(formatted_prompt)
+    if not reframe_match or not briefing_match:
+        return None
+
+    try:
+        messages = json.loads(reframe_match.group(1))
+    except json.JSONDecodeError:
+        return None
+
+    user_content = next(
+        (m.get("content", "") for m in messages if m.get("role") == "user"),
+        "",
+    )
+    q_match = FR_QUESTION_TODAY_RE.search(user_content)
+    if not q_match:
+        return None
+
+    return {
+        "user_prompt": q_match.group(1).strip(),
+        "additional_information": briefing_match.group(1).strip(),
+        "today": q_match.group(2).strip(),
+    }
+
+
 def extract_prompt_components(
     formatted_prompt: str,
     tool_name: str = "prediction-online",
@@ -297,6 +349,9 @@ def extract_prompt_components(
 
     if tool_name == "superforcaster":
         return _extract_superforcaster_prompt_components(formatted_prompt)
+
+    if tool_name == "factual_research":
+        return _extract_factual_research_prompt_components(formatted_prompt)
 
     # Default: prediction-online format
     up_match = USER_PROMPT_RE.search(formatted_prompt)
@@ -1226,6 +1281,7 @@ def replay(  # pylint: disable=too-many-statements
     is_reasoning_tool = tool_name.startswith("prediction-request-reasoning")
     is_rag_tool = tool_name.startswith("prediction-request-rag")
     is_superforcaster = tool_name == "superforcaster"
+    is_factual_research = tool_name == "factual_research"
 
     # Import prompt templates from the appropriate tool module
     if is_reasoning_tool:
@@ -1250,6 +1306,16 @@ def replay(  # pylint: disable=too-many-statements
         )
 
         system_prompt = "You are a helpful assistant."
+    elif is_factual_research:
+        # Replay only the ESTIMATE step; REFRAME + SYNTHESIS are upstream and
+        # use cached evidence. ESTIMATE_USER takes (question, today, briefing).
+        from packages.valory.customs.factual_research.factual_research import (  # pylint: disable=import-outside-toplevel
+            ESTIMATE_SYSTEM,
+            ESTIMATE_USER,
+        )
+
+        PREDICTION_PROMPT = ESTIMATE_USER
+        system_prompt = ESTIMATE_SYSTEM
     else:
         from packages.valory.customs.prediction_request.prediction_request import (  # pylint: disable=import-outside-toplevel
             PREDICTION_PROMPT,
@@ -1349,7 +1415,8 @@ def replay(  # pylint: disable=too-many-statements
                     parser_reasoning_response=parser_reasoning_response,
                 )
             else:
-                # Single-stage tool (prediction-online, superforcaster, RAG)
+                # Single-stage tool (prediction-online, superforcaster, RAG,
+                # factual_research ESTIMATE)
                 if is_rag_tool:
                     formatted_prompt = PREDICTION_PROMPT.format(
                         USER_PROMPT=row["extracted_user_prompt"],
@@ -1360,6 +1427,12 @@ def replay(  # pylint: disable=too-many-statements
                         question=row["extracted_user_prompt"],
                         today=row.get("extracted_today", ""),
                         sources=row["extracted_additional_information"],
+                    )
+                elif is_factual_research:
+                    formatted_prompt = PREDICTION_PROMPT.format(
+                        question=row["extracted_user_prompt"],
+                        today=row.get("extracted_today", ""),
+                        briefing=row["extracted_additional_information"],
                     )
                 else:
                     formatted_prompt = PREDICTION_PROMPT.format(

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -8,9 +8,11 @@ from pathlib import Path
 from typing import Any
 
 from benchmark.prompt_replay import (
+    _extract_factual_research_prompt_components,
     _load_and_filter_rows,
     _log_replay_summary,
     _prepare_output_dir,
+    extract_prompt_components,
 )
 
 
@@ -245,3 +247,83 @@ class TestPrepareOutputDir:
         output_dir = tmp_path / "out"
         _prepare_output_dir(output_dir)
         assert output_dir.is_dir()
+
+
+def _fr_prompt(
+    *,
+    question: str = "Will X happen by 2026-12-31?",
+    today: str = "2026-04-22",
+    briefing: str = "Key facts:\n- Fact one.\n- Fact two.",
+    include_briefing: bool = True,
+    reframe_body: str | None = None,
+) -> str:
+    # Mirrors full_prompt_used in factual_research.py.
+    if reframe_body is None:
+        reframe_messages = [
+            {"role": "system", "content": "REFRAME_SYSTEM"},
+            {
+                "role": "user",
+                "content": (
+                    "INPUT QUESTION:\n"
+                    f'"""{question}"""\n\n'
+                    f"Today's date: {today}\n"
+                ),
+            },
+        ]
+        reframe_body = json.dumps(reframe_messages, indent=2)
+
+    parts = [
+        f"--- REFRAME ---\n{reframe_body}\n",
+        "--- SUB-QUESTIONS ---\n{}\n",
+        "--- EVIDENCE ---\n[1] snippet\n",
+        "--- SYNTHESIS ---\n[]\n",
+    ]
+    if include_briefing:
+        parts.append(f"--- BRIEFING ---\n{briefing}\n")
+    parts.append("--- ESTIMATE ---\n[]\n")
+    parts.append("--- REASONING ---\nblah")
+    return "\n".join(parts)
+
+
+class TestExtractFactualResearchPromptComponents:
+    """Extraction for `factual_research` multi-section audit dumps."""
+
+    def test_happy_path_returns_question_briefing_today(self) -> None:
+        """Well-formed dump yields question, briefing, and today, stripped."""
+        prompt = _fr_prompt(
+            question="  Will Artemis II launch by 2026-12-31?  ",
+            today="2026-04-22",
+            briefing="  Factual summary line 1.\nLine 2.  ",
+        )
+        out = _extract_factual_research_prompt_components(prompt)
+        assert out is not None
+        assert out["user_prompt"] == "Will Artemis II launch by 2026-12-31?"
+        assert out["today"] == "2026-04-22"
+        assert out["additional_information"] == "Factual summary line 1.\nLine 2."
+
+    def test_missing_briefing_returns_none(self) -> None:
+        """No BRIEFING section → None (don't mis-route to default regexes)."""
+        prompt = _fr_prompt(include_briefing=False)
+        assert _extract_factual_research_prompt_components(prompt) is None
+
+    def test_malformed_reframe_json_returns_none(self) -> None:
+        """Invalid JSON in REFRAME block → None (no raise)."""
+        prompt = _fr_prompt(reframe_body="{this is not json")
+        assert _extract_factual_research_prompt_components(prompt) is None
+
+    def test_reframe_missing_user_message_returns_none(self) -> None:
+        """REFRAME JSON without a user message → None."""
+        reframe_body = json.dumps(
+            [{"role": "system", "content": "only system"}], indent=2
+        )
+        prompt = _fr_prompt(reframe_body=reframe_body)
+        assert _extract_factual_research_prompt_components(prompt) is None
+
+    def test_dispatch_via_extract_prompt_components(self) -> None:
+        """`extract_prompt_components` routes `factual_research` to the helper."""
+        prompt = _fr_prompt(question="Q?", today="2026-04-22", briefing="B")
+        out = extract_prompt_components(prompt, tool_name="factual_research")
+        assert out is not None
+        assert out["user_prompt"] == "Q?"
+        assert out["today"] == "2026-04-22"
+        assert out["additional_information"] == "B"

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -15,6 +15,8 @@ from benchmark.prompt_replay import (
     extract_prompt_components,
 )
 
+from packages.valory.customs.factual_research.factual_research import REFRAME_USER
+
 
 def _row(
     *,
@@ -257,17 +259,15 @@ def _fr_prompt(
     include_briefing: bool = True,
     reframe_body: str | None = None,
 ) -> str:
-    # Mirrors full_prompt_used in factual_research.py.
+    # Mirrors full_prompt_used in factual_research.py. We format the user
+    # content via the real REFRAME_USER template so a reword there breaks
+    # these tests (which is what would break prod extraction).
     if reframe_body is None:
         reframe_messages = [
             {"role": "system", "content": "REFRAME_SYSTEM"},
             {
                 "role": "user",
-                "content": (
-                    "INPUT QUESTION:\n"
-                    f'"""{question}"""\n\n'
-                    f"Today's date: {today}\n"
-                ),
+                "content": REFRAME_USER.format(question=question, today=today),
             },
         ]
         reframe_body = json.dumps(reframe_messages, indent=2)

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -319,6 +319,16 @@ class TestExtractFactualResearchPromptComponents:
         prompt = _fr_prompt(reframe_body=reframe_body)
         assert _extract_factual_research_prompt_components(prompt) is None
 
+    def test_reframe_non_list_json_returns_none(self) -> None:
+        """REFRAME JSON that parses but isn't a list → None (don't raise)."""
+        prompt = _fr_prompt(reframe_body=json.dumps({"role": "user"}))
+        assert _extract_factual_research_prompt_components(prompt) is None
+
+    def test_reframe_list_of_non_dicts_returns_none(self) -> None:
+        """REFRAME JSON list with non-dict elements → None (don't raise)."""
+        prompt = _fr_prompt(reframe_body=json.dumps(["just a string"]))
+        assert _extract_factual_research_prompt_components(prompt) is None
+
     def test_dispatch_via_extract_prompt_components(self) -> None:
         """`extract_prompt_components` routes `factual_research` to the helper."""
         prompt = _fr_prompt(question="Q?", today="2026-04-22", briefing="B")


### PR DESCRIPTION
## Summary

Implements the spec to make `/benchmark factual_research --sample N --seed S` flow through the standard pipeline (download log → enrich → replay → PR comment with Brier + reliability metrics).

Replay re-runs only the **ESTIMATE** step — REFRAME and SYNTHESIS produce the briefing using cached evidence and aren't on the critical path for prompt experiments. The question + briefing + today are recovered from the prod IPFS audit dump (`full_prompt_used` in `factual_research.py`).

## Changes

- **`.github/workflows/benchmark_replay.yaml`** — tool whitelist regex relaxed `[a-z0-9-]+` → `[a-z0-9_-]+` so the underscore name passes.
- **`benchmark/prompt_replay.py`**
  - `FR_BRIEFING_RE` / `FR_REFRAME_RE` / `FR_QUESTION_TODAY_RE` regexes for the multi-section dump.
  - `_extract_factual_research_prompt_components` pulls question + today from the REFRAME chat-messages JSON and the briefing verbatim from the BRIEFING block.
  - `extract_prompt_components` dispatches on `tool_name == "factual_research"`.
  - `_run_replay` adds an `is_factual_research` branch that imports `ESTIMATE_SYSTEM` / `ESTIMATE_USER` and formats with `(question, today, briefing)`. Structured output is already wired via `_STRUCTURED_OUTPUT_SCHEMAS`.
- **`benchmark/tests/test_prompt_replay.py`** — 5 new tests: happy path, missing BRIEFING, malformed REFRAME JSON, REFRAME without user message, dispatch.

Out of scope (per spec): replaying REFRAME / SYNTHESIS prompt changes; retiring `benchmark/factual_research_replay.py`.

## Test plan

- [x] `uv run pytest benchmark/tests/test_prompt_replay.py` — 17 passed
- [x] `uv run tomte check-code` — black/isort/flake8/mypy/pylint/darglint all green
- [ ] Local enrich + replay smoke against a recent resolved-market row (spec §Validation plan)
- [ ] CI smoke: comment `/benchmark factual_research --sample 5 --seed 42` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)