### PR TITLE
chore(tournament): register superforcaster evidence-gathering hash

### DIFF
--- a/benchmark/tournament_tools.json
+++ b/benchmark/tournament_tools.json
@@ -1,3 +1,4 @@
 {
-  "factual_research": "bafybeib7askinfzv5yolxxqojbqnmpygrg3lbxnwc77grr3nzuopha5era"
+  "factual_research": "bafybeib7askinfzv5yolxxqojbqnmpygrg3lbxnwc77grr3nzuopha5era",
+  "superforcaster": "bafybeia2bdvxuakdq27h7j43e5ebqf3qauyyzs4ccoizum73o6jxmdrlqy"
 }


### PR DESCRIPTION
## Summary

Registers the new `superforcaster` CID `bafybeia2bdvxuakdq27h7j43e5ebqf3qauyyzs4ccoizum73o6jxmdrlqy` in `benchmark/tournament_tools.json`, the allow-list `benchmark/tournament.py` consults when loading tournament tools from IPFS.

The tool is the one published by the branch in **#290** — full-article evidence extraction (Serper search → fetch top organic links → readability+markdownify cleaned text into the forecasting prompt). The CID has already been pushed to IPFS (`autonomy push-all`) and is reachable from a public gateway, so #290 does not need to be merged for the tool to be loadable here.

## Why this PR ships first

Tournament mode is the deployment gate, not a follow-up to #290. Merging this PR puts the candidate version in front of live, unresolved markets without touching production: the on-chain mech keeps serving the incumbent SF; only the offline tournament runner picks up the new CID. After roughly a week, `benchmark/score_tournament.py` will have scored enough resolutions to give a Brier-vs-incumbent comparison — the empirical signal the cached-replay benchmark cannot produce for an evidence-gathering change. #290 then merges (or doesn't) based on those outcomes.

## Test plan

- [x] `uv run pytest benchmark/tests/test_tournament_tools_config.py` — 8 / 8 pass on the new JSON.
- [x] Local smoke against the same CID (with the #290 working tree to read the captures): `python -m benchmark.tournament --tools superforcaster --max-markets 15` — 30 / 30 markets succeeded end-to-end (15 omen / 15 polymarket), mean 3.17 pages scraped per row, latency 2-13s.
- [ ] CI green.
- [ ] After merge, the next scheduled tournament run picks up superforcaster.
- [ ] `benchmark/score_tournament.py` accumulates Brier-vs-incumbent over ~7 days; #290 merges if outcomes hold up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)