### PR TITLE
fix(jury): bump grok-4.1-fast (retired) -> grok-4.3

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -15,9 +15,9 @@
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeieczrqsgnozknopbzedcgvmnou6i7f3g4jx5qvpz6nbedqsmkdt2m",
-        "custom/valory/resolve_market_jury/0.1.0": "bafybeift46ho26xi7mjsavqnrl5bik3l4oej5nqejz6a62eohkgtg5v4ym",
-        "agent/valory/mech_predict/0.1.0": "bafybeibqm4n6vlksypq46mrbjdsez6tvyj23o4edk47mxd3ruvjkrtjj7a",
-        "service/valory/mech_predict/0.1.0": "bafybeiew3qmvz43jiwuglrhhdy2ov6h3g2fzscnnhq4cyeospfsm2denoy"
+        "custom/valory/resolve_market_jury/0.1.0": "bafybeiezdf24cnpdvf42yf3t5yebr2mciphbuf6j7ccwwghpatb4avdb4y",
+        "agent/valory/mech_predict/0.1.0": "bafybeic7wapqu7jlw3pb5nr3jxpwv4nkksnc2ov6gmruqfoa3zu5j6zniq",
+        "service/valory/mech_predict/0.1.0": "bafybeigxkpxs6k3r7w663ypdu5jroyv5p2r3j34ffwycnbnq7atghwykpm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -51,7 +51,7 @@ skills:
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay
 customs:
 - valory/resolve_market:0.1.0:bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi
-- valory/resolve_market_jury:0.1.0:bafybeift46ho26xi7mjsavqnrl5bik3l4oej5nqejz6a62eohkgtg5v4ym
+- valory/resolve_market_jury:0.1.0:bafybeiezdf24cnpdvf42yf3t5yebr2mciphbuf6j7ccwwghpatb4avdb4y
 - valory/prediction_request:0.1.0:bafybeigbcls6rcqjtjrq3duo3obzpxu2ayj7vsjofixn7qvljhdmc75pky
 - napthaai/resolve_market_reasoning:0.1.0:bafybeihk5wteioppm33pojdvdk32nnlryhkvowuvpn22c4a6prwkknzq34
 - napthaai/prediction_request_rag:0.1.0:bafybeiasyiowjgwaadzmqp5hekg77bfpj22vv4abjwho2vrobhvlutfs4e

--- a/packages/valory/customs/resolve_market_jury/component.yaml
+++ b/packages/valory/customs/resolve_market_jury/component.yaml
@@ -8,7 +8,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifrz7qan24aum3xyaavvl437rdffrposlcmobujzqwyb34e5d5ule
-  resolve_market_jury.py: bafybeigh5ozjf4zfu5c22huitc6xglluc3vzsewlgevqmnvfnezkgjitbq
+  resolve_market_jury.py: bafybeicbth4b54mhj6yerpr7jmeak3qdxpijq7addokwbr43wgg4d27mpy
   tests/__init__.py: bafybeicxwzllyegjmuqjdilqfjdvskya5w5nc44nc6cb2ytvcgsldmivza
   tests/test_resolve_market_jury.py: bafybeign5lxrglt46dyckpo5evononmdmg56hpchpaswlomwp7vfvx5br4
 fingerprint_ignore_patterns: []

--- a/packages/valory/customs/resolve_market_jury/resolve_market_jury.py
+++ b/packages/valory/customs/resolve_market_jury/resolve_market_jury.py
@@ -58,7 +58,7 @@ DEFAULT_DELIVERY_RATE = 100
 # ---------------------------------------------------------------------------
 
 VOTER_MODEL_OPENAI = "openai/gpt-4.1:online"
-VOTER_MODEL_GROK = "x-ai/grok-4.1-fast:online"
+VOTER_MODEL_GROK = "x-ai/grok-4.3:online"
 VOTER_MODEL_GEMINI = "google/gemini-2.5-flash:online"
 VOTER_MODEL_CLAUDE = "anthropic/claude-haiku-4.5:online"
 JUDGE_MODEL_CLAUDE = "anthropic/claude-sonnet-4:online"

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeibqm4n6vlksypq46mrbjdsez6tvyj23o4edk47mxd3ruvjkrtjj7a
+agent: valory/mech_predict:0.1.0:bafybeic7wapqu7jlw3pb5nr3jxpwv4nkksnc2ov6gmruqfoa3zu5j6zniq
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

xAI retired ``grok-4.1-fast``. Calling the slug from the jury returns ``404 Grok 4.1 Fast is deprecated``, which the jury treats as a failed voter — silently degrading the panel to 3-voter quorum and inflating the ``credit-exhausted``-looking error population in downstream classifiers.

Direct successor per xAI's deprecation message: ``x-ai/grok-4.3``. Verified live against the OpenRouter ``/api/v1/models`` endpoint — the only Grok slugs currently listed are:

- ``x-ai/grok-4.3`` (1M ctx, \$1.25/Mtok in, \$2.50/Mtok out, \$5/1k web)
- ``x-ai/grok-4.20`` (2M ctx, same price)
- ``x-ai/grok-4.20-multi-agent`` (2M ctx, \$2/in, \$6/out)

``grok-4.3-fast`` does NOT exist (the "fast" SKU was discontinued with the 4.1 retirement).

## Cost impact

``grok-4.3`` is materially more expensive than the retired fast tier. Micro-benchmark on 3 prediction-market questions:

| Model | Avg \$/call |
|---|---|
| **x-ai/grok-4.3:online** | **\$0.02182** |
| openai/gpt-4.1-mini:online | \$0.01362 |
| google/gemini-2.5-flash:online (already on panel) | \$0.00718 |
| perplexity/sonar | \$0.00609 |

Grok input-token consumption is prompt-sensitive (ranged \$0.003 → \$0.043 across the benchmark). This PR is the **minimal correctness fix** so the jury stops losing the Grok voter; a separate optimization conversation can decide whether to swap the seat to a cheaper provider.

## Test plan

- [x] ``tomte tox -e isort,black,mypy,flake8,darglint,bandit`` all green
- [x] OpenRouter slug existence verified live via ``/api/v1/models``
- [x] 3/3 benchmark calls against ``x-ai/grok-4.3:online`` returned valid jury-schema JSON
- [x] ``autonomy packages lock`` propagated: component.yaml → agent → service → packages.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)