### PR TITLE
chore(tournament): pin to factual_research from #248, raise to 30 markets/platform

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -19,7 +19,7 @@ on:
       max_markets:
         description: 'Max markets per platform for tournament'
         required: false
-        default: '10'
+        default: '30'
       tools:
         description: 'Comma-separated subset of tools (default: every key in benchmark/tournament_tools.json)'
         required: false
@@ -305,7 +305,7 @@ jobs:
       # Inputs routed via env to avoid shell injection — see note in benchmark job.
       - name: Fetch Omen open markets
         env:
-          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '10' }}
+          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '30' }}
         run: |
           python -m benchmark.datasets.fetch_open \
             --platform omen \
@@ -313,7 +313,7 @@ jobs:
 
       - name: Fetch Polymarket open markets
         env:
-          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '10' }}
+          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '30' }}
         run: |
           python -m benchmark.datasets.fetch_open \
             --platform polymarket \
@@ -395,7 +395,7 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.BENCHMARK_GOOGLE_API_KEY }}
           GOOGLE_ENGINE_ID: ${{ secrets.BENCHMARK_GOOGLE_ENGINE_ID }}
           INPUT_TOOLS: ${{ github.event.inputs.tools }}
-          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '10' }}
+          INPUT_MAX_MARKETS: ${{ github.event.inputs.max_markets || '30' }}
         run: |
           # When INPUT_TOOLS is empty (cron run, or dispatch with the
           # default), omit --tools so tournament.py runs every tool listed

--- a/benchmark/tournament_tools.json
+++ b/benchmark/tournament_tools.json
@@ -1,16 +1,3 @@
 {
-  "prediction-online": "bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky",
-  "prediction-offline": "bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky",
-  "claude-prediction-online": "bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky",
-  "claude-prediction-offline": "bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky",
-  "superforcaster": "bafybeiduissprwj2shvd4peyibvgzvlzo4ob4hy2awij6yjgsala3cmuei",
-  "prediction-request-reasoning": "bafybeied5ljgwnpkmigy3duc3fltkwfdwyykkdo6a7l2kcx77aceka44em",
-  "prediction-request-reasoning-claude": "bafybeied5ljgwnpkmigy3duc3fltkwfdwyykkdo6a7l2kcx77aceka44em",
-  "prediction-request-rag": "bafybeiasyiowjgwaadzmqp5hekg77bfpj22vv4abjwho2vrobhvlutfs4e",
-  "prediction-request-rag-claude": "bafybeiasyiowjgwaadzmqp5hekg77bfpj22vv4abjwho2vrobhvlutfs4e",
-  "prediction-url-cot": "bafybeifxd5c3khhjrvhjmfspqiuxbm2arvnl6kyjclbyw67fb36gyh6b6u",
-  "prediction-url-cot-claude": "bafybeifxd5c3khhjrvhjmfspqiuxbm2arvnl6kyjclbyw67fb36gyh6b6u",
-  "prediction-offline-sme": "bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu",
-  "prediction-online-sme": "bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu",
-  "factual_research": "bafybeieczrqsgnozknopbzedcgvmnou6i7f3g4jx5qvpz6nbedqsmkdt2m"
+  "factual_research": "bafybeib7askinfzv5yolxxqojbqnmpygrg3lbxnwc77grr3nzuopha5era"
 }


### PR DESCRIPTION
## Summary

- Tournament mode runs **only `factual_research`** at CID `bafybeib7askinfzv5yolxxqojbqnmpygrg3lbxnwc77grr3nzuopha5era` (the candidate build from #248 — temporal-anchor discipline fix).
- Bumps tournament market budget from **10 → 30** markets/platform/day (cron default + `workflow_dispatch` input default + 3 inline fallbacks).

Daily volume: 30 markets × 2 platforms × 1 tool = **60 tournament runs/day** (down from 260 with the previous 13 tool entries × 10 markets × 2 platforms).

## Rationale

We want a focused signal on #248's `factual_research` candidate before deciding to merge it. Running it alongside the other tools dilutes the per-tool sample, and head-to-head tool comparison still happens via production logs — unaffected here.

## Out of scope

- Production benchmark, scorer, and analyze jobs (use production logs, not `open_markets.jsonl`).
- `fetch_open.py` Python defaults (500) — still overridden by the workflow's `--max-markets`.

## Test plan

- [ ] Trigger `benchmark-flywheel` via `workflow_dispatch` (or wait for the 02:30 UTC cron)
- [ ] Confirm `tournament-fetch` writes ~30 omen + ~30 polymarket entries into `open_markets.jsonl`
- [ ] Confirm `tournament-run` invokes only `factual_research` and finishes within the 90-min timeout
- [ ] Confirm rows in `tournament_predictions.jsonl` carry `tool_ipfs_hash=bafybei…era`
- [ ] Sanity-check `prediction_parse_status` distribution — flag if `ipfs_fetch_error` rate is non-zero (CID validity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)