### PR TITLE
fix(ci): restore autonomy packages sync for tournament-run

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -361,6 +361,17 @@ jobs:
       - name: Install project dependencies
         run: uv sync
 
+      # tournament.py + benchmark.ipfs_loader import from
+      # packages.valory.skills.task_execution.utils.{apis,ipfs}. Those
+      # files live in the open-autonomy `mech` upstream registry and are
+      # gitignored (.gitignore: packages/valory/*), so they only land on
+      # the runner after `autonomy packages sync` reads packages.json
+      # and pulls them from IPFS.
+      - name: Sync autonomy packages
+        run: |
+          uv run autonomy init --reset --author ci --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
+          uv run autonomy packages sync
+
       # Cache IPFS-fetched tool sources between runs. Key on
       # tournament_tools.json so a CID bump triggers a fresh fetch but
       # unchanged runs reuse cached bytes.


### PR DESCRIPTION
## Summary

- PR #251 deleted the `Sync autonomy packages` step from `tournament-run` on the rationale that tournament tools now come from IPFS at runtime, but the tournament code still imports two classes from a third-party skill that **only lands via that sync** — so the tournament step has been silently broken since #251 merged on 2026-05-12.
- The break was masked by `continue-on-error: true` on `Run tournament predictions`: today's run ([25776976202](https://github.com/valory-xyz/mech-predict/actions/runs/25776976202)) reported green while producing zero new tournament predictions and posting the previous day's stale data downstream.
- This PR restores the four-line sync step that #251 removed and adds a comment explaining the dependency so it doesn't get deleted again.

## Why the sync step is required

Two imports reach into a skill that's not in this repo's git tree:

| File | Line | Import |
|---|---|---|
| `benchmark/ipfs_loader.py` | 29 | `from packages.valory.skills.task_execution.utils.ipfs import ComponentPackageLoader` (added by #251) |
| `benchmark/tournament.py` | 46 | `from packages.valory.skills.task_execution.utils.apis import KeyChain` (preexisting) |

`packages/valory/skills/task_execution/` is owned by the `valory-xyz/mech` open-autonomy upstream registry and is gitignored here:

```
.gitignore:5: packages/valory/*
.gitignore:6: !packages/valory/customs/
.gitignore:7: !packages/valory/agents/
.gitignore:8: !packages/valory/services/
```

`autonomy packages sync` reads `packages/packages.json` and pulls each pinned hash from IPFS. Locally devs have the files on disk from past syncs; CI does not, hence:

```
File "/home/runner/.../benchmark/ipfs_loader.py", line 29, in <module>
    from packages.valory.skills.task_execution.utils.ipfs import ComponentPackageLoader
ModuleNotFoundError: No module named 'packages.valory.skills'
```

## Verification

Reproduced the CI state locally by cloning the repo fresh into `/tmp/` and running `uv sync`:

1. Pre-fix: `uv run python -m benchmark.tournament --help` -> identical `ModuleNotFoundError`.
2. Apply patch: `autonomy packages sync` pulls down `task_execution:0.1.0` (and other upstream skills) from IPFS.
3. Post-fix: `uv run python -m benchmark.tournament --help` exits 0 with full argparse output.

## Failing CI run

- [benchmark-flywheel #25776976202 (2026-05-13)](https://github.com/valory-xyz/mech-predict/actions/runs/25776976202) — `tournament-run` reported green but the `Run tournament predictions` step exited 1 with the ModuleNotFoundError above. `continue-on-error: true` masked it.

## Follow-up considered (not in this PR)

Removing `continue-on-error: true` so the next regression of this shape fails loud was discussed but deferred — keeping it preserves robustness against transient IPFS / LLM API hiccups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)