### PR TITLE
fix(benchmark): point production fetcher at maintained infra subgraphs

### DIFF
--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -64,11 +64,11 @@ PENDING_MAX_AGE_DAYS = 90
 # Subgraph endpoints — read from env with defaults
 PREDICT_OMEN_SUBGRAPH_URL = os.environ.get(
     "PREDICT_OMEN_SUBGRAPH_URL",
-    "https://predict-agents.subgraph.autonolas.tech",
+    "https://api.subgraph.autonolas.tech/api/proxy/predict-omen",
 )
 PREDICT_POLYMARKET_SUBGRAPH_URL = os.environ.get(
     "PREDICT_POLYMARKET_SUBGRAPH_URL",
-    "https://predict-polymarket-agents.subgraph.autonolas.tech",
+    "https://api.subgraph.autonolas.tech/api/proxy/predict-polymarket",
 )
 MECH_MARKETPLACE_GNOSIS_URL = os.environ.get(
     "MECH_MARKETPLACE_GNOSIS_URL",


### PR DESCRIPTION
## What

Updates the two Omen/Polymarket prediction-subgraph default URLs in `benchmark/datasets/fetch_production.py` to the maintained infra proxy endpoints, per a request from infra (Tatiana) in Slack:

| Platform | Old (deprecated) | New |
|---|---|---|
| Omen | `https://predict-agents.subgraph.autonolas.tech` | `https://api.subgraph.autonolas.tech/api/proxy/predict-omen` |
| Polymarket | `https://predict-polymarket-agents.subgraph.autonolas.tech` | `https://api.subgraph.autonolas.tech/api/proxy/predict-polymarket` |

The new URLs use the same `api.subgraph.autonolas.tech/api/proxy/` host the marketplace endpoints in this file already point at.

## Why it's safe

- Ran the script's actual Omen and Polymarket GraphQL queries against both old and new endpoints: all return **HTTP 200, identical schema, and byte-identical data** (matching `id`, `currentAnswer`, `winningIndex`, `blockTimestamp`, title). True drop-in replacements.
- Keyless — no new CI secrets required.
- The benchmark flywheel CI does not override `PREDICT_OMEN_SUBGRAPH_URL` / `PREDICT_POLYMARKET_SUBGRAPH_URL`, so these defaults are what production actually uses.
- Old endpoints still serve fresh data today, so this is a proactive migration off soon-to-be-retired infra, not a fix for a current outage.

## Scope

Only `fetch_production.py` references these URLs/env vars. The `omen.subgraph.autonolas.tech` host in `fetch_open.py` / `score_tournament.py` is a different (open-markets) subgraph that was not flagged and is left unchanged. No tests, `.example.env`, or docs reference the old URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)