### PR TITLE
fix(tournament): load IPFS tools as modules, not exec'd into a bare dict

### DIFF
--- a/benchmark/ipfs_loader.py
+++ b/benchmark/ipfs_loader.py
@@ -2,9 +2,9 @@
 IPFS-backed tool loader for tournament mode.
 
 Fetches tool source from a public IPFS gateway by CID, caches on disk,
-execs the entry_point, and returns the run callable. Used by tournament
-mode so candidate tool versions can be benchmarked without merging them
-to packages.json.
+imports the entry-point as a proper module, and returns the run callable.
+Used by tournament mode so candidate tool versions can be benchmarked
+without merging them to packages.json.
 
 One TAR GET per tool: ``Accept: application/x-tar`` on the CID returns a
 tarball whose top-level entry is a wrapper directory (named after the
@@ -12,12 +12,23 @@ package, e.g. ``superforcaster/``) containing ``component.yaml``, the
 entry-point ``.py``, and noise we ignore (``__init__.py``, ``tests/``).
 We extract just the two files we need into ``cache_dir/{cid}/`` and
 hand them to ``ComponentPackageLoader.load``.
+
+The entry-point is loaded via ``importlib.util.spec_from_file_location``
+so classes defined in it get a real ``__module__`` registered in
+``sys.modules``. ``exec(source, namespace)`` is unsafe for tool code
+that uses pydantic ``BaseModel`` with forward references (e.g.
+``List[str]``) — pydantic resolves forward refs by looking up
+``cls.__module__`` in ``sys.modules`` and falls over with
+``class-not-fully-defined`` when the class was exec'd into a bare dict
+namespace whose ``__module__`` resolves to ``'builtins'``.
 """
 
 from __future__ import annotations
 
+import importlib.util
 import io
 import logging
+import sys
 import tarfile
 import time
 from pathlib import Path
@@ -261,19 +272,26 @@ def fetch_tool_package(cid: str, cache_dir: Path = DEFAULT_CACHE_DIR) -> dict[st
 def load_tool_from_ipfs(
     cid: str, cache_dir: Path = DEFAULT_CACHE_DIR
 ) -> Callable[..., Any]:
-    """Fetch a tool package from IPFS, exec it, return its run callable.
+    """Fetch a tool package from IPFS, import it, return its run callable.
+
+    The entry-point file on disk (written by ``fetch_tool_package``) is
+    loaded via ``importlib.util.spec_from_file_location`` under a
+    CID-derived module name. The module is registered in ``sys.modules``
+    so introspection-based libraries (pydantic forward refs, dataclasses,
+    typing.get_type_hints) can resolve names from the module's namespace.
 
     :param cid: IPFS CID of the tool package.
     :param cache_dir: on-disk cache location.
     :return: the tool's run callable (``component.yaml:callable``).
-    :raises IpfsFetchError: on gateway / network failures, or if the
-        package's ``component.yaml`` does not point at the named callable.
+    :raises IpfsFetchError: on gateway / network failures, on
+        ``component.yaml`` problems, or if the entry-point module can't
+        be imported or doesn't expose the named callable.
     """
     package = fetch_tool_package(cid, cache_dir=cache_dir)
     try:
         (
             _component_yaml,
-            entry_point_source,
+            _entry_point_source,
             callable_name,
         ) = ComponentPackageLoader.load(package)
     except Exception as exc:  # pylint: disable=broad-except
@@ -281,17 +299,39 @@ def load_tool_from_ipfs(
             f"IPFS fetch failed: cid={cid} component package load failed: {exc!r}"
         ) from exc
 
-    namespace: dict[str, Any] = {}
-    try:
-        exec(entry_point_source, namespace)  # nosec B102 # pylint: disable=exec-used
-    except Exception as exc:  # pylint: disable=broad-except
+    # The entry-point name is the only non-yaml key in the package dict;
+    # `fetch_tool_package` wrote that file to `cache_dir/{cid}/{name}`.
+    entry_point_name = next(k for k in package if k != "component.yaml")
+    entry_path = _cache_path(cache_dir, cid, entry_point_name)
+
+    # Unique module name per CID — lets a candidate CID and the
+    # production CID for the same tool coexist in one process.
+    module_name = f"mech_predict_tournament_tool_{cid}"
+
+    cached_mod = sys.modules.get(module_name)
+    if cached_mod is not None and hasattr(cached_mod, callable_name):
+        return getattr(cached_mod, callable_name)
+
+    spec = importlib.util.spec_from_file_location(module_name, entry_path)
+    if spec is None or spec.loader is None:
         raise IpfsFetchError(
-            f"IPFS fetch failed: cid={cid} entry_point exec failed: {exc!r}"
+            f"IPFS fetch failed: cid={cid} could not build import spec "
+            f"for {entry_path}"
+        )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception as exc:  # pylint: disable=broad-except
+        sys.modules.pop(module_name, None)
+        raise IpfsFetchError(
+            f"IPFS fetch failed: cid={cid} entry_point module load failed: {exc!r}"
         ) from exc
 
-    if callable_name not in namespace:
+    if not hasattr(module, callable_name):
+        sys.modules.pop(module_name, None)
         raise IpfsFetchError(
             f"IPFS fetch failed: cid={cid} callable '{callable_name}' "
-            f"not found in entry_point after exec"
+            f"not found in entry_point module"
         )
-    return namespace[callable_name]
+    return getattr(module, callable_name)

--- a/benchmark/tests/test_ipfs_loader.py
+++ b/benchmark/tests/test_ipfs_loader.py
@@ -19,9 +19,11 @@
 """Tests for benchmark/ipfs_loader.py — network mocked."""
 
 import io
+import sys
 import tarfile
 import time
 from pathlib import Path
+from typing import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -35,6 +37,22 @@ from benchmark.ipfs_loader import (
 )
 
 CID = "bafybeitestcid"
+
+
+# Tests share a fixed `CID` constant while swapping out the on-disk
+# source per case, so without this teardown a later test would hit a
+# previous test's module cached under that CID in `sys.modules`.
+@pytest.fixture(autouse=True)
+def _clear_tournament_tool_modules() -> Iterator[None]:
+    """Evict cached tournament-tool modules between tests.
+
+    :yield: control to the test, then evict on teardown.
+    """
+    yield
+    stale = [k for k in sys.modules if k.startswith("mech_predict_tournament_tool_")]
+    for k in stale:
+        sys.modules.pop(k, None)
+
 
 COMPONENT_YAML = """\
 name: testtool
@@ -378,17 +396,50 @@ class TestValidateEntryPointName:
 
 
 class TestLoadToolFromIpfs:
-    """End-to-end tests: fetch + exec returns a callable."""
+    """End-to-end tests: fetch + import returns a callable."""
 
     @patch("benchmark.ipfs_loader.requests.get")
     def test_returns_callable(self, mock_get: MagicMock, tmp_path: Path) -> None:
-        """A successful fetch + exec returns the named callable."""
+        """A successful fetch + import returns the named callable."""
         mock_get.return_value = _mock_response(200, _build_tar())
         run_fn = load_tool_from_ipfs(CID, cache_dir=tmp_path)
         assert callable(run_fn)
         # Call it to confirm it's the run we wrote, not something else
         result = run_fn()
         assert result == ("ok", None, None, None, None)
+
+    # Regression test for the loader's original `exec(src, {})` path:
+    # classes got `__module__ = 'builtins'` and pydantic 2.13 couldn't
+    # resolve forward refs like `List[str]` when the OpenAI SDK validated
+    # a `response_format=SomeModel` argument. Latent on PR #251 because
+    # the smoke test ran superforcaster, which doesn't use pydantic.
+    @patch("benchmark.ipfs_loader.requests.get")
+    def test_pydantic_forward_refs_resolve(
+        self, mock_get: MagicMock, tmp_path: Path
+    ) -> None:
+        """Loaded tools whose classes use forward refs (`List[str]`) must work."""
+        pydantic_py = (
+            "from typing import List\n"
+            "from pydantic import BaseModel, Field\n"
+            "\n"
+            "class SubQuestions(BaseModel):\n"
+            "    sub_questions: List[str] = Field(...)\n"
+            "\n"
+            "def run(**kwargs):\n"
+            "    parsed = SubQuestions.model_validate(\n"
+            "        {'sub_questions': ['q1']}\n"
+            "    )\n"
+            "    return (parsed.model_dump_json(), None, None, None, None)\n"
+        )
+        mock_get.return_value = _mock_response(
+            200,
+            _build_tar(
+                files={"component.yaml": COMPONENT_YAML, "testtool.py": pydantic_py}
+            ),
+        )
+        run_fn = load_tool_from_ipfs(CID, cache_dir=tmp_path)
+        result_str, *_ = run_fn()
+        assert "q1" in result_str
 
     @patch("benchmark.ipfs_loader.requests.get")
     def test_missing_callable_raises(self, mock_get: MagicMock, tmp_path: Path) -> None:
@@ -413,7 +464,7 @@ class TestLoadToolFromIpfs:
         )
         with pytest.raises(IpfsFetchError) as exc_info:
             load_tool_from_ipfs(CID, cache_dir=tmp_path)
-        assert "exec failed" in str(exc_info.value)
+        assert "module load failed" in str(exc_info.value)
 
     @patch("benchmark.ipfs_loader.requests.get")
     def test_import_error_at_module_level_raises_ipfs_fetch_error(
@@ -431,7 +482,7 @@ class TestLoadToolFromIpfs:
         )
         with pytest.raises(IpfsFetchError) as exc_info:
             load_tool_from_ipfs(CID, cache_dir=tmp_path)
-        assert "exec failed" in str(exc_info.value)
+        assert "module load failed" in str(exc_info.value)
 
     @patch("benchmark.ipfs_loader.requests.get")
     def test_module_level_runtime_error_raises_ipfs_fetch_error(
@@ -449,7 +500,7 @@ class TestLoadToolFromIpfs:
         )
         with pytest.raises(IpfsFetchError) as exc_info:
             load_tool_from_ipfs(CID, cache_dir=tmp_path)
-        assert "exec failed" in str(exc_info.value)
+        assert "module load failed" in str(exc_info.value)
 
     @patch("benchmark.ipfs_loader.requests.get")
     def test_component_loader_value_error_surfaces_as_ipfs_fetch_error(

--- a/benchmark/tests/test_tournament.py
+++ b/benchmark/tests/test_tournament.py
@@ -265,6 +265,33 @@ class TestRunSingle:
 
         assert result["prediction_parse_status"] != "valid"
 
+    # When a tool's `with_key_rotation` bare-except returns an error-JSON
+    # (p_yes=null, error="<msg>"), the embedded error must be surfaced on
+    # the result so the prediction row carries a diagnostic instead of
+    # just `malformed` with no context.
+    @patch("benchmark.tournament.load_tool_run")
+    def test_error_json_from_tool_is_captured(self, mock_load: MagicMock) -> None:
+        """Tool error-JSON has its `error` field captured on the result."""
+        mock_fn = MagicMock(
+            return_value=(
+                '{"p_yes": null, "p_no": null, "confidence": 0.0, '
+                '"info_utility": 0.0, '
+                '"error": "SubQuestions is not fully defined"}',
+                None,
+                None,
+                None,
+                {},
+            )
+        )
+        mock_load.return_value = mock_fn
+
+        keys = KeyChain({"openai": ["fake"], "search_provider": ["google"]})
+        result = run_single("prediction-online", "Will X?", "gpt-4.1", keys, "bafycid1")
+
+        assert result["prediction_parse_status"] == "malformed"
+        assert result["p_yes"] is None
+        assert result["error"] == "SubQuestions is not fully defined"
+
     @patch("benchmark.tournament.load_tool_run")
     def test_ipfs_fetch_error_yields_row(self, mock_load: MagicMock) -> None:
         """A bad CID is recorded as ipfs_fetch_error, not raised."""

--- a/benchmark/tournament.py
+++ b/benchmark/tournament.py
@@ -210,9 +210,23 @@ def run_single(
         if len(result_tuple) > 4 and isinstance(result_tuple[4], dict):
             source_content = result_tuple[4].get("source_content")
 
+        # When the tool returns a non-valid status, surface any `error`
+        # field the tool itself wrote into its JSON response (e.g. the
+        # bare-except path in `with_key_rotation`). Without this, the
+        # row only carries `prediction_parse_status` and the real cause
+        # is unrecoverable from the JSONL after the fact.
+        tool_error: Optional[str] = None
+        if parsed["prediction_parse_status"] != "valid" and result_str:
+            try:
+                data = json.loads(result_str)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                data = None
+            if isinstance(data, dict) and data.get("error") is not None:
+                tool_error = str(data["error"])
+
         return {
             "latency_s": round(elapsed, 1),
-            "error": None,
+            "error": tool_error,
             "source_content": source_content,
             **parsed,
         }
@@ -287,6 +301,7 @@ def build_output_row(
         "p_yes": run_result["p_yes"],
         "p_no": run_result["p_no"],
         "prediction_parse_status": run_result["prediction_parse_status"],
+        "error": run_result.get("error"),
         "confidence": run_result.get("confidence"),
         "market_prob_at_prediction": market.get("current_prob"),
         "market_close_at": market.get("close_date"),


### PR DESCRIPTION
## Summary

Tournament-mode tool loading swapped from `exec(source, {})` to `importlib.util.spec_from_file_location`. The old path produced classes with `__module__ = 'builtins'`, which broke pydantic 2.13's forward-ref resolution and caused **factual_research to produce 0 valid predictions for 6+ days** (since 2026-05-14). Plus two small observability bumps so a repeat regression leaves a breadcrumb.

## The bug

PR #251 introduced `benchmark/ipfs_loader.py:load_tool_from_ipfs` with:

```python
namespace: dict[str, Any] = {}
exec(entry_point_source, namespace)
```

Classes defined in that exec'd namespace end up with `__module__ = 'builtins'`. When a tool defines

```python
class SubQuestions(BaseModel):
    sub_questions: List[str] = Field(...)
```

and the OpenAI SDK validates it via `response_format=SubQuestions`, pydantic 2.13's `model_rebuild()` looks up `cls.__module__` in `sys.modules` to resolve `List` — finds `builtins`, which has no `List`, raises `class-not-fully-defined`. The tool's `with_key_rotation` bare-except catches the exception and returns an error-JSON; `parse_tool_response` flags it `malformed` and drops the embedded error message; the workflow's `continue-on-error: true` swallows the failure signal.

Latent on the May 12 merge because the daily cron ran before merge that day, and May 13's cron crashed at a different (now-fixed) import issue. May 14 was the first cron run that actually used the new exec-loader. Every tournament-mode prediction since has been malformed.

Could've been caught earlier:
- PR #251's local smoke test ran `--tools superforcaster --max-markets 1`. Superforcaster doesn't use pydantic `BaseModel` with forward refs, so the bug never tripped. None of the other 13 seeded tools were exercised locally.
- The unchecked `[ ] Smoke-dispatch this branch via workflow_dispatch` and `[ ] Verify the next daily cron run` boxes in #251 would each have surfaced this on day 1.
- `parse_tool_response` discarding the tool's `error` field meant no breadcrumb in the JSONL — every malformed row had `latency_s: 0.0` and zero diagnostic info.

## The fix

**`benchmark/ipfs_loader.py`** — replace exec with importlib:

```python
spec = importlib.util.spec_from_file_location(module_name, entry_path)
module = importlib.util.module_from_spec(spec)
sys.modules[module_name] = module
spec.loader.exec_module(module)
return getattr(module, callable_name)
```

Classes now get `__module__ = "mech_predict_tournament_tool_<cid>"` registered in `sys.modules`, so pydantic, `typing.get_type_hints`, dataclasses, `attrs`, anything else introspection-based resolves cleanly. The on-disk cache is already written by `fetch_tool_package`, so this is a pure mechanism swap with no extra I/O. Per-CID module names mean a candidate CID and the production CID for the same tool can coexist in one process.

**`benchmark/tournament.py`** — surface the swallowed error:

- `run_single`: when parsed status isn't `valid`, peek at the raw response, and if it parses as a dict with an `error` field, attach that to the result.
- `build_output_row`: write the new `error` field onto the prediction row. Forward-compatible — existing readers ignore unknown fields.

## Tests

- **`test_pydantic_forward_refs_resolve`** — the regression test that would have caught PR #251 on day 1. A synthetic tool that mirrors factual_research's `SubQuestions` shape; passes with importlib, fails with the old exec path.
- **`test_error_json_from_tool_is_captured`** — pins the new error-trace contract.
- Existing `test_*_raises_ipfs_fetch_error` assertions updated from `"exec failed"` to `"module load failed"` to match the new wrapping.
- Added autouse fixture to evict cached modules from `sys.modules` between tests (tests reuse a fixed `CID` with different mocked source).
- All 63 unit tests pass.
- All linters pass: black, isort, flake8, mypy, pylint, darglint.

## Live verification

Ran the previously-broken pinned CID `bafybeib7askinfzv5yolxxqojbqnmpygrg3lbxnwc77grr3nzuopha5era` end-to-end against the live IPFS gateway with the cache wiped:

```
Before: {"p_yes": null, "p_no": null, "error": "SubQuestions is not fully defined..."}
After:  p_yes=0.02, p_no=0.98, confidence=0.95   (with full reasoning chain)
```

## Out of scope (deferred)

The third item from the discussion — making a 100%-error tournament-run fail the workflow step instead of being swallowed by `continue-on-error: true` — is intentionally not in this PR.

## Test plan

- [ ] Smoke-dispatch this branch via `workflow_dispatch` against benchmark_flywheel.yaml to confirm tournament-run produces valid rows before relying on the next daily cron
- [ ] Verify the next daily cron run produces non-zero valid predictions and that prediction rows now carry an `error` field on non-valid statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)