### PR TITLE
fix(superforcaster): unified C1 calibration — wins on both Omen and Polymarket

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,13 +11,13 @@
         "custom/valory/prediction_request/0.1.0": "bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky",
         "custom/valory/prepare_tx/0.1.0": "bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya",
         "custom/valory/resolve_market/0.1.0": "bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi",
-        "custom/valory/superforcaster/0.1.0": "bafybeiduissprwj2shvd4peyibvgzvlzo4ob4hy2awij6yjgsala3cmuei",
+        "custom/valory/superforcaster/0.1.0": "bafybeifxnbbhafsb32jyfl5pkh3s73ao25wys6kfhxni37pnewhsm5fj64",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeieczrqsgnozknopbzedcgvmnou6i7f3g4jx5qvpz6nbedqsmkdt2m",
         "custom/valory/resolve_market_jury/0.1.0": "bafybeift46ho26xi7mjsavqnrl5bik3l4oej5nqejz6a62eohkgtg5v4ym",
-        "agent/valory/mech_predict/0.1.0": "bafybeibqm4n6vlksypq46mrbjdsez6tvyj23o4edk47mxd3ruvjkrtjj7a",
-        "service/valory/mech_predict/0.1.0": "bafybeiew3qmvz43jiwuglrhhdy2ov6h3g2fzscnnhq4cyeospfsm2denoy"
+        "agent/valory/mech_predict/0.1.0": "bafybeihhmmcja5mauuwcc26aifxyt7mvvnvwvhjgajtqmzgfmwa5753ppe",
+        "service/valory/mech_predict/0.1.0": "bafybeig6zeen7zedzbsbxiwousjdhogekj3tmddtko4bjl57yzjfbb57nm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -61,7 +61,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
-- valory/superforcaster:0.1.0:bafybeiduissprwj2shvd4peyibvgzvlzo4ob4hy2awij6yjgsala3cmuei
+- valory/superforcaster:0.1.0:bafybeifxnbbhafsb32jyfl5pkh3s73ao25wys6kfhxni37pnewhsm5fj64
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeicurisaz4gay6r4ycq74fmxuqz6ssrfkrqoyjb5k4gc56db6kyiyu

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -7,9 +7,9 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifvbuxt54l5jsxextf6ru5yvimkfdg4gfkcsnmyvsyqcsgclg7vey
-  superforcaster.py: bafybeibfat4z2tdqvrjz6dukdz34oyb36j7bi5rqtgat42vxncai5hw6im
+  superforcaster.py: bafybeicdqq54yagrfaqnu4rsfy5hxv75xrgkshma2izzxtvfgnysbtvbeq
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
-  tests/test_superforcaster.py: bafybeigscr6ayqdkgchxxvygp25yzqlu6g6rkwg3fcbflxx2sbfpymgdqa
+  tests/test_superforcaster.py: bafybeiboaixfm4itoashxu5a4fshfe36plhnkk2tw3reznnoxz4yl7ovhm
 fingerprint_ignore_patterns: []
 entry_point: superforcaster.py
 callable: run
@@ -22,5 +22,7 @@ dependencies:
     version: ==0.25.2
   tiktoken:
     version: ==0.12.0
+  pydantic:
+    version: '>=2.0.0,<3.0.0'
   requests:
     version: ==2.32.5

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -27,6 +27,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import openai
 import requests
+from openai import OpenAI
+from pydantic import BaseModel, Field, model_validator
 from tiktoken import encoding_for_model
 
 MechResponseWithKeys = Tuple[
@@ -41,6 +43,100 @@ N_MODEL_CALLS = 1
 DEFAULT_DELIVERY_RATE = 100
 
 
+# ---------------------------------------------------------------------------
+# Pydantic schema for OpenAI Structured Outputs
+# ---------------------------------------------------------------------------
+
+
+class PredictionResult(BaseModel):
+    """Superforecaster structured output.
+
+    The text fields carry the 7-step reasoning chain (facts → pros/cons →
+    aggregation + tentative → reflection → final). Only the four numeric
+    fields at the bottom are returned on-chain per the mech protocol.
+    """
+
+    facts: str = Field(
+        ...,
+        description=(
+            "Core factual points compiled from the sources and relevant "
+            "background. Specific, relevant, no conclusions about how a "
+            "fact influences the forecast."
+        ),
+    )
+    reasons_no: str = Field(
+        ...,
+        description=(
+            "Reasons why the answer might be NO. Rate the strength of each "
+            "reason on a scale of 1-10."
+        ),
+    )
+    reasons_yes: str = Field(
+        ...,
+        description=(
+            "Reasons why the answer might be YES. Rate the strength of each "
+            "reason on a scale of 1-10."
+        ),
+    )
+    aggregation: str = Field(
+        ...,
+        description=(
+            "Aggregate considerations. Weigh competing factors, apply the "
+            "CALIBRATION block (state a base rate and justify, adjust using "
+            "specific evidence in either direction, treat absence of evidence "
+            "as informative only where check 1's scoping says so), adjust for "
+            "news negativity / sensationalism bias. End by stating a "
+            "tentative probability in [0,1]."
+        ),
+    )
+    reflection: str = Field(
+        ...,
+        description=(
+            "Sanity checks and finalisation. Apply the three checks: "
+            "EVIDENCE MATCHING, THIN EVIDENCE, NUMERIC QUESTIONS. Check for "
+            "over/underconfidence and forecasting biases. Highlight the key "
+            "factors informing the final forecast."
+        ),
+    )
+    p_yes: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Estimated probability that the event in the Question occurs.",
+    )
+    p_no: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Estimated probability that the event does NOT occur.",
+    )
+    confidence: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Confidence in the prediction (0 = lowest, 1 = highest).",
+    )
+    info_utility: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Utility of the information in the sources to inform the prediction "
+            "(0 = lowest, 1 = highest)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _check_p_yes_p_no_sum(self) -> "PredictionResult":
+        """Validate that p_yes + p_no ≈ 1."""
+        if abs(self.p_yes + self.p_no - 1.0) > 0.01:
+            raise ValueError(
+                f"p_yes + p_no must equal 1 (got {self.p_yes} + {self.p_no} = "
+                f"{self.p_yes + self.p_no})"
+            )
+        return self
+
+
 def with_key_rotation(func: Callable) -> Callable:
     """
     Decorator that retries a function with API key rotation on failure.
@@ -51,16 +147,22 @@ def with_key_rotation(func: Callable) -> Callable:
     """
 
     @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> MechResponseWithKeys:
+    def wrapper(
+        *args: Any, **kwargs: Any
+    ) -> Union[MaxCostResponse, MechResponseWithKeys]:
         # this is expected to be a KeyChain object,
         # although it is not explicitly typed as such
         api_keys = kwargs["api_keys"]
         retries_left: Dict[str, int] = api_keys.max_retries()
 
-        def execute() -> MechResponseWithKeys:
+        def execute() -> Union[MaxCostResponse, MechResponseWithKeys]:
             """Retry the function with a new key."""
             try:
-                result: MechResponse = func(*args, **kwargs)
+                result = func(*args, **kwargs)
+                # Max-cost path returns a float; pass through without appending
+                # api_keys (tuple concatenation would fail).
+                if isinstance(result, float):
+                    return result
                 return result + (api_keys,)
             except openai.RateLimitError as e:
                 # try with a new key again
@@ -81,91 +183,38 @@ def with_key_rotation(func: Callable) -> Callable:
 
 
 class OpenAIClientManager:
-    """Client context manager for OpenAI."""
+    """Context manager that creates and closes a local OpenAI client."""
 
     def __init__(self, api_key: str):
-        """Initializes with API keys"""
+        """Initializes with API key."""
         self.api_key = api_key
-        self._client: Optional["OpenAIClient"] = None
+        self._client: Optional[OpenAI] = None
 
-    def __enter__(self) -> "OpenAIClient":
-        """Initializes and returns LLM client."""
-        self._client = OpenAIClient(api_key=self.api_key)
+    def __enter__(self) -> OpenAI:
+        """Initializes and returns the OpenAI client."""
+        self._client = OpenAI(api_key=self.api_key)
         return self._client
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        """Closes the LLM client"""
+        """Closes the OpenAI client."""
         if self._client is not None:
-            self._client.client.close()
+            self._client.close()
             self._client = None
-
-
-class Usage:
-    """Usage class."""
-
-    def __init__(
-        self,
-        prompt_tokens: Optional[Any] = None,
-        completion_tokens: Optional[Any] = None,
-    ):
-        """Initializes with prompt tokens and completion tokens."""
-        self.prompt_tokens = prompt_tokens
-        self.completion_tokens = completion_tokens
-
-
-class OpenAIResponse:
-    """Response class."""
-
-    def __init__(self, content: Optional[str] = None, usage: Optional[Usage] = None):
-        """Initializes with content and usage class."""
-        self.content = content
-        self.usage = Usage()
-
-
-class OpenAIClient:
-    """OpenAI Client"""
-
-    def __init__(self, api_key: str):
-        """Initializes with API keys and client."""
-        self.api_key = api_key
-        self.client = openai.OpenAI(api_key=self.api_key)
-
-    def completions(
-        self,
-        model: str,
-        messages: List = [],  # noqa: B006
-        timeout: Optional[Union[float, int]] = None,
-        temperature: Optional[float] = None,
-        top_p: Optional[float] = None,
-        n: Optional[int] = None,
-        stop: Any = None,
-        max_tokens: Optional[float] = None,
-    ) -> Optional[OpenAIResponse]:
-        """Generate a completion from the specified LLM provider using the given model and messages."""
-        response_provider = self.client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            n=1,
-            timeout=150,
-            stop=None,
-        )
-        response = OpenAIResponse()
-        response.content = response_provider.choices[0].message.content
-        response.usage.prompt_tokens = response_provider.usage.prompt_tokens
-        response.usage.completion_tokens = response_provider.usage.completion_tokens
-        return response
 
 
 def count_tokens(text: str, model: str) -> int:
     """Count the number of tokens in a text."""
-    enc = encoding_for_model(model)
+    try:
+        enc = encoding_for_model(model)
+    except KeyError:
+        from tiktoken import get_encoding
+
+        enc = get_encoding("o200k_base")
     return len(enc.encode(text))
 
 
 DEFAULT_OPENAI_SETTINGS = {
-    "max_tokens": 500,
+    "max_tokens": 4096,
     "limit_max_tokens": 4096,
     "temperature": 0,
 }
@@ -176,6 +225,8 @@ MAX_SOURCES = 5
 COMPLETION_RETRIES = 3
 COMPLETION_DELAY = 2
 
+
+SYSTEM_PROMPT = "You are a helpful assistant."
 
 PREDICTION_PROMPT = """
 You are an advanced AI system which has been finetuned to provide calibrated probabilistic
@@ -188,7 +239,6 @@ Question:
 {question}
 
 Today's date: {today}
-Your pretraining knowledge cutoff: October 2023
 
 We have retrieved the following information for this question:
 <background>{sources}</background>
@@ -196,20 +246,21 @@ We have retrieved the following information for this question:
 Recall the question you are forecasting:
 {question}
 
-Instructions:
-1. Compress key factual information from the sources, as well as useful background information
+Return a structured PredictionResult whose fields capture the following reasoning chain:
+
+1. `facts` — Compress key factual information from the sources, as well as useful background information
 which may not be in the sources, into a list of core factual points to reference. Aim for
 information which is specific, relevant, and covers the core considerations you'll use to make
 your forecast. For this step, do not draw any conclusions about how a fact will influence your
-answer or forecast. Place this section of your response in <facts></facts> tags.
+answer or forecast.
 
-2. Provide a few reasons why the answer might be no. Rate the strength of each reason on a
-scale of 1-10. Use <no></no> tags.
+2. `reasons_no` — Provide a few reasons why the answer might be no. Rate the strength of each reason on a
+scale of 1-10.
 
-3. Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
-scale of 1-10. Use <yes></yes> tags.
+3. `reasons_yes` — Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
+scale of 1-10.
 
-4. Aggregate your considerations. Do not summarize or repeat previous points; instead,
+4. `aggregation` — Aggregate your considerations. Do not summarize or repeat previous points; instead,
 investigate how the competing factors and mechanisms interact and weigh against each other.
 Factorize your thinking across (exhaustive, mutually exclusive) cases if and only if it would be
 beneficial to your reasoning. We have detected that you overestimate world conflict, drama,
@@ -217,13 +268,22 @@ violence, and crises due to news' negativity bias, which doesn't necessarily rep
 trends or base rates. Similarly, we also have detected you overestimate dramatic, shocking,
 or emotionally charged news due to news' sensationalism bias. Therefore adjust for news'
 negativity bias and sensationalism bias by considering reasons to why your provided sources
-might be biased or exaggerated. Think like a superforecaster. Use <thinking></thinking> tags
-for this section of your response.
+might be biased or exaggerated. Think like a superforecaster.
 
-5. Output an initial probability (prediction) as a single number between 0 and 1 given steps 1-4.
-Use <tentative></tentative> tags.
+CALIBRATION (mandatory before any probability):
+- State a base-rate probability for this event category and justify it.
+- Adjust from the base rate using specific evidence in EITHER direction.
+- Absence of evidence cuts both ways. Treat "no confirmation / no announcement
+  found" as a NO signal ONLY for one-shot discretionary events that would have
+  left a public trace if they had happened. For scheduled, recurring, or
+  already-in-motion outcomes (elections/appointments on a fixed date, regular
+  data releases, contests with a set timetable), absence of fresh news is NOT
+  evidence of NO — reason from the base rate and the schedule instead.
 
-6. Reflect on your answer, performing sanity checks and mentioning any additional knowledge
+End the `aggregation` field by stating an initial tentative probability (a single number between 0 and 1)
+given steps 1-4.
+
+5. `reflection` — Reflect on your tentative answer, performing sanity checks and mentioning any additional knowledge
 or background information which may be relevant. Check for over/underconfidence, improper
 treatment of conjunctive or disjunctive conditions (only if applicable), and other forecasting
 biases when reviewing your reasoning. Consider priors/base rates, and the extent to which
@@ -231,59 +291,91 @@ case-specific information justifies the deviation between your tentative forecas
 Recall that your performance will be evaluated according to the Brier score. Be precise with tail
 probabilities. Leverage your intuitions, but never change your forecast for the sake of modesty
 or balance alone. Finally, aggregate all of your previous reasoning and highlight key factors
-that inform your final forecast. Use <thinking></thinking> tags for this portion of your response.
+that inform your final forecast.
 
-7. Output your final prediction (a number between 0 and 1 with an asterisk at the beginning and
-end of the decimal) in <answer></answer> tags.
+BEFORE FINAL ANSWER — apply all three checks:
 
+1. EVIDENCE MATCHING: Match confidence to evidence strength in BOTH
+   directions — neither inflate nor deflate. If sources confirm the event
+   occurred, a high p_yes is correct; if they confirm it cannot or did not,
+   a low p_yes is correct. Plans, proposals, and stated intentions are not
+   completed actions — but a credible, on-schedule path to the outcome is
+   evidence, not the absence of it. Do not cap a well-supported probability
+   merely because it is extreme.
 
-OUTPUT_FORMAT
-* Your output response must be only a single JSON object to be parsed by Python's "json.loads()".
-* The JSON must contain four fields: "p_yes", "p_no", "confidence", and "info_utility".
-* Each item in the JSON must have a value between 0 and 1.
+2. THIN EVIDENCE: If the evidence is genuinely weak or absent (and check 1's
+   scoping says absence is uninformative here), stay near your stated base
+   rate rather than guessing toward 0 or 1. Do not force the probability into
+   a fixed band — a confident, well-evidenced call should stay confident.
+
+3. NUMERIC QUESTIONS: For price/temperature/count thresholds, find the current
+   value and compare to the threshold, weighted by time remaining: a large gap
+   with little time left is strong evidence; the same gap with ample time is
+   weaker. The gap informs the estimate; it does not override a well-reasoned
+   forecast.
+
+6. `p_yes`, `p_no`, `confidence`, `info_utility` — the four numeric fields:
    - "p_yes": Estimated probability that the event in the "Question" occurs.
    - "p_no": Estimated probability that the event in the "Question" does not occur.
    - "confidence": A value between 0 and 1 indicating the confidence in the prediction. 0 indicates lowest
      confidence value; 1 maximum confidence value.
    - "info_utility": Utility of the information provided in "sources" to help you make the prediction.
      0 indicates lowest utility; 1 maximum utility.
-* The sum of "p_yes" and "p_no" must equal 1.
-* Output only the JSON object. Do not include any other contents in your response.
-* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
-* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
-* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
+   - Each value must be between 0 and 1.
+   - The sum of "p_yes" and "p_no" must equal 1.
 """
 
 
-def generate_prediction_with_retry(
-    client: "OpenAIClient",
+def _parse_completion(
+    client: OpenAI,
     model: str,
     messages: List[Dict[str, str]],
-    temperature: float,
-    max_tokens: int,
+    response_format: Any,
+    temperature: float = 0,
+    max_tokens: int = 4096,
     retries: int = COMPLETION_RETRIES,
     delay: int = COMPLETION_DELAY,
     counter_callback: Optional[Callable] = None,
 ) -> Tuple[Any, Optional[Callable]]:
-    """Attempt to generate a prediction with retries on failure."""
+    """Call OpenAI Structured Outputs and parse into a Pydantic model.
+
+    ``client.beta.chat.completions.parse()`` guarantees the response conforms
+    to the supplied Pydantic schema — no prompt-side JSON format instructions
+    or regex extraction required.
+
+    :param client: an initialised OpenAI client.
+    :param model: OpenAI model identifier.
+    :param messages: chat messages list (role + content dicts).
+    :param response_format: Pydantic model class used as the structured-output schema.
+    :param temperature: sampling temperature (0 = deterministic).
+    :param max_tokens: maximum tokens to generate.
+    :param retries: number of retry attempts on transient / validation failure.
+    :param delay: delay in seconds between retries.
+    :param counter_callback: optional callback tracking token usage.
+    :return: tuple of (parsed model instance, counter_callback).
+    :raises RuntimeError: if all retries exhausted without a successful parse.
+    """
     attempt = 0
     while attempt < retries:
         try:
-            response = client.completions(
+            response = client.beta.chat.completions.parse(
                 model=model,
                 messages=messages,
+                response_format=response_format,
                 temperature=temperature,
                 max_tokens=max_tokens,
-                n=1,
-                timeout=90,
-                stop=None,
+                timeout=150,
             )
 
-            if (
-                response
-                and response.content is not None
-                and counter_callback is not None
-            ):
+            parsed = response.choices[0].message.parsed
+
+            if parsed is None:
+                refusal = response.choices[0].message.refusal
+                raise ValueError(
+                    f"Model refused or returned unparseable output: {refusal}"
+                )
+
+            if counter_callback is not None:
                 counter_callback(
                     input_tokens=response.usage.prompt_tokens,
                     output_tokens=response.usage.completion_tokens,
@@ -291,13 +383,23 @@ def generate_prediction_with_retry(
                     token_counter=count_tokens,
                 )
 
-            content = response.content if response else None
-            return content, counter_callback
-        except Exception as e:
-            print(f"Attempt {attempt + 1} failed with error: {e}")
+            return parsed, counter_callback
+        except (
+            openai.APIConnectionError,
+            openai.RateLimitError,
+            openai.InternalServerError,
+            ValueError,
+        ) as e:
+            # Retry only transient failures and model-side issues:
+            #   - APIConnectionError (includes APITimeoutError) — network blips
+            #   - RateLimitError / InternalServerError — OpenAI-side retryable
+            #   - ValueError — covers pydantic ValidationError (e.g. p_yes+p_no
+            #     sum check) and the inline "Model refused…" raise above
+            print(f"[superforcaster] Attempt {attempt + 1} failed: {e}")
             time.sleep(delay)
             attempt += 1
-    raise Exception("Failed to generate prediction after retries")
+
+    raise RuntimeError("Failed to get structured LLM completion after retries")
 
 
 def fetch_additional_sources(question: Any, serper_api_key: Any) -> requests.Response:
@@ -436,26 +538,47 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
         )
         print(f"\n{prediction_prompt=}\n")
         messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": prediction_prompt},
         ]
         print("Getting prompt response...")
-        extracted_block, counter_callback = generate_prediction_with_retry(
+        prediction: PredictionResult
+        prediction, counter_callback = _parse_completion(
             client=llm_client,
             model=model,
             messages=messages,
+            response_format=PredictionResult,
             temperature=temperature,
             max_tokens=max_tokens,
-            retries=COMPLETION_RETRIES,
-            delay=COMPLETION_DELAY,
             counter_callback=counter_callback,
         )
 
-        used_params = {
+        print(f"[superforcaster] === FACTS ===\n{prediction.facts}")
+        print(f"[superforcaster] === REASONS_NO ===\n{prediction.reasons_no}")
+        print(f"[superforcaster] === REASONS_YES ===\n{prediction.reasons_yes}")
+        print(f"[superforcaster] === AGGREGATION ===\n{prediction.aggregation}")
+        print(f"[superforcaster] === REFLECTION ===\n{prediction.reflection}")
+        print(
+            f"[superforcaster] Result: p_yes={prediction.p_yes}, "
+            f"p_no={prediction.p_no}, confidence={prediction.confidence}, "
+            f"info_utility={prediction.info_utility}"
+        )
+
+        # On-chain result — only the four standard mech fields.
+        result = json.dumps(
+            {
+                "p_yes": prediction.p_yes,
+                "p_no": prediction.p_no,
+                "confidence": prediction.confidence,
+                "info_utility": prediction.info_utility,
+            }
+        )
+
+        used_params: Dict[str, Any] = {
             "model": model,
             "temperature": temperature,
             "max_tokens": max_tokens,
         }
         if return_source_content:
             used_params["source_content"] = captured_source_content
-        return extracted_block, prediction_prompt, None, counter_callback, used_params
+        return result, prediction_prompt, None, counter_callback, used_params

--- a/packages/valory/customs/superforcaster/tests/test_superforcaster.py
+++ b/packages/valory/customs/superforcaster/tests/test_superforcaster.py
@@ -17,7 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Unit tests for superforcaster: thread-safe client, offline tiktoken, and source_content."""
+"""Unit tests for superforcaster: thread-safe client, structured outputs, source_content."""
 
 import inspect
 import json
@@ -29,7 +29,8 @@ import pytest
 import packages.valory.customs.superforcaster.superforcaster as module
 from packages.valory.customs.superforcaster.superforcaster import (
     OpenAIClientManager,
-    generate_prediction_with_retry,
+    PredictionResult,
+    _parse_completion,
     run,
 )
 
@@ -37,20 +38,20 @@ from packages.valory.customs.superforcaster.superforcaster import (
 class TestOpenAIClientManager:
     """Verify OpenAIClientManager creates per-context clients without globals."""
 
-    def test_context_manager_returns_client_instance(self) -> None:
-        """__enter__ returns a fresh OpenAIClient, __exit__ closes it."""
+    def test_context_manager_returns_openai_client(self) -> None:
+        """__enter__ returns a fresh openai.OpenAI client, __exit__ closes it."""
         mgr = OpenAIClientManager(api_key="sk-test")
         with patch(
-            "packages.valory.customs.superforcaster.superforcaster.OpenAIClient"
-        ) as MockClient:
+            "packages.valory.customs.superforcaster.superforcaster.OpenAI"
+        ) as MockOpenAI:
             mock_instance = MagicMock()
-            MockClient.return_value = mock_instance
+            MockOpenAI.return_value = mock_instance
 
             with mgr as client:
                 assert client is mock_instance
-                MockClient.assert_called_once_with(api_key="sk-test")
+                MockOpenAI.assert_called_once_with(api_key="sk-test")
 
-            mock_instance.client.close.assert_called_once()
+            mock_instance.close.assert_called_once()
 
     def test_no_global_client_variable(self) -> None:
         """The module must not define a module-level 'client' variable."""
@@ -63,9 +64,9 @@ class TestOpenAIClientManager:
                         f"Module-level 'client' variable found at line {i}: {line}"
                     )
 
-    def test_generate_prediction_requires_client_param(self) -> None:
-        """generate_prediction_with_retry requires client as first param."""
-        params = list(inspect.signature(generate_prediction_with_retry).parameters)
+    def test_parse_completion_requires_client_param(self) -> None:
+        """_parse_completion requires client as first param."""
+        params = list(inspect.signature(_parse_completion).parameters)
         assert params[0] == "client"
 
 
@@ -86,8 +87,16 @@ FAKE_SERPER_RESPONSE = {
     ],
 }
 
-PREDICTION_JSON = json.dumps(
-    {"p_yes": 0.5, "p_no": 0.5, "confidence": 0.5, "info_utility": 0.5}
+FAKE_PREDICTION = PredictionResult(
+    facts="Fact 1. Fact 2.",
+    reasons_no="No 1 (strength 6). No 2 (strength 4).",
+    reasons_yes="Yes 1 (strength 5). Yes 2 (strength 3).",
+    aggregation="Base rate 0.5. Tentative: 0.5.",
+    reflection="Passes evidence bar.",
+    p_yes=0.5,
+    p_no=0.5,
+    confidence=0.5,
+    info_utility=0.5,
 )
 
 PREDICTION_PROMPT = (
@@ -110,6 +119,116 @@ def _make_mock_api_keys(return_source_content: str = "false") -> MagicMock:
     return mock
 
 
+def _mock_parse_response() -> MagicMock:
+    """Build a fake response object matching the beta.chat.completions.parse shape."""
+    return MagicMock(
+        choices=[MagicMock(message=MagicMock(parsed=FAKE_PREDICTION, refusal=None))],
+        usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+class TestStructuredOutputContract:
+    """Verify the tool uses OpenAI Structured Outputs and returns only the 4 on-chain fields."""
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_uses_beta_parse_with_prediction_result_schema(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """run() calls client.beta.chat.completions.parse with response_format=PredictionResult."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        run(
+            tool="superforcaster",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+
+        mock_client.beta.chat.completions.parse.assert_called_once()
+        kwargs = mock_client.beta.chat.completions.parse.call_args.kwargs
+        assert kwargs["response_format"] is PredictionResult
+        assert kwargs["model"] == "gpt-4.1-2025-04-14"
+        mock_client.chat.completions.create.assert_not_called()
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_returns_only_four_mech_fields_on_chain(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """The on-chain result JSON contains exactly p_yes/p_no/confidence/info_utility."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = run(
+            tool="superforcaster",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+
+        on_chain_json = result[0]
+        parsed = json.loads(on_chain_json)
+        assert set(parsed.keys()) == {"p_yes", "p_no", "confidence", "info_utility"}
+        assert "facts" not in parsed
+        assert "reasons_no" not in parsed
+        assert "aggregation" not in parsed
+        assert "reflection" not in parsed
+        assert parsed["p_yes"] == 0.5
+        assert parsed["p_no"] == 0.5
+
+
+class TestPredictionResultValidator:
+    """Pydantic sum validator rejects malformed probabilities."""
+
+    def test_valid_sum_accepted(self) -> None:
+        """p_yes + p_no = 1.0 is accepted."""
+        obj = PredictionResult(
+            facts="f",
+            reasons_no="n",
+            reasons_yes="y",
+            aggregation="a",
+            reflection="r",
+            p_yes=0.7,
+            p_no=0.3,
+            confidence=0.6,
+            info_utility=0.5,
+        )
+        assert obj.p_yes == 0.7
+
+    def test_sum_violation_rejected(self) -> None:
+        """p_yes + p_no outside 0.01 tolerance raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PredictionResult(
+                facts="f",
+                reasons_no="n",
+                reasons_yes="y",
+                aggregation="a",
+                reflection="r",
+                p_yes=0.7,
+                p_no=0.2,
+                confidence=0.6,
+                info_utility=0.5,
+            )
+
+
 class TestSuperforcasterSourceContent:
     """Verify superforcaster captures and replays source_content correctly."""
 
@@ -124,16 +243,13 @@ class TestSuperforcasterSourceContent:
         mock_fetch.return_value = mock_response
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         result = run(
             tool="superforcaster",
-            model="gpt-4o",
+            model="gpt-4.1-2025-04-14",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("true"),
             counter_callback=None,
@@ -151,17 +267,14 @@ class TestSuperforcasterSourceContent:
     ) -> None:
         """Replay with {'serper_response': ...} uses organic and peopleAlsoAsk."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         source_content = {"serper_response": FAKE_SERPER_RESPONSE}
         result = run(
             tool="superforcaster",
-            model="gpt-4o",
+            model="gpt-4.1-2025-04-14",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("true"),
             counter_callback=None,
@@ -185,16 +298,13 @@ class TestSuperforcasterSourceContent:
         mock_fetch.return_value = mock_response
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         result = run(
             tool="superforcaster",
-            model="gpt-4o",
+            model="gpt-4.1-2025-04-14",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("false"),
             counter_callback=None,

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeibqm4n6vlksypq46mrbjdsez6tvyj23o4edk47mxd3ruvjkrtjj7a
+agent: valory/mech_predict:0.1.0:bafybeihhmmcja5mauuwcc26aifxyt7mvvnvwvhjgajtqmzgfmwa5753ppe
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Problem

No `superforcaster` version is good on both platforms. The v0.17.x calibration rules were a **−11% Brier win on Omen** (matched-market) but a **+16% Brier regression on Polymarket**, which forced the v0.18.2 revert (commit `b22c7055`) back to the v0.16.5 calib-OFF implementation. So today the two deployed builds are split: calib-OFF is live on Polymarket (good there, bad on Omen), calib-ON is live on Omen (good there, bad on Polymarket). `main` cannot be good for both with a single static prompt.

## Diagnosis (production data, not guesswork)

The CI `benchmark-data` logs contained both the calib-ON and the reverted calib-OFF builds running on Polymarket in the same window (~50k SF rows). Matched-market, mix-controlled: calib-ON is **+4.1% Brier worse on Polymarket, localized to `politics`**. Mechanism — the calibration applies a **directional NO-tilt**: it demotes correct-YES politics calls, and the high-confidence YES calls that survive are 91% wrong. The original Omen NO-skew that made calibration a pure win there was fixed ~2026-04-17 (OmenStrat market-maker change; yes-rate ~20% → ~48%), so both platforms are now ~50/50 and the NO-tilt is pure downside on Polymarket — making a single unified prompt feasible.

## The fix — "C1"

Restore the v0.18.1 calibrated Structured-Outputs build and replace its calibration block with a symmetric, scoped version that keeps the overconfidence suppression (the Omen win) but removes the NO-tilt:

- absence-of-evidence "NO signal" → "cuts both ways", scoped to one-shot discretionary events only
- `EVIDENCE BAR` asymmetric `p_yes>0.80/0.90` caps → symmetric `EVIDENCE MATCHING` (keeps "plans/intentions ≠ completed")
- hard `CONFIDENCE COUPLING` clamp → `THIN EVIDENCE` (stay near base rate, no fixed band). This clamp is the rule PR #200 rolled back on `prediction-request-reasoning` to "eliminate Polymarket regression", but it was never rolled back for superforcaster.
- `NUMERIC QUESTIONS` made time-weighted; informs, does not override
- Pydantic schema field descriptions aligned to the new block

## Validation

Representative, deduplicated, category-stratified local cached-replay (198 distinct-question markets). The load-bearing results are the two **same-market, same-evidence paired** comparisons — C1 replayed vs the prompt that actually ran in production for that delivery:

| Comparison (paired, same markets) | n | Baseline Brier | C1 Brier | Δ |
|---|---|---|---|---|
| **Omen vs the live calib-ON build** | 71 | 0.1613 | **0.1511** | **−6.3%** |
| **Polymarket vs the live calib-OFF build** | 59 | 0.2400 | **0.2218** | **−7.6%** |

C1 is a single prompt that beats the prompt **currently deployed on each platform**, on both. OCW improved on both. An earlier variant (C2) was tested and rejected for regressing the Omen guard.

**Caveats — read these before trusting the numbers.** Moderate n (solid for the per-platform aggregate; per-category cells are noise — ignore them). This is local replay, not yet confirmed at scale. A third cell (C1 vs calib-ON on Polymarket, +6.3%) is **deliberately excluded** from the conclusion: it is on a different, harder market subset (baseline Brier 0.31 vs 0.24) and is not comparable to the rows above — it is not evidence about C1 vs the deployable Polymarket bar (which is calib-OFF, and C1 beats it). A clean three-way (C1 vs calib-ON vs calib-OFF on identical markets) requires the CI run below.

## Confirm at larger n before merge

Comment `/benchmark superforcaster --sample 200` on this PR (or run the `benchmark-replay` workflow) to validate at scale on a runner — this should gate the merge decision. Hashes re-locked (custom + agent + service); branch rebased on latest `main`; tests 10/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)