### PR TITLE
ci(benchmark): persist benchmark/datasets/logs/ across cron runs

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -196,6 +196,7 @@ jobs:
           include-hidden-files: true
           path: |
             benchmark/datasets/.fetch_state.json
+            benchmark/datasets/logs/
             benchmark/results/scores.json
             benchmark/results/scores_omen.json
             benchmark/results/scores_polymarket.json


### PR DESCRIPTION
## Summary

Restores raw daily log files to the `benchmark-data` artifact so the rolling-window scorer has multi-day `predicted_at` coverage to filter against. Single-line workflow change.

## Why this matters

Today, every CI cron run starts with an empty `benchmark/datasets/logs/` directory. The fetcher writes only the rows freshly resolved in the last ~24 hours into today's daily log file. The rolling-window scorer (`--period-days 3`) and the prev-rolling scorer (`--period-days 3 --period-offset-days 3`) then re-read that single small file and filter by `predicted_at`.

Most freshly-resolved rows have `predicted_at` ~4 days ago (resolution lag). For `Current 3d` window `[now-3d, now)` the filter catches almost nothing because few predictions made in the last 3 days have resolved yet. The result: Slack summaries show `insufficient data` or near-zero `n` everywhere, like:

```
Omenstrat — Current 3d Brier 0.9801 (n=1)
            Δ vs All-Time insufficient data, Δ vs Prev 3d no prev window
```

The all-time aggregate is unaffected — it reads `scores.json` which has been persisting correctly across runs.

## How the bug landed (git archaeology)

Two commits combined to produce it:

- **`cebd0345` (Apr 6)** — *"ci: update benchmark workflow for incremental scoring"*. Removed `production_log.jsonl` from the `benchmark-data` artifact and split daily logs into a separate per-run `benchmark-log-<run_id>` archive. Correct at the time: the only consumer of raw logs was the all-time scorer, which had just been switched to incremental and reads `scores.json` instead of raw logs.

- **`d98110c3` (Apr 9)** — *"feat: implement full metrics changes from PR #202 review"*. Added the `Score last 7 days` step that re-reads raw logs by `predicted_at`. New consumer of `logs/` that needs multi-day coverage. Did not restore `logs/` to the artifact upload.

From Apr 9 onward, every CI cron's rolling window has been quietly broken. Local runs worked because anyone running locally already had accumulated logs on disk.

## What changes

```diff
       path: |
         benchmark/datasets/.fetch_state.json
+        benchmark/datasets/logs/
         benchmark/results/scores.json
         ...
```

That's it. One line.

## Why this is safe — no double-counting

The scorer's all-time path dedups via `scored_row_ids.json` (also persisted), so even if the same row appears in multiple daily log files (it won't, the fetcher dedups at write time too), `scores.json` cannot double-count. The dedup chain:

1. **Fetch level (`load_existing_row_ids`)**: scans all log files in `logs/` for existing `row_id`s, skips them on write. With `logs/` populated from prior runs, today's fetch only adds genuinely-new resolutions.
2. **Scorer level (`scored_row_ids.json`)**: `scorer.update()` checks each new row against the master scored-id set. Already-scored rows skip the aggregate update.

Both layers are unchanged. Only the upload list grows.

## Round-trip verification

Existing entries like `benchmark/datasets/.fetch_state.json` already round-trip correctly via the same artifact (download path is `benchmark/`, file lands back at `benchmark/datasets/.fetch_state.json`). Adding `benchmark/datasets/logs/` follows the same path convention and lands back at `benchmark/datasets/logs/` where the fetcher writes to.

## Artifact size impact

Each daily log file is roughly 3-5MB (varies with deliveries). Over 30 cron runs that is ~100-150MB. Well within GitHub's artifact size limits. Retention stays at 90 days.

## Effect after merge

After ~7 cron runs the `logs/` directory accumulates to:

```
benchmark/datasets/logs/
  production_log_2026_04_28.jsonl
  production_log_2026_04_29.jsonl
  production_log_2026_04_30.jsonl
  production_log_2026_05_01.jsonl
  production_log_2026_05_02.jsonl
  production_log_2026_05_03.jsonl
  production_log_2026_05_04.jsonl
```

Combined `predicted_at` coverage spans the past ~14 days. Both `Current 3d` and `Prev 3d` windows catch real populations of rows, comparison tables render meaningfully, and the daily Slack summary shows actual numbers instead of `insufficient data`.

## Test plan
- [ ] CI green on this branch
- [ ] After merge, monitor first ~3 cron runs to confirm `logs/` accumulates as expected (artifact contents include `datasets/logs/production_log_*.jsonl`)
- [ ] After ~7 daily cron runs, confirm rolling Slack summary shows `n` in the hundreds/thousands per platform instead of single digits