### PR TITLE
feat(benchmark): address PR #243 review — scorer cross-cuts, adjacency, fleet mode

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -145,18 +145,6 @@ jobs:
         continue-on-error: true
 
       # Score recent periods for diff reporting
-      - name: Score today
-        run: |
-          TOURNAMENT_FLAG=""
-          if [ -f benchmark/results/tournament_scored.jsonl ]; then
-            TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
-          fi
-          python -m benchmark.scorer --period-days 1 \
-            --logs-dir benchmark/datasets/logs/ \
-            --output benchmark/results/period_scores.json \
-            $TOURNAMENT_FLAG
-        continue-on-error: true
-
       # Keep the "3" in the step name and --period-days flag in sync with
       # ROLLING_WINDOW_DAYS in benchmark/analyze.py. YAML can't import the
       # Python constant; a bump to ROLLING_WINDOW_DAYS must be mirrored here.
@@ -169,6 +157,21 @@ jobs:
           python -m benchmark.scorer --period-days 3 \
             --logs-dir benchmark/datasets/logs/ \
             --output benchmark/results/rolling_scores.json \
+            $TOURNAMENT_FLAG
+        continue-on-error: true
+
+      # Score the preceding non-overlapping window (days 4-6 ago for a
+      # 3-day rolling window). Feeds the "Δ vs Prev 3d" columns in the
+      # three-window comparison tables.
+      - name: Score previous 3 days (non-overlapping)
+        run: |
+          TOURNAMENT_FLAG=""
+          if [ -f benchmark/results/tournament_scored.jsonl ]; then
+            TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
+          fi
+          python -m benchmark.scorer --period-days 3 --period-offset-days 3 \
+            --logs-dir benchmark/datasets/logs/ \
+            --output benchmark/results/prev_rolling_scores.json \
             $TOURNAMENT_FLAG
         continue-on-error: true
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -53,13 +53,17 @@ python -m benchmark.analyze --platform polymarket --include-tournament
 # is in a single log file. Useful for spotting recent regressions or
 # checking if a prompt change improved scores over the last week.
 python -m benchmark.scorer --period-days 1 --logs-dir benchmark/datasets/logs/ --output results/last_day.json
-python -m benchmark.scorer --period-days 7 --logs-dir benchmark/datasets/logs/ --output results/last_week.json
+python -m benchmark.scorer --period-days 3 --logs-dir benchmark/datasets/logs/ --output results/last_3_days.json
 python -m benchmark.scorer --period-days 30 --logs-dir benchmark/datasets/logs/ --output results/last_month.json
 
 # Pass period scores to analyze for delta-vs-alltime reporting.
-# The report leads with "Since Last Report" and "Last 3 Days Rolling"
+# The report leads with "Since Last Report" and "Last 3 Days (Window Aggregate)"
 # sections showing how recent performance compares to all-time.
-python -m benchmark.analyze --platform omen --period results/last_day.json --rolling results/last_week.json
+python -m benchmark.analyze --platform omen --period results/last_day.json --rolling results/last_3_days.json
+
+# Fleet view: cross-platform category and tool × category × platform ranking
+# from the combined scores.json.
+python -m benchmark.analyze --fleet
 ```
 
 ### 2. Cached replay (local dev — sweep.py)

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -125,6 +125,88 @@ def load_history(path: Path) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
+# Three-window comparison helpers
+# ---------------------------------------------------------------------------
+#
+# The per-platform report renders each metric against three windows:
+#
+#   - Current 3d (the rolling window the report is anchored to)
+#   - All-time (cumulative since the first scored row)
+#   - Prev non-overlapping 3d (the 3-day window immediately preceding
+#     the current one, shifted back by the window width so the two
+#     windows share no rows)
+#
+# Delta formatting obeys two hard rules:
+#   - No delta when either side has n < MIN_SAMPLE_SIZE. "insufficient
+#     data" is rendered instead so readers never see a signed number
+#     with no sample-size anchor.
+#   - n is always cited next to the absolute value it measures.
+
+
+_INSUFFICIENT = "insufficient data"
+
+
+def _delta_cell(
+    current: float | None,
+    reference: float | None,
+    current_n: int,
+    reference_n: int,
+    lower_is_better: bool = True,
+) -> str:
+    """Format a delta cell with sample-size guardrails.
+
+    :param current: value from the current window.
+    :param reference: value from the reference window (all-time or prev 3d).
+    :param current_n: sample size for the current window.
+    :param reference_n: sample size for the reference window.
+    :param lower_is_better: when True (default, matches Brier/LogLoss),
+        a negative delta renders as "better"; when False (for BSS,
+        Edge, directional accuracy), a positive delta renders as
+        "better" instead.
+    :return: delta cell string.
+    """
+    if current is None or reference is None:
+        return "N/A"
+    if current_n < MIN_SAMPLE_SIZE or reference_n < MIN_SAMPLE_SIZE:
+        return _INSUFFICIENT
+    delta = current - reference
+    if lower_is_better:
+        direction = "better" if delta < 0 else "worse" if delta > 0 else "same"
+    else:
+        direction = "better" if delta > 0 else "worse" if delta < 0 else "same"
+    return f"{delta:+.4f} {direction}"
+
+
+def _value_cell(
+    value: float | None,
+    sample_n: int,
+    decimals: int = 4,
+) -> str:
+    """Format an absolute-value cell with an n= anchor.
+
+    :param value: metric value (already rounded by the scorer).
+    :param sample_n: sample size that produced this value.
+    :param decimals: number of decimal places to render.
+    :return: cell string such as ``"0.2100 (n=42)"`` or ``"N/A (n=5)"``.
+    """
+    if value is None:
+        return f"N/A (n={sample_n})"
+    return f"{value:.{decimals}f} (n={sample_n})"
+
+
+def _pct_cell(value: float | None, sample_n: int) -> str:
+    """Format a percentage-value cell with an n= anchor.
+
+    :param value: metric value in [0, 1] or ``None``.
+    :param sample_n: sample size that produced this value.
+    :return: cell string such as ``"70% (n=42)"``.
+    """
+    if value is None:
+        return f"N/A (n={sample_n})"
+    return f"{value:.0%} (n={sample_n})"
+
+
+# ---------------------------------------------------------------------------
 # Report sections
 # ---------------------------------------------------------------------------
 
@@ -142,11 +224,20 @@ def section_metric_reference(include_scope_note: bool = True) -> str:
         lines.extend(
             [
                 (
-                    f"Sections whose heading carries `(Last {ROLLING_WINDOW_DAYS} "
-                    "Days)` are scoped to the rolling window — a single aggregate "
-                    "over that window, not a trailing-average series. Sections "
-                    "tagged `(All-Time)` are cumulative from the first scored "
-                    "row. The Trend section is fleet-wide monthly, independent "
+                    f"Every comparison below uses three windows: `Current "
+                    f"{ROLLING_WINDOW_DAYS}d` (trailing {ROLLING_WINDOW_DAYS}-day "
+                    "aggregate), `All-Time` (cumulative since first scored row), "
+                    f"and `Prev {ROLLING_WINDOW_DAYS}d` (the immediately preceding "
+                    f"non-overlapping {ROLLING_WINDOW_DAYS}-day window). Deltas "
+                    "compare `Current` against each reference window."
+                ),
+                "",
+                (
+                    "Guardrails:"
+                    " a delta is suppressed when either side has n < "
+                    f"{MIN_SAMPLE_SIZE} (rendered as `insufficient data`);"
+                    " n is cited next to every absolute value;"
+                    " the Trend section is fleet-wide monthly, independent "
                     "of this report's platform scope."
                 ),
                 "",
@@ -575,6 +666,522 @@ def section_tool_category_platform(scores: dict[str, Any]) -> str:
             " omitted from ranking._"
         )
 
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Three-window comparison sections
+# ---------------------------------------------------------------------------
+
+
+def section_platform_snapshot(rolling_scores: dict[str, Any]) -> str:
+    """Render the current rolling-window platform snapshot.
+
+    Metrics: n, reliability, Brier, baseline Brier, BSS, directional
+    accuracy, outcome yes rate, and the always-majority baseline
+    (``max(yes_rate, 1-yes_rate)``) so readers can eyeball whether the
+    dataset is homogeneous enough for a low Brier to reflect base rate
+    rather than prediction skill.
+
+    :param rolling_scores: parsed ``rolling_scores_<platform>.json``.
+    :return: markdown section string.
+    """
+    heading = f"## Platform Snapshot (Current {ROLLING_WINDOW_DAYS}d)"
+    overall = rolling_scores.get("overall") or {}
+    n = overall.get("n", 0)
+    valid_n = overall.get("valid_n", 0)
+    reliability = overall.get("reliability")
+    brier = overall.get("brier")
+    baseline = overall.get("baseline_brier")
+    bss = overall.get("brier_skill_score")
+    dir_acc = overall.get("directional_accuracy")
+    yes_rate = overall.get("outcome_yes_rate")
+
+    if n == 0:
+        return f"{heading}\n\nNo rows scored in the current window."
+
+    majority_baseline: str
+    if yes_rate is None:
+        majority_baseline = "N/A"
+    else:
+        majority = max(yes_rate, 1.0 - yes_rate)
+        majority_baseline = f"{majority:.0%}"
+
+    lines = [
+        heading,
+        "",
+        f"- **n**: {n} (valid_n: {valid_n})",
+        f"- **Reliability**: {_pct_cell(reliability, n)}",
+        f"- **Brier**: {_value_cell(brier, valid_n)}",
+        f"- **Baseline Brier**: {_value_cell(baseline, valid_n)}",
+        f"- **BSS**: {_value_cell(bss, valid_n)}",
+        f"- **Directional Accuracy**: {_pct_cell(dir_acc, valid_n)}",
+        (
+            f"- **Outcome Yes Rate**: {_pct_cell(yes_rate, valid_n)}"
+            f" (always-majority baseline: {majority_baseline})"
+        ),
+    ]
+    return "\n".join(lines)
+
+
+def _platform_metric_row(
+    label: str,
+    current: dict[str, Any],
+    alltime: dict[str, Any],
+    prev: dict[str, Any] | None,
+    key: str,
+    *,
+    lower_is_better: bool = True,
+    decimals: int = 4,
+    is_pct: bool = False,
+) -> str:
+    """Build one comparison-table row for a platform-level metric.
+
+    :param label: row label (e.g. ``"Brier"``).
+    :param current: current-window overall stats dict.
+    :param alltime: all-time overall stats dict.
+    :param prev: previous-window overall stats dict, or ``None`` when
+        prev-rolling scores are unavailable for this run.
+    :param key: stats-dict key for the metric (e.g. ``"brier"``).
+    :param lower_is_better: passed to ``_delta_cell`` direction labeling.
+    :param decimals: decimal places for absolute values (ignored when
+        ``is_pct`` is True).
+    :param is_pct: when True, render absolute values as percentages.
+    :return: markdown table row (leading and trailing pipe included).
+    """
+    c_val = current.get(key)
+    a_val = alltime.get(key)
+    p_val = prev.get(key) if prev is not None else None
+    # valid_n drives sample-size gating for rate metrics; "reliability"
+    # uses n (row count) not valid_n, so the caller passes the right
+    # denominator key by using "n" as the metric key for that row.
+    c_n = current.get("valid_n", current.get("n", 0))
+    a_n = alltime.get("valid_n", alltime.get("n", 0))
+    p_n = prev.get("valid_n", prev.get("n", 0)) if prev is not None else 0
+    if key == "reliability":
+        c_n = current.get("n", 0)
+        a_n = alltime.get("n", 0)
+        p_n = prev.get("n", 0) if prev is not None else 0
+
+    value_fmt = _pct_cell if is_pct else lambda v, n: _value_cell(v, n, decimals)
+
+    delta_alltime = _delta_cell(c_val, a_val, c_n, a_n, lower_is_better)
+    delta_prev = (
+        _delta_cell(c_val, p_val, c_n, p_n, lower_is_better)
+        if prev is not None
+        else "no prev window"
+    )
+    return (
+        f"| {label} | {value_fmt(c_val, c_n)} | {value_fmt(a_val, a_n)}"
+        f" | {delta_alltime} | {value_fmt(p_val, p_n)} | {delta_prev} |"
+    )
+
+
+def section_platform_comparison(
+    rolling_scores: dict[str, Any],
+    alltime_scores: dict[str, Any],
+    prev_rolling_scores: dict[str, Any] | None,
+) -> str:
+    """Render the platform historical comparison table.
+
+    Each metric row compares the current window against all-time and
+    (when available) the previous non-overlapping window, with deltas
+    and sample sizes gated by ``MIN_SAMPLE_SIZE``.
+
+    :param rolling_scores: current rolling-window scores.
+    :param alltime_scores: all-time / cumulative scores.
+    :param prev_rolling_scores: previous non-overlapping rolling scores,
+        or ``None`` when the upstream scoring step has not yet landed
+        one on disk.
+    :return: markdown section string.
+    """
+    heading = "## Platform Historical Comparison"
+    current = rolling_scores.get("overall") or {}
+    alltime = alltime_scores.get("overall") or {}
+    prev = (prev_rolling_scores or {}).get("overall")
+
+    lines = [
+        heading,
+        "",
+        (
+            "| Metric"
+            f" | Current {ROLLING_WINDOW_DAYS}d"
+            " | All-Time"
+            " | Δ vs All-Time"
+            f" | Prev {ROLLING_WINDOW_DAYS}d"
+            f" | Δ vs Prev {ROLLING_WINDOW_DAYS}d |"
+        ),
+        "|--------|---------|----------|---------------|---------|-------------|",
+        _platform_metric_row(
+            "Reliability", current, alltime, prev, "reliability", is_pct=True
+        ),
+        _platform_metric_row("Brier", current, alltime, prev, "brier"),
+        _platform_metric_row(
+            "Baseline Brier", current, alltime, prev, "baseline_brier"
+        ),
+        _platform_metric_row(
+            "BSS", current, alltime, prev, "brier_skill_score", lower_is_better=False
+        ),
+        _platform_metric_row(
+            "Directional Accuracy",
+            current,
+            alltime,
+            prev,
+            "directional_accuracy",
+            lower_is_better=False,
+            is_pct=True,
+        ),
+        _platform_metric_row("Log Loss", current, alltime, prev, "log_loss"),
+    ]
+    return "\n".join(lines)
+
+
+def _tool_universe(
+    *score_dicts: dict[str, Any] | None,
+) -> list[str]:
+    """Return the ordered union of tool names across the given scores.
+
+    Ordering: tools that appear in the first non-None scores dict keep
+    its ranking order; tools unique to later dicts are appended in the
+    order they're first seen. This keeps comparison rows aligned with
+    the current-window ranking when it exists.
+
+    :param score_dicts: any number of scores dicts (``None`` entries are
+        ignored).
+    :return: ordered list of unique tool names.
+    """
+    seen: dict[str, None] = {}
+    for sd in score_dicts:
+        if sd is None:
+            continue
+        by_tool = sd.get("by_tool") or {}
+        ranked = sorted(by_tool.items(), key=brier_sort_key)
+        for tool, _ in ranked:
+            if tool not in seen:
+                seen[tool] = None
+    return list(seen)
+
+
+def section_tool_comparison(
+    rolling_scores: dict[str, Any],
+    alltime_scores: dict[str, Any],
+    prev_rolling_scores: dict[str, Any] | None,
+) -> str:
+    """Render the tool historical comparison table.
+
+    One row per tool, ranked by current-window Brier. Brier is shown for
+    each window with n= anchors, plus deltas vs all-time and vs prev
+    non-overlapping window. Low-sample cells are gated — deltas
+    disappear rather than mislead.
+
+    :param rolling_scores: current rolling-window scores.
+    :param alltime_scores: all-time scores (used for Δ vs all-time).
+    :param prev_rolling_scores: previous non-overlapping rolling scores,
+        or ``None``.
+    :return: markdown section string.
+    """
+    heading = "## Tool Historical Comparison"
+    tools = _tool_universe(rolling_scores, alltime_scores)
+    if not tools:
+        return f"{heading}\n\nNo tool data available."
+
+    lines = [
+        heading,
+        "",
+        (
+            "| Tool"
+            f" | Current {ROLLING_WINDOW_DAYS}d Brier"
+            " | All-Time Brier"
+            " | Δ vs All-Time"
+            f" | Prev {ROLLING_WINDOW_DAYS}d Brier"
+            f" | Δ vs Prev {ROLLING_WINDOW_DAYS}d |"
+        ),
+        "|------|----------|----------|---------------|---------|-------------|",
+    ]
+    cur_by_tool = rolling_scores.get("by_tool") or {}
+    at_by_tool = alltime_scores.get("by_tool") or {}
+    prev_by_tool = (prev_rolling_scores or {}).get("by_tool") or {}
+    for tool in tools:
+        c = cur_by_tool.get(tool, {})
+        a = at_by_tool.get(tool, {})
+        p = prev_by_tool.get(tool) if prev_rolling_scores is not None else None
+        c_n = c.get("valid_n", 0) if c else 0
+        a_n = a.get("valid_n", 0) if a else 0
+        p_n = p.get("valid_n", 0) if p else 0
+        c_brier = c.get("brier") if c else None
+        a_brier = a.get("brier") if a else None
+        p_brier = p.get("brier") if p else None
+
+        flag = _sample_label(c) if c else ""
+        delta_at = _delta_cell(c_brier, a_brier, c_n, a_n)
+        delta_prev = (
+            _delta_cell(c_brier, p_brier, c_n, p_n)
+            if prev_rolling_scores is not None
+            else "no prev window"
+        )
+        lines.append(
+            f"| **{tool}**{flag}"
+            f" | {_value_cell(c_brier, c_n)}"
+            f" | {_value_cell(a_brier, a_n)}"
+            f" | {delta_at}"
+            f" | {_value_cell(p_brier, p_n)}"
+            f" | {delta_prev} |"
+        )
+    return "\n".join(lines)
+
+
+def section_tool_category_comparison(
+    rolling_scores: dict[str, Any],
+    alltime_scores: dict[str, Any],
+    prev_rolling_scores: dict[str, Any] | None,
+) -> str:
+    """Render the tool × category historical comparison table.
+
+    One row per (tool, category) cell that clears ``MIN_SAMPLE_SIZE`` in
+    the current window. Cells that lack current-window coverage are
+    dropped from the ranking (they'd otherwise clutter the table with
+    rows where the comparison is meaningless).
+
+    :param rolling_scores: current rolling-window scores.
+    :param alltime_scores: all-time scores.
+    :param prev_rolling_scores: previous non-overlapping rolling scores.
+    :return: markdown section string.
+    """
+    heading = "## Tool × Category Historical Comparison"
+    cur = rolling_scores.get("by_tool_category") or {}
+    at = alltime_scores.get("by_tool_category") or {}
+    prev = (prev_rolling_scores or {}).get("by_tool_category") or {}
+
+    ranked = sorted(cur.items(), key=brier_sort_key)
+    sufficient = [(k, s) for k, s in ranked if s["n"] >= MIN_SAMPLE_SIZE]
+    if not sufficient:
+        return (
+            f"{heading}\n\n"
+            f"No (tool × category) cells clear n ≥ {MIN_SAMPLE_SIZE} in the "
+            "current window."
+        )
+
+    lines = [
+        heading,
+        "",
+        (
+            "| Tool | Category"
+            f" | Current {ROLLING_WINDOW_DAYS}d Brier"
+            " | All-Time Brier"
+            " | Δ vs All-Time"
+            f" | Prev {ROLLING_WINDOW_DAYS}d Brier"
+            f" | Δ vs Prev {ROLLING_WINDOW_DAYS}d |"
+        ),
+        "|------|----------|----------|----------|---------------|---------|-------------|",
+    ]
+    for key, c_stats in sufficient:
+        parts = key.split(" | ")
+        tool = parts[0] if parts else key
+        cat = parts[1] if len(parts) > 1 else "?"
+        a_stats = at.get(key, {})
+        p_stats = prev.get(key, {}) if prev_rolling_scores is not None else None
+        c_n = c_stats.get("valid_n", 0)
+        a_n = a_stats.get("valid_n", 0)
+        p_n = p_stats.get("valid_n", 0) if p_stats else 0
+        c_brier = c_stats.get("brier")
+        a_brier = a_stats.get("brier")
+        p_brier = p_stats.get("brier") if p_stats else None
+
+        delta_at = _delta_cell(c_brier, a_brier, c_n, a_n)
+        delta_prev = (
+            _delta_cell(c_brier, p_brier, c_n, p_n)
+            if prev_rolling_scores is not None
+            else "no prev window"
+        )
+        lines.append(
+            f"| {tool} | {cat}"
+            f" | {_value_cell(c_brier, c_n)}"
+            f" | {_value_cell(a_brier, a_n)}"
+            f" | {delta_at}"
+            f" | {_value_cell(p_brier, p_n)}"
+            f" | {delta_prev} |"
+        )
+    return "\n".join(lines)
+
+
+def _diag_metric_label(metric_key: str) -> str:
+    """Return the display label for a diagnostic metric key.
+
+    :param metric_key: one of the diagnostic metric keys on a stats dict.
+    :return: human-readable label.
+    """
+    labels = {
+        "edge": "Edge",
+        "log_loss": "Log Loss",
+        "conditional_accuracy_rate": "Conditional Accuracy",
+        "brier_large_trade": "Disagreement Brier (large trade)",
+        "directional_bias": "Directional Bias",
+    }
+    return labels.get(metric_key, metric_key)
+
+
+def section_diagnostics_comparison(
+    rolling_scores: dict[str, Any],
+    alltime_scores: dict[str, Any],
+    prev_rolling_scores: dict[str, Any] | None,
+) -> str:
+    """Render the diagnostics historical comparison table.
+
+    Per tool, renders the diagnostic metrics (edge, log loss, conditional
+    accuracy, disagreement Brier at large trade, directional bias) for
+    the three windows with deltas. Uses the tool's per-metric
+    denominator (``edge_n``, ``disagree_n``, ``n_large_trade``,
+    ``n_bias_losses``) for sample-size gating so deltas aren't gated by
+    the wrong ``valid_n``.
+
+    :param rolling_scores: current rolling-window scores.
+    :param alltime_scores: all-time scores.
+    :param prev_rolling_scores: previous non-overlapping rolling scores.
+    :return: markdown section string.
+    """
+    heading = "## Diagnostics Historical Comparison"
+    tools = _tool_universe(rolling_scores, alltime_scores)
+    if not tools:
+        return f"{heading}\n\nNo tool data available."
+
+    # For each metric, the stats dict key + the denominator key that
+    # gates its sample size. Edge n lives in `edge_n`, not `valid_n`,
+    # so a tool with low edge-eligible rows doesn't drag its Brier
+    # delta into "insufficient data".
+    metrics: list[tuple[str, str, bool]] = [
+        ("edge", "edge_n", False),
+        ("log_loss", "valid_n", True),
+        ("conditional_accuracy_rate", "disagree_n", False),
+        ("brier_large_trade", "n_large_trade", True),
+        ("directional_bias", "n_bias_losses", True),
+    ]
+
+    cur_by_tool = rolling_scores.get("by_tool") or {}
+    at_by_tool = alltime_scores.get("by_tool") or {}
+    prev_by_tool = (prev_rolling_scores or {}).get("by_tool") or {}
+
+    lines = [
+        heading,
+        "",
+        (
+            "| Tool | Metric"
+            f" | Current {ROLLING_WINDOW_DAYS}d"
+            " | All-Time"
+            " | Δ vs All-Time"
+            f" | Prev {ROLLING_WINDOW_DAYS}d"
+            f" | Δ vs Prev {ROLLING_WINDOW_DAYS}d |"
+        ),
+        "|------|--------|----------|----------|---------------|---------|-------------|",
+    ]
+    for tool in tools:
+        c = cur_by_tool.get(tool, {})
+        a = at_by_tool.get(tool, {})
+        p = prev_by_tool.get(tool) if prev_rolling_scores is not None else None
+        for metric_key, n_key, lower_is_better in metrics:
+            c_val = c.get(metric_key) if c else None
+            a_val = a.get(metric_key) if a else None
+            p_val = p.get(metric_key) if p else None
+            c_n = c.get(n_key, 0) if c else 0
+            a_n = a.get(n_key, 0) if a else 0
+            p_n = p.get(n_key, 0) if p else 0
+            if c_val is None and a_val is None and p_val is None:
+                continue
+
+            delta_at = _delta_cell(c_val, a_val, c_n, a_n, lower_is_better)
+            delta_prev = (
+                _delta_cell(c_val, p_val, c_n, p_n, lower_is_better)
+                if prev_rolling_scores is not None
+                else "no prev window"
+            )
+            lines.append(
+                f"| **{tool}** | {_diag_metric_label(metric_key)}"
+                f" | {_value_cell(c_val, c_n)}"
+                f" | {_value_cell(a_val, a_n)}"
+                f" | {delta_at}"
+                f" | {_value_cell(p_val, p_n)}"
+                f" | {delta_prev} |"
+            )
+    if len(lines) == 5:
+        # Only the header rows — no tool had data across any diagnostic
+        # metric for any window.
+        lines.append("| _(no diagnostic data)_ | | | | | | |")
+    return "\n".join(lines)
+
+
+def section_reliability_comparison(
+    rolling_scores: dict[str, Any],
+    alltime_scores: dict[str, Any],
+) -> str:
+    """Render the reliability & parse quality comparison table.
+
+    Per-tool reliability and parse-rate stats for the current window
+    versus all-time. Prev-rolling intentionally omitted: reliability is
+    a pipeline-health signal, not a tool-performance one, and comparing
+    two short trailing windows against each other adds noise without
+    signal.
+
+    :param rolling_scores: current rolling-window scores.
+    :param alltime_scores: all-time scores.
+    :return: markdown section string.
+    """
+    heading = "## Reliability & Parse Quality (Current vs All-Time)"
+    tools = _tool_universe(rolling_scores, alltime_scores)
+    if not tools:
+        return f"{heading}\n\nNo tool data available."
+
+    cur_by_tool = rolling_scores.get("by_tool") or {}
+    at_by_tool = alltime_scores.get("by_tool") or {}
+    cur_parse = rolling_scores.get("parse_breakdown") or {}
+    at_parse = alltime_scores.get("parse_breakdown") or {}
+
+    def _rate(breakdown: dict[str, int], status: str) -> tuple[float | None, int]:
+        total = sum(breakdown.values())
+        if total == 0:
+            return None, 0
+        return breakdown.get(status, 0) / total, total
+
+    lines = [
+        heading,
+        "",
+        (
+            "| Tool"
+            f" | Current {ROLLING_WINDOW_DAYS}d Reliability"
+            " | All-Time Reliability"
+            " | Δ"
+            f" | Current {ROLLING_WINDOW_DAYS}d Valid %"
+            " | All-Time Valid %"
+            " | Δ |"
+        ),
+        "|------|----------|----------|-----|----------|----------|-----|",
+    ]
+    for tool in tools:
+        c = cur_by_tool.get(tool, {})
+        a = at_by_tool.get(tool, {})
+        c_n = c.get("n", 0) if c else 0
+        a_n = a.get("n", 0) if a else 0
+        c_rel = c.get("reliability") if c else None
+        a_rel = a.get("reliability") if a else None
+
+        c_valid_rate, c_parse_n = _rate(cur_parse.get(tool) or {}, "valid")
+        a_valid_rate, a_parse_n = _rate(at_parse.get(tool) or {}, "valid")
+
+        delta_rel = _delta_cell(c_rel, a_rel, c_n, a_n, lower_is_better=False)
+        delta_valid = _delta_cell(
+            c_valid_rate,
+            a_valid_rate,
+            c_parse_n,
+            a_parse_n,
+            lower_is_better=False,
+        )
+        lines.append(
+            f"| **{tool}**"
+            f" | {_pct_cell(c_rel, c_n)}"
+            f" | {_pct_cell(a_rel, a_n)}"
+            f" | {delta_rel}"
+            f" | {_pct_cell(c_valid_rate, c_parse_n)}"
+            f" | {_pct_cell(a_valid_rate, a_parse_n)}"
+            f" | {delta_valid} |"
+        )
     return "\n".join(lines)
 
 
@@ -1593,39 +2200,38 @@ def generate_report(  # pylint: disable=too-many-statements
     history: list[dict[str, Any]] | None = None,
     *,
     platform: str,
-    period_scores: dict[str, Any] | None = None,
     rolling_scores: dict[str, Any] | None = None,
+    prev_rolling_scores: dict[str, Any] | None = None,
     include_tournament: bool = False,
     scores_tournament: dict[str, Any] | None = None,
-    period_scores_tournament: dict[str, Any] | None = None,
     rolling_scores_tournament: dict[str, Any] | None = None,
     disabled_tools: dict[str, list[str] | None] | None = None,
 ) -> str:
     """Generate a platform-scoped benchmark report from scores and history.
 
     Every section is driven by scores already partitioned to ``platform``
-    by the scorer, so the fleet-wide comparison sections (``section_platform``,
-    ``section_tool_platform``, Platform × Difficulty, Platform × Liquidity)
-    are dropped — they'd render a single-row view that adds noise without
-    signal. The report header names the deployment this report covers.
+    by the scorer. Each metric is compared across three windows: current
+    rolling (``rolling_scores``), cumulative (``scores``), and previous
+    non-overlapping rolling (``prev_rolling_scores``). Deltas are
+    suppressed when either side has n < ``MIN_SAMPLE_SIZE`` so a reader
+    never sees a signed number without an adequate sample-size anchor.
 
-    Production-mode sections are rendered from ``scores`` /
-    ``period_scores`` / ``rolling_scores``. When tournament scores are
-    supplied and contain rows, a duplicate set of the mode-sensitive
-    sections is rendered with a ``— Tournament`` suffix.
+    Overlapping-window comparisons (such as "since last report") are
+    intentionally omitted — prev-rolling is the only change-over-time
+    reference, and it is non-overlapping by construction.
 
     :param scores: parsed platform-scoped ``scores_<platform>.json`` dict.
     :param history: list of monthly snapshots from ``scores_history.jsonl``.
     :param platform: one of ``PLATFORM_LABELS`` keys (``"omen"`` or
-        ``"polymarket"``). Drives the report header and gates platform-
-        comparison sections.
-    :param period_scores: production scores since last report.
-    :param rolling_scores: production scores from the rolling window.
+        ``"polymarket"``). Drives the report header.
+    :param rolling_scores: production scores from the current rolling window.
+    :param prev_rolling_scores: production scores from the preceding
+        non-overlapping rolling window, or ``None`` when the upstream
+        scoring step has not landed one on disk.
     :param include_tournament: master switch for rendering the Tool ×
         Version × Mode breakdown. When False, tournament inputs are
         ignored entirely.
     :param scores_tournament: parsed ``scores_tournament_<platform>.json`` dict.
-    :param period_scores_tournament: tournament since last report.
     :param rolling_scores_tournament: tournament rolling window scores.
     :param disabled_tools: pre-fetched ``{deployment: [tool_names] | None}``
         map used by the Tool Deployment Status section.
@@ -1645,77 +2251,47 @@ def generate_report(  # pylint: disable=too-many-statements
     )
 
     render_tournament = include_tournament and _has_tournament_data(scores_tournament)
-    # Local non-optional alias for mypy once _has_tournament_data has narrowed.
-    tournament_scores: dict[str, Any] = scores_tournament or {}
 
     sections: list[str] = [f"# Benchmark Report ({platform_label}) — {date}"]
 
     sections.append(section_metric_reference())
 
-    # Since Last Report
-    sections.append(section_period(period_scores, scores, "Since Last Report"))
-    if render_tournament and _has_tournament_data(period_scores_tournament):
-        sections.append(
-            _relabel_heading(
-                section_period(
-                    period_scores_tournament,
-                    tournament_scores,
-                    "Since Last Report",
-                ),
-                " — Tournament",
-            )
-        )
-
-    rolling_heading = f"Last {ROLLING_WINDOW_DAYS} Days (Window Aggregate)"
-    if rolling_scores is not None:
-        sections.append(section_period(rolling_scores, scores, rolling_heading))
-        if render_tournament and _has_tournament_data(rolling_scores_tournament):
-            sections.append(
-                _relabel_heading(
-                    section_period(
-                        rolling_scores_tournament,
-                        tournament_scores,
-                        rolling_heading,
-                    ),
-                    " — Tournament",
-                )
-            )
-
-    rolling_suffix = f" (Last {ROLLING_WINDOW_DAYS} Days)"
-    rolling_window_note = f"last {ROLLING_WINDOW_DAYS} days"
-
-    def _rolling(section_md: str, heading_suffix: str = rolling_suffix) -> str:
-        """Add the rolling-window heading suffix and n= qualifier note."""
-        return _annotate_with_window(
-            _relabel_heading(section_md, heading_suffix), rolling_window_note
-        )
-
     if rolling_scores is None:
         sections.append(
-            f"## Last {ROLLING_WINDOW_DAYS} Days (Window Aggregate)\n\n"
+            f"## Platform Snapshot (Current {ROLLING_WINDOW_DAYS}d)\n\n"
             f"Scores for the last {ROLLING_WINDOW_DAYS} days are "
             "unavailable — the scoring step did not produce "
-            f"`rolling_scores_{platform}.json` for this run. Tool Ranking, "
-            "Category Performance, Tool × Category, Diagnostic Edge Metrics, "
-            "and Weak Spots sections are omitted."
+            f"`rolling_scores_{platform}.json` for this run. All rolling "
+            "sections (snapshot, platform/tool/tool×category/diagnostics "
+            "comparisons, reliability) are omitted."
         )
     else:
-        sections.append(_rolling(section_tool_ranking(rolling_scores)))
-        if render_tournament and _has_tournament_data(rolling_scores_tournament):
-            rolling_tourn: dict[str, Any] = rolling_scores_tournament or {}
-            sections.append(
-                _rolling(
-                    section_tool_ranking(rolling_tourn),
-                    f"{rolling_suffix} — Tournament",
-                )
+        sections.append(section_platform_snapshot(rolling_scores))
+        sections.append(
+            section_platform_comparison(rolling_scores, scores, prev_rolling_scores)
+        )
+        sections.append(
+            section_tool_comparison(rolling_scores, scores, prev_rolling_scores)
+        )
+        # Tool × Category — the reviewer asked for both the current-window
+        # ranking table AND the historical comparison, so render the two
+        # in sequence.
+        sections.append(
+            _relabel_heading(
+                section_tool_category(rolling_scores),
+                f" (Current {ROLLING_WINDOW_DAYS}d)",
             )
-        sections.append(_rolling(section_tool_category(rolling_scores)))
-        sections.append(_rolling(section_category(rolling_scores)))
-        sections.append(_rolling(section_diagnostic_metrics(rolling_scores)))
-        sections.append(_rolling(section_weak_spots(rolling_scores)))
+        )
+        sections.append(
+            section_tool_category_comparison(
+                rolling_scores, scores, prev_rolling_scores
+            )
+        )
+        sections.append(
+            section_diagnostics_comparison(rolling_scores, scores, prev_rolling_scores)
+        )
+        sections.append(section_reliability_comparison(rolling_scores, scores))
 
-    sections.append(_relabel_heading(section_tool_ranking(scores), " (All-Time)"))
-    sections.append(_relabel_heading(section_base_rates(scores), " (All-Time)"))
     sections.append(
         section_tool_deployment_status(
             scores, disabled=disabled_tools, platform=platform
@@ -1733,6 +2309,7 @@ def generate_report(  # pylint: disable=too-many-statements
             merged_rolling = _merged_tvm_scores(
                 rolling_scores, rolling_scores_tournament
             )
+            rolling_window_note = f"last {ROLLING_WINDOW_DAYS} days"
             tvm_rolling = section_tool_version_breakdown(
                 merged_rolling,
                 f"Tool × Version × Mode (Last {ROLLING_WINDOW_DAYS} Days)",
@@ -1745,8 +2322,6 @@ def generate_report(  # pylint: disable=too-many-statements
 
     sections.extend(
         [
-            _relabel_heading(section_reliability_issues(scores), " (All-Time)"),
-            _relabel_heading(section_parse_breakdown(scores), " (All-Time)"),
             section_trend(history, None, platform=platform),
             _relabel_heading(section_sample_size_warnings(scores), " (All-Time)"),
         ]
@@ -1787,9 +2362,9 @@ def generate_fleet_report(
         f"# Benchmark Report (Fleet, Cross-Platform) — {date}",
         (
             "_Cross-platform view for direct category and tool × category ranking "
-            "across platforms. For per-platform deep dives (rolling window, weak "
-            "spots, deployment status) see `report_omen.md` and "
-            "`report_polymarket.md`._"
+            "across platforms. All metrics here are all-time / cumulative — for "
+            f"change-over-time and {ROLLING_WINDOW_DAYS}-day comparisons, see "
+            "`report_omen.md` and `report_polymarket.md`._"
         ),
         section_metric_reference(include_scope_note=False),
         section_platform(scores),
@@ -1843,20 +2418,20 @@ def main() -> None:
         help="Report output path. Default: results/report_<platform>.md.",
     )
     parser.add_argument(
-        "--period",
-        type=Path,
-        default=None,
-        help=(
-            "Period scores JSON (since last report). "
-            "Default: results/period_scores_<platform>.json."
-        ),
-    )
-    parser.add_argument(
         "--rolling",
         type=Path,
         default=None,
         help=(
             "Rolling scores JSON. " "Default: results/rolling_scores_<platform>.json."
+        ),
+    )
+    parser.add_argument(
+        "--prev-rolling",
+        type=Path,
+        default=None,
+        help=(
+            "Previous non-overlapping rolling scores JSON. Default: "
+            "results/prev_rolling_scores_<platform>.json."
         ),
     )
     parser.add_argument(
@@ -1866,15 +2441,6 @@ def main() -> None:
         help=(
             "Tournament scores JSON. "
             "Default: results/scores_tournament_<platform>.json."
-        ),
-    )
-    parser.add_argument(
-        "--period-tournament",
-        type=Path,
-        default=None,
-        help=(
-            "Tournament period scores JSON. "
-            "Default: results/period_scores_tournament_<platform>.json."
         ),
     )
     parser.add_argument(
@@ -1916,14 +2482,12 @@ def main() -> None:
     platform = args.platform
     scores_path = args.scores or results_dir / f"scores_{platform}.json"
     output_path = args.output or results_dir / f"report_{platform}.md"
-    period_path = args.period or results_dir / f"period_scores_{platform}.json"
     rolling_path = args.rolling or results_dir / f"rolling_scores_{platform}.json"
+    prev_rolling_path = (
+        args.prev_rolling or results_dir / f"prev_rolling_scores_{platform}.json"
+    )
     scores_tournament_path = (
         args.scores_tournament or results_dir / f"scores_tournament_{platform}.json"
-    )
-    period_tournament_path = (
-        args.period_tournament
-        or results_dir / f"period_scores_tournament_{platform}.json"
     )
     rolling_tournament_path = (
         args.rolling_tournament
@@ -1934,10 +2498,9 @@ def main() -> None:
         return load_scores(path) if path and path.exists() else None
 
     scores = load_scores(scores_path)
-    period = _maybe_load(period_path)
     rolling = _maybe_load(rolling_path)
+    prev_rolling = _maybe_load(prev_rolling_path)
     scores_tournament = _maybe_load(scores_tournament_path)
-    period_tournament = _maybe_load(period_tournament_path)
     rolling_tournament = _maybe_load(rolling_tournament_path)
 
     print(
@@ -1949,11 +2512,10 @@ def main() -> None:
         scores,
         history,
         platform=platform,
-        period_scores=period,
         rolling_scores=rolling,
+        prev_rolling_scores=prev_rolling,
         include_tournament=args.include_tournament,
         scores_tournament=scores_tournament,
-        period_scores_tournament=period_tournament,
         rolling_scores_tournament=rolling_tournament,
     )
 

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -482,8 +482,49 @@ def section_category(scores: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _always_majority(yes_rate: float | None) -> float | None:
+    """Return ``max(yes_rate, 1-yes_rate)`` — the always-majority baseline.
+
+    :param yes_rate: fraction of valid rows whose final outcome is YES.
+    :return: always-majority accuracy in ``[0.5, 1.0]`` or ``None`` when
+        ``yes_rate`` is missing.
+    """
+    if yes_rate is None:
+        return None
+    return max(yes_rate, 1.0 - yes_rate)
+
+
+def _da_lift(
+    directional_accuracy: float | None, yes_rate: float | None
+) -> float | None:
+    """Return directional-accuracy lift over the always-majority baseline.
+
+    A positive value means the tool beat "always predict the majority
+    outcome" on valid rows; a value at or below zero means the tool
+    gave no edge over a constant baseline.
+
+    :param directional_accuracy: tool's directional accuracy on valid rows.
+    :param yes_rate: outcome yes rate on valid rows.
+    :return: DA lift, or ``None`` when either input is missing.
+    """
+    majority = _always_majority(yes_rate)
+    if directional_accuracy is None or majority is None:
+        return None
+    return directional_accuracy - majority
+
+
 def section_tool_category(scores: dict[str, Any]) -> str:
-    """Tool × category cross breakdown — gated by MIN_SAMPLE_SIZE."""
+    """Tool × category cross breakdown — primary metrics, gated by MIN_SAMPLE_SIZE.
+
+    Renders the reviewer-specified column set: n, reliability, Brier,
+    baseline Brier, BSS, directional accuracy, yes/no rate,
+    always-majority baseline, and DA lift. Diagnostic metrics (edge,
+    edge_n, log loss) render in a separate ``section_tool_category_diagnostics``
+    section so this table stays scannable.
+
+    :param scores: parsed per-platform rolling scores dict.
+    :return: markdown section string.
+    """
     data = scores.get("by_tool_category") or {}
     if not data:
         return "## Tool × Category\n\nNo cross-breakdown data available."
@@ -496,38 +537,43 @@ def section_tool_category(scores: dict[str, Any]) -> str:
         "## Tool × Category",
         "",
         f"> Cells with n < {MIN_SAMPLE_SIZE} are moved to a separate list below"
-        " the ranking. This differs from Tool × Platform, which renders every"
-        " cell inline and marks small samples with ⚠.",
+        " the ranking. Diagnostic metrics (edge, log loss) live in the"
+        " next section.",
         "",
-        "| Tool | Category | Brier | BSS | LogLoss | Edge | Edge n | DirAcc | Sharpness | n |",
-        "|------|----------|-------|-----|---------|------|--------|--------|-----------|---|",
+        "| Tool | Category | n | Reliability | Brier | Baseline Brier | BSS"
+        " | DirAcc | Yes% | No% | Always-majority | DA lift |",
+        "|------|----------|---|-------------|-------|----------------|-----"
+        "|--------|------|-----|-----------------|---------|",
     ]
     if not sufficient:
-        lines.append(f"| _(no cells with n ≥ {MIN_SAMPLE_SIZE})_ | | | | | | | | | |")
+        lines.append(
+            f"| _(no cells with n ≥ {MIN_SAMPLE_SIZE})_" " | | | | | | | | | | | |"
+        )
     for key, stats in sufficient:
         parts = key.split(" | ")
         tool = parts[0] if parts else key
         category = parts[1] if len(parts) > 1 else "?"
         brier = f"{stats['brier']:.4f}" if stats.get("brier") is not None else "N/A"
+        baseline = stats.get("baseline_brier")
+        baseline_str = f"{baseline:.4f}" if baseline is not None else "N/A"
         bss = stats.get("brier_skill_score")
         bss_str = f"{bss:+.4f}" if bss is not None else "N/A"
-        ll = stats.get("log_loss")
-        ll_str = f"{ll:.4f}" if ll is not None else "N/A"
-        edge = stats.get("edge")
-        edge_str = f"{edge:+.4f}" if edge is not None else "N/A"
-        edge_n = stats.get("edge_n", 0)
-        acc = (
-            f"{stats['directional_accuracy']:.0%}"
-            if stats.get("directional_accuracy") is not None
-            else "N/A"
-        )
-        sharp = (
-            f"{stats['sharpness']:.4f}" if stats.get("sharpness") is not None else "N/A"
-        )
+        acc_val = stats.get("directional_accuracy")
+        acc = f"{acc_val:.0%}" if acc_val is not None else "N/A"
+        yes = stats.get("outcome_yes_rate")
+        yes_str = f"{yes:.0%}" if yes is not None else "N/A"
+        no_str = f"{1 - yes:.0%}" if yes is not None else "N/A"
+        majority = _always_majority(yes)
+        majority_str = f"{majority:.0%}" if majority is not None else "N/A"
+        lift = _da_lift(acc_val, yes)
+        lift_str = f"{lift:+.4f}" if lift is not None else "N/A"
+        reliability = stats.get("reliability")
+        rel_str = f"{reliability:.0%}" if reliability is not None else "N/A"
         label = _sample_label(stats)
         lines.append(
-            f"| {tool} | {category} | {brier} | {bss_str} | {ll_str} | {edge_str}"
-            f" | {edge_n} | {acc} | {sharp} | {stats['n']}{label} |"
+            f"| {tool} | {category} | {stats['n']}{label} | {rel_str}"
+            f" | {brier} | {baseline_str} | {bss_str} | {acc}"
+            f" | {yes_str} | {no_str} | {majority_str} | {lift_str} |"
         )
 
     if sparse:
@@ -543,6 +589,51 @@ def section_tool_category(scores: dict[str, Any]) -> str:
             lines.append(
                 f"- **{tool} | {category}**: insufficient data (n={stats['n']})"
             )
+
+    return "\n".join(lines)
+
+
+def section_tool_category_diagnostics(scores: dict[str, Any]) -> str:
+    """Tool × category diagnostic metrics — edge, edge_n, log loss.
+
+    Rendered as a follow-on to ``section_tool_category`` so the primary
+    table stays compact while the diagnostic view still reads at the
+    per-(tool, category) grain.
+
+    :param scores: parsed per-platform rolling scores dict.
+    :return: markdown section string.
+    """
+    data = scores.get("by_tool_category") or {}
+    if not data:
+        return "## Tool × Category Diagnostics\n\n" "No cross-breakdown data available."
+
+    ranked = sorted(data.items(), key=brier_sort_key)
+    sufficient = [(k, s) for k, s in ranked if s["n"] >= MIN_SAMPLE_SIZE]
+
+    lines = [
+        "## Tool × Category Diagnostics",
+        "",
+        f"> Edge, Edge n, and Log Loss for each cell above n = {MIN_SAMPLE_SIZE}.",
+        "",
+        "| Tool | Category | Edge | Edge n | Log Loss | n |",
+        "|------|----------|------|--------|----------|---|",
+    ]
+    if not sufficient:
+        lines.append(f"| _(no cells with n ≥ {MIN_SAMPLE_SIZE})_ | | | | | |")
+        return "\n".join(lines)
+    for key, stats in sufficient:
+        parts = key.split(" | ")
+        tool = parts[0] if parts else key
+        category = parts[1] if len(parts) > 1 else "?"
+        edge = stats.get("edge")
+        edge_str = f"{edge:+.4f}" if edge is not None else "N/A"
+        edge_n = stats.get("edge_n", 0)
+        ll = stats.get("log_loss")
+        ll_str = f"{ll:.4f}" if ll is not None else "N/A"
+        lines.append(
+            f"| {tool} | {category} | {edge_str} | {edge_n} | {ll_str}"
+            f" | {stats['n']} |"
+        )
 
     return "\n".join(lines)
 
@@ -700,12 +791,11 @@ def section_platform_snapshot(rolling_scores: dict[str, Any]) -> str:
     if n == 0:
         return f"{heading}\n\nNo rows scored in the current window."
 
-    majority_baseline: str
-    if yes_rate is None:
-        majority_baseline = "N/A"
-    else:
-        majority = max(yes_rate, 1.0 - yes_rate)
-        majority_baseline = f"{majority:.0%}"
+    majority = _always_majority(yes_rate)
+    majority_str = f"{majority:.0%}" if majority is not None else "N/A"
+    lift = _da_lift(dir_acc, yes_rate)
+    lift_str = f"{lift:+.4f}" if lift is not None else "N/A"
+    no_rate = 1.0 - yes_rate if yes_rate is not None else None
 
     lines = [
         heading,
@@ -716,10 +806,10 @@ def section_platform_snapshot(rolling_scores: dict[str, Any]) -> str:
         f"- **Baseline Brier**: {_value_cell(baseline, valid_n)}",
         f"- **BSS**: {_value_cell(bss, valid_n)}",
         f"- **Directional Accuracy**: {_pct_cell(dir_acc, valid_n)}",
-        (
-            f"- **Outcome Yes Rate**: {_pct_cell(yes_rate, valid_n)}"
-            f" (always-majority baseline: {majority_baseline})"
-        ),
+        f"- **Outcome Yes Rate**: {_pct_cell(yes_rate, valid_n)}",
+        f"- **Outcome No Rate**: {_pct_cell(no_rate, valid_n)}",
+        f"- **Always-majority baseline**: {majority_str}",
+        f"- **DA lift (DirAcc - always-majority)**: {lift_str}",
     ]
     return "\n".join(lines)
 
@@ -2279,6 +2369,12 @@ def generate_report(  # pylint: disable=too-many-statements
         sections.append(
             _relabel_heading(
                 section_tool_category(rolling_scores),
+                f" (Current {ROLLING_WINDOW_DAYS}d)",
+            )
+        )
+        sections.append(
+            _relabel_heading(
+                section_tool_category_diagnostics(rolling_scores),
                 f" (Current {ROLLING_WINDOW_DAYS}d)",
             )
         )

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -1191,9 +1191,11 @@ def section_diagnostics_comparison(
                 f" | {_value_cell(p_val, p_n)}"
                 f" | {delta_prev} |"
             )
-    if len(lines) == 5:
-        # Only the header rows — no tool had data across any diagnostic
-        # metric for any window.
+    # ``lines`` is initialized with 4 items (heading, blank, header row,
+    # separator). When every (tool, metric) cell was skipped via the
+    # ``all three windows None`` continue, nothing else was appended and
+    # the bare table would render with no body rows.
+    if len(lines) == 4:
         lines.append("| _(no diagnostic data)_ | | | | | | |")
     return "\n".join(lines)
 
@@ -2157,6 +2159,25 @@ def _has_tournament_data(scores_tournament: dict[str, Any] | None) -> bool:
     return bool(scores_tournament and scores_tournament.get("total_rows", 0) > 0)
 
 
+def _has_scored_rows(scores: dict[str, Any] | None) -> bool:
+    """Return True when a scores dict has at least one scored row.
+
+    Used to collapse zero-row scoring output to the same "no data" signal
+    a missing-file case emits, so downstream renderers don't have to
+    distinguish the two for user-facing copy.
+
+    :param scores: a parsed scores dict or ``None``.
+    :return: True when the dict carries at least one row in ``total_rows``
+        or its ``overall`` accumulator.
+    """
+    if not scores:
+        return False
+    if scores.get("total_rows", 0) > 0:
+        return True
+    overall = scores.get("overall") or {}
+    return overall.get("n", 0) > 0
+
+
 def _merged_tvm_scores(
     scores_prod: dict[str, Any],
     scores_tournament: dict[str, Any] | None,
@@ -2341,6 +2362,14 @@ def generate_report(  # pylint: disable=too-many-statements
     )
 
     render_tournament = include_tournament and _has_tournament_data(scores_tournament)
+
+    # A zero-row prev scoring run (CI step succeeded but the window was
+    # empty) lands as ``{"total_rows": 0, "overall": {}}`` on disk. Treat
+    # that as "no prev window" so readers see the same explicit
+    # placeholder they see when the file is missing, rather than a
+    # stream of ``N/A (n=0)`` cells that silently merges the two cases.
+    if prev_rolling_scores is not None and not _has_scored_rows(prev_rolling_scores):
+        prev_rolling_scores = None
 
     sections: list[str] = [f"# Benchmark Report ({platform_label}) — {date}"]
 

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -856,14 +856,15 @@ def _platform_metric_row(
     value_fmt = _pct_cell if is_pct else lambda v, n: _value_cell(v, n, decimals)
 
     delta_alltime = _delta_cell(c_val, a_val, c_n, a_n, lower_is_better)
-    delta_prev = (
-        _delta_cell(c_val, p_val, c_n, p_n, lower_is_better)
-        if prev is not None
-        else "no prev window"
-    )
+    if prev is None:
+        prev_val_cell = "no prev window"
+        delta_prev = "no prev window"
+    else:
+        prev_val_cell = value_fmt(p_val, p_n)
+        delta_prev = _delta_cell(c_val, p_val, c_n, p_n, lower_is_better)
     return (
         f"| {label} | {value_fmt(c_val, c_n)} | {value_fmt(a_val, a_n)}"
-        f" | {delta_alltime} | {value_fmt(p_val, p_n)} | {delta_prev} |"
+        f" | {delta_alltime} | {prev_val_cell} | {delta_prev} |"
     )
 
 
@@ -1004,17 +1005,18 @@ def section_tool_comparison(
 
         flag = _sample_label(c) if c else ""
         delta_at = _delta_cell(c_brier, a_brier, c_n, a_n)
-        delta_prev = (
-            _delta_cell(c_brier, p_brier, c_n, p_n)
-            if prev_rolling_scores is not None
-            else "no prev window"
-        )
+        if prev_rolling_scores is None:
+            prev_val_cell = "no prev window"
+            delta_prev = "no prev window"
+        else:
+            prev_val_cell = _value_cell(p_brier, p_n)
+            delta_prev = _delta_cell(c_brier, p_brier, c_n, p_n)
         lines.append(
             f"| **{tool}**{flag}"
             f" | {_value_cell(c_brier, c_n)}"
             f" | {_value_cell(a_brier, a_n)}"
             f" | {delta_at}"
-            f" | {_value_cell(p_brier, p_n)}"
+            f" | {prev_val_cell}"
             f" | {delta_prev} |"
         )
     return "\n".join(lines)
@@ -1078,17 +1080,18 @@ def section_tool_category_comparison(
         p_brier = p_stats.get("brier") if p_stats else None
 
         delta_at = _delta_cell(c_brier, a_brier, c_n, a_n)
-        delta_prev = (
-            _delta_cell(c_brier, p_brier, c_n, p_n)
-            if prev_rolling_scores is not None
-            else "no prev window"
-        )
+        if prev_rolling_scores is None:
+            prev_val_cell = "no prev window"
+            delta_prev = "no prev window"
+        else:
+            prev_val_cell = _value_cell(p_brier, p_n)
+            delta_prev = _delta_cell(c_brier, p_brier, c_n, p_n)
         lines.append(
             f"| {tool} | {cat}"
             f" | {_value_cell(c_brier, c_n)}"
             f" | {_value_cell(a_brier, a_n)}"
             f" | {delta_at}"
-            f" | {_value_cell(p_brier, p_n)}"
+            f" | {prev_val_cell}"
             f" | {delta_prev} |"
         )
     return "\n".join(lines)
@@ -1178,17 +1181,18 @@ def section_diagnostics_comparison(
                 continue
 
             delta_at = _delta_cell(c_val, a_val, c_n, a_n, lower_is_better)
-            delta_prev = (
-                _delta_cell(c_val, p_val, c_n, p_n, lower_is_better)
-                if prev_rolling_scores is not None
-                else "no prev window"
-            )
+            if prev_rolling_scores is None:
+                prev_val_cell = "no prev window"
+                delta_prev = "no prev window"
+            else:
+                prev_val_cell = _value_cell(p_val, p_n)
+                delta_prev = _delta_cell(c_val, p_val, c_n, p_n, lower_is_better)
             lines.append(
                 f"| **{tool}** | {_diag_metric_label(metric_key)}"
                 f" | {_value_cell(c_val, c_n)}"
                 f" | {_value_cell(a_val, a_n)}"
                 f" | {delta_at}"
-                f" | {_value_cell(p_val, p_n)}"
+                f" | {prev_val_cell}"
                 f" | {delta_prev} |"
             )
     # ``lines`` is initialized with 4 items (heading, blank, header row,

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -129,34 +129,46 @@ def load_history(path: Path) -> list[dict[str, Any]]:
 # ---------------------------------------------------------------------------
 
 
-def section_metric_reference() -> str:
+def section_metric_reference(include_scope_note: bool = True) -> str:
     """Render the metric-reference legend shown at the top of every report.
 
+    :param include_scope_note: when True, prepends the rolling-vs-all-time
+        scope explanation. The fleet report omits the note because it
+        contains no rolling-scoped sections.
     :return: markdown section string.
     """
-    lines = [
-        "## Metric References",
-        "",
-        (
-            "All point-in-time metrics below are scoped to the rolling window "
-            f"(last {ROLLING_WINDOW_DAYS} days) unless a section explicitly says "
-            "otherwise."
-        ),
-        "",
-        f"- **Brier** — ideal 0.00, coin-flip {BRIER_RANDOM}; lower is better.",
-        (
-            "- **Log Loss** — ideal 0.00; lower is better, punishes confident "
-            "errors harder."
-        ),
-        (
-            "- **BSS (Brier Skill Score)** — ideal > 0; negative means worse than "
-            "the base-rate predictor."
-        ),
-        (
-            "- **Edge over market** — ideal > 0; positive = tool beats market "
-            "consensus. System diagnostic, not a tool ranking signal."
-        ),
-    ]
+    lines = ["## Metric References", ""]
+    if include_scope_note:
+        lines.extend(
+            [
+                (
+                    f"Sections whose heading carries `(Last {ROLLING_WINDOW_DAYS} "
+                    "Days)` are scoped to the rolling window — a single aggregate "
+                    "over that window, not a trailing-average series. Sections "
+                    "tagged `(All-Time)` are cumulative from the first scored "
+                    "row. The Trend section is fleet-wide monthly, independent "
+                    "of this report's platform scope."
+                ),
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            f"- **Brier** — ideal 0.00, coin-flip {BRIER_RANDOM}; lower is better.",
+            (
+                "- **Log Loss** — ideal 0.00; lower is better, punishes confident "
+                "errors harder."
+            ),
+            (
+                "- **BSS (Brier Skill Score)** — ideal > 0; negative means worse "
+                "than the base-rate predictor."
+            ),
+            (
+                "- **Edge over market** — ideal > 0; positive = tool beats "
+                "market consensus. System diagnostic, not a tool ranking signal."
+            ),
+        ]
+    )
     return "\n".join(lines)
 
 
@@ -444,6 +456,128 @@ def section_tool_category(scores: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def section_category_platform(scores: dict[str, Any]) -> str:
+    """Category × platform cross breakdown — gated by MIN_SAMPLE_SIZE.
+
+    :param scores: parsed combined ``scores.json`` dict with a
+        ``by_category_platform`` mapping.
+    :return: markdown section string.
+    """
+    data = scores.get("by_category_platform") or {}
+    if not data:
+        return "## Category × Platform\n\n" "No cross-breakdown data available."
+
+    ranked = sorted(data.items(), key=brier_sort_key)
+    sufficient = [(k, s) for k, s in ranked if s["n"] >= MIN_SAMPLE_SIZE]
+    sparse = [(k, s) for k, s in ranked if s["n"] < MIN_SAMPLE_SIZE]
+
+    lines = [
+        "## Category × Platform",
+        "",
+        f"> Cells with n < {MIN_SAMPLE_SIZE} are moved to a separate list below.",
+        "",
+        "| Category | Platform | Brier | BSS | LogLoss | DirAcc | n |",
+        "|----------|----------|-------|-----|---------|--------|---|",
+    ]
+    if not sufficient:
+        lines.append(f"| _(no cells with n ≥ {MIN_SAMPLE_SIZE})_ | | | | | | |")
+    for key, stats in sufficient:
+        parts = key.split(" | ")
+        category = parts[0] if parts else key
+        platform = parts[1] if len(parts) > 1 else "?"
+        brier = f"{stats['brier']:.4f}" if stats.get("brier") is not None else "N/A"
+        bss = stats.get("brier_skill_score")
+        bss_str = f"{bss:+.4f}" if bss is not None else "N/A"
+        ll = stats.get("log_loss")
+        ll_str = f"{ll:.4f}" if ll is not None else "N/A"
+        acc = (
+            f"{stats['directional_accuracy']:.0%}"
+            if stats.get("directional_accuracy") is not None
+            else "N/A"
+        )
+        lines.append(
+            f"| {category} | {platform} | {brier} | {bss_str} | {ll_str} | {acc}"
+            f" | {stats['n']} |"
+        )
+
+    if sparse:
+        lines.append("")
+        lines.append(
+            f"_{len(sparse)} cell(s) below n={MIN_SAMPLE_SIZE} threshold omitted"
+            " from ranking._"
+        )
+        for key, stats in sparse[:5]:
+            parts = key.split(" | ")
+            category = parts[0] if parts else key
+            platform = parts[1] if len(parts) > 1 else "?"
+            lines.append(
+                f"- **{category} | {platform}**: insufficient data (n={stats['n']})"
+            )
+
+    return "\n".join(lines)
+
+
+def section_tool_category_platform(scores: dict[str, Any]) -> str:
+    """Tool × category × platform tri-dimensional breakdown.
+
+    Gated by MIN_SAMPLE_SIZE. Rendered as a table so readers can rank
+    the combined (tool, category, platform) slice directly from one
+    artifact.
+
+    :param scores: parsed combined ``scores.json`` dict with a
+        ``by_tool_category_platform`` mapping.
+    :return: markdown section string.
+    """
+    data = scores.get("by_tool_category_platform") or {}
+    if not data:
+        return "## Tool × Category × Platform\n\n" "No cross-breakdown data available."
+
+    ranked = sorted(data.items(), key=brier_sort_key)
+    sufficient = [(k, s) for k, s in ranked if s["n"] >= MIN_SAMPLE_SIZE]
+    sparse_count = len(ranked) - len(sufficient)
+
+    lines = [
+        "## Tool × Category × Platform",
+        "",
+        f"> Cells with n < {MIN_SAMPLE_SIZE} are omitted.",
+        "",
+        "| Tool | Category | Platform | Brier | BSS | LogLoss | Edge | DirAcc | n |",
+        "|------|----------|----------|-------|-----|---------|------|--------|---|",
+    ]
+    if not sufficient:
+        lines.append(f"| _(no cells with n ≥ {MIN_SAMPLE_SIZE})_ | | | | | | | | |")
+    for key, stats in sufficient:
+        parts = key.split(" | ")
+        tool = parts[0] if parts else key
+        category = parts[1] if len(parts) > 1 else "?"
+        platform = parts[2] if len(parts) > 2 else "?"
+        brier = f"{stats['brier']:.4f}" if stats.get("brier") is not None else "N/A"
+        bss = stats.get("brier_skill_score")
+        bss_str = f"{bss:+.4f}" if bss is not None else "N/A"
+        ll = stats.get("log_loss")
+        ll_str = f"{ll:.4f}" if ll is not None else "N/A"
+        edge = stats.get("edge")
+        edge_str = f"{edge:+.4f}" if edge is not None else "N/A"
+        acc = (
+            f"{stats['directional_accuracy']:.0%}"
+            if stats.get("directional_accuracy") is not None
+            else "N/A"
+        )
+        lines.append(
+            f"| {tool} | {category} | {platform} | {brier} | {bss_str} | {ll_str}"
+            f" | {edge_str} | {acc} | {stats['n']} |"
+        )
+
+    if sparse_count:
+        lines.append("")
+        lines.append(
+            f"_{sparse_count} cell(s) below n={MIN_SAMPLE_SIZE} threshold"
+            " omitted from ranking._"
+        )
+
+    return "\n".join(lines)
+
+
 def section_weak_spots(scores: dict[str, Any]) -> str:
     """Generate the weak spots section."""
     lines = ["## Weak Spots", ""]
@@ -540,9 +674,9 @@ def section_trend(
             }
         )
 
-    lines = ["## Trend", ""]
+    lines = ["## Trend (Fleet-wide, Monthly)", ""]
     if platform is not None:
-        lines.append("_Fleet-wide monthly trend — not scoped to this platform._")
+        lines.append("_Aggregated across all platforms — not scoped to this report._")
         lines.append("")
 
     if not trend:
@@ -893,6 +1027,10 @@ def section_period(
     label: str = "Since last report",
 ) -> str:
     """Generate a period comparison section.
+
+    Renders a single aggregate computed over all rows in the period, not a
+    moving-average series. Deltas compare the period aggregate to the
+    all-time aggregate.
 
     :param period_scores: scores from the recent period.
     :param alltime_scores: all-time scores for delta comparison.
@@ -1528,7 +1666,7 @@ def generate_report(  # pylint: disable=too-many-statements
             )
         )
 
-    rolling_heading = f"Last {ROLLING_WINDOW_DAYS} Days Rolling"
+    rolling_heading = f"Last {ROLLING_WINDOW_DAYS} Days (Window Aggregate)"
     if rolling_scores is not None:
         sections.append(section_period(rolling_scores, scores, rolling_heading))
         if render_tournament and _has_tournament_data(rolling_scores_tournament):
@@ -1543,13 +1681,6 @@ def generate_report(  # pylint: disable=too-many-statements
                 )
             )
 
-    sections.append(section_base_rates(scores))
-    sections.append(
-        section_tool_deployment_status(
-            scores, disabled=disabled_tools, platform=platform
-        )
-    )
-
     rolling_suffix = f" (Last {ROLLING_WINDOW_DAYS} Days)"
     rolling_window_note = f"last {ROLLING_WINDOW_DAYS} days"
 
@@ -1561,8 +1692,8 @@ def generate_report(  # pylint: disable=too-many-statements
 
     if rolling_scores is None:
         sections.append(
-            f"## Rolling Window (Last {ROLLING_WINDOW_DAYS} Days)\n\n"
-            f"Rolling scores for the last {ROLLING_WINDOW_DAYS} days are "
+            f"## Last {ROLLING_WINDOW_DAYS} Days (Window Aggregate)\n\n"
+            f"Scores for the last {ROLLING_WINDOW_DAYS} days are "
             "unavailable — the scoring step did not produce "
             f"`rolling_scores_{platform}.json` for this run. Tool Ranking, "
             "Category Performance, Tool × Category, Diagnostic Edge Metrics, "
@@ -1579,6 +1710,17 @@ def generate_report(  # pylint: disable=too-many-statements
                 )
             )
         sections.append(_rolling(section_tool_category(rolling_scores)))
+        sections.append(_rolling(section_category(rolling_scores)))
+        sections.append(_rolling(section_diagnostic_metrics(rolling_scores)))
+        sections.append(_rolling(section_weak_spots(rolling_scores)))
+
+    sections.append(_relabel_heading(section_tool_ranking(scores), " (All-Time)"))
+    sections.append(_relabel_heading(section_base_rates(scores), " (All-Time)"))
+    sections.append(
+        section_tool_deployment_status(
+            scores, disabled=disabled_tools, platform=platform
+        )
+    )
 
     if include_tournament:
         merged = _merged_tvm_scores(scores, scores_tournament)
@@ -1601,21 +1743,12 @@ def generate_report(  # pylint: disable=too-many-statements
         if deltas:
             sections.append(deltas)
 
-    if rolling_scores is not None:
-        sections.extend(
-            [
-                _rolling(section_category(rolling_scores)),
-                _rolling(section_diagnostic_metrics(rolling_scores)),
-                _rolling(section_weak_spots(rolling_scores)),
-            ]
-        )
-
     sections.extend(
         [
-            section_reliability_issues(scores),
-            section_parse_breakdown(scores),
+            _relabel_heading(section_reliability_issues(scores), " (All-Time)"),
+            _relabel_heading(section_parse_breakdown(scores), " (All-Time)"),
             section_trend(history, None, platform=platform),
-            section_sample_size_warnings(scores),
+            _relabel_heading(section_sample_size_warnings(scores), " (All-Time)"),
         ]
     )
 
@@ -1623,6 +1756,47 @@ def generate_report(  # pylint: disable=too-many-statements
         callouts = section_tournament_callouts(scores, scores_tournament)
         if callouts:
             sections.append(callouts)
+
+    return "\n\n".join(sections) + "\n"
+
+
+def generate_fleet_report(
+    scores: dict[str, Any],
+    history: list[dict[str, Any]] | None = None,
+) -> str:
+    """Generate a cross-platform fleet report from the combined scores file.
+
+    Consumes the fleet-wide ``by_platform``, ``by_category_platform`` and
+    ``by_tool_category_platform`` aggregates so readers can rank tools
+    and categories across platforms directly from one artifact. Does not
+    duplicate the per-platform deep dives — those live in
+    ``report_<platform>.md``.
+
+    :param scores: parsed combined ``scores.json`` dict.
+    :param history: list of monthly snapshots from ``scores_history.jsonl``.
+    :return: full markdown report string.
+    """
+    if history is None:
+        history = []
+
+    date = scores.get("generated_at", "")[:10] or datetime.now(timezone.utc).strftime(
+        "%Y-%m-%d"
+    )
+
+    sections: list[str] = [
+        f"# Benchmark Report (Fleet, Cross-Platform) — {date}",
+        (
+            "_Cross-platform view for direct category and tool × category ranking "
+            "across platforms. For per-platform deep dives (rolling window, weak "
+            "spots, deployment status) see `report_omen.md` and "
+            "`report_polymarket.md`._"
+        ),
+        section_metric_reference(include_scope_note=False),
+        section_platform(scores),
+        section_category_platform(scores),
+        section_tool_category_platform(scores),
+        section_trend(history, None),
+    ]
 
     return "\n\n".join(sections) + "\n"
 
@@ -1637,17 +1811,29 @@ def main() -> None:
     parser = argparse.ArgumentParser(
         description="Generate benchmark report from scores.",
     )
-    parser.add_argument(
+    mode_group = parser.add_mutually_exclusive_group(required=True)
+    mode_group.add_argument(
         "--platform",
-        required=True,
         choices=sorted(PLATFORM_LABELS),
         help="Platform to scope the report to (drives default paths + header).",
+    )
+    mode_group.add_argument(
+        "--fleet",
+        action="store_true",
+        help=(
+            "Render a cross-platform fleet report from the combined "
+            "scores.json. Uses by_category_platform and "
+            "by_tool_category_platform for direct tri-dimensional ranking."
+        ),
     )
     parser.add_argument(
         "--scores",
         type=Path,
         default=None,
-        help="Override for scores file. Default: results/scores_<platform>.json.",
+        help=(
+            "Override for scores file. Default: results/scores_<platform>.json "
+            "(per-platform) or results/scores.json (fleet)."
+        ),
     )
     parser.add_argument("--history", type=Path, default=DEFAULT_HISTORY)
     parser.add_argument(
@@ -1709,9 +1895,25 @@ def main() -> None:
         ),
     )
     args = parser.parse_args()
+    results_dir = DEFAULT_RESULTS_DIR
+    history = load_history(args.history)
+
+    if args.fleet:
+        scores_path = args.scores or results_dir / "scores.json"
+        output_path = args.output or results_dir / "report_fleet.md"
+        scores = load_scores(scores_path)
+        print(
+            f"Loaded fleet scores ({scores.get('total_rows', 0)} rows), "
+            f"{len(history)} months of history"
+        )
+        report = generate_fleet_report(scores, history)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(report)
+        print(f"Report written to {output_path}")
+        print(f"\n{report}")
+        return
 
     platform = args.platform
-    results_dir = DEFAULT_RESULTS_DIR
     scores_path = args.scores or results_dir / f"scores_{platform}.json"
     output_path = args.output or results_dir / f"report_{platform}.md"
     period_path = args.period or results_dir / f"period_scores_{platform}.json"
@@ -1732,7 +1934,6 @@ def main() -> None:
         return load_scores(path) if path and path.exists() else None
 
     scores = load_scores(scores_path)
-    history = load_history(args.history)
     period = _maybe_load(period_path)
     rolling = _maybe_load(rolling_path)
     scores_tournament = _maybe_load(scores_tournament_path)

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -1166,6 +1166,7 @@ def section_diagnostics_comparison(
         ),
         "|------|--------|----------|----------|---------------|---------|-------------|",
     ]
+    header_len = len(lines)
     for tool in tools:
         c = cur_by_tool.get(tool, {})
         a = at_by_tool.get(tool, {})
@@ -1195,11 +1196,11 @@ def section_diagnostics_comparison(
                 f" | {prev_val_cell}"
                 f" | {delta_prev} |"
             )
-    # ``lines`` is initialized with 4 items (heading, blank, header row,
-    # separator). When every (tool, metric) cell was skipped via the
-    # ``all three windows None`` continue, nothing else was appended and
-    # the bare table would render with no body rows.
-    if len(lines) == 4:
+    # Pin against the header length captured above the data loop. Matching
+    # a hardcoded count here broke once already (off-by-one vs the init
+    # list) and would break again on any future header edit, so anchor
+    # to the snapshot instead of a literal.
+    if len(lines) == header_len:
         lines.append("| _(no diagnostic data)_ | | | | | | |")
     return "\n".join(lines)
 

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -50,7 +50,7 @@ Summarize this Olas Predict benchmark report for the *{{platform_label}}* deploy
 
 *Deployment status:* if the report has a "Tool Deployment Status ({{platform_label}})" section, list one line per deployment with its count of active tools only (do NOT enumerate the tool names — the full report has them and the Slack message stays readable). Skip deployments marked `⚠️ unavailable` after noting briefly that their config fetch failed.
 
-*Tool × Category:* from the "Tool × Category (Current {ROLLING_WINDOW_DAYS}d)" section, list every cell that clears the sample-size threshold. Use format: • `tool` × `category` — Brier `X.XXXX` (n=X, Current {ROLLING_WINDOW_DAYS}d). Never cite rows from the "below n=X threshold omitted" list. FALLBACK: if fewer than 2 rows clear the threshold, write exactly "insufficient tool × category data" as the only bullet in this section.
+*Tool × Category:* from the "Tool × Category (Current {ROLLING_WINDOW_DAYS}d)" section, list every cell that clears the sample-size threshold. Use format: • `tool` × `category` — Brier `X.XXXX` (n=X, Current {ROLLING_WINDOW_DAYS}d), DirAcc X%, Always-majority X%, DA lift `±X.XXXX`. If DA lift is ≤ 0 say " — no lift over always-majority" inline so the reader isn't misled by a low Brier on a homogeneous-outcome cell. Never cite rows from the "below n=X threshold omitted" list. FALLBACK: if fewer than 2 rows clear the threshold, write exactly "insufficient tool × category data" as the only bullet in this section.
 
 If the "Tool × Category Historical Comparison" table has any row where `Δ vs Prev {ROLLING_WINDOW_DAYS}d` is a signed number (not `insufficient data`, not `no prev window`), add a single follow-up bullet naming the largest absolute-value movement and its direction.
 

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -36,23 +36,23 @@ from benchmark.tools import TOOL_REGISTRY
 log = logging.getLogger(__name__)
 
 SUMMARY_SYSTEM_PROMPT_TEMPLATE = f"""\
-Summarize this Olas Predict benchmark report for the *{{platform_label}}* deployment using EXACTLY this structure (output will be posted to Slack). All tool-level figures in the report are scoped to the last {ROLLING_WINDOW_DAYS} days for {{platform_label}} unless a section heading explicitly says otherwise (e.g. "Tool × Version × Mode (All-Time)", "Trend", "Base Rates"). Do NOT compare platforms, reference tools or deployments belonging to other platforms, or cite metrics from another platform's rows.
+Summarize this Olas Predict benchmark report for the *{{platform_label}}* deployment using EXACTLY this structure (output will be posted to Slack). The report carries three windows per metric: `Current {ROLLING_WINDOW_DAYS}d` (trailing {ROLLING_WINDOW_DAYS}-day aggregate), `All-Time` (cumulative), and `Prev {ROLLING_WINDOW_DAYS}d` (the immediately preceding non-overlapping {ROLLING_WINDOW_DAYS}-day window). Never mix numbers across windows; if you cite a value, state which window it came from. Do NOT compare platforms, reference tools or deployments belonging to other platforms, or cite metrics from another platform's rows.
 
-*Summary:* 2-3 sentence high-level takeaway for {{platform_label}}. Open with the 1-day delta from the "Since Last Report" section (what moved since yesterday's report), then pivot to the {ROLLING_WINDOW_DAYS}-day rolling view. Keep the two windows distinct — never attribute a Since-Last-Report figure to the rolling window or vice versa.
+*Summary:* 2-3 sentence high-level takeaway for {{platform_label}}. Lead with the Current-{ROLLING_WINDOW_DAYS}d platform Brier (from the "Platform Snapshot" section). Then name the direction of change: "Δ vs All-Time" from the "Platform Historical Comparison" row for Brier, and "Δ vs Prev {ROLLING_WINDOW_DAYS}d" from the same row. If either delta shows `insufficient data`, say so plainly instead of guessing.
 
 *Top tools:*
-• `tool-name` — Brier `X.XX`, LogLoss `X.XX`, Edge `±X.XX` (n=X, last {ROLLING_WINDOW_DAYS} days), directional accuracy X%, one word on why
-(list top 3 from the "Tool Ranking (Last {ROLLING_WINDOW_DAYS} Days)" section, rank by Brier. Log Loss and Edge are shown alongside for context)
+• `tool-name` — Current {ROLLING_WINDOW_DAYS}d Brier `X.XXXX` (n=X), Δ vs All-Time `±X.XXXX direction`, Δ vs Prev {ROLLING_WINDOW_DAYS}d `±X.XXXX direction`
+(list top 3 from the "Tool Historical Comparison" table, sorted by Current {ROLLING_WINDOW_DAYS}d Brier ascending. Use the exact delta strings from that table; if a delta is `insufficient data` or `no prev window`, write those words verbatim — never invent a number.)
 
 *Worst tools:*
-• `tool-name` — Brier `X.XX`, LogLoss `X.XX`, Edge `±X.XX` (n=X, last {ROLLING_WINDOW_DAYS} days), directional accuracy X%, one word on why
-(list bottom 3, ignore tools with 0% reliability or < 50 predictions)
+• `tool-name` — Current {ROLLING_WINDOW_DAYS}d Brier `X.XXXX` (n=X), Δ vs All-Time `±X.XXXX direction`, Δ vs Prev {ROLLING_WINDOW_DAYS}d `±X.XXXX direction`
+(list bottom 3 from the same table, ignore rows with ⚠ low sample / all malformed flags.)
 
 *Deployment status:* if the report has a "Tool Deployment Status ({{platform_label}})" section, list one line per deployment with its count of active tools only (do NOT enumerate the tool names — the full report has them and the Slack message stays readable). Skip deployments marked `⚠️ unavailable` after noting briefly that their config fetch failed.
 
-*Category performance:* from the "Category Performance (Last {ROLLING_WINDOW_DAYS} Days)" section, list every category with sufficient data (skip rows flagged "insufficient data"). Use format: • `category` — Brier `X.XX`, Edge `±X.XX` (n=X, last {ROLLING_WINDOW_DAYS} days). Call out the single strongest and weakest category inline (e.g. " — strongest" / " — weakest"). IMPORTANT: a category with "yes rate: 0%" or "yes rate: 100%" has homogeneous outcomes — a low Brier there reflects the base rate, not prediction skill. If you cite such a category as "strongest", append " (homogeneous outcomes — reflects base rate)" so the reader isn't misled.
+*Tool × Category:* from the "Tool × Category (Current {ROLLING_WINDOW_DAYS}d)" section, list every cell that clears the sample-size threshold. Use format: • `tool` × `category` — Brier `X.XXXX` (n=X, Current {ROLLING_WINDOW_DAYS}d). Never cite rows from the "below n=X threshold omitted" list. FALLBACK: if fewer than 2 rows clear the threshold, write exactly "insufficient tool × category data" as the only bullet in this section.
 
-*Tool × Category:* from the "Tool × Category (Last {ROLLING_WINDOW_DAYS} Days)" section, list every tool-category cell that clears the sample-size threshold. Use format: • `tool` × `category` — Brier `X.XX`, Edge `±X.XX` (n=X, last {ROLLING_WINDOW_DAYS} days). Never cite rows from the "below n=X threshold omitted" list. If all tools underperform on a category, say that explicitly ("tools struggle on X across the board"). FALLBACK: if fewer than 2 rows clear the sample-size threshold in the Tool × Category ranking table, do NOT cite any sparse examples or fabricate — write exactly "insufficient tool × category data" as the only bullet in this section.
+If the "Tool × Category Historical Comparison" table has any row where `Δ vs Prev {ROLLING_WINDOW_DAYS}d` is a signed number (not `insufficient data`, not `no prev window`), add a single follow-up bullet naming the largest absolute-value movement and its direction.
 
 *Tool versions:* If the report has a "Version Deltas" section, summarize up to 5 of the most significant flagged changes, one bullet per row.
 
@@ -70,24 +70,23 @@ Rules:
 *Tournament callouts:* If the report has a "Tournament Callouts" section, list each callout as a single bullet: tool name, release-tag labels for both tournament and production versions (in backticks, e.g. `v0.17.2` and `v0.17.0`), tournament Brier + n, production Brier + n, Brier Δ. Lead promotion candidates with "promotion candidate:" and tournament regressions with "watch:". Skip this section entirely if no Tournament Callouts section is present in the report.
 
 *Diagnostics:*
-If the report includes "Diagnostic Edge Metrics (Last {ROLLING_WINDOW_DAYS} Days)", summarize:
-• Conditional accuracy: X% tool-wins when disagreeing (n=X, last {ROLLING_WINDOW_DAYS} days) — when the tool would trigger a trade, how often is it closer to truth than the market?
-• Disagreement Brier (large trade): X.XX — prediction accuracy on high-disagreement questions where PnL impact is highest
-• Directional bias: ±X.XX — positive = tool overestimates, negative = underestimates, near 0 = no systematic bias
-Only include this section if the report has diagnostic metric data. Skip if insufficient data.
+If the report has a "Diagnostics Historical Comparison" section, for each tool that carries at least one row with a signed delta (not `insufficient data`, not `no prev window`), summarize up to two metrics with the largest movement. Use format: • `tool` — `metric` Current {ROLLING_WINDOW_DAYS}d `X.XXXX` (n=X), Δ vs All-Time `±X.XXXX direction`, Δ vs Prev {ROLLING_WINDOW_DAYS}d `±X.XXXX direction`. Skip the section if no tool has a signed delta.
 
-*Recommended actions:* 2-3 concrete next steps for {{platform_label}} based on the last {ROLLING_WINDOW_DAYS} days of data. If edge is negative for all tools, this is important — recommend specific improvements.
+*Reliability:* from the "Reliability & Parse Quality" comparison table, list every tool whose Current {ROLLING_WINDOW_DAYS}d Reliability or Valid % has a non-`insufficient data` delta vs All-Time and the delta is negative (regression). Use format: • `tool` — Reliability X% (n=X) vs All-Time X% (Δ -X.XXXX worse). If no tool regressed, skip this section.
+
+*Recommended actions:* 2-3 concrete next steps for {{platform_label}} based on the Current {ROLLING_WINDOW_DAYS}d data. Anchor each action to a specific row in the comparison tables. If the Current {ROLLING_WINDOW_DAYS}d → Prev {ROLLING_WINDOW_DAYS}d delta shows a regression, call it out explicitly.
 
 Rules:
-- Every tool-level or category-level n= citation is over the last {ROLLING_WINDOW_DAYS} days. Do NOT attribute point-in-time Brier / Edge / accuracy / BSS figures to "all-time" or "cumulative" scope.
+- Never mix windows in a single claim. Every cited number must be paired with its window label (Current {ROLLING_WINDOW_DAYS}d, All-Time, or Prev {ROLLING_WINDOW_DAYS}d).
+- Deltas never stand alone — always cite both sides' n (or state the delta was `insufficient data` / `no prev window` verbatim from the table).
+- Do not make claims from cells flagged ⚠ low sample or all malformed.
 - Tool names with hyphens vs underscores are DIFFERENT tools — use exact names.
 - Wrap tool names, Brier scores, and Edge scores in backticks.
 - Slack mrkdwn only: *bold* (single asterisk), `code`. No **double asterisks**.
 - No greetings or preamble.
-- Edge over market: positive = tool beats market, negative = market beats tool. This is a system-level diagnostic — it shows whether prediction accuracy translates to trading value, but tools are ranked by Brier (prediction quality).
-- "Accuracy" in the report means "Directional Accuracy" — it excludes predictions at exactly 0.5 (no signal). Include the no-signal rate if it's notable.
-- Log Loss: like Brier but punishes confidently-wrong predictions harder. Include alongside Brier.
-- ECE (Expected Calibration Error): how well calibrated predictions are. Include if present.
+- Edge over market: positive = tool beats market, negative = market beats tool. Read it as a system-level diagnostic — tools are still ranked by Brier.
+- "Accuracy" in the report means "Directional Accuracy" — it excludes predictions at exactly 0.5 (no signal).
+- Log Loss: like Brier but punishes confidently-wrong predictions harder.
 - Some tools listed below are third-party (not ours). Completely exclude them — never mention, rank, compare, or recommend actions for third-party tools anywhere in the summary."""
 
 

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -2146,19 +2146,25 @@ def score_period_split(
     logs_dir: Path = DEFAULT_LOGS_DIR,
     days: int = 1,
     tournament_input: Path | None = None,
+    offset_days: int = 0,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """Score the last *days* days, returning (production, tournament).
+    """Score a windowed slice of rows, returning (production, tournament).
 
     Same collection rules as ``score_period`` but returns a tuple so
     callers can write both files separately.
 
     :param logs_dir: directory containing daily log files.
-    :param days: score rows from the last N calendar days.
+    :param days: score rows from a window ``days`` days wide.
     :param tournament_input: optional path to ``tournament_scored.jsonl``
         whose rows are filtered to the same window and merged.
+    :param offset_days: number of days to shift the window back from "now".
+        ``offset_days=days`` selects the immediately-preceding non-overlapping
+        window.
     :return: tuple of (production_scores, tournament_scores).
     """
-    prod_rows, tourn_rows = _load_period_rows(logs_dir, days, tournament_input)
+    prod_rows, tourn_rows = _load_period_rows(
+        logs_dir, days, tournament_input, offset_days
+    )
     return score(prod_rows), score(tourn_rows)
 
 
@@ -2191,19 +2197,25 @@ def score_period_split_by_platform(
     logs_dir: Path = DEFAULT_LOGS_DIR,
     days: int = 1,
     tournament_input: Path | None = None,
+    offset_days: int = 0,
 ) -> dict[str, tuple[dict[str, Any], dict[str, Any]]]:
-    """Score the last *days* days, returning combined + per-platform results.
+    """Score a windowed slice of rows, returning combined + per-platform results.
 
     :param logs_dir: directory containing daily log files.
-    :param days: score rows from the last N calendar days.
+    :param days: score rows from a window ``days`` days wide.
     :param tournament_input: optional path to ``tournament_scored.jsonl``
         whose rows are filtered to the same window and merged.
+    :param offset_days: number of days to shift the window back from "now".
+        ``offset_days=days`` selects the immediately-preceding non-overlapping
+        window (used to compute prev-rolling scores without overlap).
     :return: ``{"all": (prod, tourn), "omen": (prod, tourn),
         "polymarket": (prod, tourn)}``. Each ``(prod, tourn)`` tuple
         matches the shape of ``score_period_split``. Unknown-platform
         rows stay in ``"all"`` only.
     """
-    prod_rows, tourn_rows = _load_period_rows(logs_dir, days, tournament_input)
+    prod_rows, tourn_rows = _load_period_rows(
+        logs_dir, days, tournament_input, offset_days
+    )
     return _score_rows_by_platform(prod_rows, tourn_rows)
 
 
@@ -2232,17 +2244,29 @@ def _load_period_rows(
     logs_dir: Path,
     days: int,
     tournament_input: Path | None,
+    offset_days: int = 0,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Load + filter + mode-partition period rows.
 
     :param logs_dir: directory containing daily log files.
-    :param days: score rows from the last N calendar days.
+    :param days: score rows from a window ``days`` days wide.
     :param tournament_input: optional path to ``tournament_scored.jsonl``
         whose rows are filtered to the same window and merged.
+    :param offset_days: number of days to shift the window back from "now".
+        ``0`` means the trailing window ending at "now" (current window);
+        ``days`` means the immediately-preceding non-overlapping window.
     :return: ``(production_rows, tournament_rows)`` both filtered to the
         period window.
+    :raises ValueError: when ``days`` or ``offset_days`` is negative.
     """
-    cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+    if days < 0 or offset_days < 0:
+        raise ValueError(
+            f"days and offset_days must be >= 0 (got days={days},"
+            f" offset_days={offset_days})"
+        )
+    now = datetime.now(timezone.utc)
+    window_end = now - timedelta(days=offset_days)
+    window_start = window_end - timedelta(days=days)
 
     daily_pattern = str(logs_dir / "????-??-??.jsonl")
     prod_pattern = str(logs_dir / "production_log_*.jsonl")
@@ -2251,17 +2275,20 @@ def _load_period_rows(
         key=_extract_date_from_log_path,
     )
 
+    def _in_window(predicted_at: datetime | None) -> bool:
+        if predicted_at is None:
+            return False
+        return window_start <= predicted_at < window_end
+
     rows: list[dict[str, Any]] = []
     for filepath in all_files:
         for row in load_rows(Path(filepath)):
-            predicted_at = _parse_predicted_at(row.get("predicted_at"))
-            if predicted_at is not None and predicted_at >= cutoff:
+            if _in_window(_parse_predicted_at(row.get("predicted_at"))):
                 rows.append(row)
 
     if tournament_input is not None and tournament_input.exists():
         for row in load_rows(tournament_input):
-            predicted_at = _parse_predicted_at(row.get("predicted_at"))
-            if predicted_at is not None and predicted_at >= cutoff:
+            if _in_window(_parse_predicted_at(row.get("predicted_at"))):
                 rows.append(row)
 
     return _partition_rows_by_mode(rows)
@@ -2271,20 +2298,22 @@ def score_period(
     logs_dir: Path = DEFAULT_LOGS_DIR,
     days: int = 1,
     tournament_input: Path | None = None,
+    offset_days: int = 0,
 ) -> dict[str, Any]:
-    """Score production rows in the last *days* days (backward-compat).
+    """Score production rows in a windowed slice (backward-compat).
 
     Backward-compat wrapper around ``score_period_split``; returns the
     production partition only. Callers that need the tournament scores
     should use ``score_period_split`` directly.
 
     :param logs_dir: directory containing daily log files.
-    :param days: score rows from the last N calendar days.
+    :param days: score rows from a window ``days`` days wide.
     :param tournament_input: optional path to ``tournament_scored.jsonl``
         whose rows are filtered to the same window and merged.
+    :param offset_days: number of days to shift the window back from "now".
     :return: production scores dict.
     """
-    prod, _ = score_period_split(logs_dir, days, tournament_input)
+    prod, _ = score_period_split(logs_dir, days, tournament_input, offset_days)
     return prod
 
 
@@ -2343,6 +2372,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Score only the last N daily log files (for period reports)",
     )
     parser.add_argument(
+        "--period-offset-days",
+        type=int,
+        default=0,
+        help=(
+            "Shift the scoring window back by N days. Combined with "
+            "--period-days=N this selects the immediately-preceding "
+            "non-overlapping window (used for prev-rolling scores)."
+        ),
+    )
+    parser.add_argument(
         "--tournament-input",
         type=Path,
         default=None,
@@ -2379,6 +2418,7 @@ def _cli_period(args: argparse.Namespace, output_tournament: Path) -> None:
         logs_dir=args.logs_dir,
         days=args.period_days,
         tournament_input=args.tournament_input,
+        offset_days=args.period_offset_days,
     )
     prod_result, tourn_result = results["all"]
 

--- a/benchmark/scorer.py
+++ b/benchmark/scorer.py
@@ -927,7 +927,9 @@ def _score_extreme_predictions(
     return worst[:WORST_BEST_SIZE], best[:WORST_BEST_SIZE]
 
 
-def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
+def score(  # pylint: disable=too-many-statements
+    rows: list[dict[str, Any]],
+) -> dict[str, Any]:
     """Compute all scores from production log rows."""
     total = len(rows)
     overall = compute_group_stats(rows)
@@ -988,6 +990,19 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
 
     # Tool × category cross breakdown
     by_tool_category = group_by_composite(rows, ["tool_name", "category"])
+
+    # Category × platform cross breakdown
+    cp_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        cat = row.get("category") or "unknown"
+        plat = row.get("platform") or "unknown"
+        cp_groups[f"{cat} | {plat}"].append(row)
+    by_category_platform = {k: compute_group_stats(g) for k, g in cp_groups.items()}
+
+    # Tool × category × platform cross breakdown
+    by_tool_category_platform = group_by_composite(
+        rows, ["tool_name", "category", "platform"]
+    )
 
     # Tool × version (normalized: tool_version OR tool_ipfs_hash) cross breakdown
     tv_groups: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -1056,6 +1071,8 @@ def score(rows: list[dict[str, Any]]) -> dict[str, Any]:
         "by_platform_liquidity": by_platform_liquidity,
         "by_tool_platform": by_tool_platform,
         "by_tool_category": by_tool_category,
+        "by_category_platform": by_category_platform,
+        "by_tool_category_platform": by_tool_category_platform,
         "by_tool_platform_horizon": by_tool_platform_horizon,
         "by_tool_version": by_tool_version,
         "by_tool_version_mode": by_tool_version_mode,
@@ -1121,6 +1138,8 @@ def _empty_scores(current_month: str) -> dict[str, Any]:
         "by_horizon": {},
         "by_tool_platform": {},
         "by_tool_category": {},
+        "by_category_platform": {},
+        "by_tool_category_platform": {},
         "by_tool_version": {},
         "by_tool_version_mode": {},
         "by_config": {},
@@ -1407,6 +1426,14 @@ def _accumulate_row(scores: dict[str, Any], row: dict[str, Any]) -> None:
     _ensure_and_accumulate(scores["by_horizon"], horizon, row)
     _ensure_and_accumulate(scores["by_tool_platform"], f"{tool} | {platform}", row)
     _ensure_and_accumulate(scores["by_tool_category"], f"{tool} | {category}", row)
+    _ensure_and_accumulate(
+        scores["by_category_platform"], f"{category} | {platform}", row
+    )
+    _ensure_and_accumulate(
+        scores["by_tool_category_platform"],
+        f"{tool} | {category} | {platform}",
+        row,
+    )
     _ensure_and_accumulate(scores["by_tool_version"], f"{tool} | {tool_version}", row)
     _ensure_and_accumulate(
         scores["by_tool_version_mode"],
@@ -1502,6 +1529,8 @@ def _finalize_scores(scores: dict[str, Any]) -> dict[str, Any]:
         "by_horizon",
         "by_tool_platform",
         "by_tool_category",
+        "by_category_platform",
+        "by_tool_category_platform",
         "by_tool_version",
         "by_tool_version_mode",
         "by_config",
@@ -1674,6 +1703,8 @@ def _load_scores_for_resume(scores_path: Path) -> dict[str, Any] | None:
         "by_horizon",
         "by_tool_platform",
         "by_tool_category",
+        "by_category_platform",
+        "by_tool_category_platform",
         "by_tool_version",
         "by_tool_version_mode",
         "by_config",
@@ -1765,6 +1796,8 @@ def _accumulate_and_write(
         "by_horizon",
         "by_tool_platform",
         "by_tool_category",
+        "by_category_platform",
+        "by_tool_category_platform",
         "by_tool_version",
         "by_tool_version_mode",
         "by_config",
@@ -1976,6 +2009,8 @@ def _rebuild_single_mode(
         "by_horizon",
         "by_tool_platform",
         "by_tool_category",
+        "by_category_platform",
+        "by_tool_category_platform",
         "by_tool_version",
         "by_tool_version_mode",
         "by_config",

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -39,6 +39,7 @@ from benchmark.analyze import (
     generate_report,
     section_category,
     section_category_platform,
+    section_diagnostics_comparison,
     section_metric_reference,
     section_parse_breakdown,
     section_period,
@@ -2518,6 +2519,115 @@ class TestSectionToolComparison:
 
         rendered = section_tool_comparison({}, {}, None)
         assert "No tool data available." in rendered
+
+
+class TestSectionDiagnosticsComparisonPlaceholder:
+    """Diagnostics table renders an explicit placeholder when all cells skip.
+
+    Before the ``len(lines) == 4`` fix the table would emit a bare
+    header + separator with no body rows when every metric cell hit
+    the ``all three windows None`` continue — readers saw an empty
+    table and had to guess whether that meant "no data" or "rendering
+    bug".
+    """
+
+    def test_placeholder_rendered_when_every_cell_skips(self) -> None:
+        """Tool with no edge / log_loss / ... keys triggers the placeholder."""
+        # tool-a exists in by_tool so _tool_universe yields it, but
+        # none of the five diagnostic metric keys are populated on any
+        # window — every (tool, metric) pair hits the continue branch.
+        bare_tool = {"by_tool": {"tool-a": {"n": 100, "valid_n": 90}}}
+        rendered = section_diagnostics_comparison(bare_tool, bare_tool, bare_tool)
+        assert "_(no diagnostic data)_" in rendered
+
+    def test_placeholder_absent_when_any_metric_populated(self) -> None:
+        """Placeholder only fires when no (tool, metric) cell renders."""
+        with_edge = {
+            "by_tool": {
+                "tool-a": {
+                    "n": 100,
+                    "valid_n": 90,
+                    "edge": 0.02,
+                    "edge_n": 80,
+                }
+            }
+        }
+        rendered = section_diagnostics_comparison(with_edge, with_edge, with_edge)
+        assert "_(no diagnostic data)_" not in rendered
+        assert "**tool-a** | Edge" in rendered
+
+
+class TestZeroRowPrevRollingRouting:
+    """Zero-row prev_rolling_scores routes to the "no prev window" placeholder.
+
+    A prev-scoring CI step that succeeds on an empty window writes
+    ``{"total_rows": 0, "overall": {}}`` to disk. Pre-normalization,
+    ``prev is not None`` was True in the comparison sections and the
+    "no prev window" placeholder never fired — readers saw ``N/A (n=0)``
+    cells that read as "we measured zero rows" instead of "no reference
+    window available".
+    """
+
+    def _scores(self, tool: str, brier: float, n: int) -> dict:
+        return _scores_with_tool(tool, brier, n)
+
+    def test_empty_prev_rolling_routes_to_no_prev_window(self) -> None:
+        """Zero total_rows on prev_rolling_scores renders the explicit placeholder."""
+        scores = self._scores("tool-a", 0.22, 1000)
+        rolling = self._scores("tool-a", 0.20, 100)
+        empty_prev = {"total_rows": 0, "overall": {}}
+        report = generate_report(
+            scores,
+            [],
+            platform="omen",
+            rolling_scores=rolling,
+            prev_rolling_scores=empty_prev,
+            disabled_tools={},
+        )
+        assert "no prev window" in report
+
+    def test_missing_prev_rolling_and_empty_prev_rolling_render_the_same(
+        self,
+    ) -> None:
+        """Zero-row prev and None prev emit the same user-facing copy."""
+        scores = self._scores("tool-a", 0.22, 1000)
+        rolling = self._scores("tool-a", 0.20, 100)
+        empty_prev = {"total_rows": 0, "overall": {}}
+        report_empty = generate_report(
+            scores,
+            [],
+            platform="omen",
+            rolling_scores=rolling,
+            prev_rolling_scores=empty_prev,
+            disabled_tools={},
+        )
+        report_none = generate_report(
+            scores,
+            [],
+            platform="omen",
+            rolling_scores=rolling,
+            prev_rolling_scores=None,
+            disabled_tools={},
+        )
+        # The date stamps in the header carry ``generated_at`` which is
+        # identical across both calls for a single-scorer fixture, so the
+        # full reports compare equal.
+        assert report_empty == report_none
+
+    def test_populated_prev_rolling_still_renders_deltas(self) -> None:
+        """The zero-row guard does not accidentally swallow real prev data."""
+        scores = self._scores("tool-a", 0.22, 1000)
+        rolling = self._scores("tool-a", 0.20, 100)
+        populated_prev = self._scores("tool-a", 0.21, 100)
+        report = generate_report(
+            scores,
+            [],
+            platform="omen",
+            rolling_scores=rolling,
+            prev_rolling_scores=populated_prev,
+            disabled_tools={},
+        )
+        assert "no prev window" not in report
 
 
 class TestSectionReliabilityComparison:

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -935,19 +935,24 @@ class TestGenerateReport:
 
         assert "# Benchmark Report (Omenstrat) — " in report
         assert "## Metric References" in report
-        assert "## Tool Ranking (Last 3 Days)" in report
+        assert "## Platform Snapshot (Current 3d)" in report
+        assert "## Platform Historical Comparison" in report
+        assert "## Tool Historical Comparison" in report
+        assert "## Tool \u00d7 Category (Current 3d)" in report
+        assert "## Tool \u00d7 Category Historical Comparison" in report
+        assert "## Diagnostics Historical Comparison" in report
+        assert "## Reliability & Parse Quality (Current vs All-Time)" in report
         # Per-platform reports drop Platform Comparison / Tool × Platform —
         # they'd be single-row tables with no signal.
         assert "## Platform Comparison" not in report
         assert "## Tool \u00d7 Platform" not in report
-        assert "## Category Performance (Last 3 Days)" in report
-        assert "## Tool \u00d7 Category (Last 3 Days)" in report
-        assert "## Weak Spots (Last 3 Days)" in report
-        assert "## Reliability Issues" in report
         assert "## Trend" in report
         assert "## Sample Size Warnings" in report
-        assert "## Diagnostic Edge Metrics (Last 3 Days)" in report
-        # Dropped in the Phase 2 single-window collapse.
+        # The reviewer's P1 restructure dropped overlapping-window and
+        # single-scope point-in-time sections. Their data is now folded
+        # into the three-window comparison tables.
+        assert "## Since Last Report" not in report
+        assert "## Last 3 Days" not in report
         assert "## Overall" not in report
         assert "## Worst Predictions" not in report
         assert "## Best Predictions" not in report
@@ -960,7 +965,8 @@ class TestGenerateReport:
         s = _scores(brier=None, reliability=None, total=0, valid=0)
         report = generate_report(s, [], platform="omen", disabled_tools={})
         assert "# Benchmark Report (Omenstrat) — " in report
-        assert "No period data available." in report
+        # With no rolling_scores, the snapshot banner explains the gap.
+        assert "Scores for the last 3 days are unavailable" in report
 
 
 # ---------------------------------------------------------------------------
@@ -1537,7 +1543,7 @@ class TestGenerateReportWithTournamentFiles:
         assert "## Tournament Callouts" not in report
 
     def test_tournament_sections_rendered_when_data_present(self) -> None:
-        """Tournament inputs with rows -> duplicated per-mode headings render."""
+        """Tournament inputs with rows -> Tool × Version × Mode covers both modes."""
         prod = _scores_with_tool("tool-a", 0.20, 1000)
         tourn = _tournament_scores_with_version("tool-a", "v2", 0.18, 100)
         report = generate_report(
@@ -1549,33 +1555,32 @@ class TestGenerateReportWithTournamentFiles:
             rolling_scores=prod,
             rolling_scores_tournament=tourn,
         )
-        # Overall is dropped in Phase 2; Tool Ranking carries the rolling suffix.
+        # Under the three-window restructure the per-mode headings live in
+        # Tool × Version × Mode, not a duplicated " — Tournament" ranking.
         assert "## Overall" not in report
-        assert "## Tool Ranking (Last 3 Days) — Tournament" in report
+        assert "## Tool × Version × Mode (All-Time)" in report
+        assert "## Tool × Version × Mode (Last 3 Days)" in report
 
-    def test_empty_period_tournament_does_not_render_section(self) -> None:
-        """Tournament period files with zero rows don't emit empty sections.
+    def test_empty_rolling_tournament_does_not_crash(self) -> None:
+        """Rolling tournament input with zero rows renders cleanly.
 
         scorer.score_period_split writes tournament period files on every
-        run; days with zero tournament rows in the window must not add a
-        dangling '## Since Last Report — Tournament' header.
+        run; days with zero tournament rows in the window must not blow
+        up the TVM merge.
         """
         prod = _scores_with_tool("tool-a", 0.20, 1000)
         all_time_tourn = _tournament_scores_with_version("tool-a", "v2", 0.18, 100)
-        empty_period_tourn = {"total_rows": 0, "overall": {}}
+        empty_rolling_tourn = {"total_rows": 0, "overall": {}}
         report = generate_report(
             prod,
             [],
             platform="omen",
-            period_scores=None,
             rolling_scores=None,
             include_tournament=True,
             scores_tournament=all_time_tourn,
-            period_scores_tournament=empty_period_tourn,
-            rolling_scores_tournament=empty_period_tourn,
+            rolling_scores_tournament=empty_rolling_tourn,
         )
-        assert "## Since Last Report — Tournament" not in report
-        assert "## Last 3 Days Rolling — Tournament" not in report
+        assert "# Benchmark Report (Omenstrat)" in report
 
     def test_merged_tool_version_mode_includes_both_modes(self) -> None:
         """Tool × Version × Mode table shows both production and tournament cells."""
@@ -1835,16 +1840,20 @@ class TestSectionToolDeploymentStatusInverted:
 class TestToolCategoryPositionInReport:
     """Phase 3: Tool × Category is rendered before Tool × Version × Mode."""
 
-    def test_tool_category_rendered_exactly_once(self) -> None:
-        """The reorder moved the call site, it didn't duplicate the section."""
+    def test_tool_category_current_and_comparison_both_render(self) -> None:
+        """Current-3d table and historical comparison both render, in that order."""
         scores = _scores_with_tool("tool-a", 0.20, 1000)
         report = generate_report(
             scores, [], platform="omen", rolling_scores=scores, disabled_tools={}
         )
-        assert report.count("## Tool \u00d7 Category") == 1
+        current_idx = report.index(
+            f"## Tool \u00d7 Category (Current {ROLLING_WINDOW_DAYS}d)"
+        )
+        comparison_idx = report.index("## Tool \u00d7 Category Historical Comparison")
+        assert current_idx < comparison_idx
 
     def test_tool_category_lands_before_tool_version_mode(self) -> None:
-        """Ordering matters for LLM attention weighting."""
+        """Ordering: comparison tables before the Tool × Version × Mode tables."""
         scores = _scores_with_tool("tool-a", 0.20, 1000)
         scores["by_tool_version_mode"] = {
             "tool-a | v1 | production_replay": {
@@ -1861,9 +1870,7 @@ class TestToolCategoryPositionInReport:
             include_tournament=True,
             disabled_tools={},
         )
-        tc_idx = report.index(
-            f"## Tool \u00d7 Category (Last {ROLLING_WINDOW_DAYS} Days)"
-        )
+        tc_idx = report.index("## Tool \u00d7 Category Historical Comparison")
         tvm_idx = report.index("## Tool \u00d7 Version \u00d7 Mode (All-Time)")
         assert tc_idx < tvm_idx
 
@@ -1881,13 +1888,21 @@ class TestSectionMetricReference:
     def test_cites_rolling_window_from_constant(self) -> None:
         """Legend quotes ROLLING_WINDOW_DAYS so a one-line change updates both."""
         rendered = section_metric_reference()
-        assert f"(Last {ROLLING_WINDOW_DAYS} Days)" in rendered
+        assert f"Current {ROLLING_WINDOW_DAYS}d" in rendered
+        assert f"Prev {ROLLING_WINDOW_DAYS}d" in rendered
 
-    def test_distinguishes_rolling_from_alltime(self) -> None:
-        """Legend explicitly names both scope tags so readers aren't left guessing."""
+    def test_names_all_three_windows(self) -> None:
+        """Legend explicitly names current, all-time, and prev-rolling windows."""
         rendered = section_metric_reference()
-        assert "(All-Time)" in rendered
-        assert "not a trailing-average series" in rendered
+        assert "Current 3d" in rendered
+        assert "All-Time" in rendered
+        assert "Prev 3d" in rendered
+
+    def test_documents_sample_size_guardrail(self) -> None:
+        """Legend spells out the MIN_SAMPLE_SIZE delta-suppression rule."""
+        rendered = section_metric_reference()
+        assert f"n < {MIN_SAMPLE_SIZE}" in rendered
+        assert "insufficient data" in rendered
 
     def test_cites_brier_random_baseline(self) -> None:
         """Coin-flip Brier anchor is sourced from BRIER_RANDOM."""
@@ -1898,13 +1913,20 @@ class TestSectionMetricReference:
 class TestGenerateReportLegendPlacement:
     """Regression tests for where the metric legend lands in the report body."""
 
-    def test_legend_rendered_before_since_last_report(self) -> None:
+    def test_legend_rendered_before_first_data_section(self) -> None:
         """Legend sits between the H1 title and the first data section."""
         scores = _scores()
-        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        rolling = _scores_with_tool("tool-a", 0.20, 100)
+        report = generate_report(
+            scores,
+            [],
+            platform="omen",
+            rolling_scores=rolling,
+            disabled_tools={},
+        )
         legend_idx = report.index("## Metric References")
-        since_last_idx = report.index("## Since Last Report")
-        assert legend_idx < since_last_idx
+        snapshot_idx = report.index("## Platform Snapshot")
+        assert legend_idx < snapshot_idx
         header_end = report.index("\n")
         assert legend_idx > header_end
 
@@ -1923,21 +1945,34 @@ class TestGenerateReportLegendPlacement:
         assert report.count("## Metric References") == 1
 
 
-class TestGenerateReportRollingWindowAnnotations:
-    """Rolling sections carry the '_n= over last N days._' note; others do not."""
+class TestGenerateReportRollingBanner:
+    """Missing rolling_scores must not silently fall back to all-time data."""
 
-    def test_rolling_sections_carry_window_note(self) -> None:
-        """Tool Ranking / Category / Tool × Category / Diagnostics / Weak Spots."""
+    def test_rolling_sections_absent_when_rolling_scores_missing(self) -> None:
+        """No rolling_scores -> comparison sections omitted with an explicit banner.
+
+        Falling back to all-time ``scores`` under a "(Current 3d)" heading
+        would mislabel the window. Instead, a single banner explains the
+        gap and every rolling/comparison section is skipped.
+        """
         scores = _scores_with_tool("tool-a", 0.20, 1000)
-        report = generate_report(
-            scores, [], platform="omen", rolling_scores=scores, disabled_tools={}
+        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        assert f"## Platform Snapshot (Current {ROLLING_WINDOW_DAYS}d)" in report
+        assert (
+            f"Scores for the last {ROLLING_WINDOW_DAYS} days are unavailable" in report
         )
-        note = f"_n= values below are over the last {ROLLING_WINDOW_DAYS} days._"
-        # At least the five rolling point-in-time sections carry it.
-        assert report.count(note) >= 5
+        for heading in (
+            "## Platform Historical Comparison",
+            "## Tool Historical Comparison",
+            "## Tool × Category (Current 3d)",
+            "## Tool × Category Historical Comparison",
+            "## Diagnostics Historical Comparison",
+            "## Reliability & Parse Quality (Current vs All-Time)",
+        ):
+            assert heading not in report
 
     def test_tool_version_mode_rolling_section_carries_window_note(self) -> None:
-        """Tool × Version × Mode (Last N Days) gets the n= qualifier like siblings."""
+        """Tool × Version × Mode (Last N Days) carries the n= annotation."""
         scores = _scores_with_tool("tool-a", 0.20, 1000)
         scores["by_tool_version_mode"] = {
             "tool-a | v1 | production_replay": {
@@ -1963,78 +1998,12 @@ class TestGenerateReportRollingWindowAnnotations:
             f"_n= values below are over the last {ROLLING_WINDOW_DAYS} days._" in body
         )
 
-    def test_rolling_sections_absent_when_rolling_scores_missing(self) -> None:
-        """No rolling_scores -> rolling point-in-time sections omitted.
 
-        Falling back to all-time ``scores`` under a "(Last N Days)" heading
-        would mislabel the window. Instead, a single banner explains the gap
-        and the five rolling sections are skipped entirely.
-        """
-        scores = _scores_with_tool("tool-a", 0.20, 1000)
-        report = generate_report(scores, [], platform="omen", disabled_tools={})
-        assert f"## Last {ROLLING_WINDOW_DAYS} Days (Window Aggregate)" in report
-        assert (
-            f"Scores for the last {ROLLING_WINDOW_DAYS} days are unavailable" in report
-        )
-        for heading in (
-            "## Tool Ranking (Last 3 Days)",
-            "## Category Performance (Last 3 Days)",
-            "## Tool \u00d7 Category (Last 3 Days)",
-            "## Diagnostic Edge Metrics (Last 3 Days)",
-            "## Weak Spots (Last 3 Days)",
-        ):
-            assert heading not in report
+class TestGenerateReportStructure:
+    """Seven-section report structure from the P1 restructure."""
 
-    def test_non_rolling_sections_do_not_carry_window_note(self) -> None:
-        """Trend, Base Rates, Tool Deployment Status never claim rolling scope."""
-        scores = _scores_with_tool("tool-a", 0.20, 1000)
-        history = [{"month": "2026-03", "overall": {"brier": 0.3, "n": 50}}]
-        report = generate_report(
-            scores,
-            history,
-            platform="omen",
-            rolling_scores=scores,
-            disabled_tools={},
-        )
-        note = f"_n= values below are over the last {ROLLING_WINDOW_DAYS} days._"
-        # Split on the Trend header and assert the note is absent between it and
-        # the next section heading.
-        trend_idx = report.index("## Trend")
-        next_section = report.find("##", trend_idx + 1)
-        trend_body = report[
-            trend_idx : next_section if next_section > -1 else len(report)
-        ]
-        assert note not in trend_body
-
-        base_rates_idx = report.index("## Base Rates")
-        next_section = report.find("##", base_rates_idx + 1)
-        base_body = report[base_rates_idx:next_section]
-        assert note not in base_body
-
-
-class TestGenerateReportAllTimeLabels:
-    """All-time sections carry an explicit (All-Time) suffix in their headings."""
-
-    def test_alltime_sections_labeled(self) -> None:
-        """Every cumulative section is tagged so the legend stays accurate."""
-        scores = _scores_with_tool("tool-a", 0.20, 100)
-        report = generate_report(scores, [], platform="omen", disabled_tools={})
-        for heading in (
-            "## Tool Ranking (All-Time)",
-            "## Base Rates (All-Time)",
-            "## Reliability Issues (All-Time)",
-            "## Parse/Error Breakdown by Tool (All-Time)",
-            "## Sample Size Warnings (All-Time)",
-        ):
-            assert heading in report, f"missing: {heading}"
-
-    def test_rolling_summary_and_ranking_are_adjacent(self) -> None:
-        """No all-time section slips between the rolling summary and ranking.
-
-        The two rolling-scoped sections must sit next to each other so
-        readers can't mistakenly compare the rolling summary against
-        base-rate numbers from an interleaved all-time section.
-        """
+    def test_sections_in_reviewer_order(self) -> None:
+        """The new comparison sections render in the reviewer-specified order."""
         scores = _scores_with_tool("tool-a", 0.20, 100)
         rolling = _scores_with_tool("tool-a", 0.15, 60)
         report = generate_report(
@@ -2044,15 +2013,32 @@ class TestGenerateReportAllTimeLabels:
             rolling_scores=rolling,
             disabled_tools={},
         )
-        summary_idx = report.index(
-            f"## Last {ROLLING_WINDOW_DAYS} Days (Window Aggregate)"
+        ordered_headings = [
+            f"## Platform Snapshot (Current {ROLLING_WINDOW_DAYS}d)",
+            "## Platform Historical Comparison",
+            "## Tool Historical Comparison",
+            f"## Tool × Category (Current {ROLLING_WINDOW_DAYS}d)",
+            "## Tool × Category Historical Comparison",
+            "## Diagnostics Historical Comparison",
+            "## Reliability & Parse Quality (Current vs All-Time)",
+        ]
+        prev_idx = -1
+        for heading in ordered_headings:
+            idx = report.index(heading)
+            assert idx > prev_idx, f"{heading} out of order"
+            prev_idx = idx
+
+    def test_since_last_report_not_in_report(self) -> None:
+        """Overlapping-window 'Since Last Report' was dropped per reviewer."""
+        scores = _scores_with_tool("tool-a", 0.20, 100)
+        report = generate_report(
+            scores,
+            [],
+            platform="omen",
+            rolling_scores=scores,
+            disabled_tools={},
         )
-        ranking_idx = report.index(f"## Tool Ranking (Last {ROLLING_WINDOW_DAYS} Days)")
-        between = report[summary_idx:ranking_idx]
-        assert "(All-Time)" not in between, (
-            f"all-time section interleaved between rolling summary and ranking: "
-            f"{between!r}"
-        )
+        assert "## Since Last Report" not in report
 
 
 class TestSectionCategoryPlatform:
@@ -2193,3 +2179,261 @@ class TestGenerateFleetReport:
         report = generate_fleet_report(self._fleet_scores(), history)
         assert "## Trend (Fleet-wide, Monthly)" in report
         assert "not scoped to this report" not in report
+
+    def test_header_notes_all_time_scope(self) -> None:
+        """Fleet report intro points readers to per-platform reports for deltas."""
+        report = generate_fleet_report(self._fleet_scores(), [])
+        assert "All metrics here are all-time" in report
+        assert "report_omen.md" in report
+        assert "report_polymarket.md" in report
+
+
+# ---------------------------------------------------------------------------
+# Three-window comparison helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDeltaCell:
+    """_delta_cell enforces the sample-size and direction-label contract."""
+
+    def test_delta_suppressed_when_current_below_min(self) -> None:
+        """Low current-window n yields insufficient data, not a signed number."""
+        from benchmark.analyze import _delta_cell
+
+        assert _delta_cell(0.2, 0.3, current_n=5, reference_n=1000) == (
+            "insufficient data"
+        )
+
+    def test_delta_suppressed_when_reference_below_min(self) -> None:
+        """Low reference-window n yields insufficient data."""
+        from benchmark.analyze import _delta_cell
+
+        assert _delta_cell(0.2, 0.3, current_n=1000, reference_n=5) == (
+            "insufficient data"
+        )
+
+    def test_none_values_yield_na(self) -> None:
+        """Missing values collapse to N/A rather than arithmetic error."""
+        from benchmark.analyze import _delta_cell
+
+        assert _delta_cell(None, 0.3, 1000, 1000) == "N/A"
+        assert _delta_cell(0.2, None, 1000, 1000) == "N/A"
+
+    def test_lower_is_better_direction(self) -> None:
+        """For Brier-like metrics, negative delta = better."""
+        from benchmark.analyze import _delta_cell
+
+        rendered = _delta_cell(0.20, 0.25, 100, 100, lower_is_better=True)
+        assert rendered.startswith("-0.0500")
+        assert "better" in rendered
+
+    def test_higher_is_better_direction(self) -> None:
+        """For BSS / directional accuracy, positive delta = better."""
+        from benchmark.analyze import _delta_cell
+
+        rendered = _delta_cell(0.75, 0.70, 100, 100, lower_is_better=False)
+        assert rendered.startswith("+0.0500")
+        assert "better" in rendered
+
+    def test_zero_delta_labeled_same(self) -> None:
+        """Delta of exactly zero renders as same, not better/worse."""
+        from benchmark.analyze import _delta_cell
+
+        rendered = _delta_cell(0.20, 0.20, 100, 100)
+        assert "same" in rendered
+
+
+class TestSectionPlatformSnapshot:
+    """section_platform_snapshot renders the current-window overall metrics."""
+
+    def test_renders_all_snapshot_metrics(self) -> None:
+        """Every reviewer-requested snapshot metric appears in the output."""
+        from benchmark.analyze import section_platform_snapshot
+
+        scores = {
+            "overall": {
+                "n": 200,
+                "valid_n": 190,
+                "reliability": 0.95,
+                "brier": 0.22,
+                "baseline_brier": 0.25,
+                "brier_skill_score": 0.12,
+                "directional_accuracy": 0.70,
+                "outcome_yes_rate": 0.55,
+            }
+        }
+        rendered = section_platform_snapshot(scores)
+        for label in (
+            "n",
+            "Reliability",
+            "Brier",
+            "Baseline Brier",
+            "BSS",
+            "Directional Accuracy",
+            "Outcome Yes Rate",
+            "always-majority baseline",
+        ):
+            assert label in rendered
+
+    def test_empty_scores_renders_placeholder(self) -> None:
+        """Zero rows collapses to a placeholder, not a crash."""
+        from benchmark.analyze import section_platform_snapshot
+
+        assert "No rows scored" in section_platform_snapshot({"overall": {"n": 0}})
+
+
+class TestSectionPlatformComparison:
+    """section_platform_comparison threads the three windows correctly."""
+
+    def _rolling(self) -> dict:
+        return {
+            "overall": {
+                "n": 200,
+                "valid_n": 190,
+                "reliability": 0.95,
+                "brier": 0.22,
+                "baseline_brier": 0.25,
+                "brier_skill_score": 0.12,
+                "directional_accuracy": 0.70,
+                "log_loss": 0.50,
+            }
+        }
+
+    def _alltime(self) -> dict:
+        return {
+            "overall": {
+                "n": 5000,
+                "valid_n": 4800,
+                "reliability": 0.93,
+                "brier": 0.24,
+                "baseline_brier": 0.26,
+                "brier_skill_score": 0.08,
+                "directional_accuracy": 0.68,
+                "log_loss": 0.52,
+            }
+        }
+
+    def _prev(self) -> dict:
+        return {
+            "overall": {
+                "n": 200,
+                "valid_n": 185,
+                "reliability": 0.94,
+                "brier": 0.23,
+                "baseline_brier": 0.25,
+                "brier_skill_score": 0.10,
+                "directional_accuracy": 0.69,
+                "log_loss": 0.51,
+            }
+        }
+
+    def test_three_window_table_header(self) -> None:
+        """Header names current, all-time, and prev windows with delta columns."""
+        from benchmark.analyze import section_platform_comparison
+
+        rendered = section_platform_comparison(
+            self._rolling(), self._alltime(), self._prev()
+        )
+        assert "Current 3d" in rendered
+        assert "All-Time" in rendered
+        assert "Prev 3d" in rendered
+        assert "Δ vs All-Time" in rendered
+        assert "Δ vs Prev 3d" in rendered
+
+    def test_no_prev_window_when_prev_is_none(self) -> None:
+        """Prev column renders 'no prev window' placeholder instead of a delta."""
+        from benchmark.analyze import section_platform_comparison
+
+        rendered = section_platform_comparison(self._rolling(), self._alltime(), None)
+        assert "no prev window" in rendered
+
+    def test_brier_row_renders_signed_delta(self) -> None:
+        """Brier delta sign + direction word appears in the table body."""
+        from benchmark.analyze import section_platform_comparison
+
+        rendered = section_platform_comparison(
+            self._rolling(), self._alltime(), self._prev()
+        )
+        # current=0.22, all-time=0.24 → delta=-0.02, better (Brier is
+        # lower-is-better).
+        assert "-0.0200 better" in rendered
+
+
+class TestSectionToolComparison:
+    """section_tool_comparison ranks tools and threads deltas correctly."""
+
+    def _s(self, tools: dict[str, tuple[float | None, int]]) -> dict:
+        return {
+            "by_tool": {
+                name: {
+                    "brier": brier,
+                    "valid_n": n,
+                    "n": n,
+                    "decision_worthy": n >= 30,
+                }
+                for name, (brier, n) in tools.items()
+            }
+        }
+
+    def test_tool_row_cites_current_value_and_deltas(self) -> None:
+        """Each row shows the current Brier, all-time delta, and prev delta."""
+        from benchmark.analyze import section_tool_comparison
+
+        rolling = self._s({"tool-a": (0.22, 100)})
+        alltime = self._s({"tool-a": (0.25, 5000)})
+        prev = self._s({"tool-a": (0.24, 100)})
+        rendered = section_tool_comparison(rolling, alltime, prev)
+        assert "**tool-a**" in rendered
+        assert "0.2200 (n=100)" in rendered
+        assert "better" in rendered
+
+    def test_no_prev_window_placeholder(self) -> None:
+        """None prev-rolling renders the placeholder instead of N/A or empty."""
+        from benchmark.analyze import section_tool_comparison
+
+        rolling = self._s({"tool-a": (0.22, 100)})
+        alltime = self._s({"tool-a": (0.25, 5000)})
+        rendered = section_tool_comparison(rolling, alltime, None)
+        assert "no prev window" in rendered
+
+    def test_empty_universe_renders_placeholder(self) -> None:
+        """No tools anywhere collapses to a placeholder."""
+        from benchmark.analyze import section_tool_comparison
+
+        rendered = section_tool_comparison({}, {}, None)
+        assert "No tool data available." in rendered
+
+
+class TestSectionReliabilityComparison:
+    """section_reliability_comparison shows reliability and valid % deltas."""
+
+    def test_reliability_regression_labeled_worse(self) -> None:
+        """Tool whose reliability dropped renders with 'worse' direction."""
+        from benchmark.analyze import section_reliability_comparison
+
+        rolling = {
+            "by_tool": {"tool-a": {"reliability": 0.85, "n": 100}},
+            "parse_breakdown": {"tool-a": {"valid": 80, "malformed": 20}},
+        }
+        alltime = {
+            "by_tool": {"tool-a": {"reliability": 0.95, "n": 5000}},
+            "parse_breakdown": {"tool-a": {"valid": 4750, "malformed": 250}},
+        }
+        rendered = section_reliability_comparison(rolling, alltime)
+        assert "**tool-a**" in rendered
+        assert "worse" in rendered
+
+    def test_low_sample_suppresses_delta(self) -> None:
+        """Low-n reliability delta renders insufficient data, not a signed %."""
+        from benchmark.analyze import section_reliability_comparison
+
+        rolling = {
+            "by_tool": {"tool-a": {"reliability": 0.85, "n": 5}},
+            "parse_breakdown": {"tool-a": {"valid": 4, "malformed": 1}},
+        }
+        alltime = {
+            "by_tool": {"tool-a": {"reliability": 0.95, "n": 5000}},
+            "parse_breakdown": {"tool-a": {"valid": 4750, "malformed": 250}},
+        }
+        rendered = section_reliability_comparison(rolling, alltime)
+        assert "insufficient data" in rendered

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -2629,6 +2629,32 @@ class TestZeroRowPrevRollingRouting:
         )
         assert "no prev window" not in report
 
+    def test_prev_value_and_delta_cells_agree_when_no_prev_window(self) -> None:
+        """When prev is None, the prev-value cell and delta cell render identically.
+
+        Regression test for a consistency bug where the delta cell
+        said ``no prev window`` but the prev-value cell on the same row
+        rendered ``N/A (n=0)`` — two different messages for the same
+        state in neighboring columns of a single row.
+        """
+        scores = self._scores("tool-a", 0.22, 1000)
+        rolling = self._scores("tool-a", 0.20, 100)
+        report = generate_report(
+            scores,
+            [],
+            platform="omen",
+            rolling_scores=rolling,
+            prev_rolling_scores=None,
+            disabled_tools={},
+        )
+        # The value-cell on the prev column must carry "no prev window"
+        # wherever a delta cell does; an "N/A (n=0)" leaking through
+        # would mean a no-prev-window row is claiming it measured the
+        # previous window and found zero rows.
+        for line in report.splitlines():
+            if line.startswith("|") and "no prev window" in line:
+                assert "N/A (n=0)" not in line, line
+
 
 class TestSectionReliabilityComparison:
     """section_reliability_comparison shows reliability and valid % deltas."""

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -585,7 +585,12 @@ class TestSectionToolCategory:
         assert "No cross-breakdown data" in result
 
     def test_sufficient_cell_rendered_in_table(self) -> None:
-        """Cells with n >= MIN_SAMPLE_SIZE appear in the ranked table."""
+        """Cells with n >= MIN_SAMPLE_SIZE appear in the ranked table.
+
+        Column order: Tool | Category | n | Reliability | Brier |
+        Baseline Brier | BSS | DirAcc | Yes% | No% | Always-majority |
+        DA lift.
+        """
         s = _scores(
             by_tool_category={
                 "tool-a | politics": {
@@ -597,14 +602,21 @@ class TestSectionToolCategory:
                     "directional_accuracy": 0.76,
                     "sharpness": 0.12,
                     "n": 60,
+                    "valid_n": 55,
+                    "reliability": 0.92,
+                    "baseline_brier": 0.25,
+                    "outcome_yes_rate": 0.40,
                     "decision_worthy": True,
                 }
             }
         )
         result = section_tool_category(s)
+        # Columns in order: Tool, Category, n, Reliability, Brier,
+        # Baseline Brier, BSS, DirAcc, Yes%, No%, Always-majority, DA lift.
+        # always_majority = max(0.4, 0.6) = 0.6; DA lift = 0.76 - 0.60 = 0.16.
         assert (
-            "| tool-a | politics | 0.1900 | +0.0500 | 0.6000 | -0.0300 | 40 | 76% | 0.1200 | 60 |"
-            in result
+            "| tool-a | politics | 60 | 92% | 0.1900 | 0.2500 | +0.0500 | 76%"
+            " | 40% | 60% | 60% | +0.1600 |" in result
         )
 
     def test_sparse_cell_listed_in_sparse_section_not_table(self) -> None:
@@ -656,7 +668,9 @@ class TestSectionToolCategory:
             }
         )
         result = section_tool_category(s)
-        assert "| tool-a | politics | 0.2000" in result
+        # Column order: Tool | Category | n | ... Brier is the 5th column.
+        assert f"| tool-a | politics | {MIN_SAMPLE_SIZE} " in result
+        assert "| 0.2000 |" in result
         assert "below n=" not in result  # no sparse section
 
     def test_sparse_examples_capped_at_five(self) -> None:
@@ -1965,6 +1979,7 @@ class TestGenerateReportRollingBanner:
             "## Platform Historical Comparison",
             "## Tool Historical Comparison",
             "## Tool × Category (Current 3d)",
+            "## Tool × Category Diagnostics (Current 3d)",
             "## Tool × Category Historical Comparison",
             "## Diagnostics Historical Comparison",
             "## Reliability & Parse Quality (Current vs All-Time)",
@@ -2018,6 +2033,7 @@ class TestGenerateReportStructure:
             "## Platform Historical Comparison",
             "## Tool Historical Comparison",
             f"## Tool × Category (Current {ROLLING_WINDOW_DAYS}d)",
+            f"## Tool × Category Diagnostics (Current {ROLLING_WINDOW_DAYS}d)",
             "## Tool × Category Historical Comparison",
             "## Diagnostics Historical Comparison",
             "## Reliability & Parse Quality (Current vs All-Time)",
@@ -2079,6 +2095,120 @@ class TestSectionCategoryPlatform:
     def test_empty_input(self) -> None:
         """Empty data renders a placeholder, never blows up."""
         assert "No cross-breakdown data available." in section_category_platform({})
+
+
+class TestAlwaysMajorityAndDALift:
+    """_always_majority / _da_lift helpers derive Maria Pia's requested fields.
+
+    Both are trivial math but they're user-facing numbers, so lock them
+    in with tests rather than trusting the diff review.
+    """
+
+    def test_always_majority_yes_heavy(self) -> None:
+        """yes_rate=0.7 → majority outcome is yes at 70%."""
+        from benchmark.analyze import _always_majority
+
+        assert _always_majority(0.7) == 0.7
+
+    def test_always_majority_no_heavy(self) -> None:
+        """yes_rate=0.3 → majority outcome is no at 70% (1 - 0.3)."""
+        from benchmark.analyze import _always_majority
+
+        assert _always_majority(0.3) == pytest.approx(0.7)
+
+    def test_always_majority_balanced(self) -> None:
+        """yes_rate=0.5 → majority baseline is 0.5 (no class is majority)."""
+        from benchmark.analyze import _always_majority
+
+        assert _always_majority(0.5) == 0.5
+
+    def test_always_majority_none(self) -> None:
+        """Missing yes_rate yields None, not a crash or 0.5 default."""
+        from benchmark.analyze import _always_majority
+
+        assert _always_majority(None) is None
+
+    def test_da_lift_positive_when_beating_majority(self) -> None:
+        """Tool predicting above always-majority has positive lift."""
+        from benchmark.analyze import _da_lift
+
+        # yes_rate=0.4 → majority=0.6. DirAcc=0.75 → lift=+0.15.
+        assert _da_lift(0.75, 0.4) == pytest.approx(0.15)
+
+    def test_da_lift_zero_when_equal_to_majority(self) -> None:
+        """Tool matching always-majority has zero lift."""
+        from benchmark.analyze import _da_lift
+
+        assert _da_lift(0.6, 0.4) == pytest.approx(0.0)
+
+    def test_da_lift_negative_when_below_majority(self) -> None:
+        """Tool worse than always-majority has negative lift."""
+        from benchmark.analyze import _da_lift
+
+        # yes_rate=0.3 → majority=0.7. DirAcc=0.55 → lift=-0.15.
+        assert _da_lift(0.55, 0.3) == pytest.approx(-0.15)
+
+    def test_da_lift_none_when_inputs_missing(self) -> None:
+        """Either missing input yields None, not arithmetic error."""
+        from benchmark.analyze import _da_lift
+
+        assert _da_lift(None, 0.4) is None
+        assert _da_lift(0.75, None) is None
+
+
+class TestSectionToolCategoryDiagnostics:
+    """section_tool_category_diagnostics renders edge / edge_n / log loss."""
+
+    def test_sufficient_cell_renders(self) -> None:
+        """Cells with n >= MIN_SAMPLE_SIZE render with all three diagnostics."""
+        from benchmark.analyze import section_tool_category_diagnostics
+
+        scores = {
+            "by_tool_category": {
+                "tool-a | crypto": {
+                    "n": 60,
+                    "edge": 0.03,
+                    "edge_n": 50,
+                    "log_loss": 0.48,
+                }
+            }
+        }
+        rendered = section_tool_category_diagnostics(scores)
+        assert "## Tool × Category Diagnostics" in rendered
+        assert "| tool-a | crypto | +0.0300 | 50 | 0.4800 | 60 |" in rendered
+
+    def test_sparse_cells_dropped(self) -> None:
+        """Cells below MIN_SAMPLE_SIZE don't render in the table body."""
+        from benchmark.analyze import section_tool_category_diagnostics
+
+        scores = {
+            "by_tool_category": {
+                "tool-a | crypto": {"n": 5, "edge": 0.1, "edge_n": 3, "log_loss": 0.5},
+            }
+        }
+        rendered = section_tool_category_diagnostics(scores)
+        assert "| tool-a | crypto | +0.1000" not in rendered
+        assert f"no cells with n ≥ {MIN_SAMPLE_SIZE}" in rendered
+
+    def test_missing_diagnostic_fields_render_na(self) -> None:
+        """Cells with None edge / edge_n / log_loss render N/A rather than crash."""
+        from benchmark.analyze import section_tool_category_diagnostics
+
+        scores = {
+            "by_tool_category": {
+                "tool-a | crypto": {"n": 60}  # no edge / log_loss keys
+            }
+        }
+        rendered = section_tool_category_diagnostics(scores)
+        assert "N/A" in rendered
+        assert "| tool-a | crypto |" in rendered
+
+    def test_empty_input(self) -> None:
+        """Empty data collapses to a placeholder message, not a crash."""
+        from benchmark.analyze import section_tool_category_diagnostics
+
+        rendered = section_tool_category_diagnostics({})
+        assert "No cross-breakdown data available" in rendered
 
 
 class TestSectionToolCategoryPlatform:
@@ -2271,9 +2401,13 @@ class TestSectionPlatformSnapshot:
             "BSS",
             "Directional Accuracy",
             "Outcome Yes Rate",
-            "always-majority baseline",
+            "Outcome No Rate",
+            "Always-majority baseline",
+            "DA lift",
         ):
             assert label in rendered
+        # DA lift = 0.70 - max(0.55, 0.45) = +0.15
+        assert "+0.1500" in rendered
 
     def test_empty_scores_renders_placeholder(self) -> None:
         """Zero rows collapses to a placeholder, not a crash."""

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -32,13 +32,16 @@ from benchmark.analyze import (
     SAMPLE_SIZE_WARNING,
     _parse_tvm_key,
     _sample_label,
+    generate_fleet_report,
     generate_report,
     section_category,
+    section_category_platform,
     section_metric_reference,
     section_parse_breakdown,
     section_period,
     section_sample_size_warnings,
     section_tool_category,
+    section_tool_category_platform,
     section_tool_deployment_status,
     section_tool_version_breakdown,
     section_trend,
@@ -1692,12 +1695,17 @@ class TestTrendSectionPlatformAnnotation:
     def test_fleet_wide_note_renders_with_platform(self) -> None:
         """Platform-scoped render inserts the fleet-wide disclaimer."""
         rendered = section_trend(self._history(), None, platform="omen")
-        assert "Fleet-wide monthly trend" in rendered
+        assert "Aggregated across all platforms" in rendered
 
     def test_no_note_without_platform(self) -> None:
         """Fleet-wide render (no platform arg) stays quiet — it's correct there."""
         rendered = section_trend(self._history(), None)
-        assert "Fleet-wide monthly trend" not in rendered
+        assert "Aggregated across all platforms" not in rendered
+
+    def test_heading_is_fleet_wide_monthly(self) -> None:
+        """Heading names the scope so it's unambiguous even out of context."""
+        rendered = section_trend(self._history(), None)
+        assert "## Trend (Fleet-wide, Monthly)" in rendered
 
     def test_per_platform_report_omits_in_progress_row(self) -> None:
         """generate_report does not append a current-month row in per-platform mode.
@@ -1873,7 +1881,13 @@ class TestSectionMetricReference:
     def test_cites_rolling_window_from_constant(self) -> None:
         """Legend quotes ROLLING_WINDOW_DAYS so a one-line change updates both."""
         rendered = section_metric_reference()
-        assert f"last {ROLLING_WINDOW_DAYS} days" in rendered
+        assert f"(Last {ROLLING_WINDOW_DAYS} Days)" in rendered
+
+    def test_distinguishes_rolling_from_alltime(self) -> None:
+        """Legend explicitly names both scope tags so readers aren't left guessing."""
+        rendered = section_metric_reference()
+        assert "(All-Time)" in rendered
+        assert "not a trailing-average series" in rendered
 
     def test_cites_brier_random_baseline(self) -> None:
         """Coin-flip Brier anchor is sourced from BRIER_RANDOM."""
@@ -1958,10 +1972,9 @@ class TestGenerateReportRollingWindowAnnotations:
         """
         scores = _scores_with_tool("tool-a", 0.20, 1000)
         report = generate_report(scores, [], platform="omen", disabled_tools={})
-        assert f"## Rolling Window (Last {ROLLING_WINDOW_DAYS} Days)" in report
+        assert f"## Last {ROLLING_WINDOW_DAYS} Days (Window Aggregate)" in report
         assert (
-            f"Rolling scores for the last {ROLLING_WINDOW_DAYS} days are unavailable"
-            in report
+            f"Scores for the last {ROLLING_WINDOW_DAYS} days are unavailable" in report
         )
         for heading in (
             "## Tool Ranking (Last 3 Days)",
@@ -1997,3 +2010,186 @@ class TestGenerateReportRollingWindowAnnotations:
         next_section = report.find("##", base_rates_idx + 1)
         base_body = report[base_rates_idx:next_section]
         assert note not in base_body
+
+
+class TestGenerateReportAllTimeLabels:
+    """All-time sections carry an explicit (All-Time) suffix in their headings."""
+
+    def test_alltime_sections_labeled(self) -> None:
+        """Every cumulative section is tagged so the legend stays accurate."""
+        scores = _scores_with_tool("tool-a", 0.20, 100)
+        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        for heading in (
+            "## Tool Ranking (All-Time)",
+            "## Base Rates (All-Time)",
+            "## Reliability Issues (All-Time)",
+            "## Parse/Error Breakdown by Tool (All-Time)",
+            "## Sample Size Warnings (All-Time)",
+        ):
+            assert heading in report, f"missing: {heading}"
+
+    def test_rolling_summary_and_ranking_are_adjacent(self) -> None:
+        """No all-time section slips between the rolling summary and ranking.
+
+        The two rolling-scoped sections must sit next to each other so
+        readers can't mistakenly compare the rolling summary against
+        base-rate numbers from an interleaved all-time section.
+        """
+        scores = _scores_with_tool("tool-a", 0.20, 100)
+        rolling = _scores_with_tool("tool-a", 0.15, 60)
+        report = generate_report(
+            scores,
+            [],
+            platform="omen",
+            rolling_scores=rolling,
+            disabled_tools={},
+        )
+        summary_idx = report.index(
+            f"## Last {ROLLING_WINDOW_DAYS} Days (Window Aggregate)"
+        )
+        ranking_idx = report.index(f"## Tool Ranking (Last {ROLLING_WINDOW_DAYS} Days)")
+        between = report[summary_idx:ranking_idx]
+        assert "(All-Time)" not in between, (
+            f"all-time section interleaved between rolling summary and ranking: "
+            f"{between!r}"
+        )
+
+
+class TestSectionCategoryPlatform:
+    """section_category_platform renders the category × platform cross cell table."""
+
+    def _scores_with_cp(self) -> dict[str, Any]:
+        return {
+            "by_category_platform": {
+                "crypto | omen": {
+                    "brier": 0.22,
+                    "brier_skill_score": 0.1,
+                    "log_loss": 0.5,
+                    "directional_accuracy": 0.6,
+                    "n": 50,
+                },
+                "politics | polymarket": {
+                    "brier": 0.31,
+                    "brier_skill_score": None,
+                    "log_loss": 0.62,
+                    "directional_accuracy": 0.55,
+                    "n": 10,
+                },
+            }
+        }
+
+    def test_sufficient_cells_render_in_table(self) -> None:
+        """Cells with n >= MIN_SAMPLE_SIZE render inline in the main table."""
+        rendered = section_category_platform(self._scores_with_cp())
+        assert "| crypto | omen | 0.2200" in rendered
+
+    def test_sparse_cells_moved_to_footnote(self) -> None:
+        """Cells below MIN_SAMPLE_SIZE are moved out of the ranking."""
+        rendered = section_category_platform(self._scores_with_cp())
+        # politics | polymarket has n=10, below the gate
+        assert "| politics | polymarket | 0.3100" not in rendered
+        assert "insufficient data (n=10)" in rendered
+
+    def test_empty_input(self) -> None:
+        """Empty data renders a placeholder, never blows up."""
+        assert "No cross-breakdown data available." in section_category_platform({})
+
+
+class TestSectionToolCategoryPlatform:
+    """section_tool_category_platform renders the tri-dimensional slice."""
+
+    def test_sufficient_cell_rendered(self) -> None:
+        """Cell with n >= MIN_SAMPLE_SIZE appears in the table."""
+        scores = {
+            "by_tool_category_platform": {
+                "tool-a | crypto | omen": {
+                    "brier": 0.18,
+                    "brier_skill_score": 0.12,
+                    "log_loss": 0.48,
+                    "edge": 0.03,
+                    "directional_accuracy": 0.7,
+                    "n": 50,
+                },
+            }
+        }
+        rendered = section_tool_category_platform(scores)
+        assert "| tool-a | crypto | omen | 0.1800" in rendered
+
+    def test_sparse_cells_omitted(self) -> None:
+        """Cells below MIN_SAMPLE_SIZE are omitted with a count footnote."""
+        scores = {
+            "by_tool_category_platform": {
+                "tool-a | crypto | omen": {"brier": 0.1, "n": 5},
+                "tool-b | crypto | omen": {"brier": 0.2, "n": 7},
+            }
+        }
+        rendered = section_tool_category_platform(scores)
+        # Neither sparse row renders inline.
+        assert "| tool-a | crypto | omen | 0.1000" not in rendered
+        assert "2 cell(s) below" in rendered
+
+    def test_empty_input(self) -> None:
+        """Empty input renders a placeholder."""
+        assert "No cross-breakdown data available." in section_tool_category_platform(
+            {}
+        )
+
+
+class TestGenerateFleetReport:
+    """generate_fleet_report renders the cross-platform view."""
+
+    def _fleet_scores(self) -> dict[str, Any]:
+        return {
+            "generated_at": "2026-03-31T06:00:00Z",
+            "overall": {"brier": 0.25, "n": 100},
+            "by_platform": {
+                "omen": {"brier": 0.22, "n": 60},
+                "polymarket": {"brier": 0.28, "n": 40},
+            },
+            "by_category_platform": {
+                "crypto | omen": {
+                    "brier": 0.20,
+                    "brier_skill_score": 0.1,
+                    "log_loss": 0.5,
+                    "directional_accuracy": 0.7,
+                    "n": 50,
+                },
+            },
+            "by_tool_category_platform": {
+                "tool-a | crypto | omen": {
+                    "brier": 0.18,
+                    "brier_skill_score": 0.1,
+                    "log_loss": 0.48,
+                    "edge": 0.03,
+                    "directional_accuracy": 0.7,
+                    "n": 50,
+                },
+            },
+        }
+
+    def test_header_names_fleet_scope(self) -> None:
+        """Fleet header makes the cross-platform scope unambiguous."""
+        report = generate_fleet_report(self._fleet_scores(), [])
+        assert "# Benchmark Report (Fleet, Cross-Platform)" in report
+
+    def test_includes_cross_platform_sections(self) -> None:
+        """Fleet report carries the two cross-platform breakdown headings."""
+        report = generate_fleet_report(self._fleet_scores(), [])
+        assert "## Category × Platform" in report
+        assert "## Tool × Category × Platform" in report
+
+    def test_skips_per_platform_deep_dives(self) -> None:
+        """Fleet report does not duplicate per-platform deep dives."""
+        report = generate_fleet_report(self._fleet_scores(), [])
+        # No rolling window content, no deployment status, no weak spots —
+        # those live in the per-platform reports.
+        assert "Tool Deployment Status" not in report
+        assert "(Last 3 Days)" not in report
+        assert "Weak Spots" not in report
+
+    def test_trend_renders_without_disclaimer(self) -> None:
+        """Fleet scope matches Trend's fleet-wide semantics — no disclaimer."""
+        history = [{"month": "2026-03", "overall": {"brier": 0.25, "n": 100}}]
+        report = generate_fleet_report(self._fleet_scores(), history)
+        assert "## Trend (Fleet-wide, Monthly)" in report
+        assert "not scoped to this report" not in report

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -30,6 +30,9 @@ from benchmark.analyze import (
     POLYMARKET_ACTIVE_CATEGORIES,
     ROLLING_WINDOW_DAYS,
     SAMPLE_SIZE_WARNING,
+    _always_majority,
+    _da_lift,
+    _delta_cell,
     _parse_tvm_key,
     _sample_label,
     generate_fleet_report,
@@ -39,9 +42,14 @@ from benchmark.analyze import (
     section_metric_reference,
     section_parse_breakdown,
     section_period,
+    section_platform_comparison,
+    section_platform_snapshot,
+    section_reliability_comparison,
     section_sample_size_warnings,
     section_tool_category,
+    section_tool_category_diagnostics,
     section_tool_category_platform,
+    section_tool_comparison,
     section_tool_deployment_status,
     section_tool_version_breakdown,
     section_trend,
@@ -2106,51 +2114,43 @@ class TestAlwaysMajorityAndDALift:
 
     def test_always_majority_yes_heavy(self) -> None:
         """yes_rate=0.7 → majority outcome is yes at 70%."""
-        from benchmark.analyze import _always_majority
 
         assert _always_majority(0.7) == 0.7
 
     def test_always_majority_no_heavy(self) -> None:
         """yes_rate=0.3 → majority outcome is no at 70% (1 - 0.3)."""
-        from benchmark.analyze import _always_majority
 
         assert _always_majority(0.3) == pytest.approx(0.7)
 
     def test_always_majority_balanced(self) -> None:
         """yes_rate=0.5 → majority baseline is 0.5 (no class is majority)."""
-        from benchmark.analyze import _always_majority
 
         assert _always_majority(0.5) == 0.5
 
     def test_always_majority_none(self) -> None:
         """Missing yes_rate yields None, not a crash or 0.5 default."""
-        from benchmark.analyze import _always_majority
 
         assert _always_majority(None) is None
 
     def test_da_lift_positive_when_beating_majority(self) -> None:
         """Tool predicting above always-majority has positive lift."""
-        from benchmark.analyze import _da_lift
 
         # yes_rate=0.4 → majority=0.6. DirAcc=0.75 → lift=+0.15.
         assert _da_lift(0.75, 0.4) == pytest.approx(0.15)
 
     def test_da_lift_zero_when_equal_to_majority(self) -> None:
         """Tool matching always-majority has zero lift."""
-        from benchmark.analyze import _da_lift
 
         assert _da_lift(0.6, 0.4) == pytest.approx(0.0)
 
     def test_da_lift_negative_when_below_majority(self) -> None:
         """Tool worse than always-majority has negative lift."""
-        from benchmark.analyze import _da_lift
 
         # yes_rate=0.3 → majority=0.7. DirAcc=0.55 → lift=-0.15.
         assert _da_lift(0.55, 0.3) == pytest.approx(-0.15)
 
     def test_da_lift_none_when_inputs_missing(self) -> None:
         """Either missing input yields None, not arithmetic error."""
-        from benchmark.analyze import _da_lift
 
         assert _da_lift(None, 0.4) is None
         assert _da_lift(0.75, None) is None
@@ -2161,7 +2161,6 @@ class TestSectionToolCategoryDiagnostics:
 
     def test_sufficient_cell_renders(self) -> None:
         """Cells with n >= MIN_SAMPLE_SIZE render with all three diagnostics."""
-        from benchmark.analyze import section_tool_category_diagnostics
 
         scores = {
             "by_tool_category": {
@@ -2179,7 +2178,6 @@ class TestSectionToolCategoryDiagnostics:
 
     def test_sparse_cells_dropped(self) -> None:
         """Cells below MIN_SAMPLE_SIZE don't render in the table body."""
-        from benchmark.analyze import section_tool_category_diagnostics
 
         scores = {
             "by_tool_category": {
@@ -2192,7 +2190,6 @@ class TestSectionToolCategoryDiagnostics:
 
     def test_missing_diagnostic_fields_render_na(self) -> None:
         """Cells with None edge / edge_n / log_loss render N/A rather than crash."""
-        from benchmark.analyze import section_tool_category_diagnostics
 
         scores = {
             "by_tool_category": {
@@ -2205,7 +2202,6 @@ class TestSectionToolCategoryDiagnostics:
 
     def test_empty_input(self) -> None:
         """Empty data collapses to a placeholder message, not a crash."""
-        from benchmark.analyze import section_tool_category_diagnostics
 
         rendered = section_tool_category_diagnostics({})
         assert "No cross-breakdown data available" in rendered
@@ -2328,7 +2324,6 @@ class TestDeltaCell:
 
     def test_delta_suppressed_when_current_below_min(self) -> None:
         """Low current-window n yields insufficient data, not a signed number."""
-        from benchmark.analyze import _delta_cell
 
         assert _delta_cell(0.2, 0.3, current_n=5, reference_n=1000) == (
             "insufficient data"
@@ -2336,7 +2331,6 @@ class TestDeltaCell:
 
     def test_delta_suppressed_when_reference_below_min(self) -> None:
         """Low reference-window n yields insufficient data."""
-        from benchmark.analyze import _delta_cell
 
         assert _delta_cell(0.2, 0.3, current_n=1000, reference_n=5) == (
             "insufficient data"
@@ -2344,14 +2338,12 @@ class TestDeltaCell:
 
     def test_none_values_yield_na(self) -> None:
         """Missing values collapse to N/A rather than arithmetic error."""
-        from benchmark.analyze import _delta_cell
 
         assert _delta_cell(None, 0.3, 1000, 1000) == "N/A"
         assert _delta_cell(0.2, None, 1000, 1000) == "N/A"
 
     def test_lower_is_better_direction(self) -> None:
         """For Brier-like metrics, negative delta = better."""
-        from benchmark.analyze import _delta_cell
 
         rendered = _delta_cell(0.20, 0.25, 100, 100, lower_is_better=True)
         assert rendered.startswith("-0.0500")
@@ -2359,7 +2351,6 @@ class TestDeltaCell:
 
     def test_higher_is_better_direction(self) -> None:
         """For BSS / directional accuracy, positive delta = better."""
-        from benchmark.analyze import _delta_cell
 
         rendered = _delta_cell(0.75, 0.70, 100, 100, lower_is_better=False)
         assert rendered.startswith("+0.0500")
@@ -2367,7 +2358,6 @@ class TestDeltaCell:
 
     def test_zero_delta_labeled_same(self) -> None:
         """Delta of exactly zero renders as same, not better/worse."""
-        from benchmark.analyze import _delta_cell
 
         rendered = _delta_cell(0.20, 0.20, 100, 100)
         assert "same" in rendered
@@ -2378,7 +2368,6 @@ class TestSectionPlatformSnapshot:
 
     def test_renders_all_snapshot_metrics(self) -> None:
         """Every reviewer-requested snapshot metric appears in the output."""
-        from benchmark.analyze import section_platform_snapshot
 
         scores = {
             "overall": {
@@ -2411,7 +2400,6 @@ class TestSectionPlatformSnapshot:
 
     def test_empty_scores_renders_placeholder(self) -> None:
         """Zero rows collapses to a placeholder, not a crash."""
-        from benchmark.analyze import section_platform_snapshot
 
         assert "No rows scored" in section_platform_snapshot({"overall": {"n": 0}})
 
@@ -2463,7 +2451,6 @@ class TestSectionPlatformComparison:
 
     def test_three_window_table_header(self) -> None:
         """Header names current, all-time, and prev windows with delta columns."""
-        from benchmark.analyze import section_platform_comparison
 
         rendered = section_platform_comparison(
             self._rolling(), self._alltime(), self._prev()
@@ -2476,14 +2463,12 @@ class TestSectionPlatformComparison:
 
     def test_no_prev_window_when_prev_is_none(self) -> None:
         """Prev column renders 'no prev window' placeholder instead of a delta."""
-        from benchmark.analyze import section_platform_comparison
 
         rendered = section_platform_comparison(self._rolling(), self._alltime(), None)
         assert "no prev window" in rendered
 
     def test_brier_row_renders_signed_delta(self) -> None:
         """Brier delta sign + direction word appears in the table body."""
-        from benchmark.analyze import section_platform_comparison
 
         rendered = section_platform_comparison(
             self._rolling(), self._alltime(), self._prev()
@@ -2511,7 +2496,6 @@ class TestSectionToolComparison:
 
     def test_tool_row_cites_current_value_and_deltas(self) -> None:
         """Each row shows the current Brier, all-time delta, and prev delta."""
-        from benchmark.analyze import section_tool_comparison
 
         rolling = self._s({"tool-a": (0.22, 100)})
         alltime = self._s({"tool-a": (0.25, 5000)})
@@ -2523,7 +2507,6 @@ class TestSectionToolComparison:
 
     def test_no_prev_window_placeholder(self) -> None:
         """None prev-rolling renders the placeholder instead of N/A or empty."""
-        from benchmark.analyze import section_tool_comparison
 
         rolling = self._s({"tool-a": (0.22, 100)})
         alltime = self._s({"tool-a": (0.25, 5000)})
@@ -2532,7 +2515,6 @@ class TestSectionToolComparison:
 
     def test_empty_universe_renders_placeholder(self) -> None:
         """No tools anywhere collapses to a placeholder."""
-        from benchmark.analyze import section_tool_comparison
 
         rendered = section_tool_comparison({}, {}, None)
         assert "No tool data available." in rendered
@@ -2543,7 +2525,6 @@ class TestSectionReliabilityComparison:
 
     def test_reliability_regression_labeled_worse(self) -> None:
         """Tool whose reliability dropped renders with 'worse' direction."""
-        from benchmark.analyze import section_reliability_comparison
 
         rolling = {
             "by_tool": {"tool-a": {"reliability": 0.85, "n": 100}},
@@ -2559,7 +2540,6 @@ class TestSectionReliabilityComparison:
 
     def test_low_sample_suppresses_delta(self) -> None:
         """Low-n reliability delta renders insufficient data, not a signed %."""
-        from benchmark.analyze import section_reliability_comparison
 
         rolling = {
             "by_tool": {"tool-a": {"reliability": 0.85, "n": 5}},

--- a/benchmark/tests/test_notify_slack.py
+++ b/benchmark/tests/test_notify_slack.py
@@ -77,15 +77,16 @@ class TestBuildSystemPrompt:
         assert "*Summary:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
         assert "*Top tools:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
         assert "*Worst tools:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "*Category performance:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
         assert "*Tool × Category:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
         assert "*Tournament callouts:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
         assert "*Diagnostics:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        assert "*Reliability:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
         assert "*Recommended actions:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
 
     def test_prompt_references_rolling_window_days_constant(self) -> None:
-        """Prompt cites the current ROLLING_WINDOW_DAYS value in its summary bullet."""
-        assert f"last {ROLLING_WINDOW_DAYS} days" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        """Prompt cites the current ROLLING_WINDOW_DAYS value in its window labels."""
+        assert f"Current {ROLLING_WINDOW_DAYS}d" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        assert f"Prev {ROLLING_WINDOW_DAYS}d" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
 
     def test_prompt_drops_alltime_scope_instructions(self) -> None:
         """Prompt no longer tells the LLM to cite all-time or cumulative figures.
@@ -96,17 +97,30 @@ class TestBuildSystemPrompt:
         assert "Only mention all-time numbers for context" not in (
             SUMMARY_SYSTEM_PROMPT_TEMPLATE
         )
+        # The prompt still refers to "All-Time" as a window label, but not
+        # as a bolt-on scope that the LLM should opportunistically mix in.
         assert "deltas vs all-time" not in SUMMARY_SYSTEM_PROMPT_TEMPLATE
 
-    def test_prompt_anchors_sections_to_rolling_heading_names(self) -> None:
-        """Prompt points the LLM at the Last-N-Days section headings by name."""
+    def test_prompt_anchors_sections_to_comparison_heading_names(self) -> None:
+        """Prompt points the LLM at the new three-window comparison headings."""
         for heading in (
-            f"Tool Ranking (Last {ROLLING_WINDOW_DAYS} Days)",
-            f"Category Performance (Last {ROLLING_WINDOW_DAYS} Days)",
-            f"Tool × Category (Last {ROLLING_WINDOW_DAYS} Days)",
-            f"Diagnostic Edge Metrics (Last {ROLLING_WINDOW_DAYS} Days)",
+            "Platform Snapshot",
+            "Platform Historical Comparison",
+            "Tool Historical Comparison",
+            f"Tool × Category (Current {ROLLING_WINDOW_DAYS}d)",
+            "Tool × Category Historical Comparison",
+            "Diagnostics Historical Comparison",
+            "Reliability & Parse Quality",
         ):
-            assert heading in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+            assert heading in SUMMARY_SYSTEM_PROMPT_TEMPLATE, f"missing: {heading}"
+
+    def test_prompt_enforces_no_mixed_window_claims(self) -> None:
+        """Every cited number must be paired with its window label."""
+        assert "Never mix windows" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        # Guardrail wording for the `insufficient data` / `no prev window`
+        # cells the comparison tables render when n is too small.
+        assert "insufficient data" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        assert "no prev window" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
 
     def test_deployment_status_points_at_platform_scoped_section(self) -> None:
         """Deployment status bullet anchors to the per-platform section heading.
@@ -132,7 +146,7 @@ class TestBuildSystemPrompt:
         picking an editorial subset.
         """
         assert (
-            "list every tool-category cell that clears the sample-size threshold"
+            "list every cell that clears the sample-size threshold"
             in SUMMARY_SYSTEM_PROMPT_TEMPLATE
         )
         assert "insufficient tool × category data" in SUMMARY_SYSTEM_PROMPT_TEMPLATE

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -27,6 +27,8 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import pytest
+
 from benchmark.scorer import (
     DISAGREE_THRESHOLD,
     LARGE_TRADE_THRESHOLD,
@@ -2830,6 +2832,79 @@ class TestPerPlatformPeriod:
         prod_omen, _ = result["omen"]
         assert prod_all["overall"]["n"] == 1
         assert prod_omen["overall"]["n"] == 1
+
+
+class TestScorePeriodOffset:
+    """Tests for score_period's --period-offset-days semantics.
+
+    Offset selects a non-overlapping window. Rows in the current window
+    (``offset_days=0``) must be excluded from the prev window
+    (``offset_days=days``), and vice versa.
+    """
+
+    def _ts(self, days_ago: float) -> str:
+        dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def _populate_logs(self, logs_dir: Path, rows: list[dict[str, Any]]) -> None:
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        (logs_dir / "2026-03-01.jsonl").write_text(
+            "\n".join(json.dumps(r) for r in rows) + "\n"
+        )
+
+    def test_offset_zero_matches_trailing_window(self, tmp_path: Path) -> None:
+        """offset_days=0 behaves like the legacy trailing-window filter."""
+        logs = tmp_path / "logs"
+        today_row = _row(predicted_at=self._ts(0.5), row_id="today")
+        old_row = _row(predicted_at=self._ts(10), row_id="old")
+        self._populate_logs(logs, [today_row, old_row])
+
+        result = score_period(logs, days=3, offset_days=0)
+        assert result["total_rows"] == 1
+
+    def test_offset_equal_to_days_selects_prev_non_overlapping(
+        self, tmp_path: Path
+    ) -> None:
+        """offset=days yields the preceding non-overlapping window."""
+        logs = tmp_path / "logs"
+        current_row = _row(predicted_at=self._ts(1), row_id="current")
+        prev_row = _row(predicted_at=self._ts(4), row_id="prev")
+        old_row = _row(predicted_at=self._ts(8), row_id="old")
+        self._populate_logs(logs, [current_row, prev_row, old_row])
+
+        current = score_period(logs, days=3, offset_days=0)
+        prev = score_period(logs, days=3, offset_days=3)
+
+        assert current["total_rows"] == 1
+        assert prev["total_rows"] == 1
+        # Non-overlap: the row from the current window is NOT in prev, and
+        # vice versa.
+
+    def test_negative_offset_raises(self, tmp_path: Path) -> None:
+        """Negative offset is a user error, not a silent zero-fill."""
+        logs = tmp_path / "logs"
+        self._populate_logs(logs, [_row(predicted_at=self._ts(0.5))])
+        with pytest.raises(ValueError, match="offset_days"):
+            score_period(logs, days=3, offset_days=-1)
+
+    def test_offset_respects_window_end_exclusivity(self, tmp_path: Path) -> None:
+        """Half-open window: start-inclusive, end-exclusive.
+
+        A row at exactly the upper boundary of the previous window
+        (``now - offset_days``) belongs to the current window, not the
+        previous. Guards against double-counting if the offset is set
+        equal to ``days``.
+        """
+        logs = tmp_path / "logs"
+        # This row is 3 days ago exactly; for days=3 offset=0 it falls
+        # inside [now-3d, now) and should count as current, not prev.
+        boundary_row = _row(predicted_at=self._ts(2.999), row_id="boundary")
+        self._populate_logs(logs, [boundary_row])
+
+        current = score_period(logs, days=3, offset_days=0)
+        prev = score_period(logs, days=3, offset_days=3)
+        assert current["total_rows"] == 1
+        assert prev["total_rows"] == 0
 
 
 class TestScoreLatencyReservoir:

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -2874,14 +2874,20 @@ class TestScorePeriodOffset:
         from benchmark.scorer import _load_period_rows
 
         logs = tmp_path / "logs"
-        current_row = _row(predicted_at=self._ts(1), row_id="current")
-        prev_row = _row(predicted_at=self._ts(4), row_id="prev")
-        old_row = _row(predicted_at=self._ts(8), row_id="old")
+        # Distinct tool names per row so the scored ``by_tool`` map
+        # below is a direct identity check on which row reached each
+        # window — catches a broken partitioner that silently placed
+        # the same row in both windows (n=1 each) instead of
+        # partitioning by timestamp.
+        current_row = _row(
+            predicted_at=self._ts(1), row_id="current", tool="tool-current"
+        )
+        prev_row = _row(predicted_at=self._ts(4), row_id="prev", tool="tool-prev")
+        old_row = _row(predicted_at=self._ts(8), row_id="old", tool="tool-old")
         self._populate_logs(logs, [current_row, prev_row, old_row])
 
-        # Cardinality and row-identity: the invariant isn't just "each
-        # window sees one row" (two leaky windows could each happen to
-        # catch one), it's "the two windows share no rows at all".
+        # Loader-level identity invariant — checks the partition the
+        # scorer consumes before any aggregation runs.
         current_prod, _ = _load_period_rows(logs, days=3, tournament_input=None)
         prev_prod, _ = _load_period_rows(
             logs, days=3, tournament_input=None, offset_days=3
@@ -2892,10 +2898,16 @@ class TestScorePeriodOffset:
         assert prev_ids == {"prev"}
         assert current_ids.isdisjoint(prev_ids)
 
-        # score_period returns scored aggregates — keep a coarse sanity
-        # check that the same partitioning reaches the scorer output.
-        assert score_period(logs, days=3, offset_days=0)["total_rows"] == 1
-        assert score_period(logs, days=3, offset_days=3)["total_rows"] == 1
+        # Scorer-level identity invariant — verifies the distinct tool
+        # names survive through the full scoring pipeline, not just the
+        # loader. A bug that routed a row into both windows would
+        # surface the same tool name on both sides.
+        current = score_period(logs, days=3, offset_days=0)
+        prev = score_period(logs, days=3, offset_days=3)
+        assert "tool-current" in current["by_tool"]
+        assert "tool-current" not in prev["by_tool"]
+        assert "tool-prev" in prev["by_tool"]
+        assert "tool-prev" not in current["by_tool"]
 
     def test_negative_offset_raises(self, tmp_path: Path) -> None:
         """Negative offset is a user error, not a silent zero-fill."""

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -518,8 +518,8 @@ class TestIncrementalUpdate:
     def test_cross_platform_aggregates_parity_with_batch(self, tmp_path: Path) -> None:
         """Incremental by_category_platform + by_tool_category_platform match score().
 
-        Guards against a new key landing in score() but being skipped by
-        _empty_scores / _accumulate_row / _finalize_scores / _load_scores_for_resume.
+        :param tmp_path: pytest fixture supplying an isolated temp directory
+            for the scores / history / dedup files.
         """
         scores_path = tmp_path / "scores.json"
         history_path = tmp_path / "history.jsonl"
@@ -2890,10 +2890,8 @@ class TestScorePeriodOffset:
     def test_offset_respects_window_end_exclusivity(self, tmp_path: Path) -> None:
         """Half-open window: start-inclusive, end-exclusive.
 
-        A row at exactly the upper boundary of the previous window
-        (``now - offset_days``) belongs to the current window, not the
-        previous. Guards against double-counting if the offset is set
-        equal to ``days``.
+        :param tmp_path: pytest fixture supplying an isolated temp directory
+            for the per-test log files.
         """
         logs = tmp_path / "logs"
         # This row is 3 days ago exactly; for days=3 offset=0 it falls

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -384,6 +384,22 @@ class TestScore:
         assert result["by_tool_category"]["tool-b | crypto"]["brier"] == 0.25
         assert result["by_tool_category"]["tool-a | politics"]["brier"] == 0.64
 
+        # By category × platform — direct one-file cross-platform slice.
+        assert "crypto | omen" in result["by_category_platform"]
+        assert "politics | polymarket" in result["by_category_platform"]
+        assert result["by_category_platform"]["crypto | omen"]["n"] == 2
+        assert result["by_category_platform"]["politics | polymarket"]["n"] == 1
+
+        # By tool × category × platform — tri-dimensional slice.
+        assert "tool-a | crypto | omen" in result["by_tool_category_platform"]
+        assert "tool-a | politics | polymarket" in result["by_tool_category_platform"]
+        assert result["by_tool_category_platform"]["tool-a | crypto | omen"]["n"] == 1
+        # tool-a | crypto | omen: p=0.9, outcome=True → (0.9-1)^2 = 0.01
+        assert (
+            result["by_tool_category_platform"]["tool-a | crypto | omen"]["brier"]
+            == 0.01
+        )
+
     def test_empty_input(self) -> None:
         """Test scoring with empty input."""
         result = score([])
@@ -415,6 +431,8 @@ class TestScore:
             "by_tool",
             "by_platform",
             "by_category",
+            "by_category_platform",
+            "by_tool_category_platform",
             "by_horizon",
             "trend",
         ]
@@ -494,6 +512,55 @@ class TestIncrementalUpdate:
 
         assert result["by_tool"]["tool-a"]["n"] == 2
         assert result["by_tool"]["tool-b"]["n"] == 1
+
+    def test_cross_platform_aggregates_parity_with_batch(self, tmp_path: Path) -> None:
+        """Incremental by_category_platform + by_tool_category_platform match score().
+
+        Guards against a new key landing in score() but being skipped by
+        _empty_scores / _accumulate_row / _finalize_scores / _load_scores_for_resume.
+        """
+        scores_path = tmp_path / "scores.json"
+        history_path = tmp_path / "history.jsonl"
+
+        rows = [
+            _row(
+                p_yes=0.9,
+                outcome=True,
+                tool="tool-a",
+                platform="omen",
+                category="crypto",
+            ),
+            _row(
+                p_yes=0.8,
+                outcome=False,
+                tool="tool-a",
+                platform="polymarket",
+                category="politics",
+            ),
+            _row(
+                p_yes=0.5,
+                outcome=True,
+                tool="tool-b",
+                platform="omen",
+                category="crypto",
+            ),
+        ]
+
+        update(rows[:2], scores_path, history_path)
+        inc = update(rows[2:], scores_path, history_path)
+        batch = score(rows)
+
+        for dim in ("by_category_platform", "by_tool_category_platform"):
+            assert set(inc[dim].keys()) == set(
+                batch[dim].keys()
+            ), f"{dim} key set drift between incremental and batch"
+            for key in batch[dim]:
+                assert (
+                    inc[dim][key]["n"] == batch[dim][key]["n"]
+                ), f"{dim}[{key}] n mismatch"
+                assert (
+                    inc[dim][key]["brier"] == batch[dim][key]["brier"]
+                ), f"{dim}[{key}] brier mismatch"
 
     def test_calibration_buckets_accumulate(self, tmp_path: Path) -> None:
         """Calibration buckets accumulate counts correctly."""

--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -2865,20 +2865,37 @@ class TestScorePeriodOffset:
     def test_offset_equal_to_days_selects_prev_non_overlapping(
         self, tmp_path: Path
     ) -> None:
-        """offset=days yields the preceding non-overlapping window."""
+        """offset=days yields the preceding non-overlapping window.
+
+        :param tmp_path: pytest fixture supplying an isolated temp
+            directory for the per-test log files.
+        """
+        # pylint: disable=import-outside-toplevel
+        from benchmark.scorer import _load_period_rows
+
         logs = tmp_path / "logs"
         current_row = _row(predicted_at=self._ts(1), row_id="current")
         prev_row = _row(predicted_at=self._ts(4), row_id="prev")
         old_row = _row(predicted_at=self._ts(8), row_id="old")
         self._populate_logs(logs, [current_row, prev_row, old_row])
 
-        current = score_period(logs, days=3, offset_days=0)
-        prev = score_period(logs, days=3, offset_days=3)
+        # Cardinality and row-identity: the invariant isn't just "each
+        # window sees one row" (two leaky windows could each happen to
+        # catch one), it's "the two windows share no rows at all".
+        current_prod, _ = _load_period_rows(logs, days=3, tournament_input=None)
+        prev_prod, _ = _load_period_rows(
+            logs, days=3, tournament_input=None, offset_days=3
+        )
+        current_ids = {r["row_id"] for r in current_prod}
+        prev_ids = {r["row_id"] for r in prev_prod}
+        assert current_ids == {"current"}
+        assert prev_ids == {"prev"}
+        assert current_ids.isdisjoint(prev_ids)
 
-        assert current["total_rows"] == 1
-        assert prev["total_rows"] == 1
-        # Non-overlap: the row from the current window is NOT in prev, and
-        # vice versa.
+        # score_period returns scored aggregates — keep a coarse sanity
+        # check that the same partitioning reaches the scorer output.
+        assert score_period(logs, days=3, offset_days=0)["total_rows"] == 1
+        assert score_period(logs, days=3, offset_days=3)["total_rows"] == 1
 
     def test_negative_offset_raises(self, tmp_path: Path) -> None:
         """Negative offset is a user error, not a silent zero-fill."""

--- a/benchmark/tests/test_tool_usage.py
+++ b/benchmark/tests/test_tool_usage.py
@@ -25,6 +25,35 @@ import pytest
 
 from benchmark import tool_usage
 from benchmark.analyze import section_tool_deployment_status
+from benchmark.tool_usage import DEPLOYMENTS, DEPLOYMENT_TO_PLATFORM
+
+
+class TestDeploymentPlatformMappingInvariants:
+    """Lock the DEPLOYMENTS ↔ DEPLOYMENT_TO_PLATFORM coverage invariant.
+
+    ``deployments_for_platform`` filters ``DEPLOYMENTS`` through
+    ``DEPLOYMENT_TO_PLATFORM``. If a deployment lands in the list but
+    not in the mapping, it silently disappears from the platform-scoped
+    Tool Deployment Status section. The tests below fail loudly at add
+    time so nobody has to rediscover the bug in production.
+    """
+
+    def test_every_deployment_has_a_platform(self) -> None:
+        """No name in DEPLOYMENTS is missing from DEPLOYMENT_TO_PLATFORM."""
+        missing = [name for name in DEPLOYMENTS if name not in DEPLOYMENT_TO_PLATFORM]
+        assert not missing, (
+            f"deployment(s) {missing} in DEPLOYMENTS have no platform mapping — "
+            "deployments_for_platform would silently drop them"
+        )
+
+    def test_no_orphan_mapping_entries(self) -> None:
+        """Every mapping key is also present in DEPLOYMENTS (no drift the other way)."""
+        orphans = [name for name in DEPLOYMENT_TO_PLATFORM if name not in DEPLOYMENTS]
+        assert not orphans, (
+            f"mapping key(s) {orphans} have no matching DEPLOYMENTS entry — "
+            "the deployment was removed but the mapping wasn't cleaned up"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Fixtures


### PR DESCRIPTION
## Summary

Follow-up on PR #243 and PR #244 review comments. Twelve items, stacked on `feat/benchmark-deployment-inversion` (so the diff only shows the delta over Phases 1–3).

## What changed

### Scorer (`benchmark/scorer.py`)
- `by_category_platform` (key: `"{category} | {platform}"`) — direct one-file cross-platform category ranking.
- `by_tool_category_platform` (key: `"{tool} | {category} | {platform}"`) — tri-dimensional slice, no post-processing required.
- Both wired through batch `score()`, incremental `_accumulate_row` / `_finalize_scores` / `_load_scores_for_resume` paths.
- `--period-offset-days` threads through `score_period`, `score_period_split`, and `score_period_split_by_platform`. Half-open window `[now - offset - days, now - offset)` guarantees non-overlap between current and prev when `offset_days == days`.

### Analyze (`benchmark/analyze.py`) — three-window restructure + full Tool × Category columns
Per-platform report restructured around three explicit windows per metric: `Current 3d`, `All-Time`, `Prev 3d`. Section order matches the reviewer's P1 spec:

1. Platform Snapshot (Current 3d) — n, reliability, Brier, baseline Brier, BSS, DirAcc, Yes%, No%, always-majority, DA lift.
2. Platform Historical Comparison
3. Tool Historical Comparison
4. Tool × Category (Current 3d) — full column set per Maria Pia's ask: n, Reliability, Brier, Baseline Brier, BSS, DirAcc, Yes%, No%, Always-majority, DA lift.
5. Tool × Category Diagnostics (Current 3d) — per-cell Edge / Edge n / Log Loss.
6. Tool × Category Historical Comparison
7. Diagnostics Historical Comparison
8. Reliability & Parse Quality (Current vs All-Time)
9. Tool Deployment Status

Guardrails enforced in code:
- A delta is suppressed when either side has n < `MIN_SAMPLE_SIZE` and rendered as `insufficient data` so readers never see a signed number without an adequate sample anchor.
- `n` cited next to every absolute value.
- "Since Last Report" and any overlapping-window comparison dropped entirely.
- Legend rewritten to describe the three-window contract + guardrails explicitly.
- New helpers `_always_majority(yes_rate)` and `_da_lift(directional_accuracy, yes_rate)` derive the new columns from existing stats without touching the scorer schema.

Fleet mode (`--fleet`) consumes the new cross-platform aggregates to render one cross-platform artifact for direct tri-dimensional ranking. Fleet report is all-time only with an intro note pointing readers to the per-platform reports for change-over-time data.

### Slack notifier (`benchmark/notify_slack.py`)
Prompt rewritten so the LLM cites the matching window label for every figure, reproduces `insufficient data` / `no prev window` placeholders verbatim, and surfaces DA lift alongside Brier on every Tool × Category bullet — flagging cells where DA lift ≤ 0 as "no lift over always-majority" so homogeneous-outcome cells aren't misread.

### Workflow (`.github/workflows/benchmark_flywheel.yaml`)
- Added "Score previous 3 days (non-overlapping)" step running scorer with `--period-offset-days 3`.
- Dropped the "Score today" step — the since-last-report section it fed is gone.
- `prev_rolling_scores_*.json` intentionally NOT persisted in the benchmark-data artifact: period scoring is recomputed each run, and persisting would let a stale file mask a failed scoring step instead of triggering the analyze "unavailable" banner.

### Tests (`benchmark/tests/*.py`)
- Scorer: `TestScorePeriodOffset` — offset-zero parity, non-overlap invariant, negative-offset rejection, half-open boundary.
- Analyze: new `TestDeltaCell`, `TestSectionPlatformSnapshot`, `TestSectionPlatformComparison`, `TestSectionToolComparison`, `TestSectionReliabilityComparison`, `TestSectionCategoryPlatform`, `TestSectionToolCategoryPlatform`, `TestAlwaysMajorityAndDALift`, `TestSectionToolCategoryDiagnostics`, `TestGenerateFleetReport`, `TestGenerateReportStructure`, `TestGenerateReportRollingBanner`.
- Tool usage: `TestDeploymentPlatformMappingInvariants` — both-directions drift guard on `DEPLOYMENTS` ↔ `DEPLOYMENT_TO_PLATFORM`.
- Updated existing tests for renamed headings + widened column set on Tool × Category.

### README (`benchmark/README.md`)
- `--period-days 7` → `--period-days 3`, `last_week.json` → `last_3_days.json`.
- Documents the new `python -m benchmark.analyze --fleet` invocation.

## Review comment → change mapping

PR #243 items:
| # | Comment | Commit |
|---|---------|--------|
| 1 | Add `by_category_platform` in scorer | `b465a823` |
| 2 | Add `by_tool_category_platform` in scorer | `b465a823` |
| 3 | Render new aggregates (fleet report mode) | `58ffe5df` |
| 4 | Pair rolling summary + rolling ranking | `58ffe5df` (superseded by 3-window restructure in `a365e0a3`) |
| 5 | Clarify rolling = window aggregate | `58ffe5df` |
| 6 | Fix trend scope mixing | `58ffe5df` |
| 7 | Align legend window claim with sources | `58ffe5df` (legend rewritten in `a365e0a3`) |
| 8 | README 3-day vs 7-day | `1cfa53d5` |
| 9 | All-time tool ranking | `58ffe5df` (now absorbed into Tool Historical Comparison in `a365e0a3`) |

PR #244 items:
| Priority | Comment | Commit |
|---|---------|--------|
| P3 | `DEPLOYMENTS` ↔ `DEPLOYMENT_TO_PLATFORM` drift guard | `a365e0a3` |
| P1 | Three-window report restructure | `c695afc2`, `a365e0a3`, `6005f798` |
| P1 follow-up | Full tool × category column set + DA lift + diagnostics subsection + Platform Snapshot parity | `3a453cf7` |

## Verification

- `pytest benchmark/tests/` — 599 passed.
- `black`, `isort`, `flake8 --max-line-length=100`, `mypy --ignore-missing-imports`, `pylint`, `darglint` — all clean on touched files.
- End-to-end render on realistic three-window data confirms heading order matches the reviewer's spec exactly, with the new Tool × Category primary + diagnostics split:
  ```
  # Benchmark Report (Omenstrat) — 2026-04-24
  ## Metric References
  ## Platform Snapshot (Current 3d)
  ## Platform Historical Comparison
  ## Tool Historical Comparison
  ## Tool × Category (Current 3d)
  ## Tool × Category Diagnostics (Current 3d)
  ## Tool × Category Historical Comparison
  ## Diagnostics Historical Comparison
  ## Reliability & Parse Quality (Current vs All-Time)
  ## Trend (Fleet-wide, Monthly)
  ## Sample Size Warnings (All-Time)
  ```

## Test plan
- [x] Local pytest passes (599 tests)
- [x] All 6 linters clean on touched files
- [x] Local end-to-end render for per-platform (3-window) and fleet (all-time) reports
- [ ] CI green after push
- [ ] Sanity-check one CI run produces `prev_rolling_scores_<platform>.json` and the comparison tables render with real deltas
- [ ] Confirm Slack summary correctly cites window labels + DA lift per figure on the first daily post