### PR TITLE
fix(benchmark): per-platform report content fixes

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -27,6 +27,10 @@ on:
         required: false
         type: boolean
         default: false
+      rolling_window_days:
+        description: 'Trailing-window length (days) for the Current/Prev rolling comparison sections'
+        required: false
+        default: '7'
 
 jobs:
   # -----------------------------------------------------------------------
@@ -39,6 +43,11 @@ jobs:
     timeout-minutes: 30
     needs: [tournament-run]
     if: always() && !cancelled()
+    # Drives both the Python ROLLING_WINDOW_DAYS constant (read at import
+    # time in benchmark/analyze.py) and the --period-days flag passed to
+    # the scorer below, keeping the report and the scoring step in sync.
+    env:
+      BENCHMARK_ROLLING_WINDOW_DAYS: ${{ github.event.inputs.rolling_window_days || '7' }}
 
     steps:
       # fetch-depth: 0 so `git show <tag>:packages/packages.json` works for
@@ -144,32 +153,36 @@ jobs:
             --update benchmark/results/tournament_scored.jsonl
         continue-on-error: true
 
-      # Score recent periods for diff reporting
-      # Keep the "3" in the step name and --period-days flag in sync with
-      # ROLLING_WINDOW_DAYS in benchmark/analyze.py. YAML can't import the
-      # Python constant; a bump to ROLLING_WINDOW_DAYS must be mirrored here.
-      - name: Score last 3 days
+      # Score recent periods for diff reporting. The window length
+      # (--period-days, --period-offset-days) is driven by the
+      # BENCHMARK_ROLLING_WINDOW_DAYS env var declared at the job level
+      # so the scorer and the Python ROLLING_WINDOW_DAYS constant stay in
+      # sync from a single source.
+      - name: Score current rolling window
         run: |
           TOURNAMENT_FLAG=""
           if [ -f benchmark/results/tournament_scored.jsonl ]; then
             TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
           fi
-          python -m benchmark.scorer --period-days 3 \
+          python -m benchmark.scorer \
+            --period-days "$BENCHMARK_ROLLING_WINDOW_DAYS" \
             --logs-dir benchmark/datasets/logs/ \
             --output benchmark/results/rolling_scores.json \
             $TOURNAMENT_FLAG
         continue-on-error: true
 
-      # Score the preceding non-overlapping window (days 4-6 ago for a
-      # 3-day rolling window). Feeds the "Δ vs Prev 3d" columns in the
-      # three-window comparison tables.
-      - name: Score previous 3 days (non-overlapping)
+      # Score the preceding non-overlapping window (offset by the same
+      # window length so Current and Prev never overlap). Feeds the
+      # "Δ vs Prev Nd" columns in the three-window comparison tables.
+      - name: Score previous rolling window (non-overlapping)
         run: |
           TOURNAMENT_FLAG=""
           if [ -f benchmark/results/tournament_scored.jsonl ]; then
             TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
           fi
-          python -m benchmark.scorer --period-days 3 --period-offset-days 3 \
+          python -m benchmark.scorer \
+            --period-days "$BENCHMARK_ROLLING_WINDOW_DAYS" \
+            --period-offset-days "$BENCHMARK_ROLLING_WINDOW_DAYS" \
             --logs-dir benchmark/datasets/logs/ \
             --output benchmark/results/prev_rolling_scores.json \
             $TOURNAMENT_FLAG

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -263,6 +263,7 @@ def _active_tools_for_platform(
     disabled: dict[str, list[str] | None] | None,
     platform: str,
     scores: dict[str, Any],
+    rolling_scores: dict[str, Any] | None = None,
 ) -> frozenset[str] | None:
     """Return tools currently active on at least one deployment of ``platform``.
 
@@ -272,17 +273,20 @@ def _active_tools_for_platform(
 
     Tool-name normalization mirrors ``section_tool_deployment_status``:
     underscores and hyphens are treated as interchangeable when comparing
-    against the disabled list, but the returned set uses the names as
-    they appear in ``scores["by_tool"]`` (the form the report sections
-    iterate over).
+    against the disabled list. The returned set uses the names as they
+    appear in ``by_tool`` keys.
 
     :param disabled: ``{deployment: [tool_names] | None}`` map, where
         ``None`` indicates a fetch/parse failure for that deployment.
         ``None`` for the whole map (or an empty dict) is treated as
         "no deployment data available".
     :param platform: scorer platform key (``"omen"`` or ``"polymarket"``).
-    :param scores: parsed platform-scoped scores dict, used to recover
-        the canonical ``by_tool`` names.
+    :param scores: parsed platform-scoped all-time scores dict.
+    :param rolling_scores: parsed platform-scoped current-window scores
+        dict. The benchmarked-tool universe is the union of ``scores``
+        and ``rolling_scores`` ``by_tool`` keys so a freshly-deployed
+        tool with rolling data but no all-time history yet is still
+        included in the active set.
     :return: frozenset of active tool names, or ``None`` when **every**
         deployment of this platform has ``disabled=None`` (full fetch
         failure for the platform). Callers fall back to "show all
@@ -298,7 +302,9 @@ def _active_tools_for_platform(
         # warning and shows all tools rather than blanking the report.
         return None
 
-    benchmarked = list(scores.get("by_tool", {}).keys())
+    benchmarked = set((scores.get("by_tool") or {}).keys())
+    if rolling_scores is not None:
+        benchmarked |= set((rolling_scores.get("by_tool") or {}).keys())
 
     active: set[str] = set()
     for disabled_tools in relevant.values():
@@ -2492,7 +2498,9 @@ def generate_report(  # pylint: disable=too-many-statements
     # deployment fetch failed for this platform; the caller's fallback
     # is to skip the filter and prepend a one-line warning so the
     # reader knows the tool list is unfiltered for this run.
-    active_tools = _active_tools_for_platform(disabled_tools, platform, scores)
+    active_tools = _active_tools_for_platform(
+        disabled_tools, platform, scores, rolling_scores
+    )
 
     sections: list[str] = [f"# Benchmark Report ({platform_label}) — {date}"]
     # Warning fires only when the caller actually attempted a fetch

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -17,12 +17,22 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any, Mapping
 
 from benchmark import release_map
+
+# OMEN_CATEGORIES / POLYMARKET_ACTIVE_CATEGORIES are re-exported so
+# callers that previously imported these constants from benchmark.analyze
+# keep working after the constants moved to benchmark.categories.
+from benchmark.categories import (  # noqa: F401  # pylint: disable=unused-import
+    ACTIVE_CATEGORIES,
+    OMEN_CATEGORIES,
+    POLYMARKET_ACTIVE_CATEGORIES,
+)
 from benchmark.io import load_jsonl
 from benchmark.scorer import (
     DISAGREE_THRESHOLD,
@@ -45,7 +55,12 @@ PLATFORM_LABELS: Mapping[str, str] = MappingProxyType(
     }
 )
 
-ROLLING_WINDOW_DAYS = 3
+# Trailing-window length (in days) for the Current-window snapshot and
+# the previous non-overlapping window used by the comparison sections.
+# Read from BENCHMARK_ROLLING_WINDOW_DAYS so the CI workflow drives the
+# Python constant and the ``--period-days`` flag passed to the scorer
+# from one source of truth (see .github/workflows/benchmark_flywheel.yaml).
+ROLLING_WINDOW_DAYS = int(os.environ.get("BENCHMARK_ROLLING_WINDOW_DAYS", "7"))
 
 BRIER_RANDOM = 0.25
 BRIER_WEAK_THRESHOLD = 0.40
@@ -53,55 +68,6 @@ BSS_HARMFUL_THRESHOLD = 0.0
 RELIABILITY_ISSUE_THRESHOLD = 0.90
 SAMPLE_SIZE_WARNING = 20
 TREND_WORSENING_THRESHOLD = 0.02
-
-# Categories currently emitted by the two upstream platforms.
-# Keep these in sync with:
-#   Omen:       valory-xyz/market-creator — DEFAULT_TOPICS in
-#               packages/valory/skills/market_creation_manager_abci/propose_questions.py
-#   Polymarket: valory-xyz/trader — POLYMARKET_CATEGORY_TAGS in
-#               packages/valory/connections/polymarket_client/connection.py
-# Historical labels not in either set (e.g. "travel", "crypto", "tech") are
-# treated as legacy and skipped by weak-spot reporting.
-OMEN_CATEGORIES: frozenset[str] = frozenset(
-    {
-        "business",
-        "cryptocurrency",
-        "politics",
-        "science",
-        "technology",
-        "trending",
-        "social",
-        "health",
-        "sustainability",
-        "internet",
-        "food",
-        "pets",
-        "animals",
-        "curiosities",
-        "economy",
-        "arts",
-        "entertainment",
-        "weather",
-        "sports",
-        "finance",
-        "international",
-    }
-)
-POLYMARKET_ACTIVE_CATEGORIES: frozenset[str] = frozenset(
-    {
-        "business",
-        "politics",
-        "science",
-        "technology",
-        "health",
-        "entertainment",
-        "weather",
-        "finance",
-        "international",
-    }
-)
-ACTIVE_CATEGORIES: frozenset[str] = OMEN_CATEGORIES | POLYMARKET_ACTIVE_CATEGORIES
-
 
 # ---------------------------------------------------------------------------
 # Data loading
@@ -293,6 +259,88 @@ def _sample_label(stats: dict[str, Any]) -> str:
     return ""
 
 
+def _active_tools_for_platform(
+    disabled: dict[str, list[str] | None] | None,
+    platform: str,
+    scores: dict[str, Any],
+) -> frozenset[str] | None:
+    """Return tools currently active on at least one deployment of ``platform``.
+
+    Computed as the union of (benchmarked tools - disabled tools) across
+    every deployment of ``platform`` whose config fetch succeeded. A tool
+    is "active" if any deployment has it enabled.
+
+    Tool-name normalization mirrors ``section_tool_deployment_status``:
+    underscores and hyphens are treated as interchangeable when comparing
+    against the disabled list, but the returned set uses the names as
+    they appear in ``scores["by_tool"]`` (the form the report sections
+    iterate over).
+
+    :param disabled: ``{deployment: [tool_names] | None}`` map, where
+        ``None`` indicates a fetch/parse failure for that deployment.
+        ``None`` for the whole map (or an empty dict) is treated as
+        "no deployment data available".
+    :param platform: scorer platform key (``"omen"`` or ``"polymarket"``).
+    :param scores: parsed platform-scoped scores dict, used to recover
+        the canonical ``by_tool`` names.
+    :return: frozenset of active tool names, or ``None`` when **every**
+        deployment of this platform has ``disabled=None`` (full fetch
+        failure for the platform). Callers fall back to "show all
+        tools" plus a ``⚠ deployment config unavailable`` notice.
+    """
+    if not disabled:
+        return None
+
+    deployments = deployments_for_platform(platform)
+    relevant = {name: disabled.get(name) for name in deployments}
+    if all(disabled_tools is None for disabled_tools in relevant.values()):
+        # Every deployment for this platform failed — caller renders the
+        # warning and shows all tools rather than blanking the report.
+        return None
+
+    benchmarked = list(scores.get("by_tool", {}).keys())
+
+    active: set[str] = set()
+    for disabled_tools in relevant.values():
+        if disabled_tools is None:
+            continue
+        disabled_set = {t.replace("_", "-") for t in disabled_tools}
+        for tool in benchmarked:
+            if tool.replace("_", "-") not in disabled_set:
+                active.add(tool)
+
+    return frozenset(active)
+
+
+def _filter_by_active(
+    items: list[tuple[str, Any]],
+    active_tools: frozenset[str] | None,
+    *,
+    composite_key_separator: str | None = None,
+) -> list[tuple[str, Any]]:
+    """Drop entries whose tool name is not in ``active_tools``.
+
+    :param items: ``[(key, stats), ...]`` ranked-iteration list.
+    :param active_tools: set of tools currently deployed on the platform,
+        or ``None`` to disable filtering (caller's fallback path when
+        deployment config could not be fetched).
+    :param composite_key_separator: when set, treat ``key`` as a
+        composite ``"tool{sep}other"`` and filter on the first segment.
+        Pass ``" | "`` for ``by_tool_category`` keys.
+    :return: ``items`` with non-active entries removed; identity when
+        ``active_tools`` is ``None``.
+    """
+    if active_tools is None:
+        return items
+    if composite_key_separator is None:
+        return [(k, s) for k, s in items if k in active_tools]
+    return [
+        (k, s)
+        for k, s in items
+        if k.split(composite_key_separator, 1)[0] in active_tools
+    ]
+
+
 def section_tool_deployment_status(
     scores: dict[str, Any],
     disabled: dict[str, list[str] | None] | None = None,
@@ -360,12 +408,23 @@ def section_tool_deployment_status(
     return "\n".join(lines)
 
 
-def section_tool_ranking(scores: dict[str, Any]) -> str:
-    """Generate the tool ranking section."""
+def section_tool_ranking(
+    scores: dict[str, Any],
+    active_tools: frozenset[str] | None = None,
+) -> str:
+    """Generate the tool ranking section.
+
+    :param scores: parsed platform-scoped scores dict.
+    :param active_tools: when set, only tools in this set are ranked.
+        ``None`` (the default) preserves the legacy "show every tool
+        with rows" behaviour and is used as a fallback when deployment
+        config could not be fetched.
+    :return: markdown section string.
+    """
     tools = scores.get("by_tool", {})
-    ranked = sorted(
-        tools.items(),
-        key=brier_sort_key,
+    ranked = _filter_by_active(
+        sorted(tools.items(), key=brier_sort_key),
+        active_tools,
     )
 
     lines = ["## Tool Ranking", ""]
@@ -513,7 +572,10 @@ def _da_lift(
     return directional_accuracy - majority
 
 
-def section_tool_category(scores: dict[str, Any]) -> str:
+def section_tool_category(
+    scores: dict[str, Any],
+    active_tools: frozenset[str] | None = None,
+) -> str:
     """Tool × category cross breakdown — primary metrics, gated by MIN_SAMPLE_SIZE.
 
     Renders the reviewer-specified column set: n, reliability, Brier,
@@ -523,13 +585,20 @@ def section_tool_category(scores: dict[str, Any]) -> str:
     section so this table stays scannable.
 
     :param scores: parsed per-platform rolling scores dict.
+    :param active_tools: when set, only cells whose tool half is in this
+        set render. ``None`` disables filtering (used as the fallback
+        when deployment config could not be fetched).
     :return: markdown section string.
     """
     data = scores.get("by_tool_category") or {}
     if not data:
         return "## Tool × Category\n\nNo cross-breakdown data available."
 
-    ranked = sorted(data.items(), key=brier_sort_key)
+    ranked = _filter_by_active(
+        sorted(data.items(), key=brier_sort_key),
+        active_tools,
+        composite_key_separator=" | ",
+    )
     sufficient = [(k, s) for k, s in ranked if s["n"] >= MIN_SAMPLE_SIZE]
     sparse = [(k, s) for k, s in ranked if s["n"] < MIN_SAMPLE_SIZE]
 
@@ -593,7 +662,10 @@ def section_tool_category(scores: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def section_tool_category_diagnostics(scores: dict[str, Any]) -> str:
+def section_tool_category_diagnostics(
+    scores: dict[str, Any],
+    active_tools: frozenset[str] | None = None,
+) -> str:
     """Tool × category diagnostic metrics — edge, edge_n, log loss.
 
     Rendered as a follow-on to ``section_tool_category`` so the primary
@@ -601,13 +673,20 @@ def section_tool_category_diagnostics(scores: dict[str, Any]) -> str:
     per-(tool, category) grain.
 
     :param scores: parsed per-platform rolling scores dict.
+    :param active_tools: when set, only cells whose tool half is in this
+        set render. ``None`` disables filtering (deployment-config
+        fallback).
     :return: markdown section string.
     """
     data = scores.get("by_tool_category") or {}
     if not data:
         return "## Tool × Category Diagnostics\n\n" "No cross-breakdown data available."
 
-    ranked = sorted(data.items(), key=brier_sort_key)
+    ranked = _filter_by_active(
+        sorted(data.items(), key=brier_sort_key),
+        active_tools,
+        composite_key_separator=" | ",
+    )
     sufficient = [(k, s) for k, s in ranked if s["n"] >= MIN_SAMPLE_SIZE]
 
     lines = [
@@ -957,6 +1036,7 @@ def section_tool_comparison(
     rolling_scores: dict[str, Any],
     alltime_scores: dict[str, Any],
     prev_rolling_scores: dict[str, Any] | None,
+    active_tools: frozenset[str] | None = None,
 ) -> str:
     """Render the tool historical comparison table.
 
@@ -969,10 +1049,16 @@ def section_tool_comparison(
     :param alltime_scores: all-time scores (used for Δ vs all-time).
     :param prev_rolling_scores: previous non-overlapping rolling scores,
         or ``None``.
+    :param active_tools: when set, restrict the table to currently-deployed
+        tools so historical/tournament-only entries don't clutter the
+        per-platform report. ``None`` disables filtering (used as the
+        fallback when deployment config could not be fetched).
     :return: markdown section string.
     """
     heading = "## Tool Historical Comparison"
     tools = _tool_universe(rolling_scores, alltime_scores)
+    if active_tools is not None:
+        tools = [t for t in tools if t in active_tools]
     if not tools:
         return f"{heading}\n\nNo tool data available."
 
@@ -1026,6 +1112,7 @@ def section_tool_category_comparison(
     rolling_scores: dict[str, Any],
     alltime_scores: dict[str, Any],
     prev_rolling_scores: dict[str, Any] | None,
+    active_tools: frozenset[str] | None = None,
 ) -> str:
     """Render the tool × category historical comparison table.
 
@@ -1037,6 +1124,9 @@ def section_tool_category_comparison(
     :param rolling_scores: current rolling-window scores.
     :param alltime_scores: all-time scores.
     :param prev_rolling_scores: previous non-overlapping rolling scores.
+    :param active_tools: when set, only cells whose tool half is in this
+        set render. ``None`` disables filtering (deployment-config
+        fallback).
     :return: markdown section string.
     """
     heading = "## Tool × Category Historical Comparison"
@@ -1044,7 +1134,11 @@ def section_tool_category_comparison(
     at = alltime_scores.get("by_tool_category") or {}
     prev = (prev_rolling_scores or {}).get("by_tool_category") or {}
 
-    ranked = sorted(cur.items(), key=brier_sort_key)
+    ranked = _filter_by_active(
+        sorted(cur.items(), key=brier_sort_key),
+        active_tools,
+        composite_key_separator=" | ",
+    )
     sufficient = [(k, s) for k, s in ranked if s["n"] >= MIN_SAMPLE_SIZE]
     if not sufficient:
         return (
@@ -1117,6 +1211,7 @@ def section_diagnostics_comparison(
     rolling_scores: dict[str, Any],
     alltime_scores: dict[str, Any],
     prev_rolling_scores: dict[str, Any] | None,
+    active_tools: frozenset[str] | None = None,
 ) -> str:
     """Render the diagnostics historical comparison table.
 
@@ -1130,10 +1225,14 @@ def section_diagnostics_comparison(
     :param rolling_scores: current rolling-window scores.
     :param alltime_scores: all-time scores.
     :param prev_rolling_scores: previous non-overlapping rolling scores.
+    :param active_tools: when set, restrict the table to currently-deployed
+        tools. ``None`` disables filtering (deployment-config fallback).
     :return: markdown section string.
     """
     heading = "## Diagnostics Historical Comparison"
     tools = _tool_universe(rolling_scores, alltime_scores)
+    if active_tools is not None:
+        tools = [t for t in tools if t in active_tools]
     if not tools:
         return f"{heading}\n\nNo tool data available."
 
@@ -1208,6 +1307,7 @@ def section_diagnostics_comparison(
 def section_reliability_comparison(
     rolling_scores: dict[str, Any],
     alltime_scores: dict[str, Any],
+    active_tools: frozenset[str] | None = None,
 ) -> str:
     """Render the reliability & parse quality comparison table.
 
@@ -1219,10 +1319,14 @@ def section_reliability_comparison(
 
     :param rolling_scores: current rolling-window scores.
     :param alltime_scores: all-time scores.
+    :param active_tools: when set, restrict the table to currently-deployed
+        tools. ``None`` disables filtering (deployment-config fallback).
     :return: markdown section string.
     """
     heading = "## Reliability & Parse Quality (Current vs All-Time)"
     tools = _tool_universe(rolling_scores, alltime_scores)
+    if active_tools is not None:
+        tools = [t for t in tools if t in active_tools]
     if not tools:
         return f"{heading}\n\nNo tool data available."
 
@@ -2376,7 +2480,31 @@ def generate_report(  # pylint: disable=too-many-statements
     if prev_rolling_scores is not None and not _has_scored_rows(prev_rolling_scores):
         prev_rolling_scores = None
 
+    # Hoist the deployment-config fetch above the section calls so the
+    # comparison sections, the deployment-status section, and the
+    # warning notice all see the same map. ``None`` (the default)
+    # triggers a live fetch; an empty dict is the test-only opt-out.
+    if disabled_tools is None:
+        disabled_tools = fetch_disabled_tools()
+
+    # Restrict the per-platform comparison sections to tools currently
+    # deployed somewhere on this platform. Returns ``None`` when every
+    # deployment fetch failed for this platform; the caller's fallback
+    # is to skip the filter and prepend a one-line warning so the
+    # reader knows the tool list is unfiltered for this run.
+    active_tools = _active_tools_for_platform(disabled_tools, platform, scores)
+
     sections: list[str] = [f"# Benchmark Report ({platform_label}) — {date}"]
+    # Warning fires only when the caller actually attempted a fetch
+    # (non-empty input) but every deployment for this platform failed.
+    # Empty-dict callers are the unit-test opt-out and shouldn't see
+    # the notice.
+    if active_tools is None and disabled_tools:
+        sections.append(
+            "> ⚠️ Deployment config unavailable for this platform — comparison "
+            "sections show every benchmarked tool, including tools that may "
+            "no longer be deployed."
+        )
 
     sections.append(section_metric_reference())
 
@@ -2395,32 +2523,48 @@ def generate_report(  # pylint: disable=too-many-statements
             section_platform_comparison(rolling_scores, scores, prev_rolling_scores)
         )
         sections.append(
-            section_tool_comparison(rolling_scores, scores, prev_rolling_scores)
+            section_tool_comparison(
+                rolling_scores, scores, prev_rolling_scores, active_tools=active_tools
+            )
         )
         # Tool × Category — the reviewer asked for both the current-window
         # ranking table AND the historical comparison, so render the two
         # in sequence.
         sections.append(
             _relabel_heading(
-                section_tool_category(rolling_scores),
+                section_tool_category(rolling_scores, active_tools=active_tools),
                 f" (Current {ROLLING_WINDOW_DAYS}d)",
             )
         )
         sections.append(
             _relabel_heading(
-                section_tool_category_diagnostics(rolling_scores),
+                section_tool_category_diagnostics(
+                    rolling_scores, active_tools=active_tools
+                ),
                 f" (Current {ROLLING_WINDOW_DAYS}d)",
             )
         )
         sections.append(
             section_tool_category_comparison(
-                rolling_scores, scores, prev_rolling_scores
+                rolling_scores,
+                scores,
+                prev_rolling_scores,
+                active_tools=active_tools,
             )
         )
         sections.append(
-            section_diagnostics_comparison(rolling_scores, scores, prev_rolling_scores)
+            section_diagnostics_comparison(
+                rolling_scores,
+                scores,
+                prev_rolling_scores,
+                active_tools=active_tools,
+            )
         )
-        sections.append(section_reliability_comparison(rolling_scores, scores))
+        sections.append(
+            section_reliability_comparison(
+                rolling_scores, scores, active_tools=active_tools
+            )
+        )
 
     sections.append(
         section_tool_deployment_status(

--- a/benchmark/categories.py
+++ b/benchmark/categories.py
@@ -1,0 +1,76 @@
+"""
+Shared per-platform category taxonomies.
+
+Mirrors the upstream platforms' own category lists so the benchmark
+emits, scores, and reports categories the platforms actually trade.
+
+Keep these in sync with:
+    Omen:       valory-xyz/market-creator — DEFAULT_TOPICS in
+                packages/valory/skills/market_creation_manager_abci/propose_questions.py
+    Polymarket: valory-xyz/trader — POLYMARKET_CATEGORY_TAGS in
+                packages/valory/connections/polymarket_client/connection.py
+
+Imported by:
+    - benchmark.analyze (weak-spot filter, per-platform report sections)
+    - benchmark.datasets.fetch_production (platform-aware category classifier)
+"""
+
+from __future__ import annotations
+
+from types import MappingProxyType
+from typing import Mapping
+
+OMEN_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "business",
+        "cryptocurrency",
+        "politics",
+        "science",
+        "technology",
+        "trending",
+        "social",
+        "health",
+        "sustainability",
+        "internet",
+        "food",
+        "pets",
+        "animals",
+        "curiosities",
+        "economy",
+        "arts",
+        "entertainment",
+        "weather",
+        "sports",
+        "finance",
+        "international",
+    }
+)
+
+POLYMARKET_ACTIVE_CATEGORIES: frozenset[str] = frozenset(
+    {
+        "business",
+        "politics",
+        "science",
+        "technology",
+        "health",
+        "entertainment",
+        "weather",
+        "finance",
+        "international",
+    }
+)
+
+ACTIVE_CATEGORIES: frozenset[str] = OMEN_CATEGORIES | POLYMARKET_ACTIVE_CATEGORIES
+
+
+# Maps the scorer's platform key to the platform's allowed-category set.
+# A row whose keyword-classified category is not in the platform's set
+# should bucket as "other" — the upstream platform never emits that
+# category, so reporting it as a category in that platform's report
+# would mislead the reader.
+PLATFORM_ALLOWED_CATEGORIES: Mapping[str, frozenset[str]] = MappingProxyType(
+    {
+        "omen": OMEN_CATEGORIES,
+        "polymarket": POLYMARKET_ACTIVE_CATEGORIES,
+    }
+)

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -33,6 +33,7 @@ from typing import Any, Optional
 
 import requests
 
+from benchmark.categories import PLATFORM_ALLOWED_CATEGORIES
 from benchmark.io import append_jsonl
 
 # ---------------------------------------------------------------------------
@@ -1285,13 +1286,38 @@ def parse_tool_response(tool_response: Optional[str]) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def classify_category(question_text: str) -> str:
-    """Classify a question into a category using word-boundary keyword matching."""
+def classify_category(question_text: str, platform: Optional[str] = None) -> str:
+    """Classify a question into a category using word-boundary keyword matching.
+
+    When ``platform`` is provided, the classified category is filtered
+    against that platform's upstream taxonomy
+    (``PLATFORM_ALLOWED_CATEGORIES``); a keyword match for a category the
+    platform never emits (e.g. ``travel`` for omen, or ``curiosities``
+    for polymarket) drops to ``"other"`` so per-platform reports don't
+    show categories the platform doesn't actually trade.
+
+    :param question_text: market question, used for keyword matching.
+    :param platform: scorer platform key (``"omen"`` or ``"polymarket"``).
+        ``None`` is accepted for callers that don't yet know the
+        platform — the classifier behaves as before.
+    :return: category name, or ``"other"`` when no keyword matches or
+        the matched category is outside ``platform``'s allowed set.
+    """
     text_lower = question_text.lower()
+    matched = "other"
     for category, keywords in CATEGORY_KEYWORDS.items():
         for kw in keywords:
             if re.search(r"\b" + re.escape(kw) + r"\b", text_lower):
-                return category
+                matched = category
+                break
+        if matched != "other":
+            break
+
+    if platform is None:
+        return matched
+    allowed = PLATFORM_ALLOWED_CATEGORIES.get(platform)
+    if allowed is None or matched in allowed:
+        return matched
     return "other"
 
 
@@ -1410,7 +1436,7 @@ def build_row(
         "resolved_at": _ts_to_iso(resolved_at_ts),
         "latency_s": latency_s,
         "prediction_lead_time_days": prediction_lead_time_days,
-        "category": classify_category(question_text),
+        "category": classify_category(question_text, platform),
         "match_confidence": match_confidence,
     }
     return row

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -131,8 +131,11 @@ def _count_eligible_tools(report_text: str) -> int:
     :param report_text: full markdown report for one platform.
     :return: count of eligible rows; ``0`` when the section is absent.
     """
+    # The block terminates on the next ``^## `` heading OR at end-of-report
+    # so this helper is robust to Tool Historical Comparison being the
+    # final section.
     block_match = re.search(
-        r"^## Tool Historical Comparison\n(.*?)^## ",
+        r"^## Tool Historical Comparison\n(.*?)(?=^## |\Z)",
         report_text,
         re.S | re.M,
     )

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import sys
 from pathlib import Path
 from types import MappingProxyType
@@ -36,23 +37,45 @@ from benchmark.tools import TOOL_REGISTRY
 
 log = logging.getLogger(__name__)
 
-SUMMARY_SYSTEM_PROMPT_TEMPLATE = f"""\
+_PROMPT_HEADER = f"""\
 Summarize this Olas Predict benchmark report for the *{{platform_label}}* deployment using EXACTLY this structure (output will be posted to Slack). The report carries three windows per metric: `Current {ROLLING_WINDOW_DAYS}d` (trailing {ROLLING_WINDOW_DAYS}-day aggregate), `All-Time` (cumulative), and `Prev {ROLLING_WINDOW_DAYS}d` (the immediately preceding non-overlapping {ROLLING_WINDOW_DAYS}-day window). Never mix numbers across windows; if you cite a value, state which window it came from. Do NOT compare platforms, reference tools or deployments belonging to other platforms, or cite metrics from another platform's rows.
 
 *Summary:* 2-3 sentence high-level takeaway for {{platform_label}}. Lead with the Current-{ROLLING_WINDOW_DAYS}d platform Brier (from the "Platform Snapshot" section). Then name the direction of change: "Δ vs All-Time" from the "Platform Historical Comparison" row for Brier, and "Δ vs Prev {ROLLING_WINDOW_DAYS}d" from the same row. If either delta shows `insufficient data`, say so plainly instead of guessing.
 
-*Eligibility for Top tools / Worst tools / Tool performance bullets:* a row is eligible only if its Current {ROLLING_WINDOW_DAYS}d n is at least {MIN_SAMPLE_SIZE} AND the row carries no ⚠ low sample / ⚠ all malformed flag. Apply this filter BEFORE picking ranks — never let a flagged or below-floor row reach the top or the bottom of the list.
+*Eligibility for the tool ranking section below:* a row is eligible only if its Current {ROLLING_WINDOW_DAYS}d n is at least {MIN_SAMPLE_SIZE} AND the row carries no ⚠ low sample / ⚠ all malformed flag."""
 
-SINGLE-TOOL FALLBACK: if exactly one tool in the "Tool Historical Comparison" table is eligible, render a single `*Tool performance:*` bullet for that tool using the same format as the Top/Worst bullets, and skip both `*Top tools:*` and `*Worst tools:*` sections entirely. If zero tools are eligible, write `*Tool performance:*` with the bullet `_no eligible tools — every row is below n={MIN_SAMPLE_SIZE} or flagged_` and skip Top/Worst.
 
+_PROMPT_RANKING_NONE = f"""\
+*Tool performance:*
+• _no eligible tools — every row in the Tool Historical Comparison table is below n={MIN_SAMPLE_SIZE} or flagged_"""
+
+
+_PROMPT_RANKING_ALL = f"""\
+*Tool performance:*
+• `tool-name` — Current {ROLLING_WINDOW_DAYS}d Brier `X.XXXX` (n=X), Δ vs All-Time `±X.XXXX direction`, Δ vs Prev {ROLLING_WINDOW_DAYS}d `±X.XXXX direction`
+(list ALL eligible rows from the "Tool Historical Comparison" table, sorted by Current {ROLLING_WINDOW_DAYS}d Brier ascending. Use the exact delta strings from that table; if a delta is `insufficient data` or `no prev window`, write those words verbatim — never invent a number.)"""
+
+
+def _prompt_ranking_split(top_k: int) -> str:
+    """Top-K + Worst-K ranking block for ``top_k`` ≥ 1.
+
+    :param top_k: number of rows in each of the Top tools and Worst tools
+        bullets. Caller must guarantee the eligible set has strictly more
+        than ``2 * top_k`` rows so the two slices are non-overlapping.
+    :return: ranking block as a string suitable for inserting between
+        the prompt header and footer.
+    """
+    return f"""\
 *Top tools:*
 • `tool-name` — Current {ROLLING_WINDOW_DAYS}d Brier `X.XXXX` (n=X), Δ vs All-Time `±X.XXXX direction`, Δ vs Prev {ROLLING_WINDOW_DAYS}d `±X.XXXX direction`
-(list top 3 eligible rows from the "Tool Historical Comparison" table, sorted by Current {ROLLING_WINDOW_DAYS}d Brier ascending. Use the exact delta strings from that table; if a delta is `insufficient data` or `no prev window`, write those words verbatim — never invent a number.)
+(list top {top_k} eligible rows from the "Tool Historical Comparison" table, sorted by Current {ROLLING_WINDOW_DAYS}d Brier ascending. Use the exact delta strings from that table; if a delta is `insufficient data` or `no prev window`, write those words verbatim — never invent a number.)
 
 *Worst tools:*
 • `tool-name` — Current {ROLLING_WINDOW_DAYS}d Brier `X.XXXX` (n=X), Δ vs All-Time `±X.XXXX direction`, Δ vs Prev {ROLLING_WINDOW_DAYS}d `±X.XXXX direction`
-(list bottom 3 eligible rows from the same table, sorted by Current {ROLLING_WINDOW_DAYS}d Brier descending.)
+(list bottom {top_k} eligible rows from the same table, sorted by Current {ROLLING_WINDOW_DAYS}d Brier descending.)"""
 
+
+_PROMPT_FOOTER = f"""\
 *Deployment status:* if the report has a "Tool Deployment Status ({{platform_label}})" section, list one line per deployment with its count of active tools only (do NOT enumerate the tool names — the full report has them and the Slack message stays readable). Skip deployments marked `⚠️ unavailable` after noting briefly that their config fetch failed.
 
 *Tool × Category:* from the "Tool × Category (Current {ROLLING_WINDOW_DAYS}d)" section, list every cell that clears the sample-size threshold. Use format: • `tool` × `category` — Brier `X.XXXX` (n=X, Current {ROLLING_WINDOW_DAYS}d), DirAcc X%, Always-majority X%, DA lift `±X.XXXX`. If DA lift is ≤ 0 say " — no lift over always-majority" inline so the reader isn't misled by a low Brier on a homogeneous-outcome cell. Never cite rows from the "below n=X threshold omitted" list. FALLBACK: if fewer than 2 rows clear the threshold, write exactly "insufficient tool × category data" as the only bullet in this section.
@@ -98,14 +121,73 @@ Rules:
 _VALID_PLATFORM_LABELS: frozenset[str] = frozenset(PLATFORM_LABELS.values())
 
 
-def _build_system_prompt(platform_label: str) -> str:
-    """Fill in the platform label on the system prompt template.
+def _count_eligible_tools(report_text: str) -> int:
+    """Count tools in the Tool Historical Comparison table that pass the eligibility floor.
 
-    :param platform_label: deployment name to reference throughout the
-        summary. Must match one of the labels defined in
-        ``benchmark.analyze.PLATFORM_LABELS`` so a typo at the workflow
-        level (e.g. ``--platform-label Omenstrap``) surfaces loudly instead
-        of reaching the LLM.
+    A row is eligible when its Current-window n is at least
+    ``MIN_SAMPLE_SIZE`` and the tool name carries no ⚠ flag from
+    ``_sample_label`` (``⚠ low sample`` or ``⚠ all malformed``).
+
+    :param report_text: full markdown report for one platform.
+    :return: count of eligible rows; ``0`` when the section is absent.
+    """
+    block_match = re.search(
+        r"^## Tool Historical Comparison\n(.*?)^## ",
+        report_text,
+        re.S | re.M,
+    )
+    if block_match is None:
+        return 0
+
+    eligible = 0
+    for line in block_match.group(1).splitlines():
+        if not line.startswith("| **"):
+            continue
+        if "⚠" in line:
+            continue
+        n_match = re.search(r"\(n=(\d+)\)", line)
+        if n_match and int(n_match.group(1)) >= MIN_SAMPLE_SIZE:
+            eligible += 1
+    return eligible
+
+
+def _compute_top_k(eligible_count: int) -> int:
+    """Return the per-side bullet count for the Top/Worst split.
+
+    Constraint: Top K and Worst K must be disjoint, so ``K + K < N``,
+    i.e. ``K <= floor((N - 1) / 2)``. Capped at 3 so the message stays
+    scannable on large deployments.
+
+    A return of ``0`` is the "render a single ranked list" signal —
+    used when ``N`` is too small to support a non-overlapping split
+    (``N`` is 0, 1, or 2).
+
+    :param eligible_count: number of tools that clear the eligibility
+        floor in the Tool Historical Comparison table.
+    :return: ``K`` for the Top/Worst split, or ``0`` to switch to a
+        combined "Tool performance" listing.
+    """
+    if eligible_count <= 2:
+        return 0
+    return min(3, (eligible_count - 1) // 2)
+
+
+def _build_system_prompt(platform_label: str, eligible_count: int) -> str:
+    """Assemble the system prompt with the right tool-ranking block.
+
+    The ranking block dispatches on ``eligible_count`` so the LLM
+    only ever sees one section convention per request:
+
+    - ``0`` eligible tools → placeholder bullet under ``*Tool performance:*``
+    - ``1-2`` eligible → all eligible rows under ``*Tool performance:*``
+    - ``3+`` eligible → ``*Top tools:*`` / ``*Worst tools:*`` with K bullets
+      each, where K = ``min(3, floor((N-1)/2))``
+
+    :param platform_label: deployment name to thread into the prompt.
+        Must be one of ``benchmark.analyze.PLATFORM_LABELS`` values.
+    :param eligible_count: number of tools that clear the eligibility
+        floor in the markdown report's Tool Historical Comparison table.
+        Drives the ranking-block dispatch.
     :return: fully formatted system prompt string.
     :raises ValueError: when ``platform_label`` is empty or unknown.
     """
@@ -116,7 +198,17 @@ def _build_system_prompt(platform_label: str) -> str:
             f"platform_label must be one of {sorted(_VALID_PLATFORM_LABELS)},"
             f" got {platform_label!r}"
         )
-    return SUMMARY_SYSTEM_PROMPT_TEMPLATE.format(platform_label=platform_label)
+
+    top_k = _compute_top_k(eligible_count)
+    if eligible_count == 0:
+        ranking_block = _PROMPT_RANKING_NONE
+    elif top_k == 0:
+        ranking_block = _PROMPT_RANKING_ALL
+    else:
+        ranking_block = _prompt_ranking_split(top_k)
+
+    template = "\n\n".join([_PROMPT_HEADER, ranking_block, _PROMPT_FOOTER])
+    return template.format(platform_label=platform_label)
 
 
 MODEL = "gpt-4.1-mini"
@@ -156,13 +248,14 @@ def summarize_report(report_text: str, api_key: str, platform_label: str) -> str
     user_content = report_text
     if ownership:
         user_content = f"{ownership}\n\n{report_text}"
+    eligible_count = _count_eligible_tools(report_text)
     payload = json.dumps(
         {
             "model": MODEL,
             "messages": [
                 {
                     "role": "system",
-                    "content": _build_system_prompt(platform_label),
+                    "content": _build_system_prompt(platform_label, eligible_count),
                 },
                 {"role": "user", "content": user_content},
             ],

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -31,6 +31,7 @@ from benchmark.analyze import (
     ROLLING_WINDOW_DAYS,
     VERSION_DELTA_LOW_SAMPLE_STRICT,
 )
+from benchmark.scorer import MIN_SAMPLE_SIZE
 from benchmark.tools import TOOL_REGISTRY
 
 log = logging.getLogger(__name__)
@@ -40,13 +41,17 @@ Summarize this Olas Predict benchmark report for the *{{platform_label}}* deploy
 
 *Summary:* 2-3 sentence high-level takeaway for {{platform_label}}. Lead with the Current-{ROLLING_WINDOW_DAYS}d platform Brier (from the "Platform Snapshot" section). Then name the direction of change: "Δ vs All-Time" from the "Platform Historical Comparison" row for Brier, and "Δ vs Prev {ROLLING_WINDOW_DAYS}d" from the same row. If either delta shows `insufficient data`, say so plainly instead of guessing.
 
+*Eligibility for Top tools / Worst tools / Tool performance bullets:* a row is eligible only if its Current {ROLLING_WINDOW_DAYS}d n is at least {MIN_SAMPLE_SIZE} AND the row carries no ⚠ low sample / ⚠ all malformed flag. Apply this filter BEFORE picking ranks — never let a flagged or below-floor row reach the top or the bottom of the list.
+
+SINGLE-TOOL FALLBACK: if exactly one tool in the "Tool Historical Comparison" table is eligible, render a single `*Tool performance:*` bullet for that tool using the same format as the Top/Worst bullets, and skip both `*Top tools:*` and `*Worst tools:*` sections entirely. If zero tools are eligible, write `*Tool performance:*` with the bullet `_no eligible tools — every row is below n={MIN_SAMPLE_SIZE} or flagged_` and skip Top/Worst.
+
 *Top tools:*
 • `tool-name` — Current {ROLLING_WINDOW_DAYS}d Brier `X.XXXX` (n=X), Δ vs All-Time `±X.XXXX direction`, Δ vs Prev {ROLLING_WINDOW_DAYS}d `±X.XXXX direction`
-(list top 3 from the "Tool Historical Comparison" table, sorted by Current {ROLLING_WINDOW_DAYS}d Brier ascending. Use the exact delta strings from that table; if a delta is `insufficient data` or `no prev window`, write those words verbatim — never invent a number.)
+(list top 3 eligible rows from the "Tool Historical Comparison" table, sorted by Current {ROLLING_WINDOW_DAYS}d Brier ascending. Use the exact delta strings from that table; if a delta is `insufficient data` or `no prev window`, write those words verbatim — never invent a number.)
 
 *Worst tools:*
 • `tool-name` — Current {ROLLING_WINDOW_DAYS}d Brier `X.XXXX` (n=X), Δ vs All-Time `±X.XXXX direction`, Δ vs Prev {ROLLING_WINDOW_DAYS}d `±X.XXXX direction`
-(list bottom 3 from the same table, ignore rows with ⚠ low sample / all malformed flags.)
+(list bottom 3 eligible rows from the same table, sorted by Current {ROLLING_WINDOW_DAYS}d Brier descending.)
 
 *Deployment status:* if the report has a "Tool Deployment Status ({{platform_label}})" section, list one line per deployment with its count of active tools only (do NOT enumerate the tool names — the full report has them and the Slack message stays readable). Skip deployments marked `⚠️ unavailable` after noting briefly that their config fetch failed.
 

--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -194,7 +194,8 @@ def build_output_row(
         "resolved_at": dataset_row.get("resolved_at"),
         "latency_s": run_result["latency_s"],
         "prediction_lead_time_days": None,
-        "category": dataset_row.get("category") or classify_category(question_text),
+        "category": dataset_row.get("category")
+        or classify_category(question_text, dataset_row.get("platform")),
         "match_confidence": 1.0,
     }
 

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -2761,6 +2761,44 @@ class TestActiveToolsForPlatform:
         assert "tool-a" not in active
         assert "tool-b" in active and "tool-c" in active
 
+    def test_benchmarked_universe_unions_rolling_and_alltime(self) -> None:
+        """Tool with rolling rows but no all-time entry is still considered.
+
+        ``section_tool_comparison`` builds its row universe from the union
+        of rolling + all-time. The active set must use the same universe
+        so a freshly-deployed tool whose all-time aggregate hasn't caught
+        up yet (or whose all-time write failed mid-run) is not silently
+        filtered out.
+        """
+        all_time = {"by_tool": {"tool-a": {}, "tool-b": {}}}
+        rolling = {"by_tool": {"tool-a": {}, "tool-b": {}, "tool-new": {}}}
+        disabled: dict[str, list[str] | None] = {
+            "omenstrat Pearl": [],
+            "omenstrat QS": [],
+            "polystrat Pearl": None,
+        }
+        active = _active_tools_for_platform(
+            disabled, "omen", all_time, rolling_scores=rolling
+        )
+        assert active is not None
+        assert "tool-new" in active
+
+    def test_rolling_scores_optional_preserves_alltime_only_behaviour(self) -> None:
+        """Omitting ``rolling_scores`` falls back to the all-time-only universe.
+
+        Backward-compatible default — callers that haven't been updated
+        yet still produce the same active set as before.
+        """
+        all_time = {"by_tool": {"tool-a": {}, "tool-b": {}}}
+        disabled: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool-a"],
+            "omenstrat QS": [],
+            "polystrat Pearl": None,
+        }
+        active = _active_tools_for_platform(disabled, "omen", all_time)
+        # tool-a is disabled on Pearl but enabled on QS → in active set
+        assert active == frozenset({"tool-a", "tool-b"})
+
 
 class TestFilterByActive:
     """``_filter_by_active`` drops non-deployed tools from ranked iterations."""

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -30,9 +30,11 @@ from benchmark.analyze import (
     POLYMARKET_ACTIVE_CATEGORIES,
     ROLLING_WINDOW_DAYS,
     SAMPLE_SIZE_WARNING,
+    _active_tools_for_platform,
     _always_majority,
     _da_lift,
     _delta_cell,
+    _filter_by_active,
     _parse_tvm_key,
     _sample_label,
     generate_fleet_report,
@@ -958,10 +960,10 @@ class TestGenerateReport:
 
         assert "# Benchmark Report (Omenstrat) — " in report
         assert "## Metric References" in report
-        assert "## Platform Snapshot (Current 3d)" in report
+        assert f"## Platform Snapshot (Current {ROLLING_WINDOW_DAYS}d)" in report
         assert "## Platform Historical Comparison" in report
         assert "## Tool Historical Comparison" in report
-        assert "## Tool \u00d7 Category (Current 3d)" in report
+        assert f"## Tool \u00d7 Category (Current {ROLLING_WINDOW_DAYS}d)" in report
         assert "## Tool \u00d7 Category Historical Comparison" in report
         assert "## Diagnostics Historical Comparison" in report
         assert "## Reliability & Parse Quality (Current vs All-Time)" in report
@@ -975,7 +977,7 @@ class TestGenerateReport:
         # single-scope point-in-time sections. Their data is now folded
         # into the three-window comparison tables.
         assert "## Since Last Report" not in report
-        assert "## Last 3 Days" not in report
+        assert f"## Last {ROLLING_WINDOW_DAYS} Days" not in report
         assert "## Overall" not in report
         assert "## Worst Predictions" not in report
         assert "## Best Predictions" not in report
@@ -989,7 +991,9 @@ class TestGenerateReport:
         report = generate_report(s, [], platform="omen", disabled_tools={})
         assert "# Benchmark Report (Omenstrat) — " in report
         # With no rolling_scores, the snapshot banner explains the gap.
-        assert "Scores for the last 3 days are unavailable" in report
+        assert (
+            f"Scores for the last {ROLLING_WINDOW_DAYS} days are unavailable" in report
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1404,7 +1408,7 @@ class TestGenerateReportTournamentToggle:
             disabled_tools={},
         )
         assert "Tool × Version × Mode (All-Time)" in report
-        assert "Tool × Version × Mode (Last 3 Days)" in report
+        assert f"Tool × Version × Mode (Last {ROLLING_WINDOW_DAYS} Days)" in report
 
 
 # ---------------------------------------------------------------------------
@@ -1582,7 +1586,7 @@ class TestGenerateReportWithTournamentFiles:
         # Tool × Version × Mode, not a duplicated " — Tournament" ranking.
         assert "## Overall" not in report
         assert "## Tool × Version × Mode (All-Time)" in report
-        assert "## Tool × Version × Mode (Last 3 Days)" in report
+        assert f"## Tool × Version × Mode (Last {ROLLING_WINDOW_DAYS} Days)" in report
 
     def test_empty_rolling_tournament_does_not_crash(self) -> None:
         """Rolling tournament input with zero rows renders cleanly.
@@ -1917,9 +1921,9 @@ class TestSectionMetricReference:
     def test_names_all_three_windows(self) -> None:
         """Legend explicitly names current, all-time, and prev-rolling windows."""
         rendered = section_metric_reference()
-        assert "Current 3d" in rendered
+        assert f"Current {ROLLING_WINDOW_DAYS}d" in rendered
         assert "All-Time" in rendered
-        assert "Prev 3d" in rendered
+        assert f"Prev {ROLLING_WINDOW_DAYS}d" in rendered
 
     def test_documents_sample_size_guardrail(self) -> None:
         """Legend spells out the MIN_SAMPLE_SIZE delta-suppression rule."""
@@ -1987,8 +1991,8 @@ class TestGenerateReportRollingBanner:
         for heading in (
             "## Platform Historical Comparison",
             "## Tool Historical Comparison",
-            "## Tool × Category (Current 3d)",
-            "## Tool × Category Diagnostics (Current 3d)",
+            f"## Tool × Category (Current {ROLLING_WINDOW_DAYS}d)",
+            f"## Tool × Category Diagnostics (Current {ROLLING_WINDOW_DAYS}d)",
             "## Tool × Category Historical Comparison",
             "## Diagnostics Historical Comparison",
             "## Reliability & Parse Quality (Current vs All-Time)",
@@ -2297,7 +2301,7 @@ class TestGenerateFleetReport:
         # No rolling window content, no deployment status, no weak spots —
         # those live in the per-platform reports.
         assert "Tool Deployment Status" not in report
-        assert "(Last 3 Days)" not in report
+        assert f"(Last {ROLLING_WINDOW_DAYS} Days)" not in report
         assert "Weak Spots" not in report
 
     def test_trend_renders_without_disclaimer(self) -> None:
@@ -2456,11 +2460,11 @@ class TestSectionPlatformComparison:
         rendered = section_platform_comparison(
             self._rolling(), self._alltime(), self._prev()
         )
-        assert "Current 3d" in rendered
+        assert f"Current {ROLLING_WINDOW_DAYS}d" in rendered
         assert "All-Time" in rendered
-        assert "Prev 3d" in rendered
+        assert f"Prev {ROLLING_WINDOW_DAYS}d" in rendered
         assert "Δ vs All-Time" in rendered
-        assert "Δ vs Prev 3d" in rendered
+        assert f"Δ vs Prev {ROLLING_WINDOW_DAYS}d" in rendered
 
     def test_no_prev_window_when_prev_is_none(self) -> None:
         """Prev column renders 'no prev window' placeholder instead of a delta."""
@@ -2687,3 +2691,231 @@ class TestSectionReliabilityComparison:
         }
         rendered = section_reliability_comparison(rolling, alltime)
         assert "insufficient data" in rendered
+
+
+class TestActiveToolsForPlatform:
+    """``_active_tools_for_platform`` builds the per-platform deployed set."""
+
+    _SCORES: dict[str, dict[str, dict[str, Any]]] = {
+        "by_tool": {"tool-a": {}, "tool-b": {}, "tool-c": {}}
+    }
+
+    def test_full_failure_returns_none(self) -> None:
+        """All deployments None -> caller falls back to "show all" with a notice."""
+        disabled: dict[str, list[str] | None] = {
+            "omenstrat Pearl": None,
+            "omenstrat QS": None,
+            "polystrat Pearl": None,
+        }
+        assert _active_tools_for_platform(disabled, "omen", self._SCORES) is None
+
+    def test_partial_failure_uses_what_is_available(self) -> None:
+        """One omen deployment fails, the other still drives the active set."""
+        disabled: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool-a"],
+            "omenstrat QS": None,
+            "polystrat Pearl": None,
+        }
+        active = _active_tools_for_platform(disabled, "omen", self._SCORES)
+        # tool-a is disabled on Pearl and QS is unknown; union of (benchmarked - disabled)
+        # over successful deployments is {tool-b, tool-c}.
+        assert active == frozenset({"tool-b", "tool-c"})
+
+    def test_polystrat_failure_returns_none(self) -> None:
+        """Polystrat has one deployment — its failure means full failure."""
+        disabled: dict[str, list[str] | None] = {
+            "omenstrat Pearl": [],
+            "omenstrat QS": [],
+            "polystrat Pearl": None,
+        }
+        assert _active_tools_for_platform(disabled, "polymarket", self._SCORES) is None
+
+    def test_union_across_deployments(self) -> None:
+        """A tool active on at least one deployment is in the active set."""
+        disabled: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool-a"],
+            "omenstrat QS": ["tool-b"],
+            "polystrat Pearl": None,
+        }
+        active = _active_tools_for_platform(disabled, "omen", self._SCORES)
+        # Pearl excludes tool-a (so {tool-b, tool-c}); QS excludes tool-b (so
+        # {tool-a, tool-c}); union = {tool-a, tool-b, tool-c}.
+        assert active == frozenset({"tool-a", "tool-b", "tool-c"})
+
+    def test_empty_disabled_returns_none(self) -> None:
+        """Empty input is the test-only opt-out — caller skips both filter and warning."""
+        assert _active_tools_for_platform({}, "omen", self._SCORES) is None
+        assert _active_tools_for_platform(None, "omen", self._SCORES) is None
+
+    def test_underscore_hyphen_normalization(self) -> None:
+        """Disabled list with underscores excludes the hyphenated benchmark name."""
+        disabled: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool_a"],  # underscore variant of "tool-a"
+            "omenstrat QS": ["tool_a"],
+            "polystrat Pearl": None,
+        }
+        active = _active_tools_for_platform(disabled, "omen", self._SCORES)
+        # Both deployments disable tool-a (underscore variant), so it should
+        # NOT appear in the active set.
+        assert active is not None
+        assert "tool-a" not in active
+        assert "tool-b" in active and "tool-c" in active
+
+
+class TestFilterByActive:
+    """``_filter_by_active`` drops non-deployed tools from ranked iterations."""
+
+    def test_none_active_disables_filter(self) -> None:
+        """``active_tools=None`` is the deployment-config-fallback path: no filter."""
+        items: list[tuple[str, Any]] = [("tool-a", {}), ("tool-b", {})]
+        assert _filter_by_active(items, None) == items
+
+    def test_simple_key_filter(self) -> None:
+        """Plain tool-name keys are filtered by membership."""
+        items: list[tuple[str, Any]] = [("tool-a", {}), ("tool-b", {}), ("tool-c", {})]
+        out = _filter_by_active(items, frozenset({"tool-a", "tool-c"}))
+        assert [k for k, _ in out] == ["tool-a", "tool-c"]
+
+    def test_composite_key_filter(self) -> None:
+        """``by_tool_category`` keys filter on the tool half (before separator)."""
+        items: list[tuple[str, Any]] = [
+            ("tool-a | politics", {}),
+            ("tool-b | politics", {}),
+            ("tool-a | finance", {}),
+        ]
+        out = _filter_by_active(
+            items, frozenset({"tool-a"}), composite_key_separator=" | "
+        )
+        assert [k for k, _ in out] == ["tool-a | politics", "tool-a | finance"]
+
+
+class TestActiveToolsFilterInSections:
+    """End-to-end: each comparison section drops tools not in active_tools."""
+
+    def _scores(self, brier: float, n: int) -> dict[str, Any]:
+        return {
+            "valid_n": n,
+            "n": n,
+            "brier": brier,
+            "reliability": 0.95,
+            "directional_accuracy": 0.7,
+        }
+
+    def _by_tool(self) -> dict[str, dict[str, Any]]:
+        return {
+            "tool-a": self._scores(0.20, 200),
+            "tool-b": self._scores(0.30, 200),
+            "tool-historical": self._scores(0.15, 200),
+        }
+
+    def test_tool_comparison_drops_non_active(self) -> None:
+        """Tool Historical Comparison hides tool-historical when filter is active."""
+        rolling = {"by_tool": self._by_tool()}
+        alltime = {"by_tool": self._by_tool()}
+        rendered = section_tool_comparison(
+            rolling, alltime, None, active_tools=frozenset({"tool-a", "tool-b"})
+        )
+        assert "**tool-a**" in rendered
+        assert "**tool-b**" in rendered
+        assert "**tool-historical**" not in rendered
+
+    def test_tool_comparison_no_filter_when_none(self) -> None:
+        """``active_tools=None`` preserves the legacy "all tools" rendering."""
+        rolling = {"by_tool": self._by_tool()}
+        alltime = {"by_tool": self._by_tool()}
+        rendered = section_tool_comparison(rolling, alltime, None, active_tools=None)
+        assert "**tool-historical**" in rendered
+
+    def test_tool_category_drops_non_active_cells(self) -> None:
+        """Tool × Category snapshot hides cells whose tool is not in active set."""
+        scores = {
+            "by_tool_category": {
+                "tool-a | politics": self._scores(0.20, 200),
+                "tool-historical | politics": self._scores(0.15, 200),
+            }
+        }
+        rendered = section_tool_category(scores, active_tools=frozenset({"tool-a"}))
+        assert "tool-a | politics" in rendered or (
+            "tool-a" in rendered and "politics" in rendered
+        )
+        assert "tool-historical" not in rendered
+
+    def test_diagnostics_comparison_drops_non_active(self) -> None:
+        """Diagnostics Historical Comparison hides non-deployed tools."""
+        rolling = {
+            "by_tool": {
+                "tool-a": {
+                    "edge": 0.05,
+                    "edge_n": 200,
+                    "log_loss": 0.5,
+                    "valid_n": 200,
+                },
+                "tool-historical": {
+                    "edge": 0.10,
+                    "edge_n": 200,
+                    "log_loss": 0.4,
+                    "valid_n": 200,
+                },
+            }
+        }
+        alltime = rolling
+        rendered = section_diagnostics_comparison(
+            rolling, alltime, None, active_tools=frozenset({"tool-a"})
+        )
+        assert "**tool-a**" in rendered
+        assert "**tool-historical**" not in rendered
+
+    def test_reliability_comparison_drops_non_active(self) -> None:
+        """Reliability & Parse Quality table drops non-deployed tools."""
+        rolling = {
+            "by_tool": {
+                "tool-a": {"reliability": 0.95, "n": 200},
+                "tool-historical": {"reliability": 0.80, "n": 200},
+            },
+            "parse_breakdown": {
+                "tool-a": {"valid": 190, "malformed": 10},
+                "tool-historical": {"valid": 160, "malformed": 40},
+            },
+        }
+        alltime = rolling
+        rendered = section_reliability_comparison(
+            rolling, alltime, active_tools=frozenset({"tool-a"})
+        )
+        assert "**tool-a**" in rendered
+        assert "**tool-historical**" not in rendered
+
+
+class TestGenerateReportDeploymentConfigUnavailable:
+    """Full deployment-fetch failure renders a notice + falls back to all tools."""
+
+    def test_notice_rendered_when_all_deployments_fail(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the live fetch returns all-None, a ⚠ notice prefixes the report."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark import analyze
+
+        monkeypatch.setattr(
+            analyze,
+            "fetch_disabled_tools",
+            lambda: {
+                "omenstrat Pearl": None,
+                "omenstrat QS": None,
+                "polystrat Pearl": None,
+            },
+        )
+        scores = {
+            "by_tool": {"tool-a": {"brier": 0.20, "n": 100, "valid_n": 100}},
+            "by_tool_category": {},
+        }
+        report = generate_report(scores, [], platform="omen")
+        assert "Deployment config unavailable" in report
+
+    def test_no_notice_for_explicit_test_optout(self) -> None:
+        """``disabled_tools={}`` is the unit-test opt-out; no notice rendered."""
+        scores = {
+            "by_tool": {"tool-a": {"brier": 0.20, "n": 100, "valid_n": 100}},
+            "by_tool_category": {},
+        }
+        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        assert "Deployment config unavailable" not in report

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -2770,8 +2770,10 @@ class TestActiveToolsForPlatform:
         up yet (or whose all-time write failed mid-run) is not silently
         filtered out.
         """
-        all_time = {"by_tool": {"tool-a": {}, "tool-b": {}}}
-        rolling = {"by_tool": {"tool-a": {}, "tool-b": {}, "tool-new": {}}}
+        all_time: dict[str, Any] = {"by_tool": {"tool-a": {}, "tool-b": {}}}
+        rolling: dict[str, Any] = {
+            "by_tool": {"tool-a": {}, "tool-b": {}, "tool-new": {}}
+        }
         disabled: dict[str, list[str] | None] = {
             "omenstrat Pearl": [],
             "omenstrat QS": [],
@@ -2789,7 +2791,7 @@ class TestActiveToolsForPlatform:
         Backward-compatible default — callers that haven't been updated
         yet still produce the same active set as before.
         """
-        all_time = {"by_tool": {"tool-a": {}, "tool-b": {}}}
+        all_time: dict[str, Any] = {"by_tool": {"tool-a": {}, "tool-b": {}}}
         disabled: dict[str, list[str] | None] = {
             "omenstrat Pearl": ["tool-a"],
             "omenstrat QS": [],

--- a/benchmark/tests/test_categories.py
+++ b/benchmark/tests/test_categories.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Tests for benchmark/categories.py — shared per-platform category taxonomies."""
+
+from benchmark.categories import (
+    ACTIVE_CATEGORIES,
+    OMEN_CATEGORIES,
+    PLATFORM_ALLOWED_CATEGORIES,
+    POLYMARKET_ACTIVE_CATEGORIES,
+)
+
+
+class TestCategoryTaxonomies:
+    """Frozen-set taxonomies mirror the upstream platforms' own lists."""
+
+    def test_omen_categories_immutable(self) -> None:
+        """OMEN_CATEGORIES is a frozenset — accidental mutation is rejected."""
+        assert isinstance(OMEN_CATEGORIES, frozenset)
+
+    def test_polymarket_categories_immutable(self) -> None:
+        """POLYMARKET_ACTIVE_CATEGORIES is a frozenset."""
+        assert isinstance(POLYMARKET_ACTIVE_CATEGORIES, frozenset)
+
+    def test_active_is_union(self) -> None:
+        """ACTIVE_CATEGORIES is the union — used by fleet-level filters."""
+        assert ACTIVE_CATEGORIES == OMEN_CATEGORIES | POLYMARKET_ACTIVE_CATEGORIES
+
+    def test_polymarket_is_subset_of_omen(self) -> None:
+        """Every polystrat tag is also a market-creator topic.
+
+        The trader's tag list ``POLYMARKET_CATEGORY_TAGS`` is a strict
+        subset of market-creator's ``DEFAULT_TOPICS`` today; this test
+        catches an accidental drift introduction (e.g. adding a
+        polymarket-only tag without matching coverage on the omen side).
+        """
+        assert POLYMARKET_ACTIVE_CATEGORIES.issubset(OMEN_CATEGORIES)
+
+
+class TestPlatformAllowedCategories:
+    """``PLATFORM_ALLOWED_CATEGORIES`` exposes the platform→set mapping."""
+
+    def test_omen_key_maps_to_omen_set(self) -> None:
+        """The mapping is keyed by scorer platform string."""
+        assert PLATFORM_ALLOWED_CATEGORIES["omen"] is OMEN_CATEGORIES
+
+    def test_polymarket_key_maps_to_polymarket_set(self) -> None:
+        """The mapping is keyed by scorer platform string."""
+        assert PLATFORM_ALLOWED_CATEGORIES["polymarket"] is POLYMARKET_ACTIVE_CATEGORIES
+
+    def test_only_known_platforms(self) -> None:
+        """Mapping contains exactly omen and polymarket — guards typos."""
+        assert set(PLATFORM_ALLOWED_CATEGORIES.keys()) == {"omen", "polymarket"}
+
+
+class TestAnalyzeReExports:
+    """analyze.py re-exports the constants for backward compatibility."""
+
+    def test_omen_constant_reexported(self) -> None:
+        """``analyze.OMEN_CATEGORIES`` is the same object as in ``categories``."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark import analyze, categories
+
+        assert analyze.OMEN_CATEGORIES is categories.OMEN_CATEGORIES
+
+    def test_polymarket_constant_reexported(self) -> None:
+        """``analyze.POLYMARKET_ACTIVE_CATEGORIES`` is the same object as in ``categories``."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark import analyze, categories
+
+        assert (
+            analyze.POLYMARKET_ACTIVE_CATEGORIES
+            is categories.POLYMARKET_ACTIVE_CATEGORIES
+        )
+
+    def test_active_constant_reexported(self) -> None:
+        """``analyze.ACTIVE_CATEGORIES`` is the same object as in ``categories``."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark import analyze, categories
+
+        assert analyze.ACTIVE_CATEGORIES is categories.ACTIVE_CATEGORIES

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -343,6 +343,86 @@ class TestClassifyCategory:
         assert classify_category("WILL BITCOIN HIT $100K?") == "finance"
 
 
+class TestClassifyCategoryPlatformAware:
+    """Platform-aware filter routes off-list categories to ``other``.
+
+    When ``platform`` is provided, the keyword-classified category must be
+    in that platform's upstream taxonomy (``OMEN_CATEGORIES`` for omen,
+    ``POLYMARKET_ACTIVE_CATEGORIES`` for polymarket); otherwise the row
+    drops to ``"other"`` so per-platform reports never advertise a
+    category the platform doesn't actually trade.
+    """
+
+    def test_travel_question_omen_buckets_as_other(self) -> None:
+        """``travel`` is in CATEGORY_KEYWORDS but NOT in OMEN_CATEGORIES.
+
+        Market-creator never emits ``travel``; a keyword leak (e.g. an
+        omen question mentioning a flight or vacation) must land in
+        ``other`` instead.
+        """
+        assert (
+            classify_category("Will the airline launch a new flight route?", "omen")
+            == "other"
+        )
+
+    def test_curiosities_question_polymarket_buckets_as_other(self) -> None:
+        """``curiosities`` is not in trader's POLYMARKET_CATEGORY_TAGS."""
+        assert (
+            classify_category("Will UFO sightings double this year?", "polymarket")
+            == "other"
+        )
+
+    def test_legitimate_finance_passes_through_for_polymarket(self) -> None:
+        """Categories already in the platform's allowed set pass unchanged."""
+        assert (
+            classify_category("Will Tesla stock close above 380?", "polymarket")
+            == "business"
+        )
+        assert (
+            classify_category(
+                "Will the S&P 500 close above 7000 on Friday?", "polymarket"
+            )
+            == "finance"
+        )
+
+    def test_legitimate_omen_categories_pass_through(self) -> None:
+        """Omen questions hitting OMEN_CATEGORIES keep their bucket."""
+        assert (
+            classify_category("Will the president win the election?", "omen")
+            == "politics"
+        )
+        assert classify_category("Will the hurricane hit Florida?", "omen") == "weather"
+
+    def test_no_platform_preserves_legacy_behavior(self) -> None:
+        """``platform=None`` (default) keeps the historical, unfiltered behavior.
+
+        Used by callers that don't yet know the platform. Backward-
+        compatible — a row whose keyword matches ``travel`` still gets
+        ``travel`` back.
+        """
+        assert (
+            classify_category("Will the airline launch a new flight route?") == "travel"
+        )
+
+    def test_unknown_platform_disables_filter(self) -> None:
+        """A platform key not in ``PLATFORM_ALLOWED_CATEGORIES`` disables the filter.
+
+        Defensive: a future platform name shouldn't silently drop every
+        row to ``other`` before its allowed set is registered.
+        """
+        assert (
+            classify_category(
+                "Will the airline launch a new flight route?", "future-chain"
+            )
+            == "travel"
+        )
+
+    def test_no_keyword_match_returns_other_regardless_of_platform(self) -> None:
+        """A question with no keyword match is always ``other``."""
+        assert classify_category("Will quux?", "omen") == "other"
+        assert classify_category("Will quux?", "polymarket") == "other"
+
+
 # ---------------------------------------------------------------------------
 # _parse_request_context
 # ---------------------------------------------------------------------------

--- a/benchmark/tests/test_notify_slack.py
+++ b/benchmark/tests/test_notify_slack.py
@@ -319,6 +319,25 @@ class TestCountEligibleTools:
         )
         assert _count_eligible_tools(report) == 3
 
+    def test_counts_when_section_is_last_in_report(self) -> None:
+        r"""Block parser also terminates at end-of-report.
+
+        Without the ``\Z`` anchor, the regex needs another ``^## ``
+        heading to close the block. If a future analyze.py reorder ever
+        lands Tool Historical Comparison as the final section, the
+        helper would silently return 0 and every report would render
+        the "no eligible tools" placeholder. Pin the contract.
+        """
+        report = (
+            "## Tool Historical Comparison\n"
+            "\n"
+            "| Tool | Current 7d Brier | All-Time | Δ |\n"
+            "|------|------------------|----------|---|\n"
+            "| **a** | 0.1 (n=73) | x | x |\n"
+            "| **b** | 0.2 (n=79) | x | x |\n"
+        )
+        assert _count_eligible_tools(report) == 2
+
 
 class TestRankingBlockDispatch:
     """The prompt only ever exposes ONE section convention per request.

--- a/benchmark/tests/test_notify_slack.py
+++ b/benchmark/tests/test_notify_slack.py
@@ -24,10 +24,19 @@ import pytest
 
 from benchmark.analyze import PLATFORM_LABELS, ROLLING_WINDOW_DAYS
 from benchmark.notify_slack import (
-    SUMMARY_SYSTEM_PROMPT_TEMPLATE,
     _build_system_prompt,
+    _compute_top_k,
+    _count_eligible_tools,
     _infer_platform_label,
 )
+from benchmark.scorer import MIN_SAMPLE_SIZE
+
+
+# A "headline" prompt used by structural tests that don't care about the
+# ranking-block dispatch — eligible_count=5 puts the dispatcher in the
+# Top-K + Worst-K branch with K = 2, exercising the most common shape.
+def _default_prompt(label: str = "Omenstrat") -> str:
+    return _build_system_prompt(label, eligible_count=5)
 
 
 class TestBuildSystemPrompt:
@@ -35,74 +44,71 @@ class TestBuildSystemPrompt:
 
     def test_omenstrat_label_appears_in_prompt(self) -> None:
         """Omenstrat label renders into the Summary / Category / Actions sections."""
-        prompt = _build_system_prompt("Omenstrat")
+        prompt = _default_prompt("Omenstrat")
         assert "Omenstrat" in prompt
-        # Spot-check the sentences that should carry the label so a future
-        # template refactor doesn't silently drop deployment scoping.
         assert "for the *Omenstrat* deployment" in prompt
         assert "for Omenstrat" in prompt
 
     def test_polystrat_label_appears_in_prompt(self) -> None:
         """Polystrat label renders symmetrically to Omenstrat."""
-        prompt = _build_system_prompt("Polystrat")
+        prompt = _default_prompt("Polystrat")
         assert "Polystrat" in prompt
         assert "for the *Polystrat* deployment" in prompt
 
     def test_no_cross_platform_leakage(self) -> None:
         """Omenstrat prompt must not reference Polystrat and vice versa."""
-        omen = _build_system_prompt("Omenstrat")
+        omen = _default_prompt("Omenstrat")
         assert "Polystrat" not in omen
 
-        poly = _build_system_prompt("Polystrat")
+        poly = _default_prompt("Polystrat")
         assert "Omenstrat" not in poly
 
     def test_template_no_longer_instructs_platform_comparison(self) -> None:
         """Single-platform summaries must not ask the LLM to 'list all platforms'.
 
-        The legacy fleet-wide prompt had ``*Platform performance:* list all
-        platforms`` and ``*Edge by difficulty:* ... per platform`` blocks.
-        Both are meaningless in per-platform mode and must not bleed into
-        the new template.
+        The legacy fleet-wide prompt had ``*Platform performance:*`` and
+        ``*Edge by difficulty:* ... per platform`` blocks. Both are
+        meaningless in per-platform mode and must not bleed into the
+        per-platform template regardless of which ranking-block branch
+        the dispatcher lands in.
         """
-        # Check the raw template so the assertion is independent of any
-        # particular platform substitution.
-        assert "list all platforms" not in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "one line per platform" not in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "Platform × Difficulty" not in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        # "*Platform performance:*" was a dedicated bullet in the old prompt.
-        assert "*Platform performance:*" not in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        for n in (0, 1, 3, 5, 10):
+            prompt = _build_system_prompt("Omenstrat", eligible_count=n)
+            assert "list all platforms" not in prompt
+            assert "one line per platform" not in prompt
+            assert "Platform × Difficulty" not in prompt
+            assert "*Platform performance:*" not in prompt
 
     def test_template_still_carries_core_sections(self) -> None:
-        """Core single-platform sections remain wired up after the refactor."""
-        assert "*Summary:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "*Top tools:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "*Worst tools:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "*Tool × Category:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "*Tournament callouts:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "*Diagnostics:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "*Reliability:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "*Recommended actions:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        """Core single-platform footer sections remain wired up."""
+        prompt = _default_prompt()
+        for heading in (
+            "*Summary:*",
+            "*Tool × Category:*",
+            "*Tournament callouts:*",
+            "*Diagnostics:*",
+            "*Reliability:*",
+            "*Recommended actions:*",
+        ):
+            assert heading in prompt, f"missing: {heading}"
 
     def test_prompt_references_rolling_window_days_constant(self) -> None:
         """Prompt cites the current ROLLING_WINDOW_DAYS value in its window labels."""
-        assert f"Current {ROLLING_WINDOW_DAYS}d" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert f"Prev {ROLLING_WINDOW_DAYS}d" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        prompt = _default_prompt()
+        assert f"Current {ROLLING_WINDOW_DAYS}d" in prompt
+        assert f"Prev {ROLLING_WINDOW_DAYS}d" in prompt
 
     def test_prompt_drops_alltime_scope_instructions(self) -> None:
-        """Prompt no longer tells the LLM to cite all-time or cumulative figures.
-
-        Phase 2 drops the all-time point-in-time sections from the report, so
-        the summary must not instruct the LLM to reference them.
-        """
-        assert "Only mention all-time numbers for context" not in (
-            SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        )
+        """Prompt no longer tells the LLM to cite all-time or cumulative figures."""
+        prompt = _default_prompt()
+        assert "Only mention all-time numbers for context" not in prompt
         # The prompt still refers to "All-Time" as a window label, but not
         # as a bolt-on scope that the LLM should opportunistically mix in.
-        assert "deltas vs all-time" not in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        assert "deltas vs all-time" not in prompt
 
     def test_prompt_anchors_sections_to_comparison_heading_names(self) -> None:
         """Prompt points the LLM at the new three-window comparison headings."""
+        prompt = _default_prompt()
         for heading in (
             "Platform Snapshot",
             "Platform Historical Comparison",
@@ -112,44 +118,28 @@ class TestBuildSystemPrompt:
             "Diagnostics Historical Comparison",
             "Reliability & Parse Quality",
         ):
-            assert heading in SUMMARY_SYSTEM_PROMPT_TEMPLATE, f"missing: {heading}"
+            assert heading in prompt, f"missing: {heading}"
 
     def test_prompt_enforces_no_mixed_window_claims(self) -> None:
         """Every cited number must be paired with its window label."""
-        assert "Never mix windows" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        # Guardrail wording for the `insufficient data` / `no prev window`
-        # cells the comparison tables render when n is too small.
-        assert "insufficient data" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "no prev window" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        prompt = _default_prompt()
+        assert "Never mix windows" in prompt
+        assert "insufficient data" in prompt
+        assert "no prev window" in prompt
 
     def test_deployment_status_points_at_platform_scoped_section(self) -> None:
-        """Deployment status bullet anchors to the per-platform section heading.
-
-        Phase 3 partitioned Tool Deployment Status in analyze.py, so the
-        prompt no longer needs a lowercase-match filter — it simply names
-        the "Tool Deployment Status ({platform_label})" heading and tells
-        the LLM to summarize every deployment listed there.
-        """
-        assert (
-            '"Tool Deployment Status ({platform_label})"'
-            in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        )
-        assert "count of active tools only" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "do NOT enumerate the tool names" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "`⚠️ unavailable`" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        """Deployment status bullet anchors to the per-platform section heading."""
+        prompt = _default_prompt()
+        assert '"Tool Deployment Status (Omenstrat)"' in prompt
+        assert "count of active tools only" in prompt
+        assert "do NOT enumerate the tool names" in prompt
+        assert "`⚠️ unavailable`" in prompt
 
     def test_tool_category_prompt_lists_every_qualifying_cell(self) -> None:
-        """Tool × Category bullet instructs the LLM to list every qualifying cell.
-
-        Per-platform tables are small enough that exhaustively listing
-        cells that clear the sample-size threshold is preferable to
-        picking an editorial subset.
-        """
-        assert (
-            "list every cell that clears the sample-size threshold"
-            in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        )
-        assert "insufficient tool × category data" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        """Tool × Category bullet instructs the LLM to list every qualifying cell."""
+        prompt = _default_prompt()
+        assert "list every cell that clears the sample-size threshold" in prompt
+        assert "insufficient tool × category data" in prompt
 
 
 class TestInferPlatformLabel:
@@ -172,74 +162,201 @@ class TestInferPlatformLabel:
 class TestPromptRejectsUnformattedPlaceholder:
     """Guard against a missed ``{platform_label}`` replacement."""
 
-    def test_template_contains_placeholder(self) -> None:
-        """Template must include a ``{platform_label}`` placeholder."""
-        # Without the placeholder, _build_system_prompt becomes a no-op and
-        # the LLM loses deployment scoping silently.
-        assert "{platform_label}" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-
     def test_build_raises_on_empty_label(self) -> None:
         """Empty label is rejected — would render "for the ** deployment"."""
         with pytest.raises(ValueError, match="platform_label"):
-            _build_system_prompt("")
+            _build_system_prompt("", eligible_count=5)
 
     def test_build_raises_on_unknown_label(self) -> None:
-        """A label outside PLATFORM_LABELS is rejected before reaching the LLM.
-
-        Guards against a workflow-level typo like ``--platform-label Omenstrap``
-        silently producing a deployment-mislabeled summary.
-        """
+        """A label outside PLATFORM_LABELS is rejected before reaching the LLM."""
         with pytest.raises(ValueError, match="must be one of"):
-            _build_system_prompt("Omenstrap")
+            _build_system_prompt("Omenstrap", eligible_count=5)
 
     def test_labels_tracked_from_analyze(self) -> None:
-        """Every ``benchmark.analyze.PLATFORM_LABELS`` value is accepted.
-
-        Reusing the same import surface means a rename in analyze.py
-        (e.g. Omenstrat -> Omen Strat) doesn't drift the two modules out
-        of sync.
-        """
+        """Every ``benchmark.analyze.PLATFORM_LABELS`` value is accepted."""
         for label in PLATFORM_LABELS.values():
-            _build_system_prompt(label)
+            _build_system_prompt(label, eligible_count=5)
+
+    def test_no_unfilled_placeholder_in_rendered_prompt(self) -> None:
+        """Rendered prompt has no surviving ``{platform_label}`` after dispatch."""
+        for n in (0, 1, 3, 5, 10):
+            prompt = _build_system_prompt("Omenstrat", eligible_count=n)
+            assert "{platform_label}" not in prompt
 
 
-class TestTopToolsEligibilityFilter:
-    """Top tools must apply the same low-sample / floor filter as Worst tools."""
+class TestEligibilityBlock:
+    """Header carries the ``MIN_SAMPLE_SIZE`` floor and ⚠ flag exclusion rule."""
 
     def test_min_sample_size_floor_named_in_eligibility_block(self) -> None:
         """Eligibility block cites the live ``MIN_SAMPLE_SIZE`` constant."""
-        # pylint: disable=import-outside-toplevel
-        from benchmark.scorer import MIN_SAMPLE_SIZE
-
-        assert "Eligibility for Top tools" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert f"at least {MIN_SAMPLE_SIZE}" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-
-    def test_top_tools_lists_only_eligible_rows(self) -> None:
-        """Top-tools instruction restricts ranking to the eligible set."""
-        assert "top 3 eligible rows" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-
-    def test_worst_tools_lists_only_eligible_rows(self) -> None:
-        """Worst-tools instruction restricts ranking to the eligible set."""
-        assert "bottom 3 eligible rows" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        prompt = _default_prompt()
+        assert "Eligibility for the tool ranking section" in prompt
+        assert f"at least {MIN_SAMPLE_SIZE}" in prompt
 
     def test_eligibility_excludes_low_sample_and_malformed(self) -> None:
         """Eligibility block names both ⚠ flags so neither leaks into rankings."""
-        assert "⚠ low sample" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "⚠ all malformed" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        prompt = _default_prompt()
+        assert "⚠ low sample" in prompt
+        assert "⚠ all malformed" in prompt
 
 
-class TestSingleToolFallback:
-    """When only one tool is eligible, collapse to a single Tool performance bullet."""
+class TestComputeTopK:
+    """``_compute_top_k`` keeps Top and Worst slices disjoint at every N.
 
-    def test_single_tool_fallback_section_named(self) -> None:
-        """Prompt names the ``*Tool performance:*`` fallback heading."""
-        assert "*Tool performance:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+    Constraint: Top K + Worst K rows must come from disjoint regions of
+    the sorted eligible list, so ``2 * K < N``. The dispatcher returns
+    ``0`` for ``N <= 2`` to switch to a combined "Tool performance"
+    listing instead of a useless 1-vs-1 split.
+    """
 
-    def test_fallback_clause_mentions_skip_top_and_worst(self) -> None:
-        """Single-tool path explicitly skips both Top and Worst sections."""
-        assert "SINGLE-TOOL FALLBACK" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
-        assert "skip both" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+    @pytest.mark.parametrize(
+        "eligible,expected_k",
+        [
+            (0, 0),
+            (1, 0),
+            (2, 0),
+            (3, 1),
+            (4, 1),
+            (5, 2),
+            (6, 2),
+            (7, 3),
+            (8, 3),
+            (10, 3),
+            (50, 3),
+        ],
+    )
+    def test_k_satisfies_disjoint_constraint(
+        self, eligible: int, expected_k: int
+    ) -> None:
+        """Returned K matches the table from the design doc."""
+        assert _compute_top_k(eligible) == expected_k
+
+    @pytest.mark.parametrize("eligible", list(range(0, 50)))
+    def test_top_and_worst_are_always_disjoint(self, eligible: int) -> None:
+        """For every N, ``2 * K < N`` (or K = 0 to disable the split)."""
+        k = _compute_top_k(eligible)
+        if k > 0:
+            assert 2 * k < eligible, f"N={eligible}, K={k}: top+worst overlap"
+
+    def test_capped_at_three_for_large_eligible_sets(self) -> None:
+        """K never exceeds 3 — keeps the Slack message scannable."""
+        assert _compute_top_k(100) == 3
+        assert _compute_top_k(1000) == 3
+
+
+class TestCountEligibleTools:
+    """``_count_eligible_tools`` parses the markdown for ranking-block dispatch."""
+
+    def test_counts_rows_above_floor_only(self) -> None:
+        """Rows below ``MIN_SAMPLE_SIZE`` don't contribute."""
+        report = (
+            "## Tool Historical Comparison\n"
+            "\n"
+            "| Tool | Current 7d Brier | All-Time | Δ |\n"
+            "|------|------------------|----------|---|\n"
+            f"| **good-tool** | 0.1 (n={MIN_SAMPLE_SIZE}) | x | x |\n"
+            f"| **below-floor** | 0.1 (n={MIN_SAMPLE_SIZE - 1}) | x | x |\n"
+            "\n"
+            "## Next Section\n"
+        )
+        assert _count_eligible_tools(report) == 1
+
+    def test_drops_low_sample_flagged_rows(self) -> None:
+        """Rows carrying ``⚠ low sample`` are excluded even if n is high."""
+        report = (
+            "## Tool Historical Comparison\n"
+            "\n"
+            "| Tool | Current 7d Brier | All-Time | Δ |\n"
+            "|------|------------------|----------|---|\n"
+            "| **good-tool** | 0.1 (n=100) | x | x |\n"
+            "| **flagged-tool** ⚠ low sample | 0.0 (n=200) | x | x |\n"
+            "\n"
+            "## Next Section\n"
+        )
+        assert _count_eligible_tools(report) == 1
+
+    def test_drops_all_malformed_flagged_rows(self) -> None:
+        """``⚠ all malformed`` rows are excluded — same eligibility contract."""
+        report = (
+            "## Tool Historical Comparison\n"
+            "\n"
+            "| Tool | Current 7d Brier | All-Time | Δ |\n"
+            "|------|------------------|----------|---|\n"
+            "| **good-tool** | 0.1 (n=100) | x | x |\n"
+            "| **broken-tool** ⚠ all malformed | N/A (n=200) | x | x |\n"
+            "\n"
+            "## Next Section\n"
+        )
+        assert _count_eligible_tools(report) == 1
+
+    def test_returns_zero_when_section_absent(self) -> None:
+        """Reports without a Tool Historical Comparison section count zero."""
+        assert _count_eligible_tools("# Some other report\n") == 0
+
+    def test_returns_zero_for_empty_table(self) -> None:
+        """A section heading with no data rows counts zero."""
+        report = (
+            "## Tool Historical Comparison\n"
+            "\n"
+            "No tool data available.\n"
+            "\n"
+            "## Next Section\n"
+        )
+        assert _count_eligible_tools(report) == 0
+
+    def test_counts_three_when_all_pass_floor(self) -> None:
+        """Three rows above the floor and no flags -> three eligible."""
+        report = (
+            "## Tool Historical Comparison\n"
+            "\n"
+            "| Tool | Current 7d Brier | All-Time | Δ |\n"
+            "|------|------------------|----------|---|\n"
+            "| **a** | 0.1 (n=73) | x | x |\n"
+            "| **b** | 0.2 (n=79) | x | x |\n"
+            "| **c** | 0.3 (n=714) | x | x |\n"
+            "\n"
+            "## Next Section\n"
+        )
+        assert _count_eligible_tools(report) == 3
+
+
+class TestRankingBlockDispatch:
+    """The prompt only ever exposes ONE section convention per request.
+
+    This is what makes the dispatch deterministic: when N <= 2, the LLM
+    sees ``*Tool performance:*`` and never sees Top/Worst. When N >= 3,
+    the LLM sees Top/Worst with a specific K and never sees Tool
+    performance. There is no "skip" instruction the LLM has to obey —
+    the prohibited section is simply not in the prompt.
+    """
+
+    @pytest.mark.parametrize("eligible", [0, 1, 2])
+    def test_small_n_uses_tool_performance_only(self, eligible: int) -> None:
+        """N <= 2 -> Tool performance; Top/Worst absent from the prompt."""
+        prompt = _build_system_prompt("Omenstrat", eligible_count=eligible)
+        assert "*Tool performance:*" in prompt
+        assert "*Top tools:*" not in prompt
+        assert "*Worst tools:*" not in prompt
+
+    @pytest.mark.parametrize(
+        "eligible,top_k", [(3, 1), (4, 1), (5, 2), (6, 2), (7, 3), (10, 3)]
+    )
+    def test_large_n_uses_top_worst_only(self, eligible: int, top_k: int) -> None:
+        """N >= 3 -> Top/Worst with the right K; Tool performance absent."""
+        prompt = _build_system_prompt("Omenstrat", eligible_count=eligible)
+        assert "*Tool performance:*" not in prompt
+        assert "*Top tools:*" in prompt
+        assert "*Worst tools:*" in prompt
+        assert f"top {top_k} eligible rows" in prompt
+        assert f"bottom {top_k} eligible rows" in prompt
 
     def test_zero_eligible_renders_explicit_placeholder(self) -> None:
         """Zero-eligible case has a deterministic placeholder so the LLM doesn't guess."""
-        assert "no eligible tools" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        prompt = _build_system_prompt("Omenstrat", eligible_count=0)
+        assert "no eligible tools" in prompt
+
+    def test_one_eligible_lists_the_single_tool(self) -> None:
+        """One eligible tool -> Tool performance with one bullet, no placeholder."""
+        prompt = _build_system_prompt("Omenstrat", eligible_count=1)
+        assert "list ALL eligible rows" in prompt
+        assert "no eligible tools" not in prompt

--- a/benchmark/tests/test_notify_slack.py
+++ b/benchmark/tests/test_notify_slack.py
@@ -201,3 +201,45 @@ class TestPromptRejectsUnformattedPlaceholder:
         """
         for label in PLATFORM_LABELS.values():
             _build_system_prompt(label)
+
+
+class TestTopToolsEligibilityFilter:
+    """Top tools must apply the same low-sample / floor filter as Worst tools."""
+
+    def test_min_sample_size_floor_named_in_eligibility_block(self) -> None:
+        """Eligibility block cites the live ``MIN_SAMPLE_SIZE`` constant."""
+        # pylint: disable=import-outside-toplevel
+        from benchmark.scorer import MIN_SAMPLE_SIZE
+
+        assert "Eligibility for Top tools" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        assert f"at least {MIN_SAMPLE_SIZE}" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+
+    def test_top_tools_lists_only_eligible_rows(self) -> None:
+        """Top-tools instruction restricts ranking to the eligible set."""
+        assert "top 3 eligible rows" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+
+    def test_worst_tools_lists_only_eligible_rows(self) -> None:
+        """Worst-tools instruction restricts ranking to the eligible set."""
+        assert "bottom 3 eligible rows" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+
+    def test_eligibility_excludes_low_sample_and_malformed(self) -> None:
+        """Eligibility block names both ⚠ flags so neither leaks into rankings."""
+        assert "⚠ low sample" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        assert "⚠ all malformed" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+
+
+class TestSingleToolFallback:
+    """When only one tool is eligible, collapse to a single Tool performance bullet."""
+
+    def test_single_tool_fallback_section_named(self) -> None:
+        """Prompt names the ``*Tool performance:*`` fallback heading."""
+        assert "*Tool performance:*" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+
+    def test_fallback_clause_mentions_skip_top_and_worst(self) -> None:
+        """Single-tool path explicitly skips both Top and Worst sections."""
+        assert "SINGLE-TOOL FALLBACK" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+        assert "skip both" in SUMMARY_SYSTEM_PROMPT_TEMPLATE
+
+    def test_zero_eligible_renders_explicit_placeholder(self) -> None:
+        """Zero-eligible case has a deterministic placeholder so the LLM doesn't guess."""
+        assert "no eligible tools" in SUMMARY_SYSTEM_PROMPT_TEMPLATE


### PR DESCRIPTION
## Summary

Five tightenings of the per-platform daily benchmark report and Slack summary so each report only describes tools and categories the corresponding platform actually trades.

- **Tool ranking section dispatched on eligible count** — `notify_slack` now parses the Tool Historical Comparison table to count rows that pass the eligibility floor (`n >= MIN_SAMPLE_SIZE` AND no `⚠ low sample` / `⚠ all malformed` flag), then assembles the system prompt with **only one** ranking section visible to the LLM:
  - `N = 0` → `*Tool performance:*` placeholder
  - `N = 1, 2` → `*Tool performance:*` listing all eligible rows
  - `N >= 3` → `*Top tools:*` / `*Worst tools:*` with `K = min(3, floor((N - 1) / 2))` per side, so the two slices are always disjoint (`2K < N`)

  Replaces the previous `n=1` floor + "skip Top/Worst" instruction the LLM was bypassing. The dispatch table:

  | N | K | Sections | Hidden middle |
  |---|---|----------|---------------|
  | 0 | 0 | Tool performance (placeholder) | — |
  | 1, 2 | 0 | Tool performance (all rows) | — |
  | 3, 4 | 1 | Top 1 / Worst 1 | 1-2 |
  | 5, 6 | 2 | Top 2 / Worst 2 | 1-2 |
  | 7+ | 3 | Top 3 / Worst 3 | ≥ 1 |
- **Per-platform comparison sections restricted to currently-deployed tools** — Tool Historical, Tool × Category (+ Diagnostics), Tool × Category Historical, Diagnostics Historical, and Reliability sections now drop tools that aren't deployed on the platform's deployments. Active set is computed once at the top of `generate_report` from `fetch_disabled_tools()`. On full deployment-config fetch failure the report falls back to "show all tools" with a one-line `⚠ deployment config unavailable` notice rather than blanking the sections.
- **`ROLLING_WINDOW_DAYS` env-overridable, default 7d** — read from `BENCHMARK_ROLLING_WINDOW_DAYS`. CI workflow declares the env var at the job level and passes the same value to the scorer via `--period-days` / `--period-offset-days`, so the Python constant and the scorer flag stay in sync from one source. `workflow_dispatch` input added so manual runs can override per-run.
- **Platform-aware `classify_category`** — omen rows whose keyword match would be e.g. `travel` (not in market-creator's `DEFAULT_TOPICS`) and polymarket rows that would land in e.g. `curiosities` (not in trader's `POLYMARKET_CATEGORY_TAGS`) drop to `other`. The two upstream-mirrored sets move from `analyze.py` to a shared `benchmark/categories.py` so the fetch-time classifier and the report-time renderer import the same source. Lazy migration: existing rows on disk keep their old categorization and age out of the rolling window naturally.

## Local verification

Test webhook posts captured in [comment 1](https://github.com/valory-xyz/mech-predict/pull/249#issuecomment-4335540719) (initial run, exposed the Top/Worst overlap bug at N=3) and [comment 2](https://github.com/valory-xyz/mech-predict/pull/249#issuecomment-4335771862) (variable-K dispatch). After the fix, Omen (N=3) renders `factual_research` as Top 1 and `superforcaster` as Worst 1 with the mid-rank `prediction-offline` correctly hidden; Polystrat (N=1) renders a single `*Tool performance:*` bullet with no spurious empty Top/Worst sections.

## Test plan

- [x] Full benchmark test suite (719 tests pass)
- [x] `tomte format-code` clean
- [x] `flake8`, `mypy`, `pylint`, `darglint` clean on all changed files
- [x] Local end-to-end posts to test Slack channel verify dispatch behavior
- [ ] First scheduled CI run after merge: confirm reports show only deployed tools and Tool × Category counts in `report_polymarket.md` reflect the platform-aware classifier
- [ ] Manual workflow_dispatch with `rolling_window_days=14` overrides the constant correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)