### PR TITLE
revert(superforcaster): restore v0.16.5 implementation

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,13 +11,13 @@
         "custom/valory/prediction_request/0.1.0": "bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky",
         "custom/valory/prepare_tx/0.1.0": "bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya",
         "custom/valory/resolve_market/0.1.0": "bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi",
-        "custom/valory/superforcaster/0.1.0": "bafybeifgf3av5u6fb2bjmeu342zo4nvydioyp5qr4uunpblvap3jhlxcdy",
+        "custom/valory/superforcaster/0.1.0": "bafybeiepzi7sen65r6csqgimko7tk6axeckstkrjdwxgmrcsts4kpzinrm",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeieczrqsgnozknopbzedcgvmnou6i7f3g4jx5qvpz6nbedqsmkdt2m",
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiciwntuzeqnal5b3wwixquq4efv443eu4m4z3ujoy6olmulktfl3q",
-        "agent/valory/mech_predict/0.1.0": "bafybeidvhuawywiduroudqi7d2yvpugffr4o5t6mie4w6xv53dt6xpn6ma",
-        "service/valory/mech_predict/0.1.0": "bafybeihmbff33x2flhwgbzecprlacaekpt3ztblp67cpdyxb5hv2kjqqtm"
+        "agent/valory/mech_predict/0.1.0": "bafybeihoomhymts6fj2bzuf3jh66wd3ibleniqyzffoztvyo2njbtq4i7i",
+        "service/valory/mech_predict/0.1.0": "bafybeiga2vkjrqb475h7xgdlt5mlriqfwvfljgdg2q3j5crmyofhb6bkgu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,13 +11,13 @@
         "custom/valory/prediction_request/0.1.0": "bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky",
         "custom/valory/prepare_tx/0.1.0": "bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya",
         "custom/valory/resolve_market/0.1.0": "bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi",
-        "custom/valory/superforcaster/0.1.0": "bafybeiepzi7sen65r6csqgimko7tk6axeckstkrjdwxgmrcsts4kpzinrm",
+        "custom/valory/superforcaster/0.1.0": "bafybeiduissprwj2shvd4peyibvgzvlzo4ob4hy2awij6yjgsala3cmuei",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeieczrqsgnozknopbzedcgvmnou6i7f3g4jx5qvpz6nbedqsmkdt2m",
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiciwntuzeqnal5b3wwixquq4efv443eu4m4z3ujoy6olmulktfl3q",
-        "agent/valory/mech_predict/0.1.0": "bafybeihoomhymts6fj2bzuf3jh66wd3ibleniqyzffoztvyo2njbtq4i7i",
-        "service/valory/mech_predict/0.1.0": "bafybeiga2vkjrqb475h7xgdlt5mlriqfwvfljgdg2q3j5crmyofhb6bkgu"
+        "agent/valory/mech_predict/0.1.0": "bafybeic2wsxehtyt2s6z52pmhvlxfhdpuxt3k5nyqigiylgxjpbewiw36y",
+        "service/valory/mech_predict/0.1.0": "bafybeiecz4n6tbpkm5d5vkkt5qpllraukuesdti7dd4slr5lfne3yue5pa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -61,7 +61,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
-- valory/superforcaster:0.1.0:bafybeiepzi7sen65r6csqgimko7tk6axeckstkrjdwxgmrcsts4kpzinrm
+- valory/superforcaster:0.1.0:bafybeiduissprwj2shvd4peyibvgzvlzo4ob4hy2awij6yjgsala3cmuei
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -61,7 +61,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
-- valory/superforcaster:0.1.0:bafybeifgf3av5u6fb2bjmeu342zo4nvydioyp5qr4uunpblvap3jhlxcdy
+- valory/superforcaster:0.1.0:bafybeiepzi7sen65r6csqgimko7tk6axeckstkrjdwxgmrcsts4kpzinrm
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -17,7 +17,7 @@ params:
   default_model: gpt-4.1-2025-04-14
 dependencies:
   openai:
-    version: ==1.30.2
+    version: ==1.93.0
   httpx:
     version: ==0.25.2
   tiktoken:

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -7,9 +7,9 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifvbuxt54l5jsxextf6ru5yvimkfdg4gfkcsnmyvsyqcsgclg7vey
-  superforcaster.py: bafybeic7vbcjcq5jomciosjaez2nnktwsdlbf2ctakdrbh5nl7cgod5z6e
+  superforcaster.py: bafybeibfat4z2tdqvrjz6dukdz34oyb36j7bi5rqtgat42vxncai5hw6im
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
-  tests/test_superforcaster.py: bafybeiboaixfm4itoashxu5a4fshfe36plhnkk2tw3reznnoxz4yl7ovhm
+  tests/test_superforcaster.py: bafybeigscr6ayqdkgchxxvygp25yzqlu6g6rkwg3fcbflxx2sbfpymgdqa
 fingerprint_ignore_patterns: []
 entry_point: superforcaster.py
 callable: run
@@ -17,12 +17,10 @@ params:
   default_model: gpt-4.1-2025-04-14
 dependencies:
   openai:
-    version: ==1.93.0
+    version: ==1.30.2
   httpx:
     version: ==0.25.2
   tiktoken:
     version: ==0.12.0
-  pydantic:
-    version: '>=2.0.0,<3.0.0'
   requests:
     version: ==2.32.5

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -27,8 +27,6 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import openai
 import requests
-from openai import OpenAI
-from pydantic import BaseModel, Field, model_validator
 from tiktoken import encoding_for_model
 
 MechResponseWithKeys = Tuple[
@@ -43,99 +41,6 @@ N_MODEL_CALLS = 1
 DEFAULT_DELIVERY_RATE = 100
 
 
-# ---------------------------------------------------------------------------
-# Pydantic schema for OpenAI Structured Outputs
-# ---------------------------------------------------------------------------
-
-
-class PredictionResult(BaseModel):
-    """Superforecaster structured output.
-
-    The text fields carry the 7-step reasoning chain (facts → pros/cons →
-    aggregation + tentative → reflection → final). Only the four numeric
-    fields at the bottom are returned on-chain per the mech protocol.
-    """
-
-    facts: str = Field(
-        ...,
-        description=(
-            "Core factual points compiled from the sources and relevant "
-            "background. Specific, relevant, no conclusions about how a "
-            "fact influences the forecast."
-        ),
-    )
-    reasons_no: str = Field(
-        ...,
-        description=(
-            "Reasons why the answer might be NO. Rate the strength of each "
-            "reason on a scale of 1-10."
-        ),
-    )
-    reasons_yes: str = Field(
-        ...,
-        description=(
-            "Reasons why the answer might be YES. Rate the strength of each "
-            "reason on a scale of 1-10."
-        ),
-    )
-    aggregation: str = Field(
-        ...,
-        description=(
-            "Aggregate considerations. Weigh competing factors, apply the "
-            "CALIBRATION block (state a base rate and justify, adjust using "
-            "specific evidence, treat missing expected evidence as a NO signal), "
-            "adjust for news negativity / sensationalism bias. End by stating a "
-            "tentative probability in [0,1]."
-        ),
-    )
-    reflection: str = Field(
-        ...,
-        description=(
-            "Sanity checks and finalisation. Apply the three checks: "
-            "EVIDENCE BAR, CONFIDENCE COUPLING, NUMERIC QUESTIONS. Check for "
-            "over/underconfidence and forecasting biases. Highlight the key "
-            "factors informing the final forecast."
-        ),
-    )
-    p_yes: float = Field(
-        ...,
-        ge=0.0,
-        le=1.0,
-        description="Estimated probability that the event in the Question occurs.",
-    )
-    p_no: float = Field(
-        ...,
-        ge=0.0,
-        le=1.0,
-        description="Estimated probability that the event does NOT occur.",
-    )
-    confidence: float = Field(
-        ...,
-        ge=0.0,
-        le=1.0,
-        description="Confidence in the prediction (0 = lowest, 1 = highest).",
-    )
-    info_utility: float = Field(
-        ...,
-        ge=0.0,
-        le=1.0,
-        description=(
-            "Utility of the information in the sources to inform the prediction "
-            "(0 = lowest, 1 = highest)."
-        ),
-    )
-
-    @model_validator(mode="after")
-    def _check_p_yes_p_no_sum(self) -> "PredictionResult":
-        """Validate that p_yes + p_no ≈ 1."""
-        if abs(self.p_yes + self.p_no - 1.0) > 0.01:
-            raise ValueError(
-                f"p_yes + p_no must equal 1 (got {self.p_yes} + {self.p_no} = "
-                f"{self.p_yes + self.p_no})"
-            )
-        return self
-
-
 def with_key_rotation(func: Callable) -> Callable:
     """
     Decorator that retries a function with API key rotation on failure.
@@ -146,22 +51,16 @@ def with_key_rotation(func: Callable) -> Callable:
     """
 
     @functools.wraps(func)
-    def wrapper(
-        *args: Any, **kwargs: Any
-    ) -> Union[MaxCostResponse, MechResponseWithKeys]:
+    def wrapper(*args: Any, **kwargs: Any) -> MechResponseWithKeys:
         # this is expected to be a KeyChain object,
         # although it is not explicitly typed as such
         api_keys = kwargs["api_keys"]
         retries_left: Dict[str, int] = api_keys.max_retries()
 
-        def execute() -> Union[MaxCostResponse, MechResponseWithKeys]:
+        def execute() -> MechResponseWithKeys:
             """Retry the function with a new key."""
             try:
-                result = func(*args, **kwargs)
-                # Max-cost path returns a float; pass through without appending
-                # api_keys (tuple concatenation would fail).
-                if isinstance(result, float):
-                    return result
+                result: MechResponse = func(*args, **kwargs)
                 return result + (api_keys,)
             except openai.RateLimitError as e:
                 # try with a new key again
@@ -182,38 +81,91 @@ def with_key_rotation(func: Callable) -> Callable:
 
 
 class OpenAIClientManager:
-    """Context manager that creates and closes a local OpenAI client."""
+    """Client context manager for OpenAI."""
 
     def __init__(self, api_key: str):
-        """Initializes with API key."""
+        """Initializes with API keys"""
         self.api_key = api_key
-        self._client: Optional[OpenAI] = None
+        self._client: Optional["OpenAIClient"] = None
 
-    def __enter__(self) -> OpenAI:
-        """Initializes and returns the OpenAI client."""
-        self._client = OpenAI(api_key=self.api_key)
+    def __enter__(self) -> "OpenAIClient":
+        """Initializes and returns LLM client."""
+        self._client = OpenAIClient(api_key=self.api_key)
         return self._client
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        """Closes the OpenAI client."""
+        """Closes the LLM client"""
         if self._client is not None:
-            self._client.close()
+            self._client.client.close()
             self._client = None
+
+
+class Usage:
+    """Usage class."""
+
+    def __init__(
+        self,
+        prompt_tokens: Optional[Any] = None,
+        completion_tokens: Optional[Any] = None,
+    ):
+        """Initializes with prompt tokens and completion tokens."""
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+
+class OpenAIResponse:
+    """Response class."""
+
+    def __init__(self, content: Optional[str] = None, usage: Optional[Usage] = None):
+        """Initializes with content and usage class."""
+        self.content = content
+        self.usage = Usage()
+
+
+class OpenAIClient:
+    """OpenAI Client"""
+
+    def __init__(self, api_key: str):
+        """Initializes with API keys and client."""
+        self.api_key = api_key
+        self.client = openai.OpenAI(api_key=self.api_key)
+
+    def completions(
+        self,
+        model: str,
+        messages: List = [],  # noqa: B006
+        timeout: Optional[Union[float, int]] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        n: Optional[int] = None,
+        stop: Any = None,
+        max_tokens: Optional[float] = None,
+    ) -> Optional[OpenAIResponse]:
+        """Generate a completion from the specified LLM provider using the given model and messages."""
+        response_provider = self.client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            n=1,
+            timeout=150,
+            stop=None,
+        )
+        response = OpenAIResponse()
+        response.content = response_provider.choices[0].message.content
+        response.usage.prompt_tokens = response_provider.usage.prompt_tokens
+        response.usage.completion_tokens = response_provider.usage.completion_tokens
+        return response
 
 
 def count_tokens(text: str, model: str) -> int:
     """Count the number of tokens in a text."""
-    try:
-        enc = encoding_for_model(model)
-    except KeyError:
-        from tiktoken import get_encoding
-
-        enc = get_encoding("o200k_base")
+    enc = encoding_for_model(model)
     return len(enc.encode(text))
 
 
 DEFAULT_OPENAI_SETTINGS = {
-    "max_tokens": 4096,
+    "max_tokens": 500,
     "limit_max_tokens": 4096,
     "temperature": 0,
 }
@@ -224,8 +176,6 @@ MAX_SOURCES = 5
 COMPLETION_RETRIES = 3
 COMPLETION_DELAY = 2
 
-
-SYSTEM_PROMPT = "You are a helpful assistant."
 
 PREDICTION_PROMPT = """
 You are an advanced AI system which has been finetuned to provide calibrated probabilistic
@@ -238,6 +188,7 @@ Question:
 {question}
 
 Today's date: {today}
+Your pretraining knowledge cutoff: October 2023
 
 We have retrieved the following information for this question:
 <background>{sources}</background>
@@ -245,21 +196,20 @@ We have retrieved the following information for this question:
 Recall the question you are forecasting:
 {question}
 
-Return a structured PredictionResult whose fields capture the following reasoning chain:
-
-1. `facts` — Compress key factual information from the sources, as well as useful background information
+Instructions:
+1. Compress key factual information from the sources, as well as useful background information
 which may not be in the sources, into a list of core factual points to reference. Aim for
 information which is specific, relevant, and covers the core considerations you'll use to make
 your forecast. For this step, do not draw any conclusions about how a fact will influence your
-answer or forecast.
+answer or forecast. Place this section of your response in <facts></facts> tags.
 
-2. `reasons_no` — Provide a few reasons why the answer might be no. Rate the strength of each reason on a
-scale of 1-10.
+2. Provide a few reasons why the answer might be no. Rate the strength of each reason on a
+scale of 1-10. Use <no></no> tags.
 
-3. `reasons_yes` — Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
-scale of 1-10.
+3. Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
+scale of 1-10. Use <yes></yes> tags.
 
-4. `aggregation` — Aggregate your considerations. Do not summarize or repeat previous points; instead,
+4. Aggregate your considerations. Do not summarize or repeat previous points; instead,
 investigate how the competing factors and mechanisms interact and weigh against each other.
 Factorize your thinking across (exhaustive, mutually exclusive) cases if and only if it would be
 beneficial to your reasoning. We have detected that you overestimate world conflict, drama,
@@ -267,17 +217,13 @@ violence, and crises due to news' negativity bias, which doesn't necessarily rep
 trends or base rates. Similarly, we also have detected you overestimate dramatic, shocking,
 or emotionally charged news due to news' sensationalism bias. Therefore adjust for news'
 negativity bias and sensationalism bias by considering reasons to why your provided sources
-might be biased or exaggerated. Think like a superforecaster.
+might be biased or exaggerated. Think like a superforecaster. Use <thinking></thinking> tags
+for this section of your response.
 
-CALIBRATION (mandatory before any probability):
-- State a base-rate probability for this event category and justify it.
-- Adjust from the base rate using specific evidence only.
-- Missing expected evidence (no announcement found, no confirmation) is a NO signal.
+5. Output an initial probability (prediction) as a single number between 0 and 1 given steps 1-4.
+Use <tentative></tentative> tags.
 
-End the `aggregation` field by stating an initial tentative probability (a single number between 0 and 1)
-given steps 1-4.
-
-5. `reflection` — Reflect on your tentative answer, performing sanity checks and mentioning any additional knowledge
+6. Reflect on your answer, performing sanity checks and mentioning any additional knowledge
 or background information which may be relevant. Check for over/underconfidence, improper
 treatment of conjunctive or disjunctive conditions (only if applicable), and other forecasting
 biases when reviewing your reasoning. Consider priors/base rates, and the extent to which
@@ -285,83 +231,59 @@ case-specific information justifies the deviation between your tentative forecas
 Recall that your performance will be evaluated according to the Brier score. Be precise with tail
 probabilities. Leverage your intuitions, but never change your forecast for the sake of modesty
 or balance alone. Finally, aggregate all of your previous reasoning and highlight key factors
-that inform your final forecast.
+that inform your final forecast. Use <thinking></thinking> tags for this portion of your response.
 
-BEFORE FINAL ANSWER — apply all three checks:
+7. Output your final prediction (a number between 0 and 1 with an asterisk at the beginning and
+end of the decimal) in <answer></answer> tags.
 
-1. EVIDENCE BAR: If sources confirm the event already occurred, high p_yes is fine.
-   If not: p_yes > 0.90 needs verified commitment (signed, awarded, published).
-   p_yes > 0.80 needs strong specific evidence, not plausibility or reputation.
-   Plans, proposals, and intentions are not completed actions.
 
-2. CONFIDENCE COUPLING: If confidence < 0.3, keep p_yes between 0.30-0.70.
-   If confidence < 0.5, keep p_yes between 0.20-0.80.
-
-3. NUMERIC QUESTIONS: For price/temperature/count thresholds, find the current
-   value and compare to the threshold. A large gap overrides sentiment or forecasts.
-
-6. `p_yes`, `p_no`, `confidence`, `info_utility` — the four numeric fields:
+OUTPUT_FORMAT
+* Your output response must be only a single JSON object to be parsed by Python's "json.loads()".
+* The JSON must contain four fields: "p_yes", "p_no", "confidence", and "info_utility".
+* Each item in the JSON must have a value between 0 and 1.
    - "p_yes": Estimated probability that the event in the "Question" occurs.
    - "p_no": Estimated probability that the event in the "Question" does not occur.
    - "confidence": A value between 0 and 1 indicating the confidence in the prediction. 0 indicates lowest
      confidence value; 1 maximum confidence value.
    - "info_utility": Utility of the information provided in "sources" to help you make the prediction.
      0 indicates lowest utility; 1 maximum utility.
-   - Each value must be between 0 and 1.
-   - The sum of "p_yes" and "p_no" must equal 1.
+* The sum of "p_yes" and "p_no" must equal 1.
+* Output only the JSON object. Do not include any other contents in your response.
+* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
+* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
+* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
 """
 
 
-def _parse_completion(
-    client: OpenAI,
+def generate_prediction_with_retry(
+    client: "OpenAIClient",
     model: str,
     messages: List[Dict[str, str]],
-    response_format: Any,
-    temperature: float = 0,
-    max_tokens: int = 4096,
+    temperature: float,
+    max_tokens: int,
     retries: int = COMPLETION_RETRIES,
     delay: int = COMPLETION_DELAY,
     counter_callback: Optional[Callable] = None,
 ) -> Tuple[Any, Optional[Callable]]:
-    """Call OpenAI Structured Outputs and parse into a Pydantic model.
-
-    ``client.beta.chat.completions.parse()`` guarantees the response conforms
-    to the supplied Pydantic schema — no prompt-side JSON format instructions
-    or regex extraction required.
-
-    :param client: an initialised OpenAI client.
-    :param model: OpenAI model identifier.
-    :param messages: chat messages list (role + content dicts).
-    :param response_format: Pydantic model class used as the structured-output schema.
-    :param temperature: sampling temperature (0 = deterministic).
-    :param max_tokens: maximum tokens to generate.
-    :param retries: number of retry attempts on transient / validation failure.
-    :param delay: delay in seconds between retries.
-    :param counter_callback: optional callback tracking token usage.
-    :return: tuple of (parsed model instance, counter_callback).
-    :raises RuntimeError: if all retries exhausted without a successful parse.
-    """
+    """Attempt to generate a prediction with retries on failure."""
     attempt = 0
     while attempt < retries:
         try:
-            response = client.beta.chat.completions.parse(
+            response = client.completions(
                 model=model,
                 messages=messages,
-                response_format=response_format,
                 temperature=temperature,
                 max_tokens=max_tokens,
-                timeout=150,
+                n=1,
+                timeout=90,
+                stop=None,
             )
 
-            parsed = response.choices[0].message.parsed
-
-            if parsed is None:
-                refusal = response.choices[0].message.refusal
-                raise ValueError(
-                    f"Model refused or returned unparseable output: {refusal}"
-                )
-
-            if counter_callback is not None:
+            if (
+                response
+                and response.content is not None
+                and counter_callback is not None
+            ):
                 counter_callback(
                     input_tokens=response.usage.prompt_tokens,
                     output_tokens=response.usage.completion_tokens,
@@ -369,23 +291,13 @@ def _parse_completion(
                     token_counter=count_tokens,
                 )
 
-            return parsed, counter_callback
-        except (
-            openai.APIConnectionError,
-            openai.RateLimitError,
-            openai.InternalServerError,
-            ValueError,
-        ) as e:
-            # Retry only transient failures and model-side issues:
-            #   - APIConnectionError (includes APITimeoutError) — network blips
-            #   - RateLimitError / InternalServerError — OpenAI-side retryable
-            #   - ValueError — covers pydantic ValidationError (e.g. p_yes+p_no
-            #     sum check) and the inline "Model refused…" raise above
-            print(f"[superforcaster] Attempt {attempt + 1} failed: {e}")
+            content = response.content if response else None
+            return content, counter_callback
+        except Exception as e:
+            print(f"Attempt {attempt + 1} failed with error: {e}")
             time.sleep(delay)
             attempt += 1
-
-    raise RuntimeError("Failed to get structured LLM completion after retries")
+    raise Exception("Failed to generate prediction after retries")
 
 
 def fetch_additional_sources(question: Any, serper_api_key: Any) -> requests.Response:
@@ -524,47 +436,26 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
         )
         print(f"\n{prediction_prompt=}\n")
         messages = [
-            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "system", "content": "You are a helpful assistant."},
             {"role": "user", "content": prediction_prompt},
         ]
         print("Getting prompt response...")
-        prediction: PredictionResult
-        prediction, counter_callback = _parse_completion(
+        extracted_block, counter_callback = generate_prediction_with_retry(
             client=llm_client,
             model=model,
             messages=messages,
-            response_format=PredictionResult,
             temperature=temperature,
             max_tokens=max_tokens,
+            retries=COMPLETION_RETRIES,
+            delay=COMPLETION_DELAY,
             counter_callback=counter_callback,
         )
 
-        print(f"[superforcaster] === FACTS ===\n{prediction.facts}")
-        print(f"[superforcaster] === REASONS_NO ===\n{prediction.reasons_no}")
-        print(f"[superforcaster] === REASONS_YES ===\n{prediction.reasons_yes}")
-        print(f"[superforcaster] === AGGREGATION ===\n{prediction.aggregation}")
-        print(f"[superforcaster] === REFLECTION ===\n{prediction.reflection}")
-        print(
-            f"[superforcaster] Result: p_yes={prediction.p_yes}, "
-            f"p_no={prediction.p_no}, confidence={prediction.confidence}, "
-            f"info_utility={prediction.info_utility}"
-        )
-
-        # On-chain result — only the four standard mech fields.
-        result = json.dumps(
-            {
-                "p_yes": prediction.p_yes,
-                "p_no": prediction.p_no,
-                "confidence": prediction.confidence,
-                "info_utility": prediction.info_utility,
-            }
-        )
-
-        used_params: Dict[str, Any] = {
+        used_params = {
             "model": model,
             "temperature": temperature,
             "max_tokens": max_tokens,
         }
         if return_source_content:
             used_params["source_content"] = captured_source_content
-        return result, prediction_prompt, None, counter_callback, used_params
+        return extracted_block, prediction_prompt, None, counter_callback, used_params

--- a/packages/valory/customs/superforcaster/tests/test_superforcaster.py
+++ b/packages/valory/customs/superforcaster/tests/test_superforcaster.py
@@ -17,7 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Unit tests for superforcaster: thread-safe client, structured outputs, source_content."""
+"""Unit tests for superforcaster: thread-safe client, offline tiktoken, and source_content."""
 
 import inspect
 import json
@@ -29,8 +29,7 @@ import pytest
 import packages.valory.customs.superforcaster.superforcaster as module
 from packages.valory.customs.superforcaster.superforcaster import (
     OpenAIClientManager,
-    PredictionResult,
-    _parse_completion,
+    generate_prediction_with_retry,
     run,
 )
 
@@ -38,20 +37,20 @@ from packages.valory.customs.superforcaster.superforcaster import (
 class TestOpenAIClientManager:
     """Verify OpenAIClientManager creates per-context clients without globals."""
 
-    def test_context_manager_returns_openai_client(self) -> None:
-        """__enter__ returns a fresh openai.OpenAI client, __exit__ closes it."""
+    def test_context_manager_returns_client_instance(self) -> None:
+        """__enter__ returns a fresh OpenAIClient, __exit__ closes it."""
         mgr = OpenAIClientManager(api_key="sk-test")
         with patch(
-            "packages.valory.customs.superforcaster.superforcaster.OpenAI"
-        ) as MockOpenAI:
+            "packages.valory.customs.superforcaster.superforcaster.OpenAIClient"
+        ) as MockClient:
             mock_instance = MagicMock()
-            MockOpenAI.return_value = mock_instance
+            MockClient.return_value = mock_instance
 
             with mgr as client:
                 assert client is mock_instance
-                MockOpenAI.assert_called_once_with(api_key="sk-test")
+                MockClient.assert_called_once_with(api_key="sk-test")
 
-            mock_instance.close.assert_called_once()
+            mock_instance.client.close.assert_called_once()
 
     def test_no_global_client_variable(self) -> None:
         """The module must not define a module-level 'client' variable."""
@@ -64,9 +63,9 @@ class TestOpenAIClientManager:
                         f"Module-level 'client' variable found at line {i}: {line}"
                     )
 
-    def test_parse_completion_requires_client_param(self) -> None:
-        """_parse_completion requires client as first param."""
-        params = list(inspect.signature(_parse_completion).parameters)
+    def test_generate_prediction_requires_client_param(self) -> None:
+        """generate_prediction_with_retry requires client as first param."""
+        params = list(inspect.signature(generate_prediction_with_retry).parameters)
         assert params[0] == "client"
 
 
@@ -87,16 +86,8 @@ FAKE_SERPER_RESPONSE = {
     ],
 }
 
-FAKE_PREDICTION = PredictionResult(
-    facts="Fact 1. Fact 2.",
-    reasons_no="No 1 (strength 6). No 2 (strength 4).",
-    reasons_yes="Yes 1 (strength 5). Yes 2 (strength 3).",
-    aggregation="Base rate 0.5. Tentative: 0.5.",
-    reflection="Passes evidence bar.",
-    p_yes=0.5,
-    p_no=0.5,
-    confidence=0.5,
-    info_utility=0.5,
+PREDICTION_JSON = json.dumps(
+    {"p_yes": 0.5, "p_no": 0.5, "confidence": 0.5, "info_utility": 0.5}
 )
 
 PREDICTION_PROMPT = (
@@ -119,116 +110,6 @@ def _make_mock_api_keys(return_source_content: str = "false") -> MagicMock:
     return mock
 
 
-def _mock_parse_response() -> MagicMock:
-    """Build a fake response object matching the beta.chat.completions.parse shape."""
-    return MagicMock(
-        choices=[MagicMock(message=MagicMock(parsed=FAKE_PREDICTION, refusal=None))],
-        usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-    )
-
-
-class TestStructuredOutputContract:
-    """Verify the tool uses OpenAI Structured Outputs and returns only the 4 on-chain fields."""
-
-    @patch(f"{SF_MODULE}.OpenAIClientManager")
-    @patch(f"{SF_MODULE}.fetch_additional_sources")
-    def test_uses_beta_parse_with_prediction_result_schema(
-        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
-    ) -> None:
-        """run() calls client.beta.chat.completions.parse with response_format=PredictionResult."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = FAKE_SERPER_RESPONSE
-        mock_fetch.return_value = mock_response
-
-        mock_client = MagicMock()
-        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
-        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
-
-        run(
-            tool="superforcaster",
-            model="gpt-4.1-2025-04-14",
-            prompt=PREDICTION_PROMPT,
-            api_keys=_make_mock_api_keys(),
-            counter_callback=None,
-        )
-
-        mock_client.beta.chat.completions.parse.assert_called_once()
-        kwargs = mock_client.beta.chat.completions.parse.call_args.kwargs
-        assert kwargs["response_format"] is PredictionResult
-        assert kwargs["model"] == "gpt-4.1-2025-04-14"
-        mock_client.chat.completions.create.assert_not_called()
-
-    @patch(f"{SF_MODULE}.OpenAIClientManager")
-    @patch(f"{SF_MODULE}.fetch_additional_sources")
-    def test_returns_only_four_mech_fields_on_chain(
-        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
-    ) -> None:
-        """The on-chain result JSON contains exactly p_yes/p_no/confidence/info_utility."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = FAKE_SERPER_RESPONSE
-        mock_fetch.return_value = mock_response
-
-        mock_client = MagicMock()
-        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
-        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
-
-        result = run(
-            tool="superforcaster",
-            model="gpt-4.1-2025-04-14",
-            prompt=PREDICTION_PROMPT,
-            api_keys=_make_mock_api_keys(),
-            counter_callback=None,
-        )
-
-        on_chain_json = result[0]
-        parsed = json.loads(on_chain_json)
-        assert set(parsed.keys()) == {"p_yes", "p_no", "confidence", "info_utility"}
-        assert "facts" not in parsed
-        assert "reasons_no" not in parsed
-        assert "aggregation" not in parsed
-        assert "reflection" not in parsed
-        assert parsed["p_yes"] == 0.5
-        assert parsed["p_no"] == 0.5
-
-
-class TestPredictionResultValidator:
-    """Pydantic sum validator rejects malformed probabilities."""
-
-    def test_valid_sum_accepted(self) -> None:
-        """p_yes + p_no = 1.0 is accepted."""
-        obj = PredictionResult(
-            facts="f",
-            reasons_no="n",
-            reasons_yes="y",
-            aggregation="a",
-            reflection="r",
-            p_yes=0.7,
-            p_no=0.3,
-            confidence=0.6,
-            info_utility=0.5,
-        )
-        assert obj.p_yes == 0.7
-
-    def test_sum_violation_rejected(self) -> None:
-        """p_yes + p_no outside 0.01 tolerance raises ValidationError."""
-        from pydantic import ValidationError
-
-        with pytest.raises(ValidationError):
-            PredictionResult(
-                facts="f",
-                reasons_no="n",
-                reasons_yes="y",
-                aggregation="a",
-                reflection="r",
-                p_yes=0.7,
-                p_no=0.2,
-                confidence=0.6,
-                info_utility=0.5,
-            )
-
-
 class TestSuperforcasterSourceContent:
     """Verify superforcaster captures and replays source_content correctly."""
 
@@ -243,13 +124,16 @@ class TestSuperforcasterSourceContent:
         mock_fetch.return_value = mock_response
 
         mock_client = MagicMock()
-        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
+            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+        )
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         result = run(
             tool="superforcaster",
-            model="gpt-4.1-2025-04-14",
+            model="gpt-4o",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("true"),
             counter_callback=None,
@@ -267,14 +151,17 @@ class TestSuperforcasterSourceContent:
     ) -> None:
         """Replay with {'serper_response': ...} uses organic and peopleAlsoAsk."""
         mock_client = MagicMock()
-        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
+            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+        )
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         source_content = {"serper_response": FAKE_SERPER_RESPONSE}
         result = run(
             tool="superforcaster",
-            model="gpt-4.1-2025-04-14",
+            model="gpt-4o",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("true"),
             counter_callback=None,
@@ -298,13 +185,16 @@ class TestSuperforcasterSourceContent:
         mock_fetch.return_value = mock_response
 
         mock_client = MagicMock()
-        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
+            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+        )
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         result = run(
             tool="superforcaster",
-            model="gpt-4.1-2025-04-14",
+            model="gpt-4o",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("false"),
             counter_callback=None,

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeidvhuawywiduroudqi7d2yvpugffr4o5t6mie4w6xv53dt6xpn6ma
+agent: valory/mech_predict:0.1.0:bafybeihoomhymts6fj2bzuf3jh66wd3ibleniqyzffoztvyo2njbtq4i7i
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeihoomhymts6fj2bzuf3jh66wd3ibleniqyzffoztvyo2njbtq4i7i
+agent: valory/mech_predict:0.1.0:bafybeic2wsxehtyt2s6z52pmhvlxfhdpuxt3k5nyqigiylgxjpbewiw36y
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

Restores the `superforcaster` source code (Python + tests) to the
implementation shipped in
[v0.16.5](https://github.com/valory-xyz/mech-predict/releases/tag/v0.16.5).

The repo-wide `openai==1.93.0` pin from #118 is preserved (v0.16.5's
older `==1.30.2` is intentionally NOT brought back), so this PR is
*behaviorally* equivalent to v0.16.5 but does not republish at
v0.16.5's exact IPFS hash. New hash:
`bafybeiduissprwj2shvd4peyibvgzvlzo4ob4hy2awij6yjgsala3cmuei`.

The rest of `main` (open-autonomy 0.21.19 bump, other tool fixes, skill
changes) is preserved.

## Why this approach over a full repo revert

Rolling the whole repo back to v0.16.5 would also drop:

- open-autonomy 0.21.16 → 0.21.19 and open-aea 2.1.0 → 2.2.1 framework bumps
- Fixes in other tools (calibration, source_content_mode, tiktoken cache,
  deprecated model removals, `python-dotenv` declaration)
- Skill changes in `packages/valory/skills/*` that ship with main

`superforcaster.py` is self-contained: it only imports `openai`, `requests`,
`tiktoken`, and (post-v0.16.5) `pydantic`. It runs in isolation via
`exec()` from `task_execution`, so the framework bump does not affect its
runtime. Its dependencies are pinned in `component.yaml`, so swapping the
source is enough.

## What changed

Source files restored from the v0.16.5 tag:

- `packages/valory/customs/superforcaster/component.yaml`
- `packages/valory/customs/superforcaster/superforcaster.py`
- `packages/valory/customs/superforcaster/tests/test_superforcaster.py`

Hashes re-locked via `autonomy packages lock`. The agent and service
manifests pick up the new superforcaster reference:

- `packages/packages.json` — superforcaster hash recomputed
- `packages/valory/agents/mech_predict/aea-config.yaml` — superforcaster
  ref updated; agent hash recomputed
- `packages/valory/services/mech_predict/service.yaml` — agent ref
  recomputed

## Behavioural diff vs current main

Reverted commits (11 since v0.16.5):

- Calibration rules in PREDICTION_PROMPT (compact v4, 222 tokens)
- Confidence coupling range tweaks
- `max_tokens` bump from 500 to 4096
- Switch to OpenAI Structured Outputs via pydantic (v0.16.5 source uses
  the legacy `chat.completions.create` JSON-in-prompt pattern)
- Schema field description fixups

The pydantic dependency that was added post-v0.16.5 is removed because
the v0.16.5 source does not import it. The `openai` pin is **kept at
the repo-wide `==1.93.0`** (per #118 audit, the v0.16.5 source uses
only stable APIs that are unchanged between 1.30.2 and 1.93.0).

## Testing

Local end-to-end smoke test against live OpenAI (gpt-4.1-2025-04-14)
and Serper APIs, run twice:

- Once under `openai==1.30.2` (the v0.16.5 component.yaml pin) to
  confirm the restored source is byte-faithful to v0.16.5's behavior.
- Once under `openai==1.93.0` (the pin shipped in this PR) to confirm
  the v0.16.5 source still produces a valid prediction with the
  newer client. This is the run that matters for the merge.

Both runs:
- Fetched Serper sources
- Rendered the v0.16.5 PREDICTION_PROMPT (no calibration block,
  legacy JSON-in-prompt format)
- Returned a valid JSON probability summing to 1.0
- Returned a 6-tuple `MechResponse` as `task_execution` expects

Final published hash for this branch:

```
custom/valory/superforcaster/0.1.0:
  bafybeiduissprwj2shvd4peyibvgzvlzo4ob4hy2awij6yjgsala3cmuei
```

## Test plan

- [ ] CI: `tox -e check-hash`, `tox -e check-packages`
- [ ] CI: `tox -e check-tools`
- [ ] CI: linting / type checks
- [ ] Mech operator: pull this branch, run agent against a real
  marketplace request, verify superforcaster delivery succeeds

## Notes for reviewers

- No framework or other tool source has changed; the diff is scoped to
  the superforcaster package and the three manifests that reference it.
- Operators who specifically need the v0.16.5 published artifact
  (`bafybeiepzi7sen65r6csqgimko7tk6axeckstkrjdwxgmrcsts4kpzinrm`) in a
  running deployment can point `TOOLS_TO_PACKAGE_HASH[superforcaster]`
  to that hash directly without merging this PR. This PR republishes
  v0.16.5's source under the repo-wide `openai==1.93.0` pin, which
  produces a different artifact hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
