### PR TITLE
chore(ci): drop unused Stability / Replicate / Gnosis-RPC / Graph secrets

### DIFF
--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -195,26 +195,18 @@ jobs:
     env:
       OPENAI_SECRET_KEY: ${{ secrets.OPENAI_SECRET_KEY }}
       OPENAI_SECRET_KEYS: ${{ secrets.OPENAI_SECRET_KEYS }}
-      STABILITY_API_KEY: ${{ secrets.STABILITY_API_KEY }}
-      STABILITY_API_KEYS: ${{ secrets.STABILITY_API_KEYS }}
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       GOOGLE_API_KEYS: ${{ secrets.GOOGLE_API_KEYS }}
       GOOGLE_ENGINE_ID: ${{ secrets.GOOGLE_ENGINE_ID }}
       GOOGLE_ENGINE_IDS: ${{ secrets.GOOGLE_ENGINE_IDS }}
       CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
       CLAUDE_API_KEYS: ${{ secrets.CLAUDE_API_KEYS }}
-      REPLICATE_API_KEY: ${{ secrets.REPLICATE_API_KEY }}
-      REPLICATE_API_KEYS: ${{ secrets.REPLICATE_API_KEYS }}
       NEWS_API_KEY: ${{ secrets.NEWS_API_KEY }}
       NEWS_API_KEYS: ${{ secrets.NEWS_API_KEYS }}
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
       OPENROUTER_API_KEYS: ${{ secrets.OPENROUTER_API_KEYS }}
-      GNOSIS_RPC_URL: ${{ secrets.GNOSIS_RPC_URL }}
-      GNOSIS_RPC_URLS: ${{ secrets.GNOSIS_RPC_URLS }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       GEMINI_API_KEYS: ${{ secrets.GEMINI_API_KEYS }}
-      GRAPH_API_KEY: ${{ secrets.GRAPH_API_KEY }}
-      GRAPH_API_KEYS: ${{ secrets.GRAPH_API_KEYS }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,6 @@ DEPENDENCY_TO_SERVICES = {
     "google-api-python-client": ["google_api_key", "google_engine_id"],
     "googlesearch-python": ["google_api_key", "google_engine_id"],
     "google-generativeai": ["gemini"],
-    "replicate": ["replicate"],
 }
 
 

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # ------------------------------------------------------------------------------
 #
-#   Copyright 2024 Valory AG
+#   Copyright 2024-2026 Valory AG
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.

--- a/tests/constants.py
+++ b/tests/constants.py
@@ -25,13 +25,10 @@ from dotenv import load_dotenv
 load_dotenv()
 
 OPENAI_SECRET_KEY = os.getenv("OPENAI_SECRET_KEY")
-STABILITY_API_KEY = os.getenv("STABILITY_API_KEY")
 GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")
 GOOGLE_ENGINE_ID = os.getenv("GOOGLE_ENGINE_ID")
 CLAUDE_API_KEY = os.getenv("CLAUDE_API_KEY")
-REPLICATE_API_KEY = os.getenv("REPLICATE_API_KEY")
 NEWS_API_KEY = os.getenv("NEWS_API_KEY")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY")
-GNOSIS_RPC_URL = os.getenv("GNOSIS_RPC_URL")
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 SERPER_API_KEY = os.getenv("SERPER_API_KEY")

--- a/tests/shared_constants.py
+++ b/tests/shared_constants.py
@@ -30,14 +30,11 @@ import sys
 # which env vars a tool requires based on its dependencies.
 SERVICE_TO_ENV_VAR = {
     "openai": "OPENAI_SECRET_KEY",
-    "stabilityai": "STABILITY_API_KEY",
     "google_api_key": "GOOGLE_API_KEY",
     "google_engine_id": "GOOGLE_ENGINE_ID",
     "anthropic": "CLAUDE_API_KEY",
-    "replicate": "REPLICATE_API_KEY",
     "newsapi": "NEWS_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
-    "gnosis_rpc_url": "GNOSIS_RPC_URL",
     "gemini": "GEMINI_API_KEY",
     "serperapi": "SERPER_API_KEY",
 }


### PR DESCRIPTION
## Summary

The `integration_tests` job in `common_checks.yaml` was wiring 22 secrets (11 services × singular + plural). Four of those services have **no consumer** in any customs tool, so the env vars resolve into a void:

- **Stability** (`STABILITY_API_KEY[S]`) — zero references in `packages/*/customs/`. No tool calls `stabilityai`. The `dalle_request` tool uses OpenAI's DALL·E, not Stability.
- **Replicate** (`REPLICATE_API_KEY[S]`) — zero references anywhere. No `component.yaml` declares `replicate` as a dep.
- **Gnosis RPC** (`GNOSIS_RPC_URL[S]`) — zero `Web3`/`HTTPProvider` constructions in customs. The `prepare_tx` tool is pure LLM — it emits a transaction object as text and doesn't dial an RPC.
- **The Graph** (`GRAPH_API_KEY[S]`) — zero references anywhere, and not even listed in `tests/shared_constants.py:SERVICE_TO_ENV_VAR`, so the test harness never looked for it.

Pruning these 8 env-var entries from the workflow plus the matching dangling references in test scaffolding:

- `tests/constants.py` — removed the three unread `STABILITY_API_KEY` / `REPLICATE_API_KEY` / `GNOSIS_RPC_URL` module-level constants
- `tests/shared_constants.py` — removed the three corresponding `SERVICE_TO_ENV_VAR` entries (`stabilityai`, `replicate`, `gnosis_rpc_url`)
- `tests/conftest.py` — removed `"replicate": ["replicate"]` from `DEPENDENCY_TO_SERVICES` (no tool component.yaml lists `replicate` as a dep)

15 deletions, 4 files, no behavior change.

## Why we are *not* dropping the other keys

Each kept key has at least one real call site in `packages/*/customs/` — verified by grep:

- **`OPENAI_SECRET_KEY[S]`** — used heavily (~105 references). `api_keys["openai"]` feeds `openai.OpenAI(...)` in essentially every prediction tool.
- **`OPENROUTER_API_KEY[S]`** — used heavily (~72 references). Tools route models that aren't `gpt-*` or `claude-*` through OpenRouter, e.g. `prediction_url_cot.py:182-186` and `resolve_market_jury.py:320`.
- **`CLAUDE_API_KEY[S]`** — used by 4 production tools that construct `anthropic.Anthropic(api_key=self.api_keys["anthropic"])` directly (see `prediction_url_cot.py:178`, `prediction_request_rag.py:195`, `prediction_request_reasoning.py:209`, `prediction_request.py:279`). Claude is *not* routed via OpenRouter — the LLM-provider switch on model name sends `claude-*` to the native Anthropic SDK. `prediction_url_cot` defaults to `claude-4-sonnet-20250514`, so the Anthropic branch fires under default config.
- **`GOOGLE_API_KEY[S]` + `GOOGLE_ENGINE_ID[S]`** — Google Custom Search is the *default* (fallback) search provider. Tools read `api_keys.get("search_provider", "google")` (`prediction_url_cot.py:937`, `prediction_request_reasoning.py:1248`); only when `search_provider == "serper"` is the Serper branch taken. Since no `SERPER_API_KEY` is wired into CI today, the Google branch is what actually runs.
- **`GEMINI_API_KEY[S]`** — required by `dvilela/customs/gemini_prediction` (line 164) and `victorpolisetty/customs/gemini_request`, both of which call `generativelanguage.googleapis.com` directly via `google.generativeai`. (Note: `resolve_market_jury`'s "gemini" voter uses OpenRouter, not this key — but the two dedicated tools justify keeping it.)
- **`NEWS_API_KEY[S]`** — only one reference, but it's a real call site (`api_keys["newsapi"]`). Cheap to keep.

## Test plan

- [ ] CI `integration_tests` job still passes — the deleted env vars were unused, so no tool should miss a key it actually reads.
- [ ] Unit tests (`tomte tox -e py3.10-linux`) still pass — the touched test helpers don't change behavior for tools that don't depend on the removed pip packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
