### PR TITLE
fix(benchmark): discover Polymarket resolutions via questions entity

### DIFF
--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -720,39 +720,31 @@ OMEN_BETS_QUERY = """
 }
 """
 
-# Polymarket: bulk fetch bets from a wide window, post-filter for resolved.
-# The subgraph doesn't support filtering by resolution timestamp directly,
-# so we fetch a broad candidate window and filter in Python.
-POLYMARKET_BETS_QUERY = """
+# Polymarket: discover resolved markets directly from the questions entity.
+# The prediction subgraph supports filtering by resolution.blockTimestamp via
+# the nested-filter syntax `resolution_: { blockTimestamp_gt: ... }`, so we
+# paginate questions server-side instead of going through bets.
+POLYMARKET_RESOLVED_QUESTIONS_QUERY = """
 {
-  bets(
+  questions(
     first: %(first)s
     skip: %(skip)s
-    orderBy: blockTimestamp
-    orderDirection: desc
-    where: { blockTimestamp_gt: %(timestamp_gt)s }
+    orderBy: id
+    orderDirection: asc
+    where: { resolution_: { blockTimestamp_gt: %(resolved_after)s } }
   ) {
     id
-    blockTimestamp
-    outcomeIndex
-    question {
-      id
-      metadata {
-        title
-        outcomes
-      }
-      resolution {
-        winningIndex
-        blockTimestamp
-      }
+    metadata {
+      title
+      outcomes
+    }
+    resolution {
+      winningIndex
+      blockTimestamp
     }
   }
 }
 """
-
-# How far back to fetch Polymarket bets to find recently resolved markets.
-# Bets may have been placed months before the market resolves.
-POLYMARKET_CANDIDATE_WINDOW_DAYS = 30
 
 # ---------------------------------------------------------------------------
 # Subgraph helpers
@@ -1084,37 +1076,27 @@ def fetch_omen_resolved(resolved_after: int) -> ResolvedMarkets:
 def fetch_polymarket_resolved(resolved_after: int) -> ResolvedMarkets:
     """Bulk fetch Polymarket markets that resolved after the given timestamp.
 
-    The subgraph doesn't support filtering bets by resolution time, so we:
-    1. Fetch a wide candidate window (POLYMARKET_CANDIDATE_WINDOW_DAYS) of bets
-    2. Post-filter to resolved questions only
-    3. Only include markets where resolution.blockTimestamp > resolved_after
-    4. Deduplicate by question ID
+    Discovers resolved markets directly from the ``questions`` entity using
+    ``resolution_.blockTimestamp_gt`` as the server-side filter. This avoids
+    the previous bet-based proxy, which missed resolved questions whose
+    bets fell outside a candidate window.
 
     :param resolved_after: UNIX timestamp; only include markets resolved after this.
     :return: ResolvedMarkets indexed by ID and title.
     """
-    candidate_window = int(time.time()) - (POLYMARKET_CANDIDATE_WINDOW_DAYS * 86400)
     raw = _paginated_fetch(
         PREDICT_POLYMARKET_SUBGRAPH_URL,
-        POLYMARKET_BETS_QUERY,
-        "bets",
-        {"timestamp_gt": candidate_window},
+        POLYMARKET_RESOLVED_QUESTIONS_QUERY,
+        "questions",
+        {"resolved_after": resolved_after},
     )
 
     markets = ResolvedMarkets()
-    for bet in raw:
-        question = bet.get("question") or {}
-        resolution = question.get("resolution")
-        if resolution is None:
-            continue
-
+    for question in raw:
+        resolution = question.get("resolution") or {}
         resolved_at_ts = resolution.get("blockTimestamp")
-        if not resolved_at_ts:
-            continue
-
-        # Only include markets that resolved after our cutoff
-        resolved_at_int = int(resolved_at_ts)
-        if resolved_at_int <= resolved_after:
+        winning_index_raw = resolution.get("winningIndex")
+        if not resolved_at_ts or winning_index_raw is None:
             continue
 
         metadata = question.get("metadata") or {}
@@ -1122,20 +1104,24 @@ def fetch_polymarket_resolved(resolved_after: int) -> ResolvedMarkets:
         if not title:
             continue
 
-        winning_index = int(resolution["winningIndex"])
+        market_id = question.get("id")
+        if not market_id:
+            continue
+
         # winningIndex follows CLOB token order: 0 = Yes, 1 = No.
         # The subgraph outcomes array is unreliable (often ["No", "Yes"]),
         # so we ignore it and use the index directly.
+        winning_index = int(winning_index_raw)
         outcome = winning_index == 0
 
-        data = {
-            "outcome": outcome,
-            "resolved_at_ts": resolved_at_int,
-        }
-
-        # Polymarket question ID matches request_context.market_id
-        market_id = question.get("id")
-        markets.add(market_id, title, data)
+        markets.add(
+            market_id,
+            title,
+            {
+                "outcome": outcome,
+                "resolved_at_ts": int(resolved_at_ts),
+            },
+        )
 
     return markets
 

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -262,16 +262,18 @@ class TestMatchDelivery:
 
 
 class TestFetchPolymarketResolvedUsesQuestions:
-    """Regression: fetch_polymarket_resolved must discover via the ``questions``
-    entity using the ``resolution_.blockTimestamp_gt`` server-side filter, not
-    via bets. A question that has resolution but no bet fixture must still be
-    discovered.
+    """Regression: fetch_polymarket_resolved must discover via questions.
+
+    Uses the ``resolution_.blockTimestamp_gt`` server-side filter on the
+    ``questions`` entity, not the legacy bets path. A question that has a
+    resolution but no bet fixture must still be discovered.
     """
 
     def test_uses_questions_entity_and_skips_invalid_rows(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Discovers via ``questions``, encodes outcome, skips malformed rows."""
+        # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
         captured: dict[str, Any] = {}
@@ -335,6 +337,7 @@ class TestFetchPolymarketResolvedUsesQuestions:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """winningIndex=1 maps to outcome=False."""
+        # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
         def fake_paginated(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -257,48 +257,98 @@ class TestMatchDelivery:
 
 
 # ---------------------------------------------------------------------------
-# Polymarket resolution time filter
+# fetch_polymarket_resolved (regression: questions-entity discovery)
 # ---------------------------------------------------------------------------
 
 
-class TestPolymarketResolutionFilter:
-    """Tests that the resolution time cutoff logic works correctly.
-
-    Replicates the post-filter from fetch_polymarket_resolved:
-    a bet with resolved_at <= cutoff must be excluded.
+class TestFetchPolymarketResolvedUsesQuestions:
+    """Regression: fetch_polymarket_resolved must discover via the ``questions``
+    entity using the ``resolution_.blockTimestamp_gt`` server-side filter, not
+    via bets. A question that has resolution but no bet fixture must still be
+    discovered.
     """
 
-    @staticmethod
-    def _filter_bet(bet: dict[str, Any], resolved_after: int) -> bool:
-        """Replicate the resolution filter from fetch_polymarket_resolved."""
-        question = bet.get("question") or {}
-        resolution = question.get("resolution")
-        if resolution is None:
-            return False
-        resolved_at_ts = resolution.get("blockTimestamp")
-        if not resolved_at_ts:
-            return False
-        return int(resolved_at_ts) > resolved_after
+    def test_uses_questions_entity_and_skips_invalid_rows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Discovers via ``questions``, encodes outcome, skips malformed rows."""
+        from benchmark.datasets import fetch_production as fp
 
-    def test_resolved_after_cutoff_included(self) -> None:
-        """Test resolved after cutoff is included."""
-        bet = {"question": {"resolution": {"blockTimestamp": "1000"}}}
-        assert self._filter_bet(bet, 999) is True
+        captured: dict[str, Any] = {}
 
-    def test_resolved_at_cutoff_excluded(self) -> None:
-        """Test resolved at cutoff is excluded."""
-        bet = {"question": {"resolution": {"blockTimestamp": "1000"}}}
-        assert self._filter_bet(bet, 1000) is False
+        def fake_paginated(
+            url: str,
+            query: str,
+            entity_key: str,
+            template_vars: dict[str, Any],
+            **_kwargs: Any,
+        ) -> list[dict[str, Any]]:
+            captured["url"] = url
+            captured["query"] = query
+            captured["entity_key"] = entity_key
+            captured["template_vars"] = template_vars
+            return [
+                {
+                    "id": "0xqid_resolved",
+                    "metadata": {
+                        "title": "Will X happen by date Y?",
+                        "outcomes": ["No", "Yes"],
+                    },
+                    "resolution": {"winningIndex": 0, "blockTimestamp": "1700000000"},
+                },
+                # Edge case: missing winningIndex — must be skipped.
+                {
+                    "id": "0xqid_partial",
+                    "metadata": {"title": "Partial"},
+                    "resolution": {"blockTimestamp": "1700000000"},
+                },
+                # Edge case: missing title — must be skipped.
+                {
+                    "id": "0xqid_no_title",
+                    "metadata": {"title": ""},
+                    "resolution": {"winningIndex": 1, "blockTimestamp": "1700000000"},
+                },
+                # Edge case: null resolution — must be skipped.
+                {
+                    "id": "0xqid_null_res",
+                    "metadata": {"title": "Null resolution"},
+                    "resolution": None,
+                },
+            ]
 
-    def test_resolved_before_cutoff_excluded(self) -> None:
-        """Test resolved before cutoff is excluded."""
-        bet = {"question": {"resolution": {"blockTimestamp": "500"}}}
-        assert self._filter_bet(bet, 999) is False
+        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
+        markets = fp.fetch_polymarket_resolved(resolved_after=1_600_000_000)
 
-    def test_unresolved_excluded(self) -> None:
-        """Test unresolved bet is excluded."""
-        bet = {"question": {"resolution": None}}
-        assert self._filter_bet(bet, 0) is False
+        assert captured["entity_key"] == "questions"
+        assert "questions(" in captured["query"]
+        assert "bets(" not in captured["query"]
+        assert captured["template_vars"] == {"resolved_after": 1_600_000_000}
+
+        assert "0xqid_resolved" in markets.by_id
+        assert markets.by_id["0xqid_resolved"]["outcome"] is True
+        assert markets.by_id["0xqid_resolved"]["resolved_at_ts"] == 1_700_000_000
+        assert "0xqid_partial" not in markets.by_id
+        assert "0xqid_no_title" not in markets.by_id
+        assert "0xqid_null_res" not in markets.by_id
+
+    def test_winning_index_one_maps_to_no(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """winningIndex=1 maps to outcome=False."""
+        from benchmark.datasets import fetch_production as fp
+
+        def fake_paginated(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+            return [
+                {
+                    "id": "0xqid_no",
+                    "metadata": {"title": "Will it not happen?"},
+                    "resolution": {"winningIndex": 1, "blockTimestamp": "1700000000"},
+                },
+            ]
+
+        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
+        markets = fp.fetch_polymarket_resolved(resolved_after=0)
+        assert markets.by_id["0xqid_no"]["outcome"] is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`fetch_polymarket_resolved` discovers resolved Polymarket markets directly from the prediction subgraph's `questions` entity, using `resolution_.blockTimestamp_gt` as the server-side filter. This replaces the previous bet-based proxy, which only saw resolved questions whose markets had recent bet activity in a 30-day candidate window — and missed everything else.

The downstream join (`delivery.market_id == question.id` in `_match_delivery`) is unchanged.

## Why

The May 7 and May 8 daily benchmark runs produced `report_polymarket.md` with `n=0 Current 7d`, an empty Tool Historical Comparison table, and "insufficient tool × category data" — the symptoms of zero scored Polymarket rows reaching the report. The prior root-cause investigation ([report](https://github.com/valory-xyz/mech-predict/blob/codex/polymarket-resolution-report/benchmark/reports/2026-05-07-polymarket-resolution-discovery.md), commit `7b57728c` on `codex/polymarket-resolution-report`) traced this to the resolved-market discovery, not the deliveries fetch:

- The pipeline fetched **3,892** Polymarket deliveries with **189** unique `market_id`s.
- Direct lookup via `question(id: market_id)` found resolutions for **96** of them.
- The bet-based discovery produced **0** matches against those 189 IDs, so they all stayed pending and never became scored rows.

## What changed

- **Replace the query**: `POLYMARKET_BETS_QUERY` → `POLYMARKET_RESOLVED_QUESTIONS_QUERY`.
  Was `bets(where: { blockTimestamp_gt: now - 30d }) { question { resolution } }` (post-filter in Python).
  Now `questions(where: { resolution_: { blockTimestamp_gt: resolved_after } }) { resolution }` (server-side filter, authoritative).
- **Rewrite `fetch_polymarket_resolved`** to iterate the questions response. Same signature, same return type. Tolerant of missing `metadata`, `resolution.winningIndex`, `resolution.blockTimestamp`, `id`, `metadata.title` — those rows are skipped, not raised.
- **Drop dead constants** `POLYMARKET_BETS_QUERY` and `POLYMARKET_CANDIDATE_WINDOW_DAYS` (`grep` confirmed no other references).
- **Replace the obsolete `TestPolymarketResolutionFilter`** (it post-filtered bets — premise no longer exists) with `TestFetchPolymarketResolvedUsesQuestions`. Two methods:
  - asserts the call uses `entity_key="questions"`, `"questions(" in query`, `"bets(" not in query`, `template_vars == {"resolved_after": ...}`, encodes outcome from `winningIndex`, and skips malformed rows (missing `winningIndex`, empty title, null `resolution`);
  - asserts `winningIndex=1` maps to `outcome=False`.
- Existing tests (`TestPolymarketOutcome`, `TestMatchDelivery`, the `main()` integration tests at the bottom of the file) untouched. `_match_delivery`, `fetch_omen_resolved`, `ResolvedMarkets`, and `_paginated_fetch` untouched.

## Verification

### 1. Unit tests
```
720 passed, 1 warning in 6.41s
```
Including the two new regression tests in `TestFetchPolymarketResolvedUsesQuestions`.

### 2. Lint pipeline (tomte 0.7.0)

| Step | Result |
|---|---|
| isort | OK |
| black | OK |
| pylint | 10.00/10 |
| mypy | OK (0 issues, 91 source files) |
| flake8 | OK |
| darglint | OK |
| bandit | OK (0 issues at every confidence level) |

### 3. Side-by-side OLD vs NEW (live subgraph)

Same `resolved_after = now - 7d` cutoff, same subgraph URL:

| Metric | OLD path (bets → question → resolution) | NEW path (questions where resolution_.blockTimestamp_gt) |
|---|---:|---:|
| Resolved markets discovered | **10** | **20,539** |
| In both | 10 | 10 |
| Only in OLD | 0 | — |
| **Only in NEW (OLD missed)** | — | **20,529** |

OLD's set is a strict subset of NEW's. OLD missed 99.95% of resolved markets within the 7-day window.

Sample of markets OLD missed (top 5 by recency):
```
0x1c25d4b2…   "Game 2: Ends in Daytime?"             winningIndex=0   ts=1778237661
0xc85a4943…   "Game 3: Ends in Daytime?"             winningIndex=-1  ts=1778237659
0xe0d9c239…   "Game 3: Both Teams Destroy Barracks?" winningIndex=-1  ts=1778237657
0x647c7875…   "Game 2: Both Teams Destroy Barracks?" winningIndex=1   ts=1778237657
0x8b67f03a…   "Game 3: Both Teams Beat Roshan?"      winningIndex=-1  ts=1778237599
```

Plus the smoke market from the report:
```
0x0bd7152c…   "Will Apple (AAPL) close above $285 on May 6?"   winningIndex=0   ts=1778102111
```

### 4. End-to-end fetch_production reproduction

Local `--lookback-days 7` run with temp state files:

```
omen:        8607 matched (8580 by market_id, 27 by title)
polymarket:  1249 matched (1229 by market_id, 20 by title), 2389 still pending, 1249 rows built
Appended 9856 new rows
```

Pre-fix baseline on the same window: `polymarket=1` row.

### 5. Diagnostic script ([`compare_polymarket_resolution_sources.py`](https://github.com/valory-xyz/mech-predict/blob/codex/polymarket-resolution-report/scripts/compare_polymarket_resolution_sources.py) on `codex/polymarket-resolution-report`)

```json
{
  "resolved_via_current_bet_discovery":            42,
  "resolved_via_direct_question_discovery":        42,
  "pending_resolved_questions_missed_by_current_discovery": 0,
  "pending_ids_with_null_question_resolution":     77
}
```

`resolved_via_current_bet_discovery` is the production path (now using `questions` after this fix; the script's variable name predates the rename). It matches the independent direct-question path, and zero pending IDs are silently resolved-but-undiscovered. Pre-fix, the missed count was ~96.

### 6. Downstream report regeneration

Regenerated the full pipeline locally to confirm the downstream consumers populate correctly:

```
fetch_production --lookback-days 7
  → scorer --rebuild
  → scorer --period-days 7              (current rolling window)
  → scorer --period-days 7 --period-offset-days 7  (prev window)
  → analyze --platform polymarket
  → notify_slack --dry-run
```

The resulting `report_polymarket.md` populates every section that was empty pre-fix:

| Section | Pre-fix | Post-fix |
|---|---|---|
| Platform Snapshot (Current 7d) | n=0 | n=1236, Brier 0.2159, Reliability 99%, DirAcc 69% |
| Tool Historical Comparison | no eligible rows (every row n<30) | superforcaster eligible: Current 7d n=1186, Brier 0.2132 |
| Tool × Category (Current 7d) | "insufficient tool × category data" | international (n=470, Brier 0.2020), politics (n=602, Brier 0.2163), finance (n=104, Brier 0.2594) |
| Diagnostics Historical Comparison | no signed deltas | superforcaster: Edge -0.0469 (n=1179), Log Loss 0.6502 (n=1186), with Δ vs All-Time |

`notify_slack --dry-run` exits 0 and prints a Slack-formatted summary that fills the *Tool performance*, *Tool × Category*, *Diagnostics* and *Reliability* sections, none of which had eligible content before this PR.

## Notes for ops / what to expect after merge

1. **First post-merge prod run will produce a backfill spike.** The fetch resumes from the persisted `polymarket.last_resolved_timestamp` in the artifact cache. With the bug, that cursor never advanced past resolutions the bet-discovery missed; on the first post-fix run, every resolution that landed during the bug window will be matched and written. Expect a one-off jump in `polymarket=N`, then steady-state.
2. **`Δ vs Prev 7d` will say `insufficient data` for ~7 days** because `prev_rolling_scores_polymarket.json` was generated by the broken pipeline. It rolls forward as the post-fix window accumulates.
3. **`winningIndex=-1` (likely Polymarket's invalid/cancelled sentinel)** is preserved as `outcome=False` — same behaviour as the pre-fix code. This silently feeds invalid markets into the scorer as resolved "No". Out of scope for this PR (the prior root-cause report explicitly told us not to redefine the outcome encoding), but worth tracking as a follow-up.

## Test plan

- [x] Unit tests: `pytest benchmark/tests/` → 720 passed
- [x] Lint pipeline: `tomte tox -e isort,black,pylint,mypy,flake8,darglint,bandit` → all green
- [x] Side-by-side OLD vs NEW against live subgraph (10 vs 20,539)
- [x] End-to-end `fetch_production --lookback-days 7` (1249 polymarket rows vs broken-baseline 1)
- [x] Diagnostic script: production-path == direct-question-path, 0 missed
- [x] `notify_slack --dry-run` against the post-fix `report_polymarket.md` (exits 0, summary populates every previously-empty section)
- [ ] Verify on the next scheduled CI run that the post-merge benchmark report has populated tool/category sections

## Refs

- Root-cause report: `benchmark/reports/2026-05-07-polymarket-resolution-discovery.md` (currently on branch `codex/polymarket-resolution-report`; will land separately)
- Diagnostic script: [`scripts/compare_polymarket_resolution_sources.py`](https://github.com/valory-xyz/mech-predict/blob/codex/polymarket-resolution-report/scripts/compare_polymarket_resolution_sources.py) (same branch)