### PR TITLE
feat(benchmark): single-window report collapse (Phase 2)

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -157,13 +157,13 @@ jobs:
             $TOURNAMENT_FLAG
         continue-on-error: true
 
-      - name: Score last 7 days
+      - name: Score last 3 days
         run: |
           TOURNAMENT_FLAG=""
           if [ -f benchmark/results/tournament_scored.jsonl ]; then
             TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
           fi
-          python -m benchmark.scorer --period-days 7 \
+          python -m benchmark.scorer --period-days 3 \
             --logs-dir benchmark/datasets/logs/ \
             --output benchmark/results/rolling_scores.json \
             $TOURNAMENT_FLAG

--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -157,6 +157,9 @@ jobs:
             $TOURNAMENT_FLAG
         continue-on-error: true
 
+      # Keep the "3" in the step name and --period-days flag in sync with
+      # ROLLING_WINDOW_DAYS in benchmark/analyze.py. YAML can't import the
+      # Python constant; a bump to ROLLING_WINDOW_DAYS must be mirrored here.
       - name: Score last 3 days
         run: |
           TOURNAMENT_FLAG=""

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -53,7 +53,7 @@ python -m benchmark.scorer --period-days 7 --logs-dir benchmark/datasets/logs/ -
 python -m benchmark.scorer --period-days 30 --logs-dir benchmark/datasets/logs/ --output results/last_month.json
 
 # Pass period scores to analyze for delta-vs-alltime reporting.
-# The report will lead with "Since Last Report" and "Last 7 Days Rolling"
+# The report will lead with "Since Last Report" and "Last 3 Days Rolling"
 # sections showing how recent performance compares to all-time.
 python -m benchmark.analyze --period results/last_day.json --rolling results/last_week.json
 ```

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import statistics
 from datetime import datetime, timezone
 from pathlib import Path
 from types import MappingProxyType
@@ -55,13 +54,6 @@ BSS_HARMFUL_THRESHOLD = 0.0
 RELIABILITY_ISSUE_THRESHOLD = 0.90
 SAMPLE_SIZE_WARNING = 20
 TREND_WORSENING_THRESHOLD = 0.02
-
-# Calibration interpretation thresholds (logit-scale Platt scaling).
-# On the logit scale, deviations from 1.0/0.0 are larger than on the
-# probability scale. These are initial values; validate against real data.
-CAL_SLOPE_OVERCONFIDENT = 0.7
-CAL_SLOPE_UNDERCONFIDENT = 1.3
-CAL_INTERCEPT_NOTABLE = 0.3
 
 # Categories currently emitted by the two upstream platforms.
 # Keep these in sync with:
@@ -165,60 +157,6 @@ def section_metric_reference() -> str:
             "- **Edge over market** — ideal > 0; positive = tool beats market "
             "consensus. System diagnostic, not a tool ranking signal."
         ),
-    ]
-    return "\n".join(lines)
-
-
-def section_overall(scores: dict[str, Any]) -> str:
-    """Generate the overall summary section."""
-    o = scores["overall"]
-    if scores["total_rows"] == 0:
-        return "## Overall\n\nNo predictions to score."
-
-    rel_str = f"{o['reliability']:.0%}" if o["reliability"] is not None else "N/A"
-    brier_str = str(o["brier"]) if o["brier"] is not None else "N/A"
-    acc_str = (
-        f"{o['directional_accuracy']:.0%}"
-        if o.get("directional_accuracy") is not None
-        else "N/A"
-    )
-    no_sig = o.get("no_signal_rate")
-    no_sig_str = f"{no_sig:.2%}" if no_sig is not None else "N/A"
-    ll = o.get("log_loss")
-    ll_str = f"{ll:.4f}" if ll is not None else "N/A"
-    sharp_str = f"{o['sharpness']:.4f}" if o.get("sharpness") is not None else "N/A"
-    bss = o.get("brier_skill_score")
-    bss_str = f"{bss:+.4f}" if bss is not None else "N/A"
-    baseline_str = str(o.get("baseline_brier", "N/A"))
-    # Edge over market
-    edge = o.get("edge")
-    edge_n = o.get("edge_n", 0)
-    edge_str = f"{edge:+.4f}" if edge is not None else "N/A"
-    epr = o.get("edge_positive_rate")
-    epr_str = f"{epr:.0%}" if epr is not None else "N/A"
-
-    lines = [
-        "## Overall",
-        "",
-        f"- Predictions scored: {scores['valid_rows']} / {scores['total_rows']}"
-        f" ({rel_str} reliability)",
-        f"- Overall Brier: {brier_str}",
-        f"- Baseline Brier: {baseline_str}"
-        " (naive predictor using observed base rate)",
-        f"- Brier Skill Score: {bss_str}",
-        "  - BSS > 0 = better than base rate, BSS = 0 = no skill,"
-        " BSS < 0 = worse than base rate",
-        f"- Edge over market: {edge_str} (n={edge_n})",
-        "  - Positive = tool beats market consensus, negative = market wins",
-        f"  - Edge positive rate: {epr_str}"
-        " (fraction of questions where tool beat market)",
-        f"- Directional Accuracy: {acc_str}"
-        f" (n_directional={o.get('n_directional', 0)})",
-        f"- No-signal rate: {no_sig_str}"
-        f" ({o.get('no_signal_count', 0)} predictions at exactly 0.5)",
-        f"- Log Loss: {ll_str}",
-        f"- Sharpness: {sharp_str}",
-        "  - 0.0 = all predictions at 50/50, 0.5 = maximally decisive",
     ]
     return "\n".join(lines)
 
@@ -572,64 +510,6 @@ def section_reliability_issues(scores: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def section_worst_predictions(scores: dict[str, Any], n: int = 10) -> str:
-    """Generate the worst predictions section from scores.worst_10.
-
-    :param scores: scores dict with ``worst_10`` list.
-    :param n: max entries to show.
-    :return: markdown section string.
-    """
-    entries = scores.get("worst_10", [])
-    lines = ["## Worst Predictions", ""]
-    if not entries:
-        lines.append("No prediction data available.")
-        return "\n".join(lines)
-
-    for i, entry in enumerate(entries[:n], 1):
-        outcome_str = "Yes" if entry["final_outcome"] else "No"
-        q = entry.get("question_text", "?")
-        if len(q) > 80:
-            q = q[:77] + "..."
-        lines.append(
-            f'{i}. "{q}"'
-            f"\n   {entry['tool_name']} predicted p_yes={entry['p_yes']:.2f},"
-            f" outcome: {outcome_str} (Brier: {entry['brier']:.4f})"
-            f"\n   Category: {entry.get('category', '?')},"
-            f" Platform: {entry.get('platform', '?')}"
-        )
-
-    return "\n".join(lines)
-
-
-def section_best_predictions(scores: dict[str, Any], n: int = 10) -> str:
-    """Generate the best predictions section from scores.best_10.
-
-    :param scores: scores dict with ``best_10`` list.
-    :param n: max entries to show.
-    :return: markdown section string.
-    """
-    entries = scores.get("best_10", [])
-    lines = ["## Best Predictions", ""]
-    if not entries:
-        lines.append("No prediction data available.")
-        return "\n".join(lines)
-
-    for i, entry in enumerate(entries[:n], 1):
-        outcome_str = "Yes" if entry["final_outcome"] else "No"
-        q = entry.get("question_text", "?")
-        if len(q) > 80:
-            q = q[:77] + "..."
-        lines.append(
-            f'{i}. "{q}"'
-            f"\n   {entry['tool_name']} predicted p_yes={entry['p_yes']:.2f},"
-            f" outcome: {outcome_str} (Brier: {entry['brier']:.4f})"
-            f"\n   Category: {entry.get('category', '?')},"
-            f" Platform: {entry.get('platform', '?')}"
-        )
-
-    return "\n".join(lines)
-
-
 def section_trend(
     history: list[dict[str, Any]],
     scores: dict[str, Any] | None = None,
@@ -761,117 +641,6 @@ def section_tool_platform(scores: dict[str, Any]) -> str:
             f"| {tool} | {platform} | {brier} | {bss_str} | {ll_str2} | {edge_str}"
             f" | {edge_n} | {acc} | {sharp} | {stats['n']}{label} |"
         )
-
-    return "\n".join(lines)
-
-
-_EDGE_SECTION_HEADER = "## Edge Over Market (System Diagnostic)"
-
-
-def section_edge_analysis(scores: dict[str, Any], platform: str | None = None) -> str:
-    """Edge-over-market analysis — per platform, difficulty, and liquidity.
-
-    When ``platform`` is set, the scores input is already partitioned to
-    one platform, so the per-platform / platform × difficulty / platform
-    × liquidity sub-blocks are degenerate (one row each) and skipped.
-
-    :param scores: parsed scores dict.
-    :param platform: when set, suppresses the platform-comparison sub-blocks.
-    :return: markdown section string.
-    """
-    elig = scores.get("edge_eligibility", {})
-    n_eligible = elig.get("n_eligible", 0)
-    n_total = elig.get("n_total", 0)
-    if n_eligible == 0:
-        return (
-            f"{_EDGE_SECTION_HEADER}\n\n"
-            "No edge-eligible rows (need market_prob_at_prediction)."
-        )
-
-    pct = f" ({n_eligible / n_total:.1%} of total)" if n_total > 0 else ""
-    lines = [
-        _EDGE_SECTION_HEADER,
-        "",
-        "Edge measures whether prediction accuracy translates to trading"
-        " value — it is not a tool ranking metric.",
-        "",
-        f"Edge-eligible rows: {n_eligible} / {n_total}{pct}",
-        "",
-    ]
-
-    # Sub-blocks below compare platforms; skip them when the input is
-    # already platform-scoped.
-    if platform is not None:
-        return "\n".join(lines).rstrip()
-
-    # Per-platform edge
-    by_plat = scores.get("by_platform", {})
-    if by_plat:
-        lines.append("### By Platform")
-        lines.append("")
-        for plat, stats in sorted(by_plat.items()):
-            edge = stats.get("edge")
-            edge_n = stats.get("edge_n", 0)
-            epr = stats.get("edge_positive_rate")
-            if edge is not None:
-                lines.append(
-                    f"- **{plat}**: edge {edge:+.4f},"
-                    f" positive rate {epr:.0%}, edge_n={edge_n}"
-                )
-        lines.append("")
-
-    # Platform × difficulty
-    pd = scores.get("by_platform_difficulty", {})
-    pd_filtered = {
-        k: v for k, v in pd.items() if v.get("edge") is not None and "unknown" not in k
-    }
-    if pd_filtered:
-        lines.append("### By Platform × Difficulty")
-        lines.append("")
-        lines.append(
-            "| Platform | Difficulty | Edge | Edge +rate | Edge n | Brier | n |"
-        )
-        lines.append(
-            "|----------|-----------|------|------------|--------|-------|---|"
-        )
-        for key, stats in sorted(pd_filtered.items()):
-            parts = key.split(" | ")
-            plat, diff = parts[0], parts[1] if len(parts) > 1 else "?"
-            edge = stats["edge"]
-            epr = stats.get("edge_positive_rate", 0)
-            brier = stats.get("brier")
-            brier_str = f"{brier:.4f}" if brier is not None else "N/A"
-            lines.append(
-                f"| {plat} | {diff} | {edge:+.4f} | {epr:.0%}"
-                f" | {stats.get('edge_n', 0)} | {brier_str} | {stats['n']} |"
-            )
-        lines.append("")
-
-    # Platform × liquidity
-    pl = scores.get("by_platform_liquidity", {})
-    pl_filtered = {
-        k: v for k, v in pl.items() if v.get("edge") is not None and "unknown" not in k
-    }
-    if pl_filtered:
-        lines.append("### By Platform × Liquidity")
-        lines.append("")
-        lines.append(
-            "| Platform | Liquidity | Edge | Edge +rate | Edge n | Brier | n |"
-        )
-        lines.append(
-            "|----------|-----------|------|------------|--------|-------|---|"
-        )
-        for key, stats in sorted(pl_filtered.items()):
-            parts = key.split(" | ")
-            plat, liq = parts[0], parts[1] if len(parts) > 1 else "?"
-            edge = stats["edge"]
-            epr = stats.get("edge_positive_rate", 0)
-            brier = stats.get("brier")
-            brier_str = f"{brier:.4f}" if brier is not None else "N/A"
-            lines.append(
-                f"| {plat} | {liq} | {edge:+.4f} | {epr:.0%}"
-                f" | {stats.get('edge_n', 0)} | {brier_str} | {stats['n']} |"
-            )
 
     return "\n".join(lines)
 
@@ -1036,92 +805,6 @@ def section_diagnostic_metrics(scores: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def section_calibration(scores: dict[str, Any]) -> str:
-    """Calibration analysis — are predictions overconfident or underconfident?"""
-    cal = scores.get("calibration", [])
-    if not cal:
-        return "## Calibration\n\nNo calibration data available."
-
-    lines = [
-        "## Calibration",
-        "",
-        "| Predicted Range | Avg Predicted | Realized Yes-Rate | Gap | n |",
-        "|-----------------|---------------|-------------------|-----|---|",
-    ]
-    for bucket in cal:
-        if bucket.get("n", 0) == 0:
-            continue
-        avg_p = f"{bucket['avg_predicted']:.2f}"
-        realized = f"{bucket['realized_rate']:.2f}"
-        gap = bucket["gap"]
-        gap_str = f"{gap:+.2f}"
-        lines.append(
-            f"| {bucket['bin']} | {avg_p} | {realized} | {gap_str} | {bucket['n']} |"
-        )
-
-    # ECE and calibration regression
-    ece = scores.get("ece")
-    if ece is not None:
-        lines.append("")
-        lines.append(f"**ECE (Expected Calibration Error):** {ece:.4f}")
-        lines.append("  - 0 = perfectly calibrated, higher = worse")
-    cal_int = scores.get("calibration_intercept")
-    cal_slope = scores.get("calibration_slope")
-    if cal_int is not None and cal_slope is not None:
-        lines.append(
-            f"**Calibration regression:** intercept={cal_int:+.4f},"
-            f" slope={cal_slope:.4f}"
-        )
-        if cal_slope < CAL_SLOPE_OVERCONFIDENT:
-            lines.append(
-                "  - Slope < 1.0 → predictions too extreme"
-                " (overpredicts high-confidence, underpredicts low-confidence)"
-            )
-        elif cal_slope > CAL_SLOPE_UNDERCONFIDENT:
-            lines.append("  - Slope > 1.0 → predictions too compressed toward 0.5")
-        # Intercept is evaluated at logit(p_yes)=0, i.e. p_yes=0.5.
-        # Only interpret when slope is not too far from 1.0; with extreme
-        # slopes the intercept alone is ambiguous.
-        if abs(cal_slope - 1.0) < 0.4 and abs(cal_int) > CAL_INTERCEPT_NOTABLE:
-            if cal_int > 0:
-                lines.append(
-                    "  - Positive intercept at p=0.5 midpoint"
-                    " (tool underpredicts at the 50% probability point)"
-                )
-            else:
-                lines.append(
-                    "  - Negative intercept at p=0.5 midpoint"
-                    " (tool overpredicts at the 50% probability point)"
-                )
-
-    # Summary interpretation
-    lines.append("")
-    high_conf = [
-        b for b in cal if b.get("avg_predicted", 0) > 0.7 and b.get("n", 0) > 0
-    ]
-    low_conf = [b for b in cal if b.get("avg_predicted", 0) < 0.3 and b.get("n", 0) > 0]
-    if high_conf:
-        avg_gap = sum(b["gap"] for b in high_conf) / len(high_conf)
-        if avg_gap > 0.1:
-            lines.append(
-                "**High-confidence bins overpredict** — predicted high yes-probability"
-                " but realized rate is much lower."
-            )
-        elif avg_gap < -0.1:
-            lines.append(
-                "**High-confidence bins underpredict** — realized rate exceeds predictions."
-            )
-    if low_conf:
-        avg_gap = sum(b["gap"] for b in low_conf) / len(low_conf)
-        if avg_gap < -0.1:
-            lines.append(
-                "**Low-confidence bins underpredict** — predicted low yes-probability"
-                " but events happen more often than predicted."
-            )
-
-    return "\n".join(lines)
-
-
 def section_parse_breakdown(scores: dict[str, Any]) -> str:
     """Per-tool parse status breakdown from scores.parse_breakdown.
 
@@ -1144,40 +827,6 @@ def section_parse_breakdown(scores: dict[str, Any]) -> str:
         lines.append(
             f"| {tool} | {c.get('valid', 0)} | {c.get('malformed', 0)}"
             f" | {c.get('missing_fields', 0)} | {c.get('error', 0)} | {total} |"
-        )
-
-    return "\n".join(lines)
-
-
-def section_latency(scores: dict[str, Any]) -> str:
-    """Latency breakdown from scores.latency_reservoir.
-
-    :param scores: scores dict with ``latency_reservoir`` mapping.
-    :return: markdown section string.
-    """
-    by_tool = scores.get("latency_reservoir", {})
-    if not by_tool:
-        return "## Latency\n\nNo latency data available."
-
-    # Filter out empty reservoirs
-    by_tool = {t: vals for t, vals in by_tool.items() if vals}
-    if not by_tool:
-        return "## Latency\n\nNo latency data available."
-
-    lines = [
-        "## Latency (seconds)",
-        "",
-        "| Tool | Median | Mean | p95 | n |",
-        "|------|--------|------|-----|---|",
-    ]
-    for tool in sorted(by_tool, key=lambda t: statistics.median(by_tool[t])):
-        vals = sorted(by_tool[tool])
-        med = statistics.median(vals)
-        mean = statistics.mean(vals)
-        p95_idx = min(int(len(vals) * 0.95), len(vals) - 1)
-        p95 = vals[p95_idx]
-        lines.append(
-            f"| {tool} | {med:.0f}s | {mean:.0f}s | {p95:.0f}s | {len(vals)} |"
         )
 
     return "\n".join(lines)
@@ -1875,18 +1524,19 @@ def generate_report(
         )
 
     rolling_heading = f"Last {ROLLING_WINDOW_DAYS} Days Rolling"
-    sections.append(section_period(rolling_scores, scores, rolling_heading))
-    if render_tournament and _has_tournament_data(rolling_scores_tournament):
-        sections.append(
-            _relabel_heading(
-                section_period(
-                    rolling_scores_tournament,
-                    tournament_scores,
-                    rolling_heading,
-                ),
-                " — Tournament",
+    if rolling_scores is not None:
+        sections.append(section_period(rolling_scores, scores, rolling_heading))
+        if render_tournament and _has_tournament_data(rolling_scores_tournament):
+            sections.append(
+                _relabel_heading(
+                    section_period(
+                        rolling_scores_tournament,
+                        tournament_scores,
+                        rolling_heading,
+                    ),
+                    " — Tournament",
+                )
             )
-        )
 
     sections.append(section_base_rates(scores))
     sections.append(section_tool_deployment_status(scores, disabled=disabled_tools))

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -1891,12 +1891,6 @@ def generate_report(
     sections.append(section_base_rates(scores))
     sections.append(section_tool_deployment_status(scores, disabled=disabled_tools))
 
-    rolling_for_sections = rolling_scores if rolling_scores is not None else scores
-    rolling_tournament_for_sections = (
-        rolling_scores_tournament
-        if rolling_scores_tournament is not None
-        else tournament_scores
-    )
     rolling_suffix = f" (Last {ROLLING_WINDOW_DAYS} Days)"
     rolling_window_note = f"last {ROLLING_WINDOW_DAYS} days"
 
@@ -1906,14 +1900,24 @@ def generate_report(
             _relabel_heading(section_md, heading_suffix), rolling_window_note
         )
 
-    sections.append(_rolling(section_tool_ranking(rolling_for_sections)))
-    if render_tournament:
+    if rolling_scores is None:
         sections.append(
-            _rolling(
-                section_tool_ranking(rolling_tournament_for_sections),
-                f"{rolling_suffix} — Tournament",
-            )
+            f"## Rolling Window (Last {ROLLING_WINDOW_DAYS} Days)\n\n"
+            f"Rolling scores for the last {ROLLING_WINDOW_DAYS} days are "
+            "unavailable — the scoring step did not produce "
+            f"`rolling_scores_{platform}.json` for this run. Tool Ranking, "
+            "Category Performance, Tool × Category, Diagnostic Edge Metrics, "
+            "and Weak Spots sections are omitted."
         )
+    else:
+        sections.append(_rolling(section_tool_ranking(rolling_scores)))
+        if render_tournament and rolling_scores_tournament is not None:
+            sections.append(
+                _rolling(
+                    section_tool_ranking(rolling_scores_tournament),
+                    f"{rolling_suffix} — Tournament",
+                )
+            )
 
     if include_tournament:
         merged = _merged_tvm_scores(scores, scores_tournament)
@@ -1931,17 +1935,23 @@ def generate_report(
                 f"Tool × Version × Mode (Last {ROLLING_WINDOW_DAYS} Days)",
             )
             if tvm_rolling:
-                sections.append(tvm_rolling)
+                sections.append(_annotate_with_window(tvm_rolling, rolling_window_note))
         deltas = section_version_deltas(merged)
         if deltas:
             sections.append(deltas)
 
+    if rolling_scores is not None:
+        sections.extend(
+            [
+                _rolling(section_category(rolling_scores)),
+                _rolling(section_tool_category(rolling_scores)),
+                _rolling(section_diagnostic_metrics(rolling_scores)),
+                _rolling(section_weak_spots(rolling_scores)),
+            ]
+        )
+
     sections.extend(
         [
-            _rolling(section_category(rolling_for_sections)),
-            _rolling(section_tool_category(rolling_for_sections)),
-            _rolling(section_diagnostic_metrics(rolling_for_sections)),
-            _rolling(section_weak_spots(rolling_for_sections)),
             section_reliability_issues(scores),
             section_parse_breakdown(scores),
             section_trend(history, None, platform=platform),

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -1647,6 +1647,22 @@ def _relabel_heading(section_md: str, suffix: str) -> str:
     return "\n".join(lines)
 
 
+def _annotate_with_window(section_md: str, window_label: str) -> str:
+    """Insert an italicized window qualifier under the first ``## Heading``.
+
+    :param section_md: rendered markdown for a single section.
+    :param window_label: phrase describing the window (e.g. ``"last 3 days"``).
+    :return: the section markdown with the qualifier line inserted.
+    """
+    lines = section_md.split("\n")
+    if not lines or not lines[0].startswith("## "):
+        return section_md
+    note = f"_n= values below are over the {window_label}._"
+    if len(lines) >= 2 and lines[1] == "":
+        return "\n".join([lines[0], "", note, ""] + lines[2:])
+    return "\n".join([lines[0], "", note, ""] + lines[1:])
+
+
 def _has_tournament_data(scores_tournament: dict[str, Any] | None) -> bool:
     """Return True when a tournament scores dict has any rows to report."""
     return bool(scores_tournament and scores_tournament.get("total_rows", 0) > 0)
@@ -1882,13 +1898,18 @@ def generate_report(
         else tournament_scores
     )
     rolling_suffix = f" (Last {ROLLING_WINDOW_DAYS} Days)"
+    rolling_window_note = f"last {ROLLING_WINDOW_DAYS} days"
 
-    sections.append(
-        _relabel_heading(section_tool_ranking(rolling_for_sections), rolling_suffix)
-    )
+    def _rolling(section_md: str, heading_suffix: str = rolling_suffix) -> str:
+        """Add the rolling-window heading suffix and n= qualifier note."""
+        return _annotate_with_window(
+            _relabel_heading(section_md, heading_suffix), rolling_window_note
+        )
+
+    sections.append(_rolling(section_tool_ranking(rolling_for_sections)))
     if render_tournament:
         sections.append(
-            _relabel_heading(
+            _rolling(
                 section_tool_ranking(rolling_tournament_for_sections),
                 f"{rolling_suffix} — Tournament",
             )
@@ -1917,14 +1938,10 @@ def generate_report(
 
     sections.extend(
         [
-            _relabel_heading(section_category(rolling_for_sections), rolling_suffix),
-            _relabel_heading(
-                section_tool_category(rolling_for_sections), rolling_suffix
-            ),
-            _relabel_heading(
-                section_diagnostic_metrics(rolling_for_sections), rolling_suffix
-            ),
-            _relabel_heading(section_weak_spots(rolling_for_sections), rolling_suffix),
+            _rolling(section_category(rolling_for_sections)),
+            _rolling(section_tool_category(rolling_for_sections)),
+            _rolling(section_diagnostic_metrics(rolling_for_sections)),
+            _rolling(section_weak_spots(rolling_for_sections)),
             section_reliability_issues(scores),
             section_parse_breakdown(scores),
             section_trend(history, scores, platform=platform),

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -138,6 +138,37 @@ def load_history(path: Path) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
+def section_metric_reference() -> str:
+    """Render the metric-reference legend shown at the top of every report.
+
+    :return: markdown section string.
+    """
+    lines = [
+        "## Metric References",
+        "",
+        (
+            "All point-in-time metrics below are scoped to the rolling window "
+            f"(last {ROLLING_WINDOW_DAYS} days) unless a section explicitly says "
+            "otherwise."
+        ),
+        "",
+        f"- **Brier** — ideal 0.00, coin-flip {BRIER_RANDOM}; lower is better.",
+        (
+            "- **Log Loss** — ideal 0.00; lower is better, punishes confident "
+            "errors harder."
+        ),
+        (
+            "- **BSS (Brier Skill Score)** — ideal > 0; negative means worse than "
+            "the base-rate predictor."
+        ),
+        (
+            "- **Edge over market** — ideal > 0; positive = tool beats market "
+            "consensus. System diagnostic, not a tool ranking signal."
+        ),
+    ]
+    return "\n".join(lines)
+
+
 def section_overall(scores: dict[str, Any]) -> str:
     """Generate the overall summary section."""
     o = scores["overall"]
@@ -1810,6 +1841,8 @@ def generate_report(
     tournament_scores: dict[str, Any] = scores_tournament or {}
 
     sections: list[str] = [f"# Benchmark Report ({platform_label}) — {date}"]
+
+    sections.append(section_metric_reference())
 
     # Since Last Report
     sections.append(section_period(period_scores, scores, "Since Last Report"))

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -1564,10 +1564,11 @@ def generate_report(
         )
     else:
         sections.append(_rolling(section_tool_ranking(rolling_scores)))
-        if render_tournament and rolling_scores_tournament is not None:
+        if render_tournament and _has_tournament_data(rolling_scores_tournament):
+            rolling_tourn: dict[str, Any] = rolling_scores_tournament or {}
             sections.append(
                 _rolling(
-                    section_tool_ranking(rolling_scores_tournament),
+                    section_tool_ranking(rolling_tourn),
                     f"{rolling_suffix} — Tournament",
                 )
             )

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -47,6 +47,8 @@ PLATFORM_LABELS: Mapping[str, str] = MappingProxyType(
     }
 )
 
+ROLLING_WINDOW_DAYS = 3
+
 BRIER_RANDOM = 0.25
 BRIER_WEAK_THRESHOLD = 0.40
 BSS_HARMFUL_THRESHOLD = 0.0
@@ -1205,7 +1207,7 @@ def section_period(
     alltime_scores: dict[str, Any],
     label: str = "Since last report",
 ) -> str:
-    """Generate a period comparison section (since-last-report or rolling 7d).
+    """Generate a period comparison section.
 
     :param period_scores: scores from the recent period.
     :param alltime_scores: all-time scores for delta comparison.
@@ -1779,13 +1781,13 @@ def generate_report(
         ``"polymarket"``). Drives the report header and gates platform-
         comparison sections.
     :param period_scores: production scores since last report.
-    :param rolling_scores: production scores from the last 7 days.
+    :param rolling_scores: production scores from the rolling window.
     :param include_tournament: master switch for rendering the Tool ×
         Version × Mode breakdown. When False, tournament inputs are
         ignored entirely.
     :param scores_tournament: parsed ``scores_tournament_<platform>.json`` dict.
     :param period_scores_tournament: tournament since last report.
-    :param rolling_scores_tournament: tournament last 7 days.
+    :param rolling_scores_tournament: tournament rolling window scores.
     :param disabled_tools: pre-fetched ``{deployment: [tool_names] | None}``
         map used by the Tool Deployment Status section.
     :return: full markdown report string.
@@ -1823,15 +1825,15 @@ def generate_report(
             )
         )
 
-    # Last 7 Days Rolling
-    sections.append(section_period(rolling_scores, scores, "Last 7 Days Rolling"))
+    rolling_heading = f"Last {ROLLING_WINDOW_DAYS} Days Rolling"
+    sections.append(section_period(rolling_scores, scores, rolling_heading))
     if render_tournament and _has_tournament_data(rolling_scores_tournament):
         sections.append(
             _relabel_heading(
                 section_period(
                     rolling_scores_tournament,
                     tournament_scores,
-                    "Last 7 Days Rolling",
+                    rolling_heading,
                 ),
                 " — Tournament",
             )
@@ -1870,7 +1872,8 @@ def generate_report(
                 rolling_scores, rolling_scores_tournament
             )
             tvm_rolling = section_tool_version_breakdown(
-                merged_rolling, "Tool × Version × Mode (Last 7 Days)"
+                merged_rolling,
+                f"Tool × Version × Mode (Last {ROLLING_WINDOW_DAYS} Days)",
             )
             if tvm_rolling:
                 sections.append(tvm_rolling)

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -1872,27 +1872,28 @@ def generate_report(
             )
         )
 
-    # Overall
-    sections.append(section_overall(scores))
-    if render_tournament:
-        sections.append(
-            _relabel_heading(section_overall(tournament_scores), " — Tournament")
-        )
-
-    # Base Rates — production only
     sections.append(section_base_rates(scores))
-
-    # Tool Deployment Status — which tools are blocked on each consumer
     sections.append(section_tool_deployment_status(scores, disabled=disabled_tools))
 
-    # Tool Ranking
-    sections.append(section_tool_ranking(scores))
+    rolling_for_sections = rolling_scores if rolling_scores is not None else scores
+    rolling_tournament_for_sections = (
+        rolling_scores_tournament
+        if rolling_scores_tournament is not None
+        else tournament_scores
+    )
+    rolling_suffix = f" (Last {ROLLING_WINDOW_DAYS} Days)"
+
+    sections.append(
+        _relabel_heading(section_tool_ranking(rolling_for_sections), rolling_suffix)
+    )
     if render_tournament:
         sections.append(
-            _relabel_heading(section_tool_ranking(tournament_scores), " — Tournament")
+            _relabel_heading(
+                section_tool_ranking(rolling_tournament_for_sections),
+                f"{rolling_suffix} — Tournament",
+            )
         )
 
-    # Tool × Version × Mode — merged
     if include_tournament:
         merged = _merged_tvm_scores(scores, scores_tournament)
         tvm_section = section_tool_version_breakdown(
@@ -1910,32 +1911,27 @@ def generate_report(
             )
             if tvm_rolling:
                 sections.append(tvm_rolling)
-        # Version Deltas — temporal ordering, within-mode only, per tool.
         deltas = section_version_deltas(merged)
         if deltas:
             sections.append(deltas)
 
-    # section_platform / section_tool_platform are intentionally dropped:
-    # they're fleet-wide comparisons and the input is platform-scoped.
     sections.extend(
         [
-            section_category(scores),
-            section_tool_category(scores),
-            section_edge_analysis(scores, platform=platform),
-            section_diagnostic_metrics(scores),
-            section_calibration(scores),
-            section_weak_spots(scores),
+            _relabel_heading(section_category(rolling_for_sections), rolling_suffix),
+            _relabel_heading(
+                section_tool_category(rolling_for_sections), rolling_suffix
+            ),
+            _relabel_heading(
+                section_diagnostic_metrics(rolling_for_sections), rolling_suffix
+            ),
+            _relabel_heading(section_weak_spots(rolling_for_sections), rolling_suffix),
             section_reliability_issues(scores),
             section_parse_breakdown(scores),
-            section_latency(scores),
-            section_worst_predictions(scores),
-            section_best_predictions(scores),
             section_trend(history, scores, platform=platform),
             section_sample_size_warnings(scores),
         ]
     )
 
-    # Tournament Callouts — cross-mode
     if render_tournament:
         callouts = section_tournament_callouts(scores, scores_tournament)
         if callouts:

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -20,7 +20,11 @@ from types import MappingProxyType
 from typing import Mapping
 from urllib.request import Request, urlopen
 
-from benchmark.analyze import PLATFORM_LABELS, VERSION_DELTA_LOW_SAMPLE_STRICT
+from benchmark.analyze import (
+    PLATFORM_LABELS,
+    ROLLING_WINDOW_DAYS,
+    VERSION_DELTA_LOW_SAMPLE_STRICT,
+)
 from benchmark.tools import TOOL_REGISTRY
 
 log = logging.getLogger(__name__)
@@ -28,7 +32,7 @@ log = logging.getLogger(__name__)
 SUMMARY_SYSTEM_PROMPT_TEMPLATE = f"""\
 Summarize this Olas Predict benchmark report for the *{{platform_label}}* deployment using EXACTLY this structure (output will be posted to Slack). Every number in this report is already scoped to {{platform_label}} — do NOT compare platforms or reference the other deployment.
 
-*Summary:* 2-3 sentence high-level takeaway for {{platform_label}} — lead with what changed since last report and in the last 7 days. Only mention all-time numbers for context. Include deltas vs all-time where available.
+*Summary:* 2-3 sentence high-level takeaway for {{platform_label}} — lead with what changed since last report and in the last {ROLLING_WINDOW_DAYS} days. Only mention all-time numbers for context. Include deltas vs all-time where available.
 
 *Top tools:*
 • `tool-name` — Brier `X.XX`, LogLoss `X.XX`, Edge `±X.XX` (n=X), directional accuracy X%, one word on why

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -30,23 +30,23 @@ from benchmark.tools import TOOL_REGISTRY
 log = logging.getLogger(__name__)
 
 SUMMARY_SYSTEM_PROMPT_TEMPLATE = f"""\
-Summarize this Olas Predict benchmark report for the *{{platform_label}}* deployment using EXACTLY this structure (output will be posted to Slack). Every number in this report is already scoped to {{platform_label}} — do NOT compare platforms or reference the other deployment.
+Summarize this Olas Predict benchmark report for the *{{platform_label}}* deployment using EXACTLY this structure (output will be posted to Slack). All tool-level figures in the report are scoped to the last {ROLLING_WINDOW_DAYS} days for {{platform_label}} unless a section heading explicitly says otherwise (e.g. "Tool × Version × Mode (All-Time)", "Trend", "Base Rates"). Do NOT compare platforms, reference tools or deployments belonging to other platforms, or cite metrics from another platform's rows.
 
-*Summary:* 2-3 sentence high-level takeaway for {{platform_label}} — lead with what changed since last report and in the last {ROLLING_WINDOW_DAYS} days. Only mention all-time numbers for context. Include deltas vs all-time where available.
+*Summary:* 2-3 sentence high-level takeaway for {{platform_label}} covering the last {ROLLING_WINDOW_DAYS} days — lead with what changed since the last report.
 
 *Top tools:*
-• `tool-name` — Brier `X.XX`, LogLoss `X.XX`, Edge `±X.XX` (n=X), directional accuracy X%, one word on why
-(list top 3, rank by Brier. Log Loss and Edge are shown alongside for context)
+• `tool-name` — Brier `X.XX`, LogLoss `X.XX`, Edge `±X.XX` (n=X, last {ROLLING_WINDOW_DAYS} days), directional accuracy X%, one word on why
+(list top 3 from the "Tool Ranking (Last {ROLLING_WINDOW_DAYS} Days)" section, rank by Brier. Log Loss and Edge are shown alongside for context)
 
 *Worst tools:*
-• `tool-name` — Brier `X.XX`, LogLoss `X.XX`, Edge `±X.XX` (n=X), directional accuracy X%, one word on why
+• `tool-name` — Brier `X.XX`, LogLoss `X.XX`, Edge `±X.XX` (n=X, last {ROLLING_WINDOW_DAYS} days), directional accuracy X%, one word on why
 (list bottom 3, ignore tools with 0% reliability or < 50 predictions)
 
 *Deployment status:* if the report has a "Tool Deployment Status" section, include only deployments whose name starts with the lowercase of "{{platform_label}}". One line per qualifying deployment listing its disabled tools. Skip deployments with no disabled tools, and skip the entire block if no qualifying deployments have content. The "Tool Deployment Status" section is fleet-wide in the report source — do NOT mention deployments belonging to other platforms. Note any fetch-failure banner briefly, but only when it concerns a {{platform_label}}-linked deployment.
 
-*Category performance:* from the "Category Performance" section, list every category with sufficient data (skip rows flagged "insufficient data"). Use format: • `category` — Brier `X.XX`, Edge `±X.XX` (n=X). Call out the single strongest and weakest category inline (e.g. " — strongest" / " — weakest"). This is the answer to "where do our agents do well vs poorly" for {{platform_label}} — always include when data is present. IMPORTANT: a category with "yes rate: 0%" or "yes rate: 100%" has homogeneous outcomes — a low Brier there reflects the base rate, not prediction skill. If you cite such a category as "strongest", append " (homogeneous outcomes — reflects base rate)" so the reader isn't misled.
+*Category performance:* from the "Category Performance (Last {ROLLING_WINDOW_DAYS} Days)" section, list every category with sufficient data (skip rows flagged "insufficient data"). Use format: • `category` — Brier `X.XX`, Edge `±X.XX` (n=X, last {ROLLING_WINDOW_DAYS} days). Call out the single strongest and weakest category inline (e.g. " — strongest" / " — weakest"). IMPORTANT: a category with "yes rate: 0%" or "yes rate: 100%" has homogeneous outcomes — a low Brier there reflects the base rate, not prediction skill. If you cite such a category as "strongest", append " (homogeneous outcomes — reflects base rate)" so the reader isn't misled.
 
-*Tool × Category highlights:* from the "Tool × Category" section, pick 2–4 standout tool-category combinations (best performers, worst performers, or weaknesses). Only use rows above the sample-size threshold — never cite rows from the "below n=X threshold omitted" list. If all tools underperform on a category, say that explicitly ("tools struggle on X across the board"). FALLBACK: if fewer than 2 rows clear the sample-size threshold in the Tool × Category ranking table, do NOT cite any sparse examples or fabricate — write exactly "insufficient tool × category data" as the only bullet in this section.
+*Tool × Category highlights:* from the "Tool × Category (Last {ROLLING_WINDOW_DAYS} Days)" section, pick 2–4 standout tool-category combinations (best performers, worst performers, or weaknesses). Only use rows above the sample-size threshold — never cite rows from the "below n=X threshold omitted" list. If all tools underperform on a category, say that explicitly ("tools struggle on X across the board"). FALLBACK: if fewer than 2 rows clear the sample-size threshold in the Tool × Category ranking table, do NOT cite any sparse examples or fabricate — write exactly "insufficient tool × category data" as the only bullet in this section.
 
 *Tool versions:* If the report has a "Version Deltas" section, summarize up to 5 of the most significant flagged changes, one bullet per row.
 
@@ -64,15 +64,16 @@ Rules:
 *Tournament callouts:* If the report has a "Tournament Callouts" section, list each callout as a single bullet: tool name, release-tag labels for both tournament and production versions (in backticks, e.g. `v0.17.2` and `v0.17.0`), tournament Brier + n, production Brier + n, Brier Δ. Lead promotion candidates with "promotion candidate:" and tournament regressions with "watch:". Skip this section entirely if no Tournament Callouts section is present in the report.
 
 *Diagnostics:*
-If the report includes "Diagnostic Edge Metrics", summarize:
-• Conditional accuracy: X% tool-wins when disagreeing (n=X) — when the tool would trigger a trade, how often is it closer to truth than the market?
+If the report includes "Diagnostic Edge Metrics (Last {ROLLING_WINDOW_DAYS} Days)", summarize:
+• Conditional accuracy: X% tool-wins when disagreeing (n=X, last {ROLLING_WINDOW_DAYS} days) — when the tool would trigger a trade, how often is it closer to truth than the market?
 • Disagreement Brier (large trade): X.XX — prediction accuracy on high-disagreement questions where PnL impact is highest
 • Directional bias: ±X.XX — positive = tool overestimates, negative = underestimates, near 0 = no systematic bias
 Only include this section if the report has diagnostic metric data. Skip if insufficient data.
 
-*Recommended actions:* 2-3 concrete next steps for {{platform_label}} based on the data. If edge is negative for all tools, this is important — recommend specific improvements.
+*Recommended actions:* 2-3 concrete next steps for {{platform_label}} based on the last {ROLLING_WINDOW_DAYS} days of data. If edge is negative for all tools, this is important — recommend specific improvements.
 
 Rules:
+- Every tool-level or category-level n= citation is over the last {ROLLING_WINDOW_DAYS} days. Do NOT attribute point-in-time Brier / Edge / accuracy / BSS figures to "all-time" or "cumulative" scope.
 - Tool names with hyphens vs underscores are DIFFERENT tools — use exact names.
 - Wrap tool names, Brier scores, and Edge scores in backticks.
 - Slack mrkdwn only: *bold* (single asterisk), `code`. No **double asterisks**.

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 SUMMARY_SYSTEM_PROMPT_TEMPLATE = f"""\
 Summarize this Olas Predict benchmark report for the *{{platform_label}}* deployment using EXACTLY this structure (output will be posted to Slack). All tool-level figures in the report are scoped to the last {ROLLING_WINDOW_DAYS} days for {{platform_label}} unless a section heading explicitly says otherwise (e.g. "Tool × Version × Mode (All-Time)", "Trend", "Base Rates"). Do NOT compare platforms, reference tools or deployments belonging to other platforms, or cite metrics from another platform's rows.
 
-*Summary:* 2-3 sentence high-level takeaway for {{platform_label}} covering the last {ROLLING_WINDOW_DAYS} days — lead with what changed since the last report.
+*Summary:* 2-3 sentence high-level takeaway for {{platform_label}}. Open with the 1-day delta from the "Since Last Report" section (what moved since yesterday's report), then pivot to the {ROLLING_WINDOW_DAYS}-day rolling view. Keep the two windows distinct — never attribute a Since-Last-Report figure to the rolling window or vice versa.
 
 *Top tools:*
 • `tool-name` — Brier `X.XX`, LogLoss `X.XX`, Edge `±X.XX` (n=X, last {ROLLING_WINDOW_DAYS} days), directional accuracy X%, one word on why

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -861,7 +861,7 @@ def brier_sort_key(item: tuple[str, dict[str, Any]]) -> float:
 
 
 def _score_latency_reservoir(rows: list[dict[str, Any]]) -> dict[str, list[float]]:
-    """Return up to ``LATENCY_RESERVOIR_SIZE`` most recent latencies per tool.
+    """Return the last ``LATENCY_RESERVOIR_SIZE`` latencies per tool in insertion order.
 
     :param rows: input rows.
     :return: ``{tool_name: [latencies]}``. Tools with no ``latency_s``
@@ -903,7 +903,9 @@ def _score_extreme_predictions(
         outcome = row.get("final_outcome")
         if p_yes is None or outcome is None:
             continue
-        question = row.get("question_text", "")
+        question = row.get("question_text")
+        if not question:
+            continue
         entry = {
             "question_text": question,
             "tool_name": row.get("tool_name") or "unknown",

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -860,6 +860,71 @@ def brier_sort_key(item: tuple[str, dict[str, Any]]) -> float:
     return brier if brier is not None else 999.0
 
 
+def _score_latency_reservoir(rows: list[dict[str, Any]]) -> dict[str, list[float]]:
+    """Return up to ``LATENCY_RESERVOIR_SIZE`` most recent latencies per tool.
+
+    :param rows: input rows.
+    :return: ``{tool_name: [latencies]}``. Tools with no ``latency_s``
+        values are omitted.
+    """
+    reservoir: dict[str, list[float]] = {}
+    for row in rows:
+        latency = row.get("latency_s")
+        if latency is None:
+            continue
+        tool = row.get("tool_name") or "unknown"
+        reservoir.setdefault(tool, []).append(latency)
+    for tool, samples in reservoir.items():
+        if len(samples) > LATENCY_RESERVOIR_SIZE:
+            reservoir[tool] = samples[-LATENCY_RESERVOIR_SIZE:]
+    return reservoir
+
+
+def _score_extreme_predictions(
+    rows: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Return the top-``WORST_BEST_SIZE`` worst and best predictions by Brier.
+
+    Considers only valid rows (parse status ``"valid"`` with both
+    ``p_yes`` and ``final_outcome`` present). Deduplicated by
+    ``question_text``: each question contributes at most one entry per
+    list.
+
+    :param rows: input rows.
+    :return: ``(worst, best)``. Worst sorted by Brier descending, best
+        ascending. Each truncated to ``WORST_BEST_SIZE``.
+    """
+    worst_by_q: dict[str, dict[str, Any]] = {}
+    best_by_q: dict[str, dict[str, Any]] = {}
+    for row in rows:
+        if row.get("prediction_parse_status") != "valid":
+            continue
+        p_yes = row.get("p_yes")
+        outcome = row.get("final_outcome")
+        if p_yes is None or outcome is None:
+            continue
+        question = row.get("question_text", "")
+        entry = {
+            "question_text": question,
+            "tool_name": row.get("tool_name") or "unknown",
+            "p_yes": p_yes,
+            "final_outcome": outcome,
+            "brier": round(brier_score(p_yes, outcome), 4),
+            "platform": row.get("platform") or "unknown",
+            "category": row.get("category"),
+        }
+        prev_worst = worst_by_q.get(question)
+        if prev_worst is None or entry["brier"] > prev_worst["brier"]:
+            worst_by_q[question] = entry
+        prev_best = best_by_q.get(question)
+        if prev_best is None or entry["brier"] < prev_best["brier"]:
+            best_by_q[question] = entry
+
+    worst = sorted(worst_by_q.values(), key=lambda e: e["brier"], reverse=True)
+    best = sorted(best_by_q.values(), key=lambda e: e["brier"])
+    return worst[:WORST_BEST_SIZE], best[:WORST_BEST_SIZE]
+
+
 def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Compute all scores from production log rows."""
     total = len(rows)
@@ -966,6 +1031,9 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         },
     }
 
+    latency_reservoir = _score_latency_reservoir(rows)
+    worst_10, best_10 = _score_extreme_predictions(rows)
+
     return {
         "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
         "total_rows": total,
@@ -990,6 +1058,9 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         **cal_reg,
         "calibration_by_tool": calibration_by_tool,
         "edge_eligibility": edge_eligibility,
+        "latency_reservoir": latency_reservoir,
+        "worst_10": worst_10,
+        "best_10": best_10,
     }
 
 

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -1033,6 +1033,11 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         },
     }
 
+    # Schema parity with _accumulate_and_write: both score() and the
+    # incremental path write the same finalized dict shape to
+    # scores_<platform>.json. Kept even when generate_report does not
+    # render Latency / Worst / Best so consumers reading the JSON
+    # directly see the same keys regardless of which path produced it.
     latency_reservoir = _score_latency_reservoir(rows)
     worst_10, best_10 = _score_extreme_predictions(rows)
 
@@ -1450,10 +1455,11 @@ def _accumulate_row(scores: dict[str, Any], row: dict[str, Any]) -> None:
             reservoir.pop(0)
 
     # Worst / best 10 (deduplicated by question_text)
-    if is_valid:
+    question_text = row.get("question_text")
+    if is_valid and question_text:
         row_brier = brier_score(row["p_yes"], row["final_outcome"])
         entry = {
-            "question_text": row.get("question_text", ""),
+            "question_text": question_text,
             "tool_name": tool,
             "p_yes": row["p_yes"],
             "final_outcome": row["final_outcome"],

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -1061,7 +1061,9 @@ class TestGenerateReport:
             ],
         )
         history = [{"month": "2026-03", "overall": {"brier": 0.3, "n": 50}}]
-        report = generate_report(s, history, platform="omen", disabled_tools={})
+        report = generate_report(
+            s, history, platform="omen", rolling_scores=s, disabled_tools={}
+        )
 
         assert "# Benchmark Report (Omenstrat) — " in report
         assert "## Metric References" in report
@@ -1676,6 +1678,8 @@ class TestGenerateReportWithTournamentFiles:
             platform="omen",
             include_tournament=True,
             scores_tournament=tourn,
+            rolling_scores=prod,
+            rolling_scores_tournament=tourn,
         )
         # Overall is dropped in Phase 2; Tool Ranking carries the rolling suffix.
         assert "## Overall" not in report
@@ -1954,16 +1958,71 @@ class TestGenerateReportRollingWindowAnnotations:
     def test_rolling_sections_carry_window_note(self) -> None:
         """Tool Ranking / Category / Tool × Category / Diagnostics / Weak Spots."""
         scores = _scores_with_tool("tool-a", 0.20, 1000)
-        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        report = generate_report(
+            scores, [], platform="omen", rolling_scores=scores, disabled_tools={}
+        )
         note = f"_n= values below are over the last {ROLLING_WINDOW_DAYS} days._"
         # At least the five rolling point-in-time sections carry it.
         assert report.count(note) >= 5
+
+    def test_tool_version_mode_rolling_section_carries_window_note(self) -> None:
+        """Tool × Version × Mode (Last N Days) gets the n= qualifier like siblings."""
+        scores = _scores_with_tool("tool-a", 0.20, 1000)
+        scores["by_tool_version_mode"] = {
+            "tool-a | v1 | production_replay": {
+                "n": 1000,
+                "valid_n": 1000,
+                "brier": 0.2,
+            }
+        }
+        report = generate_report(
+            scores,
+            [],
+            platform="omen",
+            rolling_scores=scores,
+            include_tournament=True,
+            disabled_tools={},
+        )
+        heading_idx = report.index(
+            f"## Tool × Version × Mode (Last {ROLLING_WINDOW_DAYS} Days)"
+        )
+        next_heading = report.find("##", heading_idx + 1)
+        body = report[heading_idx : next_heading if next_heading > -1 else len(report)]
+        assert (
+            f"_n= values below are over the last {ROLLING_WINDOW_DAYS} days._" in body
+        )
+
+    def test_rolling_sections_absent_when_rolling_scores_missing(self) -> None:
+        """No rolling_scores -> rolling point-in-time sections omitted.
+
+        Falling back to all-time ``scores`` under a "(Last N Days)" heading
+        would mislabel the window. Instead, a single banner explains the gap
+        and the five rolling sections are skipped entirely.
+        """
+        scores = _scores_with_tool("tool-a", 0.20, 1000)
+        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        assert f"## Rolling Window (Last {ROLLING_WINDOW_DAYS} Days)" in report
+        assert "Rolling scores for the last 3 days are unavailable" in report
+        for heading in (
+            "## Tool Ranking (Last 3 Days)",
+            "## Category Performance (Last 3 Days)",
+            "## Tool \u00d7 Category (Last 3 Days)",
+            "## Diagnostic Edge Metrics (Last 3 Days)",
+            "## Weak Spots (Last 3 Days)",
+        ):
+            assert heading not in report
 
     def test_non_rolling_sections_do_not_carry_window_note(self) -> None:
         """Trend, Base Rates, Tool Deployment Status never claim rolling scope."""
         scores = _scores_with_tool("tool-a", 0.20, 1000)
         history = [{"month": "2026-03", "overall": {"brier": 0.3, "n": 50}}]
-        report = generate_report(scores, history, platform="omen", disabled_tools={})
+        report = generate_report(
+            scores,
+            history,
+            platform="omen",
+            rolling_scores=scores,
+            disabled_tools={},
+        )
         note = f"_n= values below are over the last {ROLLING_WINDOW_DAYS} days._"
         # Split on the Trend header and assert the note is absent between it and
         # the next section heading.

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -1813,7 +1813,10 @@ class TestGenerateReportRollingWindowAnnotations:
         scores = _scores_with_tool("tool-a", 0.20, 1000)
         report = generate_report(scores, [], platform="omen", disabled_tools={})
         assert f"## Rolling Window (Last {ROLLING_WINDOW_DAYS} Days)" in report
-        assert "Rolling scores for the last 3 days are unavailable" in report
+        assert (
+            f"Rolling scores for the last {ROLLING_WINDOW_DAYS} days are unavailable"
+            in report
+        )
         for heading in (
             "## Tool Ranking (Last 3 Days)",
             "## Category Performance (Last 3 Days)",

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -1064,28 +1064,33 @@ class TestGenerateReport:
         report = generate_report(s, history, platform="omen", disabled_tools={})
 
         assert "# Benchmark Report (Omenstrat) — " in report
-        assert "## Overall" in report
-        assert "## Tool Ranking" in report
+        assert "## Metric References" in report
+        assert "## Tool Ranking (Last 3 Days)" in report
         # Per-platform reports drop Platform Comparison / Tool × Platform —
         # they'd be single-row tables with no signal.
         assert "## Platform Comparison" not in report
         assert "## Tool \u00d7 Platform" not in report
-        assert "## Category Performance" in report
-        assert "## Tool \u00d7 Category" in report
-        assert "## Weak Spots" in report
+        assert "## Category Performance (Last 3 Days)" in report
+        assert "## Tool \u00d7 Category (Last 3 Days)" in report
+        assert "## Weak Spots (Last 3 Days)" in report
         assert "## Reliability Issues" in report
-        assert "## Worst Predictions" in report
-        assert "## Best Predictions" in report
         assert "## Trend" in report
         assert "## Sample Size Warnings" in report
-        assert "## Diagnostic Edge Metrics" in report
+        assert "## Diagnostic Edge Metrics (Last 3 Days)" in report
+        # Dropped in the Phase 2 single-window collapse.
+        assert "## Overall" not in report
+        assert "## Worst Predictions" not in report
+        assert "## Best Predictions" not in report
+        assert "## Edge Over Market" not in report
+        assert "## Calibration" not in report
+        assert "## Latency" not in report
 
     def test_empty_data_no_crash(self) -> None:
         """Test empty data does not crash."""
         s = _scores(brier=None, reliability=None, total=0, valid=0)
         report = generate_report(s, [], platform="omen", disabled_tools={})
         assert "# Benchmark Report (Omenstrat) — " in report
-        assert "No predictions to score" in report
+        assert "No period data available." in report
 
 
 # ---------------------------------------------------------------------------
@@ -1672,8 +1677,9 @@ class TestGenerateReportWithTournamentFiles:
             include_tournament=True,
             scores_tournament=tourn,
         )
-        assert "## Overall — Tournament" in report
-        assert "## Tool Ranking — Tournament" in report
+        # Overall is dropped in Phase 2; Tool Ranking carries the rolling suffix.
+        assert "## Overall" not in report
+        assert "## Tool Ranking (Last 3 Days) — Tournament" in report
 
     def test_empty_period_tournament_does_not_render_section(self) -> None:
         """Tournament period files with zero rows don't emit empty sections.

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -33,12 +33,8 @@ from benchmark.analyze import (
     _parse_tvm_key,
     _sample_label,
     generate_report,
-    section_best_predictions,
     section_category,
-    section_edge_analysis,
-    section_latency,
     section_metric_reference,
-    section_overall,
     section_parse_breakdown,
     section_period,
     section_sample_size_warnings,
@@ -47,7 +43,6 @@ from benchmark.analyze import (
     section_trend,
     section_version_deltas,
     section_weak_spots,
-    section_worst_predictions,
 )
 from benchmark.scorer import MIN_SAMPLE_SIZE
 
@@ -113,50 +108,6 @@ def _scores(
         "parse_breakdown": parse_breakdown or {},
         "latency_reservoir": latency_reservoir or {},
     }
-
-
-# ---------------------------------------------------------------------------
-# section_overall
-# ---------------------------------------------------------------------------
-
-
-class TestSectionOverall:
-    """Tests for section_overall."""
-
-    def test_normal(self) -> None:
-        """Test normal scores with valid brier and reliability."""
-        result = section_overall(_scores(brier=0.31, reliability=0.95))
-        assert "0.31" in result
-        assert "95%" in result
-
-    def test_empty_dataset(self) -> None:
-        """Test empty dataset with no predictions."""
-        result = section_overall(
-            _scores(brier=None, reliability=None, total=0, valid=0)
-        )
-        assert "No predictions to score" in result
-
-    def test_all_invalid(self) -> None:
-        """Test all invalid predictions."""
-        result = section_overall(_scores(brier=None, reliability=0.0, total=5, valid=0))
-        assert "N/A" in result  # Brier is N/A
-
-    def test_no_signal_rate_small_value_renders_two_decimals(self) -> None:
-        """No-signal rate formats with 2 decimal places.
-
-        Previously rendered as ':.0%' which rounded tiny-but-nonzero
-        rates like 0.00072 to '0%' even though the count shown next to
-        it was clearly positive. Two decimals surface values in the
-        0.01%-1% range where the no-signal rate typically lives.
-        """
-        s = _scores(brier=0.3, reliability=0.95)
-        s["overall"]["no_signal_rate"] = 0.00072
-        s["overall"]["no_signal_count"] = 142
-        result = section_overall(s)
-        assert "0.07%" in result
-        assert "142 predictions at exactly 0.5" in result
-        # Make sure the rendered value is not the stale '0%' form.
-        assert "No-signal rate: 0%" not in result
 
 
 # ---------------------------------------------------------------------------
@@ -912,68 +863,6 @@ class TestSectionPeriod:
 
 
 # ---------------------------------------------------------------------------
-# section_worst_predictions / section_best_predictions
-# ---------------------------------------------------------------------------
-
-
-class TestSectionWorstPredictions:
-    """Tests for section_worst_predictions."""
-
-    def test_renders_entries(self) -> None:
-        """Test rendering worst prediction entries."""
-        s = _scores(
-            worst_10=[
-                {
-                    "question_text": "Will X happen?",
-                    "tool_name": "tool-a",
-                    "p_yes": 0.95,
-                    "final_outcome": False,
-                    "brier": 0.9025,
-                    "platform": "omen",
-                    "category": "finance",
-                },
-            ]
-        )
-        result = section_worst_predictions(s)
-        assert "Will X happen?" in result
-        assert "0.9025" in result
-        assert "tool-a" in result
-
-    def test_empty(self) -> None:
-        """Test empty worst predictions."""
-        result = section_worst_predictions(_scores())
-        assert "No prediction data" in result
-
-
-class TestSectionBestPredictions:
-    """Tests for section_best_predictions."""
-
-    def test_renders_entries(self) -> None:
-        """Test rendering best prediction entries."""
-        s = _scores(
-            best_10=[
-                {
-                    "question_text": "Will Y happen?",
-                    "tool_name": "tool-b",
-                    "p_yes": 0.98,
-                    "final_outcome": True,
-                    "brier": 0.0004,
-                    "platform": "polymarket",
-                    "category": "politics",
-                },
-            ]
-        )
-        result = section_best_predictions(s)
-        assert "Will Y happen?" in result
-        assert "0.0004" in result
-
-    def test_empty(self) -> None:
-        """Test empty best predictions."""
-        result = section_best_predictions(_scores())
-        assert "No prediction data" in result
-
-
-# ---------------------------------------------------------------------------
 # Parse breakdown
 # ---------------------------------------------------------------------------
 
@@ -996,31 +885,6 @@ class TestSectionParseBreakdown:
         """Test empty parse breakdown."""
         result = section_parse_breakdown(_scores())
         assert "No parse data" in result
-
-
-# ---------------------------------------------------------------------------
-# Latency
-# ---------------------------------------------------------------------------
-
-
-class TestSectionLatency:
-    """Tests for section_latency."""
-
-    def test_renders_table(self) -> None:
-        """Test rendering latency table."""
-        s = _scores(
-            latency_reservoir={
-                "tool-a": [10, 12, 15, 20, 25, 30, 8, 11, 14, 18],
-            }
-        )
-        result = section_latency(s)
-        assert "tool-a" in result
-        assert "Median" in result
-
-    def test_empty(self) -> None:
-        """Test empty latency data."""
-        result = section_latency(_scores())
-        assert "No latency data" in result
 
 
 # ---------------------------------------------------------------------------
@@ -1811,59 +1675,6 @@ class TestGenerateReportPerPlatform:
             "omen": "Omenstrat",
             "polymarket": "Polystrat",
         }
-
-
-class TestSectionEdgeAnalysisPlatformGate:
-    """section_edge_analysis drops platform sub-blocks when platform is set."""
-
-    def _scores_with_edge(self) -> dict[str, Any]:
-        """Minimal scores dict with edge data on every platform breakdown."""
-        return {
-            "edge_eligibility": {"n_eligible": 100, "n_total": 100},
-            "by_platform": {
-                "omen": {
-                    "edge": 0.05,
-                    "edge_n": 80,
-                    "edge_positive_rate": 0.6,
-                },
-            },
-            "by_platform_difficulty": {
-                "omen | hard": {
-                    "edge": 0.03,
-                    "edge_n": 40,
-                    "edge_positive_rate": 0.55,
-                    "brier": 0.24,
-                    "n": 50,
-                },
-            },
-            "by_platform_liquidity": {
-                "omen | high": {
-                    "edge": 0.04,
-                    "edge_n": 30,
-                    "edge_positive_rate": 0.6,
-                    "brier": 0.22,
-                    "n": 40,
-                },
-            },
-        }
-
-    def test_platform_sub_blocks_dropped_when_platform_set(self) -> None:
-        """Single-platform scores: sub-blocks degenerate to one row, drop them."""
-        s = self._scores_with_edge()
-        rendered = section_edge_analysis(s, platform="omen")
-        assert "### By Platform" not in rendered
-        assert "### By Platform \u00d7 Difficulty" not in rendered
-        assert "### By Platform \u00d7 Liquidity" not in rendered
-        # Section header and eligibility summary still render.
-        assert "Edge-eligible rows: 100 / 100" in rendered
-
-    def test_platform_sub_blocks_present_when_platform_not_set(self) -> None:
-        """Fleet-wide render keeps sub-blocks (backwards-compat for callers)."""
-        s = self._scores_with_edge()
-        rendered = section_edge_analysis(s)
-        assert "### By Platform" in rendered
-        assert "### By Platform \u00d7 Difficulty" in rendered
-        assert "### By Platform \u00d7 Liquidity" in rendered
 
 
 class TestTrendSectionPlatformAnnotation:

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -24,9 +24,11 @@ import pytest
 
 from benchmark.analyze import (
     ACTIVE_CATEGORIES,
+    BRIER_RANDOM,
     OMEN_CATEGORIES,
     PLATFORM_LABELS,
     POLYMARKET_ACTIVE_CATEGORIES,
+    ROLLING_WINDOW_DAYS,
     SAMPLE_SIZE_WARNING,
     _parse_tvm_key,
     _sample_label,
@@ -35,6 +37,7 @@ from benchmark.analyze import (
     section_category,
     section_edge_analysis,
     section_latency,
+    section_metric_reference,
     section_overall,
     section_parse_breakdown,
     section_period,
@@ -1873,3 +1876,52 @@ class TestTrendSectionPlatformAnnotation:
         """Fleet-wide render (no platform arg) stays quiet — it's correct there."""
         rendered = section_trend(self._history(), None)
         assert "Fleet-wide monthly trend" not in rendered
+
+
+class TestSectionMetricReference:
+    """Tests for section_metric_reference."""
+
+    def test_renders_heading_and_core_metrics(self) -> None:
+        """Legend names every headline metric the report renders."""
+        rendered = section_metric_reference()
+        assert "## Metric References" in rendered
+        for label in ("Brier", "Log Loss", "BSS", "Edge over market"):
+            assert label in rendered
+
+    def test_cites_rolling_window_from_constant(self) -> None:
+        """Legend quotes ROLLING_WINDOW_DAYS so a one-line change updates both."""
+        rendered = section_metric_reference()
+        assert f"last {ROLLING_WINDOW_DAYS} days" in rendered
+
+    def test_cites_brier_random_baseline(self) -> None:
+        """Coin-flip Brier anchor is sourced from BRIER_RANDOM."""
+        rendered = section_metric_reference()
+        assert f"coin-flip {BRIER_RANDOM}" in rendered
+
+
+class TestGenerateReportLegendPlacement:
+    """Regression tests for where the metric legend lands in the report body."""
+
+    def test_legend_rendered_before_since_last_report(self) -> None:
+        """Legend sits between the H1 title and the first data section."""
+        scores = _scores()
+        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        legend_idx = report.index("## Metric References")
+        since_last_idx = report.index("## Since Last Report")
+        assert legend_idx < since_last_idx
+        header_end = report.index("\n")
+        assert legend_idx > header_end
+
+    def test_legend_rendered_exactly_once(self) -> None:
+        """Legend is not duplicated across production + tournament branches."""
+        scores = _scores()
+        tourn = _scores_with_tool("tool-a", 0.20, 1000)
+        report = generate_report(
+            scores,
+            [],
+            platform="omen",
+            include_tournament=True,
+            scores_tournament=tourn,
+            disabled_tools={},
+        )
+        assert report.count("## Metric References") == 1

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -1497,7 +1497,7 @@ class TestGenerateReportTournamentToggle:
             disabled_tools={},
         )
         assert "Tool × Version × Mode (All-Time)" in report
-        assert "Tool × Version × Mode (Last 7 Days)" in report
+        assert "Tool × Version × Mode (Last 3 Days)" in report
 
 
 # ---------------------------------------------------------------------------
@@ -1694,7 +1694,7 @@ class TestGenerateReportWithTournamentFiles:
             rolling_scores_tournament=empty_period_tourn,
         )
         assert "## Since Last Report — Tournament" not in report
-        assert "## Last 7 Days Rolling — Tournament" not in report
+        assert "## Last 3 Days Rolling — Tournament" not in report
 
     def test_merged_tool_version_mode_includes_both_modes(self) -> None:
         """Tool × Version × Mode table shows both production and tournament cells."""

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -1931,3 +1931,35 @@ class TestGenerateReportLegendPlacement:
             disabled_tools={},
         )
         assert report.count("## Metric References") == 1
+
+
+class TestGenerateReportRollingWindowAnnotations:
+    """Rolling sections carry the '_n= over last N days._' note; others do not."""
+
+    def test_rolling_sections_carry_window_note(self) -> None:
+        """Tool Ranking / Category / Tool × Category / Diagnostics / Weak Spots."""
+        scores = _scores_with_tool("tool-a", 0.20, 1000)
+        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        note = f"_n= values below are over the last {ROLLING_WINDOW_DAYS} days._"
+        # At least the five rolling point-in-time sections carry it.
+        assert report.count(note) >= 5
+
+    def test_non_rolling_sections_do_not_carry_window_note(self) -> None:
+        """Trend, Base Rates, Tool Deployment Status never claim rolling scope."""
+        scores = _scores_with_tool("tool-a", 0.20, 1000)
+        history = [{"month": "2026-03", "overall": {"brier": 0.3, "n": 50}}]
+        report = generate_report(scores, history, platform="omen", disabled_tools={})
+        note = f"_n= values below are over the last {ROLLING_WINDOW_DAYS} days._"
+        # Split on the Trend header and assert the note is absent between it and
+        # the next section heading.
+        trend_idx = report.index("## Trend")
+        next_section = report.find("##", trend_idx + 1)
+        trend_body = report[
+            trend_idx : next_section if next_section > -1 else len(report)
+        ]
+        assert note not in trend_body
+
+        base_rates_idx = report.index("## Base Rates")
+        next_section = report.find("##", base_rates_idx + 1)
+        base_body = report[base_rates_idx:next_section]
+        assert note not in base_body

--- a/benchmark/tests/test_notify_slack.py
+++ b/benchmark/tests/test_notify_slack.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from benchmark.analyze import PLATFORM_LABELS
+from benchmark.analyze import PLATFORM_LABELS, ROLLING_WINDOW_DAYS
 from benchmark.notify_slack import (
     SUMMARY_SYSTEM_PROMPT_TEMPLATE,
     _build_system_prompt,
@@ -82,6 +82,12 @@ class TestBuildSystemPrompt:
         assert "*Tournament callouts:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
         assert "*Diagnostics:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
         assert "*Recommended actions:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+
+    def test_prompt_references_rolling_window_days_constant(self) -> None:
+        """Prompt cites the current ROLLING_WINDOW_DAYS value in its summary bullet."""
+        assert (
+            f"in the last {ROLLING_WINDOW_DAYS} days" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        )
 
     def test_deployment_status_scoped_to_platform(self) -> None:
         """Deployment status bullet filters the fleet-wide section per platform.

--- a/benchmark/tests/test_notify_slack.py
+++ b/benchmark/tests/test_notify_slack.py
@@ -40,7 +40,7 @@ class TestBuildSystemPrompt:
         # Spot-check the sentences that should carry the label so a future
         # template refactor doesn't silently drop deployment scoping.
         assert "for the *Omenstrat* deployment" in prompt
-        assert "scoped to Omenstrat" in prompt
+        assert "for Omenstrat" in prompt
 
     def test_polystrat_label_appears_in_prompt(self) -> None:
         """Polystrat label renders symmetrically to Omenstrat."""
@@ -85,9 +85,28 @@ class TestBuildSystemPrompt:
 
     def test_prompt_references_rolling_window_days_constant(self) -> None:
         """Prompt cites the current ROLLING_WINDOW_DAYS value in its summary bullet."""
-        assert (
-            f"in the last {ROLLING_WINDOW_DAYS} days" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        assert f"last {ROLLING_WINDOW_DAYS} days" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+
+    def test_prompt_drops_alltime_scope_instructions(self) -> None:
+        """Prompt no longer tells the LLM to cite all-time or cumulative figures.
+
+        Phase 2 drops the all-time point-in-time sections from the report, so
+        the summary must not instruct the LLM to reference them.
+        """
+        assert "Only mention all-time numbers for context" not in (
+            SUMMARY_SYSTEM_PROMPT_TEMPLATE
         )
+        assert "deltas vs all-time" not in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+
+    def test_prompt_anchors_sections_to_rolling_heading_names(self) -> None:
+        """Prompt points the LLM at the Last-N-Days section headings by name."""
+        for heading in (
+            f"Tool Ranking (Last {ROLLING_WINDOW_DAYS} Days)",
+            f"Category Performance (Last {ROLLING_WINDOW_DAYS} Days)",
+            f"Tool × Category (Last {ROLLING_WINDOW_DAYS} Days)",
+            f"Diagnostic Edge Metrics (Last {ROLLING_WINDOW_DAYS} Days)",
+        ):
+            assert heading in SUMMARY_SYSTEM_PROMPT_TEMPLATE
 
     def test_deployment_status_scoped_to_platform(self) -> None:
         """Deployment status bullet filters the fleet-wide section per platform.

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -594,6 +594,25 @@ class TestIncrementalUpdate:
         same_q = [w for w in result["worst_10"] if w["question_text"] == "Same Q?"][0]
         assert same_q["brier"] == round(0.9**2, 4)  # worst of the two
 
+    def test_worst_best_skip_rows_without_question_text(self, tmp_path: Path) -> None:
+        """Without the guard, empty/missing questions collide into one "" bucket."""
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        good = {**_row(p_yes=0.9, outcome=False), "question_text": "Readable Q?"}
+        empty_question = {**_row(p_yes=0.95, outcome=False), "question_text": ""}
+        missing_question = _row(p_yes=0.1, outcome=True)
+        missing_question.pop("question_text", None)
+
+        result = update(
+            [good, empty_question, missing_question], scores_path, history_path
+        )
+
+        worst_qs = [w["question_text"] for w in result["worst_10"]]
+        best_qs = [b["question_text"] for b in result["best_10"]]
+        assert worst_qs == ["Readable Q?"]
+        assert best_qs == ["Readable Q?"]
+
     def test_mixed_valid_invalid(self, tmp_path: Path) -> None:
         """Malformed rows count toward n but not valid_n or Brier."""
         scores_path = tmp_path / "scores.json"
@@ -2838,6 +2857,19 @@ class TestScoreExtremePredictions:
         no_outcome["final_outcome"] = None
 
         worst, best = _score_extreme_predictions([valid, invalid_status, no_outcome])
+        assert [e["question_text"] for e in worst] == ["q-valid"]
+        assert [e["question_text"] for e in best] == ["q-valid"]
+
+    def test_excludes_rows_with_empty_or_missing_question_text(self) -> None:
+        """Without the guard, empty/missing questions collide into one "" bucket."""
+        valid = self._valid_row("q-valid", 0.5, True)
+        empty_question = self._valid_row("", 0.9, False)
+        missing_question = _row(p_yes=0.1, outcome=True)
+        missing_question.pop("question_text", None)
+
+        worst, best = _score_extreme_predictions(
+            [valid, empty_question, missing_question]
+        )
         assert [e["question_text"] for e in worst] == ["q-valid"]
         assert [e["question_text"] for e in best] == ["q-valid"]
 

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -41,6 +41,8 @@ from benchmark.scorer import (
     _empty_group,
     _is_edge_eligible,
     _partition_rows_by_platform,
+    _score_extreme_predictions,
+    _score_latency_reservoir,
     brier_score,
     classify_difficulty,
     classify_disagreement,
@@ -2693,3 +2695,171 @@ class TestPerPlatformPeriod:
         for scope in ("all", *PLATFORMS):
             prod, _ = result[scope]
             assert prod["overall"]["n"] == 0
+
+
+class TestScoreLatencyReservoir:
+    """Tests for _score_latency_reservoir."""
+
+    def test_groups_latencies_by_tool(self) -> None:
+        """Per-tool latency lists are returned in insertion order."""
+        rows = [
+            {**_row(tool="tool-a"), "latency_s": 1.0},
+            {**_row(tool="tool-b"), "latency_s": 5.0},
+            {**_row(tool="tool-a"), "latency_s": 2.0},
+        ]
+        reservoir = _score_latency_reservoir(rows)
+        assert reservoir == {"tool-a": [1.0, 2.0], "tool-b": [5.0]}
+
+    def test_omits_rows_without_latency(self) -> None:
+        """Rows lacking latency_s do not create empty entries."""
+        rows = [
+            _row(tool="tool-a"),
+            {**_row(tool="tool-b"), "latency_s": 3.0},
+        ]
+        reservoir = _score_latency_reservoir(rows)
+        assert reservoir == {"tool-b": [3.0]}
+
+    def test_caps_at_reservoir_size_keeping_most_recent(self) -> None:
+        """Lists exceeding LATENCY_RESERVOIR_SIZE drop the oldest entries."""
+        excess = LATENCY_RESERVOIR_SIZE + 5
+        rows = [{**_row(tool="tool-a"), "latency_s": float(i)} for i in range(excess)]
+        reservoir = _score_latency_reservoir(rows)
+        assert len(reservoir["tool-a"]) == LATENCY_RESERVOIR_SIZE
+        assert reservoir["tool-a"][0] == float(excess - LATENCY_RESERVOIR_SIZE)
+        assert reservoir["tool-a"][-1] == float(excess - 1)
+
+    def test_missing_tool_name_defaults_to_unknown(self) -> None:
+        """Rows without tool_name land under the 'unknown' bucket."""
+        row = _row()
+        row.pop("tool_name", None)
+        row["tool_name"] = None
+        row["latency_s"] = 0.5
+        reservoir = _score_latency_reservoir([row])
+        assert reservoir == {"unknown": [0.5]}
+
+    def test_empty_input(self) -> None:
+        """No rows -> empty reservoir."""
+        assert not _score_latency_reservoir([])
+
+
+class TestScoreExtremePredictions:
+    """Tests for _score_extreme_predictions."""
+
+    def _valid_row(self, question: str, p_yes: float, outcome: bool) -> dict[str, Any]:
+        """Build a valid row with a question_text for dedup checks."""
+        row = _row(p_yes=p_yes, outcome=outcome)
+        row["question_text"] = question
+        return row
+
+    def test_returns_worst_sorted_descending_by_brier(self) -> None:
+        """Worst list is sorted highest Brier first."""
+        rows = [
+            self._valid_row("q1", 0.9, False),  # brier 0.81
+            self._valid_row("q2", 0.6, True),  # brier 0.16
+            self._valid_row("q3", 0.5, True),  # brier 0.25
+        ]
+        worst, _ = _score_extreme_predictions(rows)
+        assert [e["question_text"] for e in worst] == ["q1", "q3", "q2"]
+
+    def test_returns_best_sorted_ascending_by_brier(self) -> None:
+        """Best list is sorted lowest Brier first."""
+        rows = [
+            self._valid_row("q1", 0.9, False),
+            self._valid_row("q2", 0.6, True),
+            self._valid_row("q3", 0.5, True),
+        ]
+        _, best = _score_extreme_predictions(rows)
+        assert [e["question_text"] for e in best] == ["q2", "q3", "q1"]
+
+    def test_truncates_to_worst_best_size(self) -> None:
+        """Lists are capped at WORST_BEST_SIZE entries each."""
+        rows = [
+            self._valid_row(f"q{i}", 0.1 + 0.01 * i, True)
+            for i in range(WORST_BEST_SIZE + 5)
+        ]
+        worst, best = _score_extreme_predictions(rows)
+        assert len(worst) == WORST_BEST_SIZE
+        assert len(best) == WORST_BEST_SIZE
+
+    def test_deduplicates_by_question_keeping_correct_extreme(self) -> None:
+        """Duplicate questions collapse: worst keeps highest, best keeps lowest."""
+        rows = [
+            self._valid_row("q1", 0.9, False),  # brier 0.81
+            self._valid_row("q1", 0.4, False),  # brier 0.16 (same question, better)
+            self._valid_row("q2", 0.5, True),  # brier 0.25
+        ]
+        worst, best = _score_extreme_predictions(rows)
+        # q1 appears once in each list, with the extremum Brier preserved.
+        q1_worst = [e for e in worst if e["question_text"] == "q1"]
+        q1_best = [e for e in best if e["question_text"] == "q1"]
+        assert len(q1_worst) == 1
+        assert len(q1_best) == 1
+        assert q1_worst[0]["brier"] == 0.81
+        assert q1_best[0]["brier"] == 0.16
+
+    def test_excludes_invalid_rows(self) -> None:
+        """Rows with non-'valid' parse status, missing p_yes, or missing outcome drop out."""
+        valid = self._valid_row("q-valid", 0.5, True)
+        invalid_status = _row(status="invalid")
+        invalid_status["question_text"] = "q-invalid"
+        no_outcome = self._valid_row("q-no-outcome", 0.5, True)
+        no_outcome["final_outcome"] = None
+
+        worst, best = _score_extreme_predictions([valid, invalid_status, no_outcome])
+        assert [e["question_text"] for e in worst] == ["q-valid"]
+        assert [e["question_text"] for e in best] == ["q-valid"]
+
+    def test_empty_input(self) -> None:
+        """No rows -> empty lists."""
+        worst, best = _score_extreme_predictions([])
+        assert worst == []
+        assert best == []
+
+    def test_entry_carries_expected_fields(self) -> None:
+        """Each entry exposes question, tool, p_yes, outcome, brier, platform, category."""
+        row = self._valid_row("q1", 0.8, False)
+        row["platform"] = "polymarket"
+        row["category"] = "politics"
+        row["tool_name"] = "tool-x"
+
+        worst, _ = _score_extreme_predictions([row])
+        entry = worst[0]
+        assert entry == {
+            "question_text": "q1",
+            "tool_name": "tool-x",
+            "p_yes": 0.8,
+            "final_outcome": False,
+            "brier": 0.64,
+            "platform": "polymarket",
+            "category": "politics",
+        }
+
+
+class TestScoreIncludesNewRollingFields:
+    """Regression tests confirming score() returns latency_reservoir + worst_10 + best_10."""
+
+    def test_score_output_contains_latency_reservoir(self) -> None:
+        """score() emits latency_reservoir keyed by tool."""
+        rows = [
+            {**_row(tool="tool-a"), "latency_s": 2.5},
+            {**_row(tool="tool-a"), "latency_s": 3.5},
+        ]
+        result = score(rows)
+        assert result["latency_reservoir"] == {"tool-a": [2.5, 3.5]}
+
+    def test_score_output_contains_worst_and_best(self) -> None:
+        """score() emits worst_10 and best_10 populated from valid rows."""
+        rows = [
+            {**_row(p_yes=0.9, outcome=False), "question_text": "q-worst"},
+            {**_row(p_yes=0.1, outcome=False), "question_text": "q-best"},
+        ]
+        result = score(rows)
+        assert result["worst_10"][0]["question_text"] == "q-worst"
+        assert result["best_10"][0]["question_text"] == "q-best"
+
+    def test_score_output_empty_rolling_fields_on_no_data(self) -> None:
+        """Empty rows -> empty rolling fields (no KeyError downstream)."""
+        result = score([])
+        assert result["latency_reservoir"] == {}
+        assert result["worst_10"] == []
+        assert result["best_10"] == []


### PR DESCRIPTION
## Summary

Phase 2 of the benchmark report restructure, stacked on top of #237. Collapses the rendered report to a single rolling window, anchors every tool/category metric to "Last 3 Days", drops the all-time point-in-time sections, and rewrites the Slack summary prompt to match. Adds a metric reference legend and per-section window annotations so readers can't confuse the window even without scrolling back to the heading.

Retargets to `main` once #237 lands. Until then the PR base is `feat/benchmark-per-platform-reports` so only the Phase 2 delta shows in the diff.

## What changed

### Scorer (`benchmark/scorer.py`)
`score()` now returns three fields that previously lived only in the incremental accumulator path:
- `latency_reservoir` — last `LATENCY_RESERVOIR_SIZE` latencies per tool, in insertion order.
- `worst_10` — top-10 worst predictions by Brier.
- `best_10` — top-10 best predictions by Brier.

Rows with missing `question_text` are skipped from the extreme lists (they'd collide into a single dedup bucket and surface as an unreadable example).

### Analyze (`benchmark/analyze.py`)
- `ROLLING_WINDOW_DAYS = 3` as the single source of truth for the rolling window. Report headings, Slack prompt, and tests all read from it.
- `section_metric_reference()` renders a legend (Brier / Log Loss / BSS / Edge with their ideal values) right after the H1. Anchors every point-in-time section to the rolling window unless the section heading explicitly says otherwise.
- `_annotate_with_window()` inserts `_n= values below are over the last N days._` under each rolling section heading so a reader can tell at a glance what window a row is scoped to.
- `generate_report` drops Overall, Edge Over Market, Calibration, Latency, Worst Predictions, Best Predictions. Tool Ranking, Category Performance, Tool × Category, Diagnostic Edge Metrics, and Weak Spots are now sourced from `rolling_scores_<platform>.json` with a `(Last 3 Days)` heading suffix. Tool × Version × Mode still renders both All-Time and rolling views; the rolling variant carries the same n= annotation as its siblings.
- When `rolling_scores` is missing (e.g. the `Score last 3 days` step failed with `continue-on-error: true`), the rolling sections are omitted and a `## Rolling Window (Last 3 Days)` banner explains the gap. Dropped the earlier fallback to all-time `scores` under the rolling heading — that was the same "data/heading mismatch" class as the Phase 1 trend-section bug.

### Workflow (`.github/workflows/benchmark_flywheel.yaml`)
`--period-days 7` → `--period-days 3`; step renamed to match.

### Slack notifier (`benchmark/notify_slack.py`)
- Prompt rewritten to assume single-window input. Every tool- and category-level bullet is anchored to a "Last 3 Days" section heading by name; n= citations carry an explicit "last 3 days" qualifier.
- The Summary bullet splits across the two windows: open with the 1-day delta from "Since Last Report", pivot to the rolling view, never attribute a figure from one window to the other.
- Removed all references to "all-time" / "cumulative" / "deltas vs all-time".

## Commits

1. `feat(benchmark): add latency_reservoir, worst_10, best_10 to score() output`
2. `feat(benchmark): reduce rolling window from 7 to 3 days`
3. `feat(benchmark): add metric reference legend at top of report`
4. `feat(benchmark): collapse report to single rolling window`
5. `feat(benchmark): rewrite slack summary prompt for single-window scope`
6. `feat(benchmark): annotate rolling sections with window qualifier note`
7. `fix(benchmark): skip rolling sections when rolling_scores is missing`
8. `fix(benchmark): tighten _score_latency_reservoir and _score_extreme_predictions`
9. `fix(benchmark): split slack summary bullet across the two windows`

Commits 7–9 are audit follow-ups from a local review pass.

## Verification

- `pytest benchmark/tests/` — 552 passed locally.
- `black` / `isort` / `flake8 --max-line-length=100` / `mypy` / `pylint` (with project disables) / `darglint` — all clean on the touched files.
- Standalone integration proof on 68 realistic rows across both platforms: full-inputs report renders the 5 rolling sections with annotations, `rolling_scores=None` path emits the banner and omits all 5 rolling sections (no window-mislabel leak), Slack prompt for both platforms has no cross-platform leakage.

## Test plan
- [x] `pytest benchmark/tests/` — all pass locally
- [x] Lint gate — all 6 linters clean on touched files
- [x] Local end-to-end render on realistic data (`rolling_scores` present)
- [x] Local end-to-end render with `rolling_scores=None` (banner path)
- [x] Slack prompt build for Omenstrat and Polystrat (no cross-platform leakage)
- [ ] End-to-end `workflow_dispatch` run against main after merge — confirm two Slack messages land, rolling sections render with "(Last 3 Days)" headings and n= annotations, banner renders only when `rolling_scores_<platform>.json` is genuinely missing
