### PR TITLE
fix(benchmark): resolve Polymarket tournament markets in scorer

### DIFF
--- a/benchmark/score_tournament.py
+++ b/benchmark/score_tournament.py
@@ -217,22 +217,23 @@ def check_polymarket_resolutions(
             log.warning("Polymarket fetch failed for %s: %s", cid, exc)
             continue
 
-        # Defensive guard: only trust a response that echoes back the
-        # condition ID we asked for. If a future API change ever ignores
-        # the filter again (the original bug), this prevents applying the
-        # wrong market's outcome to this prediction.
+        # Defensive guard: only trust a response that echoes back the exact
+        # condition ID we asked for. A missing or mismatched id means the
+        # filter was ignored (the original bug); applying that market's
+        # outcome would attribute the wrong result to this prediction.
         returned_cid = str(m.get("conditionId", "")).lower()
-        if returned_cid and returned_cid != cid.lower():
+        if not returned_cid or returned_cid != cid.lower():
             log.warning(
                 "Polymarket returned conditionId=%s for query %s; skipping",
-                m.get("conditionId"),
+                returned_cid,
                 cid,
             )
             continue
 
-        # Authoritative resolution signal: UMA has finalized the market.
-        # The `resolved` field is frequently null even on settled markets,
-        # so fall back to it but treat umaResolutionStatus as primary.
+        # A market counts as resolved if Gamma's `resolved` flag is set or
+        # UMA has finalized it. `resolved` is frequently null even on settled
+        # markets, so the umaResolutionStatus check is what actually catches
+        # most resolutions in practice.
         uma_resolved = str(m.get("umaResolutionStatus", "")).lower() == "resolved"
         is_resolved = bool(m.get("resolved")) or uma_resolved
 

--- a/benchmark/score_tournament.py
+++ b/benchmark/score_tournament.py
@@ -196,9 +196,15 @@ def check_polymarket_resolutions(
 
     for cid in condition_ids:
         try:
+            # Gamma's filter param is `condition_ids` (snake_case); the
+            # camelCase `conditionId` is silently ignored and returns the
+            # default open-markets list instead. Resolved markets are
+            # `closed`, and Gamma's default query hides closed markets, so
+            # `closed=true` is required for a resolution lookup to return
+            # anything at all.
             resp = requests.get(
                 f"{POLYMARKET_GAMMA_URL}/markets",
-                params={"conditionId": cid},
+                params={"condition_ids": cid, "closed": "true"},
                 timeout=15,
             )
             if resp.status_code != 200:
@@ -211,8 +217,24 @@ def check_polymarket_resolutions(
             log.warning("Polymarket fetch failed for %s: %s", cid, exc)
             continue
 
-        # Check explicit resolved flag first, fall back to price proxy
-        is_resolved = m.get("resolved", False)
+        # Defensive guard: only trust a response that echoes back the
+        # condition ID we asked for. If a future API change ever ignores
+        # the filter again (the original bug), this prevents applying the
+        # wrong market's outcome to this prediction.
+        returned_cid = str(m.get("conditionId", "")).lower()
+        if returned_cid and returned_cid != cid.lower():
+            log.warning(
+                "Polymarket returned conditionId=%s for query %s; skipping",
+                m.get("conditionId"),
+                cid,
+            )
+            continue
+
+        # Authoritative resolution signal: UMA has finalized the market.
+        # The `resolved` field is frequently null even on settled markets,
+        # so fall back to it but treat umaResolutionStatus as primary.
+        uma_resolved = str(m.get("umaResolutionStatus", "")).lower() == "resolved"
+        is_resolved = bool(m.get("resolved")) or uma_resolved
 
         prices_raw = m.get("outcomePrices", "[]")
         try:

--- a/benchmark/tests/test_score_tournament.py
+++ b/benchmark/tests/test_score_tournament.py
@@ -213,6 +213,70 @@ class TestCheckPolymarketResolutions:
         assert "cid_4" in result
         assert result["cid_4"]["outcome"] is True  # 0.97 > 0.03 → Yes
 
+    @patch("benchmark.score_tournament.requests.get")
+    def test_query_uses_condition_ids_and_closed_filter(
+        self, mock_get: MagicMock
+    ) -> None:
+        """Gamma is queried with `condition_ids` (snake_case) + `closed=true`."""
+        # camelCase `conditionId` is silently ignored by Gamma (returns the
+        # default open-markets list), and resolved markets are only returned
+        # under `closed=true`. Pinning the params guards against a regression
+        # to the original silent-no-op behavior.
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = []
+        mock_get.return_value = mock_resp
+
+        check_polymarket_resolutions(["cid_xyz"])
+
+        _, kwargs = mock_get.call_args
+        assert kwargs["params"] == {"condition_ids": "cid_xyz", "closed": "true"}
+
+    @patch("benchmark.score_tournament.requests.get")
+    def test_uma_resolved_with_null_resolved_field(self, mock_get: MagicMock) -> None:
+        """Real Gamma shape: `resolved` null but umaResolutionStatus=resolved."""
+        # Settled markets routinely return ``resolved: null``; the function
+        # must treat ``umaResolutionStatus == "resolved"`` as authoritative so
+        # these get scored instead of silently dropped.
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        # Unsettled prices (no side ≥0.99) so the price proxy alone would
+        # skip this row — only the umaResolutionStatus gate + argmax fallback
+        # can score it. Keeps the test falsifiable against the old code.
+        mock_resp.json.return_value = [
+            {
+                "conditionId": "cid_uma",
+                "resolved": None,
+                "umaResolutionStatus": "resolved",
+                "outcomes": '["Yes", "No"]',
+                "outcomePrices": '["0.04", "0.96"]',
+            }
+        ]
+        mock_get.return_value = mock_resp
+
+        result = check_polymarket_resolutions(["cid_uma"])
+        assert result["cid_uma"]["outcome"] is False  # highest price on "No"
+
+    @patch("benchmark.score_tournament.requests.get")
+    def test_wrong_condition_id_is_skipped(self, mock_get: MagicMock) -> None:
+        """A response echoing a different conditionId must not be applied."""
+        # Guards the original failure mode: an ignored filter returned an
+        # unrelated market whose outcome was applied to the queried prediction.
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = [
+            {
+                "conditionId": "some_other_market",
+                "umaResolutionStatus": "resolved",
+                "outcomes": '["Yes", "No"]',
+                "outcomePrices": '["1", "0"]',
+            }
+        ]
+        mock_get.return_value = mock_resp
+
+        result = check_polymarket_resolutions(["cid_requested"])
+        assert not result
+
     def test_empty_input(self) -> None:
         """Test empty input returns empty dict."""
         result = check_polymarket_resolutions([])

--- a/benchmark/tests/test_score_tournament.py
+++ b/benchmark/tests/test_score_tournament.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from benchmark.score_tournament import (
     check_omen_resolutions,
     check_polymarket_resolutions,
@@ -142,19 +143,26 @@ class TestCheckOmenResolutions:
 class TestCheckPolymarketResolutions:
     """Tests for check_polymarket_resolutions."""
 
+    @staticmethod
+    def _make_mock_resp(payload: Any, status: int = 200) -> MagicMock:
+        """Build a mock requests response returning ``payload`` from ``.json()``."""
+        resp = MagicMock()
+        resp.status_code = status
+        resp.json.return_value = payload
+        return resp
+
     @patch("benchmark.score_tournament.requests.get")
     def test_resolved_yes(self, mock_get: MagicMock) -> None:
         """Test resolved Yes market returns True outcome."""
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = [
-            {
-                "conditionId": "cid_1",
-                "outcomes": '["Yes", "No"]',
-                "outcomePrices": '["1.0", "0.0"]',
-            }
-        ]
-        mock_get.return_value = mock_resp
+        mock_get.return_value = self._make_mock_resp(
+            [
+                {
+                    "conditionId": "cid_1",
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["1.0", "0.0"]',
+                }
+            ]
+        )
 
         result = check_polymarket_resolutions(["cid_1"])
         assert "cid_1" in result
@@ -163,16 +171,15 @@ class TestCheckPolymarketResolutions:
     @patch("benchmark.score_tournament.requests.get")
     def test_resolved_no(self, mock_get: MagicMock) -> None:
         """Test resolved No market returns False outcome."""
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = [
-            {
-                "conditionId": "cid_2",
-                "outcomes": '["Yes", "No"]',
-                "outcomePrices": '["0.0", "1.0"]',
-            }
-        ]
-        mock_get.return_value = mock_resp
+        mock_get.return_value = self._make_mock_resp(
+            [
+                {
+                    "conditionId": "cid_2",
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["0.0", "1.0"]',
+                }
+            ]
+        )
 
         result = check_polymarket_resolutions(["cid_2"])
         assert result["cid_2"]["outcome"] is False
@@ -180,16 +187,15 @@ class TestCheckPolymarketResolutions:
     @patch("benchmark.score_tournament.requests.get")
     def test_unresolved_skipped(self, mock_get: MagicMock) -> None:
         """Test unresolved market is skipped."""
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = [
-            {
-                "conditionId": "cid_3",
-                "outcomes": '["Yes", "No"]',
-                "outcomePrices": '["0.55", "0.45"]',
-            }
-        ]
-        mock_get.return_value = mock_resp
+        mock_get.return_value = self._make_mock_resp(
+            [
+                {
+                    "conditionId": "cid_3",
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["0.55", "0.45"]',
+                }
+            ]
+        )
 
         result = check_polymarket_resolutions(["cid_3"])
         assert len(result) == 0
@@ -197,17 +203,16 @@ class TestCheckPolymarketResolutions:
     @patch("benchmark.score_tournament.requests.get")
     def test_resolved_flag_with_unsettled_prices(self, mock_get: MagicMock) -> None:
         """API says resolved=True but prices haven't hit 1.0 — should still score."""
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = [
-            {
-                "conditionId": "cid_4",
-                "resolved": True,
-                "outcomes": '["Yes", "No"]',
-                "outcomePrices": '["0.97", "0.03"]',
-            }
-        ]
-        mock_get.return_value = mock_resp
+        mock_get.return_value = self._make_mock_resp(
+            [
+                {
+                    "conditionId": "cid_4",
+                    "resolved": True,
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["0.97", "0.03"]',
+                }
+            ]
+        )
 
         result = check_polymarket_resolutions(["cid_4"])
         assert "cid_4" in result
@@ -222,10 +227,7 @@ class TestCheckPolymarketResolutions:
         # default open-markets list), and resolved markets are only returned
         # under `closed=true`. Pinning the params guards against a regression
         # to the original silent-no-op behavior.
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = []
-        mock_get.return_value = mock_resp
+        mock_get.return_value = self._make_mock_resp([])
 
         check_polymarket_resolutions(["cid_xyz"])
 
@@ -238,21 +240,20 @@ class TestCheckPolymarketResolutions:
         # Settled markets routinely return ``resolved: null``; the function
         # must treat ``umaResolutionStatus == "resolved"`` as authoritative so
         # these get scored instead of silently dropped.
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
         # Unsettled prices (no side ≥0.99) so the price proxy alone would
         # skip this row — only the umaResolutionStatus gate + argmax fallback
         # can score it. Keeps the test falsifiable against the old code.
-        mock_resp.json.return_value = [
-            {
-                "conditionId": "cid_uma",
-                "resolved": None,
-                "umaResolutionStatus": "resolved",
-                "outcomes": '["Yes", "No"]',
-                "outcomePrices": '["0.04", "0.96"]',
-            }
-        ]
-        mock_get.return_value = mock_resp
+        mock_get.return_value = self._make_mock_resp(
+            [
+                {
+                    "conditionId": "cid_uma",
+                    "resolved": None,
+                    "umaResolutionStatus": "resolved",
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["0.04", "0.96"]',
+                }
+            ]
+        )
 
         result = check_polymarket_resolutions(["cid_uma"])
         assert result["cid_uma"]["outcome"] is False  # highest price on "No"
@@ -262,19 +263,62 @@ class TestCheckPolymarketResolutions:
         """A response echoing a different conditionId must not be applied."""
         # Guards the original failure mode: an ignored filter returned an
         # unrelated market whose outcome was applied to the queried prediction.
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = [
-            {
-                "conditionId": "some_other_market",
-                "umaResolutionStatus": "resolved",
-                "outcomes": '["Yes", "No"]',
-                "outcomePrices": '["1", "0"]',
-            }
-        ]
-        mock_get.return_value = mock_resp
+        mock_get.return_value = self._make_mock_resp(
+            [
+                {
+                    "conditionId": "some_other_market",
+                    "umaResolutionStatus": "resolved",
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["1", "0"]',
+                }
+            ]
+        )
 
         result = check_polymarket_resolutions(["cid_requested"])
+        assert not result
+
+    @patch("benchmark.score_tournament.requests.get")
+    def test_missing_condition_id_is_skipped(self, mock_get: MagicMock) -> None:
+        """A response with no conditionId key at all must not be applied."""
+        # Same "filter was ignored" failure class as a mismatched id: when the
+        # response omits conditionId entirely the guard must still skip, rather
+        # than falling through and attributing this market's outcome.
+        mock_get.return_value = self._make_mock_resp(
+            [
+                {
+                    "umaResolutionStatus": "resolved",
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["1", "0"]',
+                }
+            ]
+        )
+
+        result = check_polymarket_resolutions(["cid_requested"])
+        assert not result
+
+    @pytest.mark.parametrize("status", ["disputed", "pending", ""])
+    @patch("benchmark.score_tournament.requests.get")
+    def test_non_resolved_uma_status_not_scored(
+        self, mock_get: MagicMock, status: str
+    ) -> None:
+        """Only `umaResolutionStatus == "resolved"` counts; other states defer."""
+        # Pins that an in-flight UMA status (disputed/pending) or an empty
+        # status does NOT score the row. Prices are unsettled (<0.99) so the
+        # price proxy can't score it either — the umaResolutionStatus gate is
+        # the only thing under test.
+        mock_get.return_value = self._make_mock_resp(
+            [
+                {
+                    "conditionId": "cid_x",
+                    "resolved": None,
+                    "umaResolutionStatus": status,
+                    "outcomes": '["Yes", "No"]',
+                    "outcomePrices": '["0.55", "0.45"]',
+                }
+            ]
+        )
+
+        result = check_polymarket_resolutions(["cid_x"])
         assert not result
 
     def test_empty_input(self) -> None:


### PR DESCRIPTION
## Problem

Polymarket tournament predictions never received a `final_outcome`, so **no Polymarket tournament data has ever reached the daily report**. The Tool × Version × Mode tables and Tournament Callouts in `report_polymarket.md` were Omen-only; `scores_tournament_polymarket.json` was `total_rows: 0`.

Surfaced while checking the 2026-05-25 flywheel run: 1,267 Polymarket tournament predictions were made, **0** were scored (Omen: 3,660/4,084 scored fine).

## Root cause

Two compounding bugs in `check_polymarket_resolutions` (`benchmark/score_tournament.py`):

- **Wrong query param.** The Gamma `/markets` call used `conditionId` (camelCase), which Gamma **silently ignores** — it returned the default open-markets list, so every lookup inspected the same unrelated `market[0]`, found it unresolved, and skipped. The correct filter is `condition_ids` (snake_case). *(Latent hazard: had that default market ever settled ≥0.99, its outcome would have been applied to every queried prediction.)*
- **Missing `closed` filter.** Resolved markets are `closed`, and Gamma's default query hides closed markets, so `closed=true` is required for a resolution lookup to return anything.

## Fix

- Query with `params={"condition_ids": cid, "closed": "true"}`.
- Treat `umaResolutionStatus == "resolved"` as the authoritative resolution signal (Gamma's `resolved` field is frequently `null` even on settled markets).
- Add a defensive guard that skips any response whose `conditionId` does not echo the queried id — so a future silently-ignored filter can never apply the wrong market's outcome.

Resolution gate is intentionally conservative: only **formally resolved** markets are scored. Markets whose prices have settled (~0.998) but that Polymarket still flags `closed=false` are deferred to a later daily run once finalized (the scorer accumulates), rather than risking a premature/wrong outcome.

## Validation (against the 2026-05-25 run)

- Fixed function resolves **50/50** formally-resolved Polymarket markets with **0 outcome mismatches** vs an independent price-winner cross-check (22 Yes / 28 No).
- `score_tournament`: **0 → 724** scored Polymarket prediction rows.
- `scorer`: `scores_tournament_polymarket.json` **0 → 68 rows / 18 TVM keys**.
- `analyze`: `report_polymarket.md` **0 → 18 tournament rows**.
- Omen path is byte-isolated (diff touches only `check_polymarket_resolutions`); all 4 Omen unit tests pass — no Omen regression.
- New regression tests pin the query params, the `umaResolutionStatus` gate, and the wrong-`conditionId` guard. Verified falsifiable (fail on pre-fix code, pass after). Full suite: 18 passed.
- Lint clean: `black-check`, `isort-check`, `flake8`, `mypy`, `pylint`, `darglint`.

## Notes

- This means the Polymarket arm of the superforcaster both-platforms comparison has had **no tournament data the entire time**; it will begin populating from the next flywheel run.
- Polymarket `resolved_at` remains a `datetime.now()` approximation (pre-existing — Gamma exposes no resolution timestamp), so Polymarket lead-time is approximate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
