### PR TITLE
fix(benchmark): bump OpenAI summarize timeout 30s → 120s

### DIFF
--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -276,7 +276,7 @@ def summarize_report(report_text: str, api_key: str, platform_label: str) -> str
         },
     )
     with urlopen(
-        req, timeout=30
+        req, timeout=120
     ) as resp:  # nosec B310 — fixed https URL, not user-controlled
         body = json.loads(resp.read())
 


### PR DESCRIPTION
## Summary

- The 30s read timeout on the Slack-notify OpenAI call (`benchmark/notify_slack.py:summarize_report`) sat right at gpt-4.1-mini's tail latency for a full benchmark report, intermittently failing CI.
- Bumped per-attempt timeout to 120s — ~3-4× the observed worst case, plenty of headroom without changing retry/error semantics.

## Why

Failing CI run: https://github.com/valory-xyz/mech-predict/actions/runs/26139969318/job/76883444314 — `TimeoutError: The read operation timed out` while summarizing the Polystrat report.

Measured locally against the same `report_polymarket.md` artifact from that run:

| Run | Report | Actual time | 30s cap | 120s cap |
| --- | --- | --- | --- | --- |
| 1 | polymarket (Polystrat) | 33.7s | ❌ would fail | ✅ |
| 1 | omen (Omenstrat) | 25.0s | ✅ (just) | ✅ |
| 2 | polymarket | 18.5s | ✅ | ✅ |
| 3 | polymarket | 20.0s | ✅ | ✅ |

The call's natural variance (~18-35s) crosses the 30s cap often enough to fail CI semi-regularly. This is not a transient network blip — it's that the cap is too tight for the call's own latency distribution.

## Test plan

- [ ] CI runs the next scheduled `benchmark-flywheel` and `Post Polystrat summary to Slack` step passes.