### PR TITLE
fix(benchmark): freeze scorer test time to avoid month-rollover bombs

### DIFF
--- a/benchmark/tests/test_scorer.py
+++ b/benchmark/tests/test_scorer.py
@@ -1284,7 +1284,10 @@ class TestEdgeIncremental:
         scores_path = tmp_path / "scores.json"
         history_path = tmp_path / "history.jsonl"
 
-        # Write old-format scores.json (no edge fields)
+        # Write old-format scores.json (no edge fields). Pin scorer time to
+        # the same month as ``current_month`` so update() doesn't trigger a
+        # month-rollover reset of accumulators on the 1st of any later
+        # month — the test exercises edge backfill, not month rollover.
         old_scores = {
             "current_month": "2026-04",
             "generated_at": "2026-04-08T00:00:00Z",
@@ -1318,7 +1321,10 @@ class TestEdgeIncremental:
 
         # Add a new row with market_prob
         rows = [_row(p_yes=0.8, outcome=True, market_prob=0.5)]
-        result = update(rows, scores_path, history_path)
+        with patch("benchmark.scorer.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 4, 8, tzinfo=timezone.utc)
+            mock_dt.side_effect = datetime
+            result = update(rows, scores_path, history_path)
 
         # Old rows didn't have edge, new one does
         assert result["overall"]["edge_n"] == 1
@@ -1465,7 +1471,10 @@ class TestUpdateDedup:
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir()
 
-        # Write rows spanning two months to a log file
+        # Write rows spanning two months to a log file. Times pinned via
+        # mock_dt below so "current month" is April 2026, regardless of
+        # when the test actually runs — the assertion depends on april_r1
+        # being in-month and march_r1 being out-of-month.
         rows = [
             _row(
                 p_yes=0.7,
@@ -1485,21 +1494,24 @@ class TestUpdateDedup:
             for r in rows:
                 f.write(json.dumps(r) + "\n")
 
-        # Rebuild from log files
-        rebuild(
-            logs_dir=logs_dir,
-            scores_path=scores_path,
-            history_path=history_path,
-            dedup_path=dedup_path,
-        )
+        with patch("benchmark.scorer.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 4, 8, tzinfo=timezone.utc)
+            mock_dt.side_effect = datetime
+            # Rebuild from log files
+            rebuild(
+                logs_dir=logs_dir,
+                scores_path=scores_path,
+                history_path=history_path,
+                dedup_path=dedup_path,
+            )
 
-        # Verify rebuild tracked both row_ids in the dedup file
-        saved_ids = json.loads(dedup_path.read_text())
-        assert "march_r1" in saved_ids
-        assert "april_r1" in saved_ids
+            # Verify rebuild tracked both row_ids in the dedup file
+            saved_ids = json.loads(dedup_path.read_text())
+            assert "march_r1" in saved_ids
+            assert "april_r1" in saved_ids
 
-        # Now call update() with the same rows — should all be skipped
-        result = update(rows, scores_path, history_path, dedup_path)
+            # Now call update() with the same rows — should all be skipped
+            result = update(rows, scores_path, history_path, dedup_path)
         # n should still be 1 (only april_r1 in current month accumulators)
         # because rebuild() only accumulates the last month into scores.json
         # but dedup file contains both months' IDs


### PR DESCRIPTION
## Summary

Two scorer tests have hardcoded fixture dates and unfrozen time, so they pass only while today's month matches the fixtures' assumed "current month". Both started failing on **2026-05-01** because `update()` / `rebuild()` reset accumulators when the stored `current_month` doesn't match `datetime.now()`'s month — neither March nor April rows qualified, so `n=0` instead of expected `n=11` / `n=1`.

Verified the failures reproduce on `main` with no other changes (failing run: https://github.com/valory-xyz/mech-predict/actions/runs/25218115887/job/73943572145, but `main` itself reproduces the same `pytest benchmark/tests/test_scorer.py` failure today).

The fix wraps each test in `patch("benchmark.scorer.datetime")` pinning "now" to a date inside the fixture's window. This is the same pattern already used by `test_dedup_survives_month_rollover` in the same file (no new dep, no scorer.py changes).

Affected tests:
- `TestEdgeIncremental::test_resume_with_old_scores`
- `TestUpdateDedup::test_rebuild_then_update_deduplicates`

## Test plan

- [x] Both tests fail on `main` today (2026-05-01); reproduced locally
- [x] Both tests pass after this fix
- [x] Full `benchmark/tests/test_scorer.py` suite still green: **192/192 pass**
- [x] `uv run tomte check-code` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)