### PR TITLE
feat(benchmark): resolve Tool Deployment Status from trader valid_mechs

### DIFF
--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -40,7 +40,7 @@ from benchmark.scorer import (
     MIN_SAMPLE_SIZE,
     brier_sort_key,
 )
-from benchmark.tool_usage import deployments_for_platform, fetch_disabled_tools
+from benchmark.tool_usage import deployments_for_platform, fetch_valid_tools
 
 DEFAULT_RESULTS_DIR = Path(__file__).parent / "results"
 DEFAULT_HISTORY = DEFAULT_RESULTS_DIR / "scores_history.jsonl"
@@ -260,26 +260,27 @@ def _sample_label(stats: dict[str, Any]) -> str:
 
 
 def _active_tools_for_platform(
-    disabled: dict[str, list[str] | None] | None,
+    valid: dict[str, list[str] | None] | None,
     platform: str,
     scores: dict[str, Any],
     rolling_scores: dict[str, Any] | None = None,
 ) -> frozenset[str] | None:
-    """Return tools currently active on at least one deployment of ``platform``.
+    """Return tools currently selectable on at least one deployment of ``platform``.
 
-    Computed as the union of (benchmarked tools - disabled tools) across
+    Computed as the union of (benchmarked tools ∩ selectable tools) across
     every deployment of ``platform`` whose config fetch succeeded. A tool
-    is "active" if any deployment has it enabled.
+    is "active" if any deployment can select it (i.e. it is offered by one
+    of that deployment's whitelisted mechs).
 
     Tool-name normalization mirrors ``section_tool_deployment_status``:
     underscores and hyphens are treated as interchangeable when comparing
-    against the disabled list. The returned set uses the names as they
+    against the selectable list. The returned set uses the names as they
     appear in ``by_tool`` keys.
 
-    :param disabled: ``{deployment: [tool_names] | None}`` map, where
-        ``None`` indicates a fetch/parse failure for that deployment.
-        ``None`` for the whole map (or an empty dict) is treated as
-        "no deployment data available".
+    :param valid: ``{deployment: [tool_names] | None}`` map of selectable
+        tools, where ``None`` indicates a fetch/parse failure for that
+        deployment. ``None`` for the whole map (or an empty dict) is
+        treated as "no deployment data available".
     :param platform: scorer platform key (``"omen"`` or ``"polymarket"``).
     :param scores: parsed platform-scoped all-time scores dict.
     :param rolling_scores: parsed platform-scoped current-window scores
@@ -288,16 +289,16 @@ def _active_tools_for_platform(
         tool with rolling data but no all-time history yet is still
         included in the active set.
     :return: frozenset of active tool names, or ``None`` when **every**
-        deployment of this platform has ``disabled=None`` (full fetch
+        deployment of this platform has ``valid=None`` (full fetch
         failure for the platform). Callers fall back to "show all
         tools" plus a ``⚠ deployment config unavailable`` notice.
     """
-    if not disabled:
+    if not valid:
         return None
 
     deployments = deployments_for_platform(platform)
-    relevant = {name: disabled.get(name) for name in deployments}
-    if all(disabled_tools is None for disabled_tools in relevant.values()):
+    relevant = {name: valid.get(name) for name in deployments}
+    if all(valid_tools is None for valid_tools in relevant.values()):
         # Every deployment for this platform failed — caller renders the
         # warning and shows all tools rather than blanking the report.
         return None
@@ -307,12 +308,12 @@ def _active_tools_for_platform(
         benchmarked |= set((rolling_scores.get("by_tool") or {}).keys())
 
     active: set[str] = set()
-    for disabled_tools in relevant.values():
-        if disabled_tools is None:
+    for valid_tools in relevant.values():
+        if valid_tools is None:
             continue
-        disabled_set = {t.replace("_", "-") for t in disabled_tools}
+        valid_set = {t.replace("_", "-") for t in valid_tools}
         for tool in benchmarked:
-            if tool.replace("_", "-") not in disabled_set:
+            if tool.replace("_", "-") in valid_set:
                 active.add(tool)
 
     return frozenset(active)
@@ -349,38 +350,39 @@ def _filter_by_active(
 
 def section_tool_deployment_status(
     scores: dict[str, Any],
-    disabled: dict[str, list[str] | None] | None = None,
+    valid: dict[str, list[str] | None] | None = None,
     platform: str | None = None,
 ) -> str:
-    """Render which benchmarked tools are active on each deployment.
+    """Render which benchmarked tools are selectable on each deployment.
 
     Deployments are filtered to ``platform`` when set; active tools are
-    the benchmarked tools minus the disabled tools for that deployment.
-    Failed-fetch deployments are called out so ``⚠️ unavailable`` is
-    never confused with "all tools active".
+    the benchmarked tools intersected with the selectable tools for that
+    deployment (the tools its whitelisted mechs offer). Failed-fetch
+    deployments are called out so ``⚠️ unavailable`` is never confused
+    with "no tools active".
 
     :param scores: parsed ``scores.json`` dict.
-    :param disabled: pre-fetched ``{deployment: [tool_names] | None}`` map.
-        Pass ``None`` to fetch on the fly (the daily-report default). Pass
-        an empty dict to skip the section entirely (tests use this to avoid
-        the live GitHub fetch).
+    :param valid: pre-fetched ``{deployment: [tool_names] | None}`` map of
+        selectable tools. Pass ``None`` to fetch on the fly (the
+        daily-report default). Pass an empty dict to skip the section
+        entirely (tests use this to avoid the live fetch).
     :param platform: when set, restrict the section to deployments matching
         this platform key (``"omen"`` or ``"polymarket"``).
     :return: markdown section string, or ``""`` when the caller opted out.
     """
-    if disabled is None:
-        disabled = fetch_disabled_tools()
+    if valid is None:
+        valid = fetch_valid_tools()
 
     # Explicit skip contract: an empty dict means "caller opted out" (used by
     # unit tests).  Returning "" means the section heading is omitted so the
     # report doesn't advertise a section that was never computed.
-    if not disabled:
+    if not valid:
         return ""
 
     if platform is not None:
         allowed = set(deployments_for_platform(platform))
-        disabled = {name: v for name, v in disabled.items() if name in allowed}
-        if not disabled:
+        valid = {name: v for name, v in valid.items() if name in allowed}
+        if not valid:
             return ""
 
     tools = scores.get("by_tool", {})
@@ -391,7 +393,7 @@ def section_tool_deployment_status(
         heading = f"## Tool Deployment Status ({PLATFORM_LABELS[platform]})"
     lines = [heading, ""]
 
-    failed = [name for name in disabled if disabled.get(name) is None]
+    failed = [name for name in valid if valid.get(name) is None]
     if failed:
         lines.append(
             "> ⚠️ Could not fetch deployment config for: "
@@ -399,12 +401,12 @@ def section_tool_deployment_status(
         )
         lines.append("")
 
-    for deployment, disabled_tools in disabled.items():
-        if disabled_tools is None:
+    for deployment, valid_tools in valid.items():
+        if valid_tools is None:
             lines.append(f"- **{deployment}** — ⚠️ unavailable")
             continue
-        disabled_set = {t.replace("_", "-") for t in disabled_tools}
-        active = [t for t in benchmarked if t.replace("_", "-") not in disabled_set]
+        valid_set = {t.replace("_", "-") for t in valid_tools}
+        active = [t for t in benchmarked if t.replace("_", "-") in valid_set]
         if not active:
             lines.append(f"- **{deployment}** — no benchmarked tools active")
             continue
@@ -2431,7 +2433,7 @@ def generate_report(  # pylint: disable=too-many-statements
     include_tournament: bool = False,
     scores_tournament: dict[str, Any] | None = None,
     rolling_scores_tournament: dict[str, Any] | None = None,
-    disabled_tools: dict[str, list[str] | None] | None = None,
+    valid_tools: dict[str, list[str] | None] | None = None,
 ) -> str:
     """Generate a platform-scoped benchmark report from scores and history.
 
@@ -2459,8 +2461,8 @@ def generate_report(  # pylint: disable=too-many-statements
         ignored entirely.
     :param scores_tournament: parsed ``scores_tournament_<platform>.json`` dict.
     :param rolling_scores_tournament: tournament rolling window scores.
-    :param disabled_tools: pre-fetched ``{deployment: [tool_names] | None}``
-        map used by the Tool Deployment Status section.
+    :param valid_tools: pre-fetched ``{deployment: [tool_names] | None}``
+        map of selectable tools used by the Tool Deployment Status section.
     :return: full markdown report string.
     """
     if platform not in PLATFORM_LABELS:
@@ -2490,8 +2492,8 @@ def generate_report(  # pylint: disable=too-many-statements
     # comparison sections, the deployment-status section, and the
     # warning notice all see the same map. ``None`` (the default)
     # triggers a live fetch; an empty dict is the test-only opt-out.
-    if disabled_tools is None:
-        disabled_tools = fetch_disabled_tools()
+    if valid_tools is None:
+        valid_tools = fetch_valid_tools()
 
     # Restrict the per-platform comparison sections to tools currently
     # deployed somewhere on this platform. Returns ``None`` when every
@@ -2499,7 +2501,7 @@ def generate_report(  # pylint: disable=too-many-statements
     # is to skip the filter and prepend a one-line warning so the
     # reader knows the tool list is unfiltered for this run.
     active_tools = _active_tools_for_platform(
-        disabled_tools, platform, scores, rolling_scores
+        valid_tools, platform, scores, rolling_scores
     )
 
     sections: list[str] = [f"# Benchmark Report ({platform_label}) — {date}"]
@@ -2507,7 +2509,7 @@ def generate_report(  # pylint: disable=too-many-statements
     # (non-empty input) but every deployment for this platform failed.
     # Empty-dict callers are the unit-test opt-out and shouldn't see
     # the notice.
-    if active_tools is None and disabled_tools:
+    if active_tools is None and valid_tools:
         sections.append(
             "> ⚠️ Deployment config unavailable for this platform — comparison "
             "sections show every benchmarked tool, including tools that may "
@@ -2575,9 +2577,7 @@ def generate_report(  # pylint: disable=too-many-statements
         )
 
     sections.append(
-        section_tool_deployment_status(
-            scores, disabled=disabled_tools, platform=platform
-        )
+        section_tool_deployment_status(scores, valid=valid_tools, platform=platform)
     )
 
     if include_tournament:

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -270,7 +270,7 @@ def _active_tools_for_platform(
     Computed as the union of (benchmarked tools ∩ selectable tools) across
     every deployment of ``platform`` whose config fetch succeeded. A tool
     is "active" if any deployment can select it (i.e. it is offered by one
-    of that deployment's whitelisted mechs).
+    of that deployment's allow-listed mechs).
 
     Tool-name normalization mirrors ``section_tool_deployment_status``:
     underscores and hyphens are treated as interchangeable when comparing
@@ -357,7 +357,7 @@ def section_tool_deployment_status(
 
     Deployments are filtered to ``platform`` when set; active tools are
     the benchmarked tools intersected with the selectable tools for that
-    deployment (the tools its whitelisted mechs offer). Failed-fetch
+    deployment (the tools its allow-listed mechs offer). Failed-fetch
     deployments are called out so ``⚠️ unavailable`` is never confused
     with "no tools active".
 

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -954,7 +954,7 @@ class TestGenerateReport:
         )
         history = [{"month": "2026-03", "overall": {"brier": 0.3, "n": 50}}]
         report = generate_report(
-            s, history, platform="omen", rolling_scores=s, disabled_tools={}
+            s, history, platform="omen", rolling_scores=s, valid_tools={}
         )
 
         assert "# Benchmark Report (Omenstrat) — " in report
@@ -987,7 +987,7 @@ class TestGenerateReport:
     def test_empty_data_no_crash(self) -> None:
         """Test empty data does not crash."""
         s = _scores(brier=None, reliability=None, total=0, valid=0)
-        report = generate_report(s, [], platform="omen", disabled_tools={})
+        report = generate_report(s, [], platform="omen", valid_tools={})
         assert "# Benchmark Report (Omenstrat) — " in report
         # With no rolling_scores, the snapshot banner explains the gap.
         assert (
@@ -1369,7 +1369,7 @@ class TestGenerateReportTournamentToggle:
     def test_off_by_default_omits_tournament_sections(self) -> None:
         """Default behavior: no tournament sections in the rendered report."""
         s = self._scores_with_versions()
-        report = generate_report(s, [], platform="omen", disabled_tools={})
+        report = generate_report(s, [], platform="omen", valid_tools={})
         assert "Tool × Version × Mode" not in report
         assert "Version Deltas" not in report
 
@@ -1380,7 +1380,7 @@ class TestGenerateReportTournamentToggle:
         """
         s = self._scores_with_versions()
         report = generate_report(
-            s, [], platform="omen", include_tournament=True, disabled_tools={}
+            s, [], platform="omen", include_tournament=True, valid_tools={}
         )
         assert "Tool × Version × Mode (All-Time)" in report
         assert "## Version Deltas" in report
@@ -1404,7 +1404,7 @@ class TestGenerateReportTournamentToggle:
             platform="omen",
             rolling_scores=rolling,
             include_tournament=True,
-            disabled_tools={},
+            valid_tools={},
         )
         assert "Tool × Version × Mode (All-Time)" in report
         assert f"Tool × Version × Mode (Last {ROLLING_WINDOW_DAYS} Days)" in report
@@ -1670,13 +1670,13 @@ class TestGenerateReportPerPlatform:
     def test_header_uses_deployment_label_for_omen(self) -> None:
         """Omen scores render with 'Omenstrat' in the header."""
         s = _scores()
-        report = generate_report(s, [], platform="omen", disabled_tools={})
+        report = generate_report(s, [], platform="omen", valid_tools={})
         assert "# Benchmark Report (Omenstrat) — " in report
 
     def test_header_uses_deployment_label_for_polymarket(self) -> None:
         """Polymarket scores render with 'Polystrat' in the header."""
         s = _scores()
-        report = generate_report(s, [], platform="polymarket", disabled_tools={})
+        report = generate_report(s, [], platform="polymarket", valid_tools={})
         assert "# Benchmark Report (Polystrat) — " in report
 
     def test_platform_comparison_absent(self) -> None:
@@ -1687,20 +1687,20 @@ class TestGenerateReportPerPlatform:
         s["by_platform"] = {
             "omen": {"brier": 0.2, "n": 100, "edge": 0.04, "edge_n": 80},
         }
-        report = generate_report(s, [], platform="omen", disabled_tools={})
+        report = generate_report(s, [], platform="omen", valid_tools={})
         assert "## Platform Comparison" not in report
 
     def test_tool_platform_section_absent(self) -> None:
         """Tool × Platform section never renders in per-platform mode."""
         s = _scores()
-        report = generate_report(s, [], platform="omen", disabled_tools={})
+        report = generate_report(s, [], platform="omen", valid_tools={})
         assert "## Tool \u00d7 Platform" not in report
 
     def test_rejects_unknown_platform(self) -> None:
         """Unknown platform raises ValueError with a helpful message."""
         s = _scores()
         with pytest.raises(ValueError, match="platform must be one of"):
-            generate_report(s, [], platform="gnosis", disabled_tools={})
+            generate_report(s, [], platform="gnosis", valid_tools={})
 
     def test_platform_labels_are_deployment_names(self) -> None:
         """Label map pairs scorer keys with the team's deployment names."""
@@ -1749,13 +1749,13 @@ class TestTrendSectionPlatformAnnotation:
         prod = _scores_with_tool("tool-a", 0.20, 1000)
         prod["current_month"] = "2026-04"
         history = [{"month": "2026-03", "overall": {"brier": 0.2, "n": 100}}]
-        report = generate_report(prod, history, platform="omen", disabled_tools={})
+        report = generate_report(prod, history, platform="omen", valid_tools={})
         assert "*(in progress)*" not in report
         assert "2026-04" not in report
 
 
 class TestSectionToolDeploymentStatusInverted:
-    """Phase 3: section renders active tools per deployment, scoped to platform."""
+    """Phase 3: section renders selectable tools per deployment, scoped to platform."""
 
     def _scores_with_tools(self, *tools: str) -> dict[str, Any]:
         return {"by_tool": {t: {"brier": 0.2, "n": 100, "valid_n": 100} for t in tools}}
@@ -1763,101 +1763,88 @@ class TestSectionToolDeploymentStatusInverted:
     def test_omen_platform_hides_polystrat_deployment(self) -> None:
         """Omenstrat report never mentions polystrat Pearl."""
         scores = self._scores_with_tools("tool-a", "tool-b")
-        disabled: dict[str, list[str] | None] = {
-            "omenstrat Pearl": [],
-            "omenstrat QS": [],
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool-a"],
             "polystrat Pearl": ["tool-a"],
         }
-        rendered = section_tool_deployment_status(scores, disabled, platform="omen")
+        rendered = section_tool_deployment_status(scores, valid, platform="omen")
         assert "omenstrat Pearl" in rendered
-        assert "omenstrat QS" in rendered
         assert "polystrat" not in rendered
 
     def test_polymarket_platform_hides_omenstrat_deployments(self) -> None:
         """Polystrat report never mentions omenstrat-anything."""
         scores = self._scores_with_tools("tool-a")
-        disabled: dict[str, list[str] | None] = {
+        valid: dict[str, list[str] | None] = {
             "omenstrat Pearl": ["tool-a"],
-            "omenstrat QS": ["tool-a"],
-            "polystrat Pearl": [],
+            "polystrat Pearl": ["tool-a"],
         }
-        rendered = section_tool_deployment_status(
-            scores, disabled, platform="polymarket"
-        )
+        rendered = section_tool_deployment_status(scores, valid, platform="polymarket")
         assert "polystrat Pearl" in rendered
         assert "omenstrat" not in rendered
 
     def test_heading_carries_platform_label(self) -> None:
         """Section heading is scoped with the deployment label."""
         scores = self._scores_with_tools("tool-a")
-        disabled: dict[str, list[str] | None] = {
+        valid: dict[str, list[str] | None] = {
             "omenstrat Pearl": [],
-            "omenstrat QS": [],
             "polystrat Pearl": [],
         }
-        rendered = section_tool_deployment_status(scores, disabled, platform="omen")
+        rendered = section_tool_deployment_status(scores, valid, platform="omen")
         assert rendered.startswith("## Tool Deployment Status (Omenstrat)")
 
-    def test_active_tools_exclude_disabled(self) -> None:
-        """Active tools are the benchmarked set with disabled tools removed."""
+    def test_active_tools_are_allow_listed(self) -> None:
+        """Active tools are the benchmarked set intersected with the allow-list."""
         scores = self._scores_with_tools("tool-a", "tool-b", "tool-c")
-        disabled: dict[str, list[str] | None] = {
-            "omenstrat Pearl": ["tool-b"],
-            "omenstrat QS": [],
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool-a", "tool-c"],
             "polystrat Pearl": [],
         }
-        rendered = section_tool_deployment_status(scores, disabled, platform="omen")
+        rendered = section_tool_deployment_status(scores, valid, platform="omen")
         pearl_line = [
             line for line in rendered.splitlines() if "omenstrat Pearl" in line
         ][0]
         assert "`tool-a`" in pearl_line
         assert "`tool-c`" in pearl_line
         assert "`tool-b`" not in pearl_line
-        qs_line = [line for line in rendered.splitlines() if "omenstrat QS" in line][0]
-        for expected in ("`tool-a`", "`tool-b`", "`tool-c`"):
-            assert expected in qs_line
 
-    def test_normalizes_underscores_in_disabled_list(self) -> None:
-        """Config files sometimes list prediction_request_X; treat as equivalent."""
+    def test_normalizes_underscores_in_allow_list(self) -> None:
+        """Manifests sometimes list prediction_request_X; treat as equivalent."""
         scores = self._scores_with_tools("prediction-request-reasoning")
-        disabled: dict[str, list[str] | None] = {
+        valid: dict[str, list[str] | None] = {
             "omenstrat Pearl": ["prediction_request_reasoning"],
-            "omenstrat QS": [],
             "polystrat Pearl": [],
         }
-        rendered = section_tool_deployment_status(scores, disabled, platform="omen")
+        rendered = section_tool_deployment_status(scores, valid, platform="omen")
         pearl_line = [
             line for line in rendered.splitlines() if "omenstrat Pearl" in line
         ][0]
-        assert "prediction-request-reasoning" not in pearl_line
+        assert "`prediction-request-reasoning`" in pearl_line
 
     def test_failed_fetch_renders_unavailable_banner(self) -> None:
         """Deployment whose fetch returned None is not claimed as empty."""
         scores = self._scores_with_tools("tool-a")
-        disabled: dict[str, list[str] | None] = {
+        valid: dict[str, list[str] | None] = {
             "omenstrat Pearl": None,
-            "omenstrat QS": [],
-            "polystrat Pearl": [],
+            "polystrat Pearl": ["tool-a"],
         }
-        rendered = section_tool_deployment_status(scores, disabled, platform="omen")
+        rendered = section_tool_deployment_status(scores, valid, platform="omen")
         assert "omenstrat Pearl" in rendered
         assert "⚠️ unavailable" in rendered
 
     def test_fleet_wide_mode_still_supported(self) -> None:
         """platform=None keeps the legacy fleet-wide render for ad-hoc callers."""
         scores = self._scores_with_tools("tool-a")
-        disabled: dict[str, list[str] | None] = {
-            "omenstrat Pearl": [],
-            "omenstrat QS": [],
-            "polystrat Pearl": [],
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool-a"],
+            "polystrat Pearl": ["tool-a"],
         }
-        rendered = section_tool_deployment_status(scores, disabled, platform=None)
-        for deployment in ("omenstrat Pearl", "omenstrat QS", "polystrat Pearl"):
+        rendered = section_tool_deployment_status(scores, valid, platform=None)
+        for deployment in ("omenstrat Pearl", "polystrat Pearl"):
             assert deployment in rendered
         assert "(Omenstrat)" not in rendered
         assert "(Polystrat)" not in rendered
 
-    def test_empty_disabled_opts_out_of_section(self) -> None:
+    def test_empty_valid_opts_out_of_section(self) -> None:
         """Existing contract: empty dict skips the section entirely."""
         scores = self._scores_with_tools("tool-a")
         assert section_tool_deployment_status(scores, {}, platform="omen") == ""
@@ -1870,7 +1857,7 @@ class TestToolCategoryPositionInReport:
         """Current-3d table and historical comparison both render, in that order."""
         scores = _scores_with_tool("tool-a", 0.20, 1000)
         report = generate_report(
-            scores, [], platform="omen", rolling_scores=scores, disabled_tools={}
+            scores, [], platform="omen", rolling_scores=scores, valid_tools={}
         )
         current_idx = report.index(
             f"## Tool \u00d7 Category (Current {ROLLING_WINDOW_DAYS}d)"
@@ -1894,7 +1881,7 @@ class TestToolCategoryPositionInReport:
             platform="omen",
             rolling_scores=scores,
             include_tournament=True,
-            disabled_tools={},
+            valid_tools={},
         )
         tc_idx = report.index("## Tool \u00d7 Category Historical Comparison")
         tvm_idx = report.index("## Tool \u00d7 Version \u00d7 Mode (All-Time)")
@@ -1948,7 +1935,7 @@ class TestGenerateReportLegendPlacement:
             [],
             platform="omen",
             rolling_scores=rolling,
-            disabled_tools={},
+            valid_tools={},
         )
         legend_idx = report.index("## Metric References")
         snapshot_idx = report.index("## Platform Snapshot")
@@ -1966,7 +1953,7 @@ class TestGenerateReportLegendPlacement:
             platform="omen",
             include_tournament=True,
             scores_tournament=tourn,
-            disabled_tools={},
+            valid_tools={},
         )
         assert report.count("## Metric References") == 1
 
@@ -1982,7 +1969,7 @@ class TestGenerateReportRollingBanner:
         gap and every rolling/comparison section is skipped.
         """
         scores = _scores_with_tool("tool-a", 0.20, 1000)
-        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        report = generate_report(scores, [], platform="omen", valid_tools={})
         assert f"## Platform Snapshot (Current {ROLLING_WINDOW_DAYS}d)" in report
         assert (
             f"Scores for the last {ROLLING_WINDOW_DAYS} days are unavailable" in report
@@ -2014,7 +2001,7 @@ class TestGenerateReportRollingBanner:
             platform="omen",
             rolling_scores=scores,
             include_tournament=True,
-            disabled_tools={},
+            valid_tools={},
         )
         heading_idx = report.index(
             f"## Tool × Version × Mode (Last {ROLLING_WINDOW_DAYS} Days)"
@@ -2038,7 +2025,7 @@ class TestGenerateReportStructure:
             [],
             platform="omen",
             rolling_scores=rolling,
-            disabled_tools={},
+            valid_tools={},
         )
         ordered_headings = [
             f"## Platform Snapshot (Current {ROLLING_WINDOW_DAYS}d)",
@@ -2064,7 +2051,7 @@ class TestGenerateReportStructure:
             [],
             platform="omen",
             rolling_scores=scores,
-            disabled_tools={},
+            valid_tools={},
         )
         assert "## Since Last Report" not in report
 
@@ -2585,7 +2572,7 @@ class TestZeroRowPrevRollingRouting:
             platform="omen",
             rolling_scores=rolling,
             prev_rolling_scores=empty_prev,
-            disabled_tools={},
+            valid_tools={},
         )
         assert "no prev window" in report
 
@@ -2602,7 +2589,7 @@ class TestZeroRowPrevRollingRouting:
             platform="omen",
             rolling_scores=rolling,
             prev_rolling_scores=empty_prev,
-            disabled_tools={},
+            valid_tools={},
         )
         report_none = generate_report(
             scores,
@@ -2610,7 +2597,7 @@ class TestZeroRowPrevRollingRouting:
             platform="omen",
             rolling_scores=rolling,
             prev_rolling_scores=None,
-            disabled_tools={},
+            valid_tools={},
         )
         # The date stamps in the header carry ``generated_at`` which is
         # identical across both calls for a single-scorer fixture, so the
@@ -2628,7 +2615,7 @@ class TestZeroRowPrevRollingRouting:
             platform="omen",
             rolling_scores=rolling,
             prev_rolling_scores=populated_prev,
-            disabled_tools={},
+            valid_tools={},
         )
         assert "no prev window" not in report
 
@@ -2648,7 +2635,7 @@ class TestZeroRowPrevRollingRouting:
             platform="omen",
             rolling_scores=rolling,
             prev_rolling_scores=None,
-            disabled_tools={},
+            valid_tools={},
         )
         # The value-cell on the prev column must carry "no prev window"
         # wherever a delta cell does; an "N/A (n=0)" leaking through
@@ -2693,72 +2680,68 @@ class TestSectionReliabilityComparison:
 
 
 class TestActiveToolsForPlatform:
-    """``_active_tools_for_platform`` builds the per-platform deployed set."""
+    """``_active_tools_for_platform`` builds the per-platform selectable set.
+
+    Each platform now maps to a single deployment (omen → omenstrat Pearl,
+    polymarket → polystrat Pearl), so the active set is the benchmarked
+    universe intersected with that deployment's selectable-tools allow-list.
+    """
 
     _SCORES: dict[str, dict[str, dict[str, Any]]] = {
         "by_tool": {"tool-a": {}, "tool-b": {}, "tool-c": {}}
     }
 
-    def test_full_failure_returns_none(self) -> None:
-        """All deployments None -> caller falls back to "show all" with a notice."""
-        disabled: dict[str, list[str] | None] = {
+    def test_failure_returns_none(self) -> None:
+        """The platform's only deployment None -> caller shows all + notice."""
+        valid: dict[str, list[str] | None] = {
             "omenstrat Pearl": None,
-            "omenstrat QS": None,
+            "polystrat Pearl": ["tool-a"],
+        }
+        assert _active_tools_for_platform(valid, "omen", self._SCORES) is None
+
+    def test_active_set_is_benchmarked_intersect_allow_list(self) -> None:
+        """Active set is benchmarked ∩ the deployment's selectable tools."""
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool-a", "tool-c"],
             "polystrat Pearl": None,
         }
-        assert _active_tools_for_platform(disabled, "omen", self._SCORES) is None
+        active = _active_tools_for_platform(valid, "omen", self._SCORES)
+        assert active == frozenset({"tool-a", "tool-c"})
 
-    def test_partial_failure_uses_what_is_available(self) -> None:
-        """One omen deployment fails, the other still drives the active set."""
-        disabled: dict[str, list[str] | None] = {
+    def test_selectable_tool_not_benchmarked_is_ignored(self) -> None:
+        """A selectable tool with no benchmark rows never enters the active set."""
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool-a", "tool-z"],  # tool-z not benchmarked
+            "polystrat Pearl": None,
+        }
+        active = _active_tools_for_platform(valid, "omen", self._SCORES)
+        assert active == frozenset({"tool-a"})
+
+    def test_each_platform_reads_only_its_deployment(self) -> None:
+        """Polymarket draws from polystrat Pearl, not the omen deployment."""
+        valid: dict[str, list[str] | None] = {
             "omenstrat Pearl": ["tool-a"],
-            "omenstrat QS": None,
-            "polystrat Pearl": None,
+            "polystrat Pearl": ["tool-b"],
         }
-        active = _active_tools_for_platform(disabled, "omen", self._SCORES)
-        # tool-a is disabled on Pearl and QS is unknown; union of (benchmarked - disabled)
-        # over successful deployments is {tool-b, tool-c}.
-        assert active == frozenset({"tool-b", "tool-c"})
+        active = _active_tools_for_platform(valid, "polymarket", self._SCORES)
+        assert active == frozenset({"tool-b"})
 
-    def test_polystrat_failure_returns_none(self) -> None:
-        """Polystrat has one deployment — its failure means full failure."""
-        disabled: dict[str, list[str] | None] = {
-            "omenstrat Pearl": [],
-            "omenstrat QS": [],
-            "polystrat Pearl": None,
-        }
-        assert _active_tools_for_platform(disabled, "polymarket", self._SCORES) is None
-
-    def test_union_across_deployments(self) -> None:
-        """A tool active on at least one deployment is in the active set."""
-        disabled: dict[str, list[str] | None] = {
-            "omenstrat Pearl": ["tool-a"],
-            "omenstrat QS": ["tool-b"],
-            "polystrat Pearl": None,
-        }
-        active = _active_tools_for_platform(disabled, "omen", self._SCORES)
-        # Pearl excludes tool-a (so {tool-b, tool-c}); QS excludes tool-b (so
-        # {tool-a, tool-c}); union = {tool-a, tool-b, tool-c}.
-        assert active == frozenset({"tool-a", "tool-b", "tool-c"})
-
-    def test_empty_disabled_returns_none(self) -> None:
+    def test_empty_valid_returns_none(self) -> None:
         """Empty input is the test-only opt-out — caller skips both filter and warning."""
         assert _active_tools_for_platform({}, "omen", self._SCORES) is None
         assert _active_tools_for_platform(None, "omen", self._SCORES) is None
 
     def test_underscore_hyphen_normalization(self) -> None:
-        """Disabled list with underscores excludes the hyphenated benchmark name."""
-        disabled: dict[str, list[str] | None] = {
+        """Allow-list with underscores still matches the hyphenated benchmark name."""
+        valid: dict[str, list[str] | None] = {
             "omenstrat Pearl": ["tool_a"],  # underscore variant of "tool-a"
-            "omenstrat QS": ["tool_a"],
             "polystrat Pearl": None,
         }
-        active = _active_tools_for_platform(disabled, "omen", self._SCORES)
-        # Both deployments disable tool-a (underscore variant), so it should
-        # NOT appear in the active set.
+        active = _active_tools_for_platform(valid, "omen", self._SCORES)
+        # The underscore variant matches "tool-a", which is the only active tool.
         assert active is not None
-        assert "tool-a" not in active
-        assert "tool-b" in active and "tool-c" in active
+        assert "tool-a" in active
+        assert "tool-b" not in active and "tool-c" not in active
 
     def test_benchmarked_universe_unions_rolling_and_alltime(self) -> None:
         """Tool with rolling rows but no all-time entry is still considered.
@@ -2773,13 +2756,12 @@ class TestActiveToolsForPlatform:
         rolling: dict[str, Any] = {
             "by_tool": {"tool-a": {}, "tool-b": {}, "tool-new": {}}
         }
-        disabled: dict[str, list[str] | None] = {
-            "omenstrat Pearl": [],
-            "omenstrat QS": [],
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["tool-new"],
             "polystrat Pearl": None,
         }
         active = _active_tools_for_platform(
-            disabled, "omen", all_time, rolling_scores=rolling
+            valid, "omen", all_time, rolling_scores=rolling
         )
         assert active is not None
         assert "tool-new" in active
@@ -2791,14 +2773,12 @@ class TestActiveToolsForPlatform:
         yet still produce the same active set as before.
         """
         all_time: dict[str, Any] = {"by_tool": {"tool-a": {}, "tool-b": {}}}
-        disabled: dict[str, list[str] | None] = {
+        valid: dict[str, list[str] | None] = {
             "omenstrat Pearl": ["tool-a"],
-            "omenstrat QS": [],
             "polystrat Pearl": None,
         }
-        active = _active_tools_for_platform(disabled, "omen", all_time)
-        # tool-a is disabled on Pearl but enabled on QS → in active set
-        assert active == frozenset({"tool-a", "tool-b"})
+        active = _active_tools_for_platform(valid, "omen", all_time)
+        assert active == frozenset({"tool-a"})
 
 
 class TestFilterByActive:
@@ -2936,10 +2916,9 @@ class TestGenerateReportDeploymentConfigUnavailable:
 
         monkeypatch.setattr(
             analyze,
-            "fetch_disabled_tools",
+            "fetch_valid_tools",
             lambda: {
                 "omenstrat Pearl": None,
-                "omenstrat QS": None,
                 "polystrat Pearl": None,
             },
         )
@@ -2951,10 +2930,10 @@ class TestGenerateReportDeploymentConfigUnavailable:
         assert "Deployment config unavailable" in report
 
     def test_no_notice_for_explicit_test_optout(self) -> None:
-        """``disabled_tools={}`` is the unit-test opt-out; no notice rendered."""
+        """``valid_tools={}`` is the unit-test opt-out; no notice rendered."""
         scores = {
             "by_tool": {"tool-a": {"brier": 0.20, "n": 100, "valid_n": 100}},
             "by_tool_category": {},
         }
-        report = generate_report(scores, [], platform="omen", disabled_tools={})
+        report = generate_report(scores, [], platform="omen", valid_tools={})
         assert "Deployment config unavailable" not in report

--- a/benchmark/tests/test_tool_usage.py
+++ b/benchmark/tests/test_tool_usage.py
@@ -19,6 +19,7 @@
 """Tests for benchmark/tool_usage.py and the deployment-status report section."""
 
 import json
+from typing import Callable
 from urllib.error import URLError
 
 import pytest
@@ -53,58 +54,40 @@ class TestDeploymentPlatformMappingInvariants:
             "the deployment was removed but the mapping wasn't cleaned up"
         )
 
+    def test_every_deployment_has_resolution_config(self) -> None:
+        """Every deployment can be resolved (trader service dir + chain)."""
+        config = tool_usage._DEPLOYMENT_CONFIG  # pylint: disable=protected-access
+        missing = [name for name in DEPLOYMENTS if name not in config]
+        assert not missing, (
+            f"deployment(s) {missing} have no _DEPLOYMENT_CONFIG entry — "
+            "fetch_valid_tools would never resolve them"
+        )
+
+    def test_resolution_chains_are_known(self) -> None:
+        """Each deployment's chain has a marketplace subgraph URL."""
+        config = tool_usage._DEPLOYMENT_CONFIG  # pylint: disable=protected-access
+        for name, (_service, chain) in config.items():
+            assert (
+                chain in tool_usage.MARKETPLACE_SUBGRAPH_URL
+            ), f"{name} resolves on chain {chain!r} with no subgraph URL"
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
-PEARL_ONLY_MARKER = "omenstrat-only-marker"
-POLYSTRAT_ONLY_MARKER = "polystrat-only-marker"
 
-OPERATE_APP_TS_SAMPLE = f"""
-export const PREDICT_SERVICE_TEMPLATE = {{
-  env_variables: {{
-    IRRELEVANT_TOOLS: {{
-      name: 'Irrelevant tools',
-      description: '',
-      value:
-        '["native-transfer","echo","prediction-online-lite","{PEARL_ONLY_MARKER}"]',
-      provision_type: EnvProvisionType.FIXED,
-    }},
-    GENAI_API_KEY: {{ name: 'Gemini' }},
-  }},
-}};
-
-export const PREDICT_POLYMARKET_SERVICE_TEMPLATE = {{
-  env_variables: {{
-    IRRELEVANT_TOOLS: {{
-      name: 'Irrelevant tools',
-      description: '',
-      value:
-        '["native-transfer","echo","prediction-online-lite","{POLYSTRAT_ONLY_MARKER}"]',
-      provision_type: EnvProvisionType.FIXED,
-    }},
-  }},
-}};
-"""
-
-QUICKSTART_JSON_SAMPLE = json.dumps(
-    {
-        "name": "Trader Agent",
-        "env_variables": {
-            "IRRELEVANT_TOOLS": {
-                "name": "Irrelevant tools",
-                "value": json.dumps(
-                    [
-                        "native-transfer",
-                        "echo",
-                        "openai-gpt-4",
-                    ]
-                ),
-            },
-        },
-    }
-)
+def _service_yaml(addresses: list[str]) -> str:
+    """Build a trader service.yaml stub carrying a valid_mechs env default."""
+    payload = json.dumps(addresses)
+    return (
+        "    models:\n"
+        "      params:\n"
+        "        args:\n"
+        "          some_other_param: ${SOME_OTHER:int:5}\n"
+        f"          valid_mechs: ${{VALID_MECHS:list:{payload}}}\n"
+        "          trailing_param: ${TRAILING:bool:true}\n"
+    )
 
 
 def _scores_with_tools(tool_names: list[str]) -> dict:
@@ -122,141 +105,337 @@ def _scores_with_tools(tool_names: list[str]) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# parse_operate_app_ts
+# latest_trader_ref
 # ---------------------------------------------------------------------------
 
 
-class TestParseOperateAppTs:
-    """Tests for parse_operate_app_ts."""
+class TestLatestTraderRef:
+    """Tests for latest_trader_ref."""
 
-    def test_extracts_both_templates(self) -> None:
-        """Each template's block is identified by name, not by file order."""
-        result = tool_usage.parse_operate_app_ts(OPERATE_APP_TS_SAMPLE)
-        # Template-unique markers prove the mapping didn't silently swap.
-        assert PEARL_ONLY_MARKER in result["omenstrat Pearl"]
-        assert PEARL_ONLY_MARKER not in result["polystrat Pearl"]
-        assert POLYSTRAT_ONLY_MARKER in result["polystrat Pearl"]
-        assert POLYSTRAT_ONLY_MARKER not in result["omenstrat Pearl"]
-
-    def test_identity_survives_template_reorder(self) -> None:
-        """If the file declares polystrat before omenstrat, labels still match."""
-        halves = OPERATE_APP_TS_SAMPLE.split(
-            "export const PREDICT_POLYMARKET_SERVICE_TEMPLATE", maxsplit=1
+    def test_returns_latest_tag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The first (newest) release's tag_name is returned."""
+        monkeypatch.setattr(
+            tool_usage,
+            "_http_get",
+            lambda url: json.dumps(
+                [{"tag_name": "v1.2.3-rc1"}, {"tag_name": "v1.2.2"}]
+            ),
         )
-        reordered = (
-            "export const PREDICT_POLYMARKET_SERVICE_TEMPLATE" + halves[1] + halves[0]
+        assert tool_usage.latest_trader_ref() == "v1.2.3-rc1"
+
+    def test_empty_release_list_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No releases -> ValueError (so the caller degrades, not crashes)."""
+        monkeypatch.setattr(tool_usage, "_http_get", lambda url: "[]")
+        with pytest.raises(ValueError, match="no trader releases"):
+            tool_usage.latest_trader_ref()
+
+    def test_missing_tag_name_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A release object without tag_name -> ValueError."""
+        monkeypatch.setattr(
+            tool_usage, "_http_get", lambda url: json.dumps([{"id": 1}])
         )
-        result = tool_usage.parse_operate_app_ts(reordered)
-        assert PEARL_ONLY_MARKER in result["omenstrat Pearl"]
-        assert POLYSTRAT_ONLY_MARKER in result["polystrat Pearl"]
-
-    def test_rejects_missing_template(self) -> None:
-        """Missing a template raises instead of silently returning a partial dict."""
-        single = OPERATE_APP_TS_SAMPLE.split(
-            "export const PREDICT_POLYMARKET_SERVICE_TEMPLATE", maxsplit=1
-        )[0]
-        with pytest.raises(
-            ValueError, match="no IRRELEVANT_TOOLS block found for template"
-        ):
-            tool_usage.parse_operate_app_ts(single)
-
-    def test_rejects_non_string_items(self) -> None:
-        """Array with non-string items raises ValueError."""
-        bad = OPERATE_APP_TS_SAMPLE.replace('"echo"', "123")
-        with pytest.raises(ValueError, match="must be a JSON array of strings"):
-            tool_usage.parse_operate_app_ts(bad)
+        with pytest.raises(ValueError, match="no tag_name"):
+            tool_usage.latest_trader_ref()
 
 
 # ---------------------------------------------------------------------------
-# parse_quickstart_config
+# parse_valid_mechs
 # ---------------------------------------------------------------------------
 
 
-class TestParseQuickstartConfig:
-    """Tests for parse_quickstart_config."""
+class TestParseValidMechs:
+    """Tests for parse_valid_mechs."""
 
     def test_happy_path(self) -> None:
-        """Standard shape returns the parsed list."""
-        assert tool_usage.parse_quickstart_config(QUICKSTART_JSON_SAMPLE) == [
-            "native-transfer",
-            "echo",
-            "openai-gpt-4",
-        ]
+        """The address list is extracted in order from the env default."""
+        yaml_source = _service_yaml(["0xAAA", "0xbbb"])
+        assert tool_usage.parse_valid_mechs(yaml_source) == ["0xAAA", "0xbbb"]
 
-    def test_missing_path_raises(self) -> None:
-        """Missing env_variables.IRRELEVANT_TOOLS raises KeyError."""
-        bad = json.dumps({"env_variables": {}})
-        with pytest.raises(KeyError):
-            tool_usage.parse_quickstart_config(bad)
+    def test_empty_list_returns_empty(self) -> None:
+        """An empty whitelist is a real state ([], not an error)."""
+        assert tool_usage.parse_valid_mechs(_service_yaml([])) == []
+
+    def test_missing_valid_mechs_raises(self) -> None:
+        """Absent valid_mechs line -> ValueError (no silent empty result)."""
+        with pytest.raises(ValueError, match="no valid_mechs"):
+            tool_usage.parse_valid_mechs("models:\n  params: {}\n")
+
+    def test_non_string_items_raise(self) -> None:
+        """A non-string array element -> ValueError."""
+        bad = "      valid_mechs: ${VALID_MECHS:list:[1,2,3]}\n"
+        with pytest.raises(ValueError, match="array of strings"):
+            tool_usage.parse_valid_mechs(bad)
 
 
 # ---------------------------------------------------------------------------
-# fetch_disabled_tools (fetch-failure handling)
+# fetch_tools_for_metadata
 # ---------------------------------------------------------------------------
 
 
-class TestFetchDisabledTools:
-    """Tests for fetch_disabled_tools and its failure semantics."""
+class TestFetchToolsForMetadata:
+    """Tests for fetch_tools_for_metadata."""
 
-    def test_both_sources_succeed(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """All three deployment slots populated when both HTTP calls succeed."""
-
-        def fake_get(url: str) -> str:
-            if "olas-operate-app" in url:
-                return OPERATE_APP_TS_SAMPLE
-            return QUICKSTART_JSON_SAMPLE
-
-        monkeypatch.setattr(tool_usage, "_http_get", fake_get)
-        result = tool_usage.fetch_disabled_tools()
-        pearl = result["omenstrat Pearl"]
-        assert pearl is not None
-        assert set(pearl) >= {"native-transfer", "echo", PEARL_ONLY_MARKER}
-        assert result["omenstrat QS"] == ["native-transfer", "echo", "openai-gpt-4"]
-        polystrat = result["polystrat Pearl"]
-        assert polystrat is not None and POLYSTRAT_ONLY_MARKER in polystrat
-
-    def test_operate_app_fetch_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """operate-app failure -> None for both Pearl slots, QS still works."""
-
-        def fake_get(url: str) -> str:
-            if "olas-operate-app" in url:
-                raise URLError("network down")
-            return QUICKSTART_JSON_SAMPLE
-
-        monkeypatch.setattr(tool_usage, "_http_get", fake_get)
-        result = tool_usage.fetch_disabled_tools()
-        assert result["omenstrat Pearl"] is None
-        assert result["polystrat Pearl"] is None
-        assert result["omenstrat QS"] == ["native-transfer", "echo", "openai-gpt-4"]
-
-    def test_quickstart_fetch_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Quickstart failure -> None for QS only, Pearl slots still populated."""
-
-        def fake_get(url: str) -> str:
-            if "olas-operate-app" in url:
-                return OPERATE_APP_TS_SAMPLE
-            raise URLError("network down")
-
-        monkeypatch.setattr(tool_usage, "_http_get", fake_get)
-        result = tool_usage.fetch_disabled_tools()
-        assert result["omenstrat QS"] is None
-        assert result["omenstrat Pearl"] is not None
-
-    def test_malformed_response_is_not_raised(
+    def test_parses_tools_and_builds_cid_url(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Parse errors are swallowed so the daily report is never blocked."""
+        """0x is stripped and CID_PREFIX prepended; tools array is returned."""
+        seen: dict[str, str] = {}
 
         def fake_get(url: str) -> str:
-            return "not valid content"
+            seen["url"] = url
+            return json.dumps({"name": "Mech", "tools": ["a", "b"]})
 
         monkeypatch.setattr(tool_usage, "_http_get", fake_get)
-        result = tool_usage.fetch_disabled_tools()
-        assert all(v is None for v in result.values())
+        tools = tool_usage.fetch_tools_for_metadata("0xdeadbeef")
+        assert tools == ["a", "b"]
+        assert seen["url"] == (
+            f"{tool_usage.IPFS_GATEWAY_URL}/{tool_usage.CID_PREFIX}deadbeef"
+        )
+
+    def test_missing_tools_key_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A manifest with no tools array -> ValueError."""
+        monkeypatch.setattr(
+            tool_usage, "_http_get", lambda url: json.dumps({"name": "Mech"})
+        )
+        with pytest.raises(ValueError, match="no tools array"):
+            tool_usage.fetch_tools_for_metadata("0xabc")
+
+    def test_non_string_tools_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A tools array with non-string items -> ValueError."""
+        monkeypatch.setattr(
+            tool_usage, "_http_get", lambda url: json.dumps({"tools": [1, 2]})
+        )
+        with pytest.raises(ValueError, match="no tools array"):
+            tool_usage.fetch_tools_for_metadata("0xabc")
 
 
 # ---------------------------------------------------------------------------
-# Rendering of the deployment-status section
+# resolve_mech_tools
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMechTools:
+    """Tests for resolve_mech_tools."""
+
+    def test_empty_addresses_makes_no_network_call(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty whitelist short-circuits to [] without touching the subgraph."""
+
+        def boom(*_args: object, **_kwargs: object) -> object:
+            raise AssertionError("network must not be touched for empty whitelist")
+
+        monkeypatch.setattr(tool_usage, "_post_graphql", boom)
+        monkeypatch.setattr(tool_usage, "fetch_tools_for_metadata", boom)
+        assert tool_usage.resolve_mech_tools([], "http://subgraph") == []
+
+    def test_unions_and_dedupes_shared_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tools across mechs are unioned; a shared metadata hash is fetched once."""
+        monkeypatch.setattr(
+            tool_usage,
+            "_post_graphql",
+            lambda url, query: {
+                "meches": [
+                    {"address": "0xa", "service": {"metadata": [{"metadata": "0x11"}]}},
+                    {"address": "0xb", "service": {"metadata": [{"metadata": "0x11"}]}},
+                    {"address": "0xc", "service": {"metadata": [{"metadata": "0x22"}]}},
+                ]
+            },
+        )
+        fetched: list[str] = []
+
+        def fake_tools(metadata_hash: str) -> list[str]:
+            fetched.append(metadata_hash)
+            return {"0x11": ["superforcaster", "factual_research"], "0x22": ["jury"]}[
+                metadata_hash
+            ]
+
+        monkeypatch.setattr(tool_usage, "fetch_tools_for_metadata", fake_tools)
+        tools = tool_usage.resolve_mech_tools(["0xa", "0xb", "0xc"], "http://subgraph")
+        # Sorted union across all distinct manifests.
+        assert tools == ["factual_research", "jury", "superforcaster"]
+        # The shared 0x11 manifest is fetched exactly once (dedup), not twice.
+        assert sorted(fetched) == ["0x11", "0x22"]
+
+    def test_query_lowercases_and_quotes_addresses(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The subgraph query embeds the addresses, lowercased and quoted."""
+        captured: dict[str, str] = {}
+
+        def fake_post(url: str, query: str) -> dict:
+            captured["query"] = query
+            return {"meches": []}
+
+        monkeypatch.setattr(tool_usage, "_post_graphql", fake_post)
+        tool_usage.resolve_mech_tools(["0xAbC", "0xDEF"], "http://subgraph")
+        assert '"0xabc"' in captured["query"]
+        assert '"0xdef"' in captured["query"]
+        assert "0xAbC" not in captured["query"]
+
+    def test_subgraph_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A GraphQL/network error is raised so the caller can mark unavailable."""
+
+        def fake_post(url: str, query: str) -> dict:
+            raise URLError("subgraph down")
+
+        monkeypatch.setattr(tool_usage, "_post_graphql", fake_post)
+        with pytest.raises(URLError):
+            tool_usage.resolve_mech_tools(["0xa"], "http://subgraph")
+
+
+# ---------------------------------------------------------------------------
+# fetch_valid_tools (end-to-end resolution + failure handling)
+# ---------------------------------------------------------------------------
+
+RELEASE_TAG = "v9.9.9-test"
+PEARL_MECH = "0xpearlmech"
+POLY_MECH = "0xpolymech"
+PEARL_META = "0x1111"
+POLY_META = "0x2222"
+
+
+def _routed_http_get(
+    pearl_addrs: list[str], poly_addrs: list[str]
+) -> Callable[[str], str]:
+    """Build a fake _http_get routing by URL: releases, service.yamls, IPFS."""
+
+    def fake_get(url: str) -> str:
+        if "api.github.com" in url:
+            return json.dumps([{"tag_name": RELEASE_TAG}])
+        if "trader_pearl" in url:
+            assert RELEASE_TAG in url  # yaml fetched at the resolved release tag
+            return _service_yaml(pearl_addrs)
+        if "polymarket_trader" in url:
+            assert RELEASE_TAG in url
+            return _service_yaml(poly_addrs)
+        if url.endswith(PEARL_META[2:]):
+            return json.dumps({"tools": ["prediction-online", "shared-tool"]})
+        if url.endswith(POLY_META[2:]):
+            return json.dumps({"tools": ["echo", "shared-tool"]})
+        raise AssertionError(f"unexpected URL: {url}")
+
+    return fake_get
+
+
+def _routed_post_graphql(url: str, query: str) -> dict:
+    """Fake subgraph: route by chain, return each chain's mech metadata."""
+    if "marketplace-gnosis" in url:
+        return {
+            "meches": [
+                {
+                    "address": PEARL_MECH,
+                    "service": {"metadata": [{"metadata": PEARL_META}]},
+                }
+            ]
+        }
+    if "marketplace-polygon" in url:
+        return {
+            "meches": [
+                {
+                    "address": POLY_MECH,
+                    "service": {"metadata": [{"metadata": POLY_META}]},
+                }
+            ]
+        }
+    raise AssertionError(f"unexpected subgraph URL: {url}")
+
+
+class TestFetchValidTools:
+    """Tests for fetch_valid_tools and its per-deployment failure isolation."""
+
+    def test_both_deployments_succeed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Each deployment resolves to the sorted union of its mechs' tools."""
+        monkeypatch.setattr(
+            tool_usage, "_http_get", _routed_http_get([PEARL_MECH], [POLY_MECH])
+        )
+        monkeypatch.setattr(tool_usage, "_post_graphql", _routed_post_graphql)
+        result = tool_usage.fetch_valid_tools()
+        assert result["omenstrat Pearl"] == ["prediction-online", "shared-tool"]
+        assert result["polystrat Pearl"] == ["echo", "shared-tool"]
+
+    def test_release_fetch_fails_blanks_all(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed release lookup leaves every deployment None (never raised)."""
+
+        def fake_get(url: str) -> str:
+            if "api.github.com" in url:
+                raise URLError("github down")
+            raise AssertionError("should not reach per-deployment fetch")
+
+        monkeypatch.setattr(tool_usage, "_http_get", fake_get)
+        result = tool_usage.fetch_valid_tools()
+        assert all(v is None for v in result.values())
+
+    def test_one_deployment_yaml_fails_isolated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failing service.yaml nulls only that deployment; the other resolves."""
+        base = _routed_http_get([PEARL_MECH], [POLY_MECH])
+
+        def fake_get(url: str) -> str:
+            if "trader_pearl" in url:
+                raise URLError("yaml 404")
+            return base(url)
+
+        monkeypatch.setattr(tool_usage, "_http_get", fake_get)
+        monkeypatch.setattr(tool_usage, "_post_graphql", _routed_post_graphql)
+        result = tool_usage.fetch_valid_tools()
+        assert result["omenstrat Pearl"] is None
+        assert result["polystrat Pearl"] == ["echo", "shared-tool"]
+
+    def test_one_subgraph_fails_isolated(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A subgraph failure nulls only the affected deployment."""
+        monkeypatch.setattr(
+            tool_usage, "_http_get", _routed_http_get([PEARL_MECH], [POLY_MECH])
+        )
+
+        def fake_post(url: str, query: str) -> dict:
+            if "marketplace-gnosis" in url:
+                raise URLError("subgraph down")
+            return _routed_post_graphql(url, query)
+
+        monkeypatch.setattr(tool_usage, "_post_graphql", fake_post)
+        result = tool_usage.fetch_valid_tools()
+        assert result["omenstrat Pearl"] is None
+        assert result["polystrat Pearl"] == ["echo", "shared-tool"]
+
+    def test_malformed_yaml_not_raised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A service.yaml missing valid_mechs nulls that deployment, never raises."""
+        base = _routed_http_get([PEARL_MECH], [POLY_MECH])
+
+        def fake_get(url: str) -> str:
+            if "trader_pearl" in url:
+                return "garbage: yaml: without: valid_mechs\n"
+            return base(url)
+
+        monkeypatch.setattr(tool_usage, "_http_get", fake_get)
+        monkeypatch.setattr(tool_usage, "_post_graphql", _routed_post_graphql)
+        result = tool_usage.fetch_valid_tools()
+        assert result["omenstrat Pearl"] is None
+        assert result["polystrat Pearl"] == ["echo", "shared-tool"]
+
+    def test_empty_valid_mechs_is_empty_list_not_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty valid_mechs resolves to [] (a real state) without a subgraph call."""
+        monkeypatch.setattr(tool_usage, "_http_get", _routed_http_get([], [POLY_MECH]))
+
+        def fake_post(url: str, query: str) -> dict:
+            assert "marketplace-gnosis" not in url  # no mechs -> no gnosis query
+            return _routed_post_graphql(url, query)
+
+        monkeypatch.setattr(tool_usage, "_post_graphql", fake_post)
+        result = tool_usage.fetch_valid_tools()
+        assert result["omenstrat Pearl"] == []
+        assert result["polystrat Pearl"] == ["echo", "shared-tool"]
+
+
+# ---------------------------------------------------------------------------
+# Rendering of the deployment-status section (allow-list semantics)
 # ---------------------------------------------------------------------------
 
 
@@ -264,22 +443,19 @@ class TestSectionToolDeploymentStatus:
     """Rendering review: every code path produces the output a reader expects."""
 
     def test_active_tools_rendered(self) -> None:
-        """Each deployment shows the benchmarked tools that are NOT disabled."""
+        """Each deployment shows the benchmarked tools that ARE selectable."""
         scores = _scores_with_tools(["echo", "prediction-online"])
-        disabled: dict[str, list[str] | None] = {
-            "omenstrat Pearl": ["echo"],
-            "omenstrat QS": ["echo", "prediction-online"],
-            "polystrat Pearl": [],
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["prediction-online"],
+            "polystrat Pearl": ["echo", "prediction-online"],
         }
-        result = section_tool_deployment_status(scores, disabled=disabled)
+        result = section_tool_deployment_status(scores, valid=valid)
         assert "## Tool Deployment Status" in result
         pearl_line = next(
             line for line in result.splitlines() if "omenstrat Pearl" in line
         )
         assert "`prediction-online`" in pearl_line
         assert "`echo`" not in pearl_line
-        qs_line = next(line for line in result.splitlines() if "omenstrat QS" in line)
-        assert "no benchmarked tools active" in qs_line
         poly_line = next(
             line for line in result.splitlines() if "polystrat Pearl" in line
         )
@@ -287,38 +463,65 @@ class TestSectionToolDeploymentStatus:
         assert "`prediction-online`" in poly_line
 
     def test_tool_in_config_but_not_benchmarked_is_hidden(self) -> None:
-        """Disabled entries naming non-benchmarked tools don't affect the active list."""
+        """Allow-list entries naming non-benchmarked tools don't invent rows."""
         scores = _scores_with_tools(["prediction-online"])
-        disabled: dict[str, list[str] | None] = {
-            "omenstrat Pearl": ["echo"],  # not in scores, ignored
-            "omenstrat QS": [],
-            "polystrat Pearl": [],
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["prediction-online", "echo"],  # echo not benchmarked
+            "polystrat Pearl": ["echo"],  # only non-benchmarked -> empty
         }
-        result = section_tool_deployment_status(scores, disabled=disabled)
+        result = section_tool_deployment_status(scores, valid=valid)
         assert "`echo`" not in result
         pearl_line = next(
             line for line in result.splitlines() if "omenstrat Pearl" in line
         )
         assert "`prediction-online`" in pearl_line
+        poly_line = next(
+            line for line in result.splitlines() if "polystrat Pearl" in line
+        )
+        assert "no benchmarked tools active" in poly_line
 
-    def test_no_disabled_tools_means_all_tools_active(self) -> None:
-        """With nothing disabled, every benchmarked tool appears on every deployment."""
+    def test_full_allow_list_means_all_tools_active(self) -> None:
+        """With every tool selectable, each appears once per deployment."""
         scores = _scores_with_tools(["prediction-online"])
-        disabled: dict[str, list[str] | None] = {
+        valid: dict[str, list[str] | None] = {
+            name: ["prediction-online"] for name in tool_usage.DEPLOYMENTS
+        }
+        result = section_tool_deployment_status(scores, valid=valid)
+        assert result.count("`prediction-online`") == len(tool_usage.DEPLOYMENTS)
+
+    def test_empty_allow_list_means_no_active(self) -> None:
+        """An empty allow-list renders 'no benchmarked tools active'."""
+        scores = _scores_with_tools(["prediction-online"])
+        valid: dict[str, list[str] | None] = {
             name: [] for name in tool_usage.DEPLOYMENTS
         }
-        result = section_tool_deployment_status(scores, disabled=disabled)
-        assert result.count("`prediction-online`") == len(tool_usage.DEPLOYMENTS)
+        result = section_tool_deployment_status(scores, valid=valid)
+        assert "`prediction-online`" not in result
+        assert result.count("no benchmarked tools active") == len(
+            tool_usage.DEPLOYMENTS
+        )
+
+    def test_normalizes_underscore_hyphen(self) -> None:
+        """Allow-list spelling with underscores still matches hyphen tool names."""
+        scores = _scores_with_tools(["prediction-request-reasoning-claude"])
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["prediction_request_reasoning_claude"],
+            "polystrat Pearl": [],
+        }
+        result = section_tool_deployment_status(scores, valid=valid)
+        pearl_line = next(
+            line for line in result.splitlines() if "omenstrat Pearl" in line
+        )
+        assert "`prediction-request-reasoning-claude`" in pearl_line
 
     def test_fetch_failure_renders_unavailable_banner(self) -> None:
         """Failed deployments render ⚠️ unavailable instead of a false 'active' list."""
         scores = _scores_with_tools(["echo"])
-        disabled: dict[str, list[str] | None] = {
+        valid: dict[str, list[str] | None] = {
             "omenstrat Pearl": None,
-            "omenstrat QS": ["echo"],
-            "polystrat Pearl": None,
+            "polystrat Pearl": ["echo"],
         }
-        result = section_tool_deployment_status(scores, disabled=disabled)
+        result = section_tool_deployment_status(scores, valid=valid)
         assert "Could not fetch deployment config" in result
         pearl_line = next(
             line
@@ -330,28 +533,22 @@ class TestSectionToolDeploymentStatus:
             for line in result.splitlines()
             if line.startswith("- **polystrat Pearl**")
         )
-        qs_line = next(
-            line
-            for line in result.splitlines()
-            if line.startswith("- **omenstrat QS**")
-        )
         assert "⚠️ unavailable" in pearl_line
-        assert "⚠️ unavailable" in poly_line
-        assert "no benchmarked tools active" in qs_line
+        assert "`echo`" in poly_line
 
     def test_empty_dict_opts_out_entirely(self) -> None:
         """Empty dict means "caller opted out" and returns an empty string."""
         scores = _scores_with_tools(["echo"])
-        result = section_tool_deployment_status(scores, disabled={})
+        result = section_tool_deployment_status(scores, valid={})
         assert result == ""
 
     def test_all_fetches_fail_no_false_active_claim(self) -> None:
         """If everything fails, no deployment claims active tools."""
         scores = _scores_with_tools(["echo"])
-        disabled: dict[str, list[str] | None] = {
+        valid: dict[str, list[str] | None] = {
             name: None for name in tool_usage.DEPLOYMENTS
         }
-        result = section_tool_deployment_status(scores, disabled=disabled)
+        result = section_tool_deployment_status(scores, valid=valid)
         assert "Could not fetch deployment config" in result
         assert "`echo`" not in result
         assert result.count("⚠️ unavailable") == len(tool_usage.DEPLOYMENTS)
@@ -369,12 +566,11 @@ class TestSectionToolDeploymentStatus:
                 "mid-tool": {"brier": 0.30, "n": 10},
             },
         }
-        disabled: dict[str, list[str] | None] = {
-            "omenstrat Pearl": [],
-            "omenstrat QS": [],
+        valid: dict[str, list[str] | None] = {
+            "omenstrat Pearl": ["slow-tool", "fast-tool", "mid-tool"],
             "polystrat Pearl": [],
         }
-        result = section_tool_deployment_status(scores, disabled=disabled)
+        result = section_tool_deployment_status(scores, valid=valid)
         pearl_line = next(
             line for line in result.splitlines() if "omenstrat Pearl" in line
         )

--- a/benchmark/tests/test_tool_usage.py
+++ b/benchmark/tests/test_tool_usage.py
@@ -267,7 +267,15 @@ class TestResolveMechTools:
 
         def fake_post(url: str, query: str) -> dict:
             captured["query"] = query
-            return {"meches": []}
+            # Return both requested addresses so resolve_mech_tools doesn't
+            # short-circuit on a missing-address ValueError before we get to
+            # inspect the recorded query string.
+            return {
+                "meches": [
+                    {"address": "0xabc", "service": {"metadata": []}},
+                    {"address": "0xdef", "service": {"metadata": []}},
+                ]
+            }
 
         monkeypatch.setattr(tool_usage, "_post_graphql", fake_post)
         tool_usage.resolve_mech_tools(["0xAbC", "0xDEF"], "http://subgraph")
@@ -284,6 +292,37 @@ class TestResolveMechTools:
         monkeypatch.setattr(tool_usage, "_post_graphql", fake_post)
         with pytest.raises(URLError):
             tool_usage.resolve_mech_tools(["0xa"], "http://subgraph")
+
+    def test_missing_subgraph_addresses_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Subgraph omitting any requested address raises ValueError listing them."""
+        monkeypatch.setattr(
+            tool_usage,
+            "_post_graphql",
+            lambda url, query: {
+                "meches": [
+                    {
+                        "address": "0xa",
+                        "service": {"metadata": [{"metadata": "0x11"}]},
+                    }
+                ]
+            },
+        )
+
+        def boom(_metadata_hash: str) -> list[str]:
+            raise AssertionError("IPFS must not be touched after missing-addr raise")
+
+        monkeypatch.setattr(tool_usage, "fetch_tools_for_metadata", boom)
+        with pytest.raises(ValueError) as excinfo:
+            tool_usage.resolve_mech_tools(
+                ["0xA", "0xMissing1", "0xMissing2"], "http://subgraph"
+            )
+        # Resolved address must not appear; missing ones must.
+        message = str(excinfo.value)
+        assert "0xmissing1" in message
+        assert "0xmissing2" in message
+        assert "0xa" not in message
 
 
 # ---------------------------------------------------------------------------

--- a/benchmark/tests/test_tool_usage.py
+++ b/benchmark/tests/test_tool_usage.py
@@ -25,48 +25,23 @@ from urllib.error import URLError
 import pytest
 from benchmark import tool_usage
 from benchmark.analyze import section_tool_deployment_status
-from benchmark.tool_usage import DEPLOYMENTS, DEPLOYMENT_TO_PLATFORM
 
 
-class TestDeploymentPlatformMappingInvariants:
-    """Lock the DEPLOYMENTS ↔ DEPLOYMENT_TO_PLATFORM coverage invariant.
+class TestDeploymentConfigInvariants:
+    """Lock invariants on the single ``_DEPLOYMENTS`` source of truth.
 
-    ``deployments_for_platform`` filters ``DEPLOYMENTS`` through
-    ``DEPLOYMENT_TO_PLATFORM``. If a deployment lands in the list but
-    not in the mapping, it silently disappears from the platform-scoped
-    Tool Deployment Status section. The tests below fail loudly at add
-    time so nobody has to rediscover the bug in production.
+    With ``DEPLOYMENTS`` and ``DEPLOYMENT_TO_PLATFORM`` derived directly
+    from ``_DEPLOYMENTS``, drift between those three views is no longer
+    possible by construction. The remaining real invariant is that every
+    chain referenced in ``_DEPLOYMENTS`` has a marketplace subgraph URL —
+    adding a new chain without wiring up the URL would crash
+    ``fetch_valid_tools`` at lookup time.
     """
 
-    def test_every_deployment_has_a_platform(self) -> None:
-        """No name in DEPLOYMENTS is missing from DEPLOYMENT_TO_PLATFORM."""
-        missing = [name for name in DEPLOYMENTS if name not in DEPLOYMENT_TO_PLATFORM]
-        assert not missing, (
-            f"deployment(s) {missing} in DEPLOYMENTS have no platform mapping — "
-            "deployments_for_platform would silently drop them"
-        )
-
-    def test_no_orphan_mapping_entries(self) -> None:
-        """Every mapping key is also present in DEPLOYMENTS (no drift the other way)."""
-        orphans = [name for name in DEPLOYMENT_TO_PLATFORM if name not in DEPLOYMENTS]
-        assert not orphans, (
-            f"mapping key(s) {orphans} have no matching DEPLOYMENTS entry — "
-            "the deployment was removed but the mapping wasn't cleaned up"
-        )
-
-    def test_every_deployment_has_resolution_config(self) -> None:
-        """Every deployment can be resolved (trader service dir + chain)."""
-        config = tool_usage._DEPLOYMENT_CONFIG  # pylint: disable=protected-access
-        missing = [name for name in DEPLOYMENTS if name not in config]
-        assert not missing, (
-            f"deployment(s) {missing} have no _DEPLOYMENT_CONFIG entry — "
-            "fetch_valid_tools would never resolve them"
-        )
-
-    def test_resolution_chains_are_known(self) -> None:
+    def test_every_chain_has_a_subgraph_url(self) -> None:
         """Each deployment's chain has a marketplace subgraph URL."""
-        config = tool_usage._DEPLOYMENT_CONFIG  # pylint: disable=protected-access
-        for name, (_service, chain) in config.items():
+        deployments = tool_usage._DEPLOYMENTS  # pylint: disable=protected-access
+        for name, (_service, chain, _platform) in deployments.items():
             assert (
                 chain in tool_usage.MARKETPLACE_SUBGRAPH_URL
             ), f"{name} resolves on chain {chain!r} with no subgraph URL"
@@ -113,15 +88,16 @@ class TestLatestTraderRef:
     """Tests for latest_trader_ref."""
 
     def test_returns_latest_tag(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """The first (newest) release's tag_name is returned."""
-        monkeypatch.setattr(
-            tool_usage,
-            "_http_get",
-            lambda url: json.dumps(
-                [{"tag_name": "v1.2.3-rc1"}, {"tag_name": "v1.2.2"}]
-            ),
-        )
+        """First (newest) release's tag_name is returned; URL pins ``per_page=1``."""
+        seen: dict[str, str] = {}
+
+        def fake_get(url: str) -> str:
+            seen["url"] = url
+            return json.dumps([{"tag_name": "v1.2.3-rc1"}, {"tag_name": "v1.2.2"}])
+
+        monkeypatch.setattr(tool_usage, "_http_get", fake_get)
         assert tool_usage.latest_trader_ref() == "v1.2.3-rc1"
+        assert "per_page=1" in seen["url"]
 
     def test_empty_release_list_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """No releases -> ValueError (so the caller degrades, not crashes)."""
@@ -147,12 +123,12 @@ class TestParseValidMechs:
     """Tests for parse_valid_mechs."""
 
     def test_happy_path(self) -> None:
-        """The address list is extracted in order from the env default."""
-        yaml_source = _service_yaml(["0xAAA", "0xbbb"])
-        assert tool_usage.parse_valid_mechs(yaml_source) == ["0xAAA", "0xbbb"]
+        """The address list is extracted in order and lowercased at the boundary."""
+        yaml_source = _service_yaml(["0xAAA", "0xbBB"])
+        assert tool_usage.parse_valid_mechs(yaml_source) == ["0xaaa", "0xbbb"]
 
     def test_empty_list_returns_empty(self) -> None:
-        """An empty whitelist is a real state ([], not an error)."""
+        """An empty allow-list is a real state ([], not an error)."""
         assert tool_usage.parse_valid_mechs(_service_yaml([])) == []
 
     def test_missing_valid_mechs_raises(self) -> None:
@@ -208,6 +184,14 @@ class TestFetchToolsForMetadata:
         with pytest.raises(ValueError, match="no tools array"):
             tool_usage.fetch_tools_for_metadata("0xabc")
 
+    def test_html_response_raises_value_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """IPFS gateway returning HTML (cache miss / 504) -> ValueError (caught upstream)."""
+        monkeypatch.setattr(tool_usage, "_http_get", lambda url: "<html>504</html>")
+        with pytest.raises(ValueError):
+            tool_usage.fetch_tools_for_metadata("0xabc")
+
 
 # ---------------------------------------------------------------------------
 # resolve_mech_tools
@@ -220,10 +204,10 @@ class TestResolveMechTools:
     def test_empty_addresses_makes_no_network_call(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """An empty whitelist short-circuits to [] without touching the subgraph."""
+        """An empty allow-list short-circuits to [] without touching the subgraph."""
 
         def boom(*_args: object, **_kwargs: object) -> object:
-            raise AssertionError("network must not be touched for empty whitelist")
+            raise AssertionError("network must not be touched for empty allow-list")
 
         monkeypatch.setattr(tool_usage, "_post_graphql", boom)
         monkeypatch.setattr(tool_usage, "fetch_tools_for_metadata", boom)
@@ -267,17 +251,24 @@ class TestResolveMechTools:
 
         def fake_post(url: str, query: str) -> dict:
             captured["query"] = query
-            # Return both requested addresses so resolve_mech_tools doesn't
-            # short-circuit on a missing-address ValueError before we get to
-            # inspect the recorded query string.
+            # Return both requested addresses *with* metadata so resolve_mech_tools
+            # doesn't short-circuit on missing-address / empty-metadata
+            # ValueErrors before we get to inspect the recorded query string.
             return {
                 "meches": [
-                    {"address": "0xabc", "service": {"metadata": []}},
-                    {"address": "0xdef", "service": {"metadata": []}},
+                    {
+                        "address": "0xabc",
+                        "service": {"metadata": [{"metadata": "0x11"}]},
+                    },
+                    {
+                        "address": "0xdef",
+                        "service": {"metadata": [{"metadata": "0x11"}]},
+                    },
                 ]
             }
 
         monkeypatch.setattr(tool_usage, "_post_graphql", fake_post)
+        monkeypatch.setattr(tool_usage, "fetch_tools_for_metadata", lambda _h: ["t"])
         tool_usage.resolve_mech_tools(["0xAbC", "0xDEF"], "http://subgraph")
         assert '"0xabc"' in captured["query"]
         assert '"0xdef"' in captured["query"]
@@ -323,6 +314,70 @@ class TestResolveMechTools:
         assert "0xmissing1" in message
         assert "0xmissing2" in message
         assert "0xa" not in message
+
+    def test_all_addresses_missing_raises_with_every_address(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Empty meches list raises with every requested address (pins subtraction direction)."""
+        monkeypatch.setattr(
+            tool_usage, "_post_graphql", lambda url, query: {"meches": []}
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            tool_usage.resolve_mech_tools(["0xa", "0xb"], "http://subgraph")
+        message = str(excinfo.value)
+        assert "0xa" in message and "0xb" in message
+
+    def test_all_addresses_returned_but_no_metadata_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Addresses present but every mech lacks on-chain metadata -> ValueError."""
+        monkeypatch.setattr(
+            tool_usage,
+            "_post_graphql",
+            lambda url, query: {
+                "meches": [
+                    {"address": "0xa", "service": None},
+                    {"address": "0xb", "service": {"metadata": []}},
+                ]
+            },
+        )
+
+        def boom(_metadata_hash: str) -> list[str]:
+            raise AssertionError("IPFS must not be touched when no metadata is present")
+
+        monkeypatch.setattr(tool_usage, "fetch_tools_for_metadata", boom)
+        with pytest.raises(ValueError, match="none have on-chain metadata"):
+            tool_usage.resolve_mech_tools(["0xa", "0xb"], "http://subgraph")
+
+    def test_partial_metadata_unions_present_skips_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mechs with ``service=None`` / empty metadata are skipped when at least one resolves."""
+        monkeypatch.setattr(
+            tool_usage,
+            "_post_graphql",
+            lambda url, query: {
+                "meches": [
+                    {"address": "0xa", "service": None},
+                    {
+                        "address": "0xb",
+                        "service": {"metadata": [{"metadata": "0x22"}]},
+                    },
+                ]
+            },
+        )
+
+        def fake_tools(metadata_hash: str) -> list[str]:
+            assert (
+                metadata_hash == "0x22"
+            ), f"unexpected metadata fetch: {metadata_hash}"
+            return ["superforcaster"]
+
+        monkeypatch.setattr(tool_usage, "fetch_tools_for_metadata", fake_tools)
+        assert tool_usage.resolve_mech_tools(["0xa", "0xb"], "http://subgraph") == [
+            "superforcaster"
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/benchmark/tool_usage.py
+++ b/benchmark/tool_usage.py
@@ -16,13 +16,22 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-"""Fetch per-deployment IRRELEVANT_TOOLS lists so the daily report can annotate them.
+"""Resolve the per-deployment set of selectable tools so the daily report can annotate them.
 
-Each consumer (olas-operate-app Pearl, quickstart QS) stores the list as a
-JSON-encoded string in a public config on GitHub ``main``.  We return a
-``{deployment: [tool_names] | None}`` map; ``None`` signals a fetch or parse
-failure for that deployment so consumers can render "unavailable" rather
-than falsely claiming "no tools disabled".
+The trader no longer filters tools with a per-tool allow/deny list. Instead
+each deployment's ``service.yaml`` ships a ``valid_mechs`` whitelist of mech
+contract addresses, and the trader may select **any** tool offered by those
+mechs in the marketplace. We therefore resolve the allow-list dynamically:
+
+1. Find the latest ``valory-xyz/trader`` release tag.
+2. Read each deployment's ``service.yaml`` at that tag and parse ``valid_mechs``.
+3. Resolve each mech address to its tools via the marketplace subgraph
+   (mech → on-chain metadata CID → IPFS metadata ``tools`` list).
+4. A deployment's selectable tools are the union across its ``valid_mechs``.
+
+We return a ``{deployment: [tool_names] | None}`` map; ``None`` signals a fetch
+or parse failure for that deployment so consumers can render "unavailable"
+rather than falsely claiming a tool is (or is not) selectable.
 """
 
 from __future__ import annotations
@@ -31,7 +40,7 @@ import json
 import logging
 import re
 from types import MappingProxyType
-from typing import Mapping
+from typing import Any, Mapping
 from urllib.error import URLError
 from urllib.request import Request, urlopen
 
@@ -40,7 +49,6 @@ log = logging.getLogger(__name__)
 # Deployments we report on. Order is the column order in the rendered line.
 DEPLOYMENTS: tuple[str, ...] = (
     "omenstrat Pearl",
-    "omenstrat QS",
     "polystrat Pearl",
 )
 
@@ -49,8 +57,17 @@ DEPLOYMENTS: tuple[str, ...] = (
 DEPLOYMENT_TO_PLATFORM: Mapping[str, str] = MappingProxyType(
     {
         "omenstrat Pearl": "omen",
-        "omenstrat QS": "omen",
         "polystrat Pearl": "polymarket",
+    }
+)
+
+# Per-deployment resolution config: deployment -> (trader service dir, chain).
+# The trader service dir names the ``service.yaml`` carrying ``valid_mechs``;
+# the chain selects the marketplace subgraph the mech addresses live on.
+_DEPLOYMENT_CONFIG: Mapping[str, tuple[str, str]] = MappingProxyType(
+    {
+        "omenstrat Pearl": ("trader_pearl", "gnosis"),
+        "polystrat Pearl": ("polymarket_trader", "polygon"),
     }
 )
 
@@ -66,39 +83,53 @@ def deployments_for_platform(platform: str) -> tuple[str, ...]:
     )
 
 
-# Source URLs (GitHub raw, ``main`` branch).
-OPERATE_APP_TRADER_TS_URL = (
-    "https://raw.githubusercontent.com/valory-xyz/olas-operate-app/"
-    "main/frontend/constants/serviceTemplates/service/trader.ts"
+# Source URLs.
+# Latest published release (includes pre-releases); ``[0]`` is the most recent.
+TRADER_RELEASES_URL = (
+    "https://api.github.com/repos/valory-xyz/trader/releases?per_page=1"
 )
-QUICKSTART_CONFIG_URL = (
-    "https://raw.githubusercontent.com/valory-xyz/quickstart/"
-    "main/configs/config_predict_trader.json"
+# Filled with the resolved release tag and the trader service dir.
+TRADER_SERVICE_YAML_URL = (
+    "https://raw.githubusercontent.com/valory-xyz/trader/"
+    "{ref}/packages/valory/services/{service}/service.yaml"
 )
+# Olas Mech Marketplace subgraphs, per chain.
+MARKETPLACE_SUBGRAPH_URL: Mapping[str, str] = MappingProxyType(
+    {
+        "gnosis": "https://api.subgraph.autonolas.tech/api/proxy/marketplace-gnosis",
+        "polygon": "https://api.subgraph.autonolas.tech/api/proxy/marketplace-polygon",
+    }
+)
+# IPFS gateway and the CIDv1 prefix mech-interact prepends to a metadata hash.
+IPFS_GATEWAY_URL = "https://gateway.autonolas.tech/ipfs"
+CID_PREFIX = "f01701220"
 
-# Fetch timeout (seconds). Short so a stalled GitHub never blocks the
+# Fetch timeout (seconds). Short so a stalled endpoint never blocks the
 # daily report pipeline.
-FETCH_TIMEOUT = 10
+FETCH_TIMEOUT = 30
 
-# Matches an ``IRRELEVANT_TOOLS`` block anchored to a specific exported
-# template name (e.g. ``PREDICT_SERVICE_TEMPLATE``).  The capture group is
-# the JSON-array-of-strings payload under ``value:``.  Anchoring to the
-# template name protects us against silent relabel if the two template
-# declarations are ever reordered in ``trader.ts``.
-_TS_TEMPLATE_BLOCK_TEMPLATE = (
-    r"{template_name}\b[\s\S]*?"
-    r"IRRELEVANT_TOOLS\s*:\s*\{{[^}}]*?value\s*:\s*'(?P<value>\[[^']*\])'"
+# Matches the ``valid_mechs`` env-override default in a trader ``service.yaml``:
+# ``valid_mechs: ${VALID_MECHS:list:["0x..","0x.."]}`` on a single line. The
+# inner ``[...]`` is valid JSON (array of double-quoted addresses); ``[^\]]*``
+# is safe because addresses never contain ``]``.
+_VALID_MECHS_RE = re.compile(
+    r"valid_mechs\s*:\s*\$\{VALID_MECHS:list:(?P<list>\[[^\]]*\])\}"
 )
-_OMENSTRAT_PEARL_TEMPLATE = "PREDICT_SERVICE_TEMPLATE"
-_POLYSTRAT_PEARL_TEMPLATE = "PREDICT_POLYMARKET_SERVICE_TEMPLATE"
+
+# Subgraph query: resolve a set of mech addresses to their on-chain metadata
+# CID. ``meches`` is keyed internally by id but carries the contract
+# ``address``; ``%(addrs)s`` is a comma-separated list of quoted addresses.
+_MECHES_QUERY = (
+    "{ meches(first: 1000, where: {address_in: [%(addrs)s]}) "
+    "{ address service { metadata { metadata } } } }"
+)
 
 
 def _normalize_tool_name(name: str) -> str:
     """Return a canonical form for cross-convention tool-name matching.
 
-    Operate-app and quickstart lists sometimes use ``prediction_request_X``
-    while the benchmark logs use ``prediction-request-X`` for the same tool;
-    the config authors defensively list both variants.  Treat underscores
+    Mech metadata and the benchmark logs sometimes spell the same tool
+    ``prediction_request_X`` vs ``prediction-request-X``. Treat underscores
     and hyphens as interchangeable so we don't under-report.
 
     :param name: raw tool name.
@@ -119,29 +150,37 @@ def _http_get(url: str) -> str:
     req = Request(url, headers={"User-Agent": "mech-predict-benchmark"})
     with urlopen(
         req, timeout=FETCH_TIMEOUT
-    ) as resp:  # nosec B310 — fixed mech-tool registry URL
+    ) as resp:  # nosec B310 — fixed registry/subgraph/IPFS URLs
         return resp.read().decode("utf-8")
 
 
-def _extract_template_irrelevant_tools(source: str, template_name: str) -> list[str]:
-    """Extract the IRRELEVANT_TOOLS list for one named template.
+def _post_graphql(url: str, query: str) -> dict[str, Any]:
+    """POST a GraphQL ``query`` to ``url`` and return the ``data`` object.
 
-    :param source: full text of ``trader.ts``.
-    :param template_name: exported template identifier
-        (e.g. ``PREDICT_SERVICE_TEMPLATE``).
-    :return: parsed list of tool names.
-    :raises ValueError: when no IRRELEVANT_TOOLS block is found for this template.
+    Propagates ``URLError`` (or subclasses) on network failure.
+
+    :param url: GraphQL endpoint.
+    :param query: GraphQL query string.
+    :return: the ``data`` object from the JSON response.
+    :raises ValueError: when the response reports GraphQL ``errors``.
     """
-    pattern = re.compile(
-        _TS_TEMPLATE_BLOCK_TEMPLATE.format(template_name=template_name),
-        re.DOTALL,
+    body = json.dumps({"query": query}).encode("utf-8")
+    req = Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "mech-predict-benchmark",
+        },
+        method="POST",
     )
-    match = pattern.search(source)
-    if match is None:
-        raise ValueError(
-            f"no IRRELEVANT_TOOLS block found for template {template_name}"
-        )
-    return _parse_json_string_list(match.group("value"))
+    with urlopen(
+        req, timeout=FETCH_TIMEOUT
+    ) as resp:  # nosec B310 — fixed marketplace subgraph URLs
+        payload = json.loads(resp.read().decode("utf-8"))
+    if payload.get("errors"):
+        raise ValueError(f"GraphQL errors from {url}: {payload['errors']}")
+    return payload.get("data") or {}
 
 
 def _parse_json_string_list(raw: str) -> list[str]:
@@ -153,73 +192,129 @@ def _parse_json_string_list(raw: str) -> list[str]:
     """
     parsed = json.loads(raw)
     if not isinstance(parsed, list) or not all(isinstance(x, str) for x in parsed):
-        raise ValueError("IRRELEVANT_TOOLS value must be a JSON array of strings")
+        raise ValueError("expected a JSON array of strings")
     return parsed
 
 
-def parse_operate_app_ts(source: str) -> dict[str, list[str]]:
-    """Parse IRRELEVANT_TOOLS for each exported template in ``trader.ts``.
+def latest_trader_ref() -> str:
+    """Return the tag of the most recent ``valory-xyz/trader`` release.
 
-    Template identity is anchored to the exported identifier
-    (``PREDICT_SERVICE_TEMPLATE`` for omenstrat Pearl and
-    ``PREDICT_POLYMARKET_SERVICE_TEMPLATE`` for polystrat Pearl), not file
-    order, so silent relabel is impossible if the two declarations are
-    ever reordered.  Propagates ``ValueError`` from
-    ``_extract_template_irrelevant_tools`` when either template's block
-    is missing.
+    The releases endpoint lists published releases (pre-releases included)
+    newest-first, so ``[0].tag_name`` is the latest deployable trader version.
+    Propagates ``URLError`` (or subclasses) on network failure.
 
-    :param source: full text of ``trader.ts``.
-    :return: ``{"omenstrat Pearl": [...], "polystrat Pearl": [...]}``.
+    :return: the release tag (e.g. ``"v0.38.0-rc1"``).
+    :raises ValueError: when no release or no ``tag_name`` is present.
     """
-    return {
-        "omenstrat Pearl": _extract_template_irrelevant_tools(
-            source, _OMENSTRAT_PEARL_TEMPLATE
-        ),
-        "polystrat Pearl": _extract_template_irrelevant_tools(
-            source, _POLYSTRAT_PEARL_TEMPLATE
-        ),
-    }
+    releases = json.loads(_http_get(TRADER_RELEASES_URL))
+    if not isinstance(releases, list) or not releases:
+        raise ValueError("no trader releases found")
+    tag = releases[0].get("tag_name")
+    if not isinstance(tag, str) or not tag:
+        raise ValueError("latest trader release has no tag_name")
+    return tag
 
 
-def parse_quickstart_config(source: str) -> list[str]:
-    """Parse ``env_variables.IRRELEVANT_TOOLS.value`` from the quickstart JSON.
+def parse_valid_mechs(yaml_source: str) -> list[str]:
+    """Extract the ``valid_mechs`` whitelist from a trader ``service.yaml``.
 
-    Propagates ``KeyError`` when the expected path is missing, and
-    ``ValueError`` (from ``_parse_json_string_list`` or ``json.loads``)
-    when the value is not a JSON array of strings.
-
-    :param source: full text of the quickstart ``config_predict_trader.json``.
-    :return: the parsed list of irrelevant tool names.
+    :param yaml_source: full text of a trader ``service.yaml``.
+    :return: list of mech contract addresses (empty list is a real state:
+        "no mechs whitelisted").
+    :raises ValueError: when the ``valid_mechs`` env-default line is absent
+        or its payload is not a JSON array of strings.
     """
-    data = json.loads(source)
-    raw = data["env_variables"]["IRRELEVANT_TOOLS"]["value"]
-    return _parse_json_string_list(raw)
+    match = _VALID_MECHS_RE.search(yaml_source)
+    if match is None:
+        raise ValueError("no valid_mechs env default found in service.yaml")
+    return _parse_json_string_list(match.group("list"))
 
 
-def fetch_disabled_tools() -> dict[str, list[str] | None]:
-    """Return ``{deployment: [tool_names] | None}`` for all deployments.
+def fetch_tools_for_metadata(metadata_hash: str) -> list[str]:
+    """Fetch the tools manifest for one mech metadata hash from IPFS.
 
-    ``None`` signals a fetch or parse failure for that deployment so the
-    renderer can say "unavailable" instead of falsely claiming nothing is
-    disabled.  Failures are logged but never raised — the daily report
-    must never be blocked by a flaky GitHub fetch.
+    The subgraph stores the metadata as a hex hash; mech-interact resolves
+    it to a CIDv1 by prepending ``CID_PREFIX`` (after dropping any ``0x``).
+    Propagates ``URLError`` (or subclasses) on network failure.
 
-    :return: disabled-tools map keyed by deployment name.
+    :param metadata_hash: hex metadata hash from the subgraph
+        (e.g. ``0x204398...``).
+    :return: the tool names advertised in the manifest's ``tools`` array.
+    :raises ValueError: when the manifest has no JSON ``tools`` array of strings.
     """
-    disabled: dict[str, list[str] | None] = {name: None for name in DEPLOYMENTS}
+    digest = metadata_hash[2:] if metadata_hash.startswith("0x") else metadata_hash
+    url = f"{IPFS_GATEWAY_URL}/{CID_PREFIX}{digest}"
+    manifest = json.loads(_http_get(url))
+    tools = manifest.get("tools") if isinstance(manifest, dict) else None
+    if not isinstance(tools, list) or not all(isinstance(t, str) for t in tools):
+        raise ValueError(f"metadata {metadata_hash} has no tools array of strings")
+    return tools
+
+
+def resolve_mech_tools(addresses: list[str], subgraph_url: str) -> list[str]:
+    """Resolve a deployment's ``valid_mechs`` to the union of tools they offer.
+
+    Looks up each address' on-chain metadata CID via the marketplace
+    subgraph, then fetches each distinct manifest from IPFS and unions the
+    advertised tools. Distinct metadata hashes are de-duplicated so mechs
+    sharing a manifest are fetched once. Propagates ``URLError`` on a
+    subgraph/IPFS network failure and ``ValueError`` on a GraphQL error or
+    a malformed IPFS manifest, so the caller can mark the deployment
+    unavailable.
+
+    :param addresses: mech contract addresses (the parsed ``valid_mechs``).
+    :param subgraph_url: marketplace subgraph endpoint for the chain.
+    :return: sorted union of advertised tool names; ``[]`` when ``addresses``
+        is empty (a real "no mechs whitelisted" state, not a failure).
+    """
+    if not addresses:
+        return []
+    quoted = ",".join(f'"{addr.lower()}"' for addr in addresses)
+    data = _post_graphql(subgraph_url, _MECHES_QUERY % {"addrs": quoted})
+
+    metadata_hashes: set[str] = set()
+    for mech in data.get("meches") or []:
+        manifests = (mech.get("service") or {}).get("metadata") or []
+        if manifests and manifests[0].get("metadata"):
+            metadata_hashes.add(manifests[0]["metadata"])
+
+    tools: set[str] = set()
+    for metadata_hash in metadata_hashes:
+        tools.update(fetch_tools_for_metadata(metadata_hash))
+    return sorted(tools)
+
+
+def fetch_valid_tools() -> dict[str, list[str] | None]:
+    """Return ``{deployment: [selectable_tool_names] | None}`` for all deployments.
+
+    For each deployment: read its ``service.yaml`` at the latest trader
+    release, parse ``valid_mechs``, and resolve those mechs to the union of
+    tools they advertise in the marketplace. ``None`` signals a fetch or
+    parse failure for that deployment so the renderer can say "unavailable"
+    instead of falsely claiming a tool is or is not selectable. Failures are
+    logged but never raised — the daily report must never be blocked by a
+    flaky GitHub/subgraph/IPFS fetch.
+
+    :return: selectable-tools map keyed by deployment name.
+    """
+    valid: dict[str, list[str] | None] = {name: None for name in DEPLOYMENTS}
 
     try:
-        ts_source = _http_get(OPERATE_APP_TRADER_TS_URL)
-        pearl = parse_operate_app_ts(ts_source)
-        disabled["omenstrat Pearl"] = pearl["omenstrat Pearl"]
-        disabled["polystrat Pearl"] = pearl["polystrat Pearl"]
+        ref = latest_trader_ref()
     except (URLError, ValueError, OSError) as exc:
-        log.warning("operate-app fetch/parse failed: %s", exc)
+        log.warning("trader release resolution failed: %s", exc)
+        return valid  # every deployment stays None
 
-    try:
-        qs_source = _http_get(QUICKSTART_CONFIG_URL)
-        disabled["omenstrat QS"] = parse_quickstart_config(qs_source)
-    except (URLError, ValueError, KeyError, OSError) as exc:
-        log.warning("quickstart fetch/parse failed: %s", exc)
+    for deployment, (service, chain) in _DEPLOYMENT_CONFIG.items():
+        try:
+            yaml_source = _http_get(
+                TRADER_SERVICE_YAML_URL.format(ref=ref, service=service)
+            )
+            mechs = parse_valid_mechs(yaml_source)
+            valid[deployment] = resolve_mech_tools(
+                mechs, MARKETPLACE_SUBGRAPH_URL[chain]
+            )
+        except (URLError, ValueError, OSError) as exc:
+            log.warning("%s selectable-tools resolution failed: %s", deployment, exc)
 
-    return disabled
+    return valid

--- a/benchmark/tool_usage.py
+++ b/benchmark/tool_usage.py
@@ -19,7 +19,7 @@
 """Resolve the per-deployment set of selectable tools so the daily report can annotate them.
 
 The trader no longer filters tools with a per-tool allow/deny list. Instead
-each deployment's ``service.yaml`` ships a ``valid_mechs`` whitelist of mech
+each deployment's ``service.yaml`` ships a ``valid_mechs`` allow-list of mech
 contract addresses, and the trader may select **any** tool offered by those
 mechs in the marketplace. We therefore resolve the allow-list dynamically:
 
@@ -46,29 +46,29 @@ from urllib.request import Request, urlopen
 
 log = logging.getLogger(__name__)
 
-# Deployments we report on. Order is the column order in the rendered line.
-DEPLOYMENTS: tuple[str, ...] = (
-    "omenstrat Pearl",
-    "polystrat Pearl",
+# Single source of truth for every deployment we report on. Each entry maps
+# the deployment name to ``(trader_service_dir, chain, platform)``:
+#   * ``trader_service_dir`` selects which trader ``service.yaml`` to read
+#     for ``valid_mechs`` at the latest trader release.
+#   * ``chain`` selects the marketplace subgraph the mech addresses live on.
+#   * ``platform`` is the scorer key used to filter the report section.
+# Adding a new deployment requires editing exactly this one structure; the
+# public ``DEPLOYMENTS`` tuple and ``DEPLOYMENT_TO_PLATFORM`` mapping below
+# are derived from it.
+_DEPLOYMENTS: Mapping[str, tuple[str, str, str]] = MappingProxyType(
+    {
+        "omenstrat Pearl": ("trader_pearl", "gnosis", "omen"),
+        "polystrat Pearl": ("polymarket_trader", "polygon", "polymarket"),
+    }
 )
+
+# Deployments we report on. Order is the column order in the rendered line.
+DEPLOYMENTS: tuple[str, ...] = tuple(_DEPLOYMENTS)
 
 # Maps each deployment name to the scorer's platform key. Drives the
 # per-platform filter on the Tool Deployment Status section.
 DEPLOYMENT_TO_PLATFORM: Mapping[str, str] = MappingProxyType(
-    {
-        "omenstrat Pearl": "omen",
-        "polystrat Pearl": "polymarket",
-    }
-)
-
-# Per-deployment resolution config: deployment -> (trader service dir, chain).
-# The trader service dir names the ``service.yaml`` carrying ``valid_mechs``;
-# the chain selects the marketplace subgraph the mech addresses live on.
-_DEPLOYMENT_CONFIG: Mapping[str, tuple[str, str]] = MappingProxyType(
-    {
-        "omenstrat Pearl": ("trader_pearl", "gnosis"),
-        "polystrat Pearl": ("polymarket_trader", "polygon"),
-    }
+    {name: platform for name, (_service, _chain, platform) in _DEPLOYMENTS.items()}
 )
 
 
@@ -84,7 +84,11 @@ def deployments_for_platform(platform: str) -> tuple[str, ...]:
 
 
 # Source URLs.
-# Latest published release (includes pre-releases); ``[0]`` is the most recent.
+# Latest published release (pre-releases intentionally included: the trader
+# is shipped via pre-release tags like ``v0.38.7-rc1`` and that is what is
+# actually deployed). ``per_page=1`` keeps the response to one element, so
+# ``[0]`` is the newest tag. Any network / parse failure here degrades the
+# whole Tool Deployment Status section to ``⚠️ unavailable`` (never raises).
 TRADER_RELEASES_URL = (
     "https://api.github.com/repos/valory-xyz/trader/releases?per_page=1"
 )
@@ -118,10 +122,11 @@ _VALID_MECHS_RE = re.compile(
 
 # Subgraph query: resolve a set of mech addresses to their on-chain metadata
 # CID. ``meches`` is keyed internally by id but carries the contract
-# ``address``; ``%(addrs)s`` is a comma-separated list of quoted addresses.
+# ``address``; ``{addrs}`` is rendered with a comma-separated list of quoted
+# addresses at call time via ``.format(addrs=...)``.
 _MECHES_QUERY = (
-    "{ meches(first: 1000, where: {address_in: [%(addrs)s]}) "
-    "{ address service { metadata { metadata } } } }"
+    "{{ meches(first: 1000, where: {{address_in: [{addrs}]}}) "
+    "{{ address service {{ metadata {{ metadata }} }} }} }}"
 )
 
 
@@ -162,7 +167,11 @@ def _post_graphql(url: str, query: str) -> dict[str, Any]:
     :param url: GraphQL endpoint.
     :param query: GraphQL query string.
     :return: the ``data`` object from the JSON response.
-    :raises ValueError: when the response reports GraphQL ``errors``.
+    :raises ValueError: when the response reports GraphQL ``errors`` or when
+        ``data`` is missing / not a JSON object. Spec-compliant subgraphs
+        always send a dict; defending here converts a hypothetical
+        ``AttributeError`` from downstream ``data.get(...)`` calls into the
+        normal ``None``-fallback path in ``fetch_valid_tools``.
     """
     body = json.dumps({"query": query}).encode("utf-8")
     req = Request(
@@ -180,7 +189,10 @@ def _post_graphql(url: str, query: str) -> dict[str, Any]:
         payload = json.loads(resp.read().decode("utf-8"))
     if payload.get("errors"):
         raise ValueError(f"GraphQL errors from {url}: {payload['errors']}")
-    return payload.get("data") or {}
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise ValueError(f"unexpected data type from {url}: {type(data).__name__}")
+    return data
 
 
 def _parse_json_string_list(raw: str) -> list[str]:
@@ -216,18 +228,22 @@ def latest_trader_ref() -> str:
 
 
 def parse_valid_mechs(yaml_source: str) -> list[str]:
-    """Extract the ``valid_mechs`` whitelist from a trader ``service.yaml``.
+    """Extract the ``valid_mechs`` allow-list from a trader ``service.yaml``.
+
+    Addresses are returned lowercased so every downstream caller receives a
+    canonical-cased value without needing to know about the subgraph's
+    lowercase normalisation convention.
 
     :param yaml_source: full text of a trader ``service.yaml``.
     :return: list of mech contract addresses (empty list is a real state:
-        "no mechs whitelisted").
+        "no mechs allow-listed").
     :raises ValueError: when the ``valid_mechs`` env-default line is absent
         or its payload is not a JSON array of strings.
     """
     match = _VALID_MECHS_RE.search(yaml_source)
     if match is None:
         raise ValueError("no valid_mechs env default found in service.yaml")
-    return _parse_json_string_list(match.group("list"))
+    return [addr.lower() for addr in _parse_json_string_list(match.group("list"))]
 
 
 def fetch_tools_for_metadata(metadata_hash: str) -> list[str]:
@@ -262,23 +278,30 @@ def resolve_mech_tools(addresses: list[str], subgraph_url: str) -> list[str]:
     a malformed IPFS manifest, so the caller can mark the deployment
     unavailable.
 
-    A subgraph response that omits any requested address (typo'd
-    ``valid_mechs`` entry, mech not yet indexed, address on the wrong chain,
-    etc.) is treated as a hard failure — silently unioning only the resolved
-    manifests would shrink the allow-list and look indistinguishable from a
-    real "no tools selectable" state on the daily report.
+    Two cases are treated as hard failures so the deployment falls back to
+    ``⚠️ unavailable`` rather than to a silently shrunk allow-list:
+
+    * The subgraph response omits any requested address (typo'd
+      ``valid_mechs`` entry, mech not yet indexed, address on the wrong
+      chain, etc.).
+    * Every requested address is returned but none carries a usable
+      on-chain metadata hash (``service`` is ``null`` or ``metadata`` is
+      empty) — without this guard the deployment would resolve to ``[]``
+      and render "no benchmarked tools active", indistinguishable from a
+      legitimately empty ``valid_mechs``.
 
     :param addresses: mech contract addresses (the parsed ``valid_mechs``).
     :param subgraph_url: marketplace subgraph endpoint for the chain.
     :return: sorted union of advertised tool names; ``[]`` when ``addresses``
-        is empty (a real "no mechs whitelisted" state, not a failure).
+        is empty (a real "no mechs allow-listed" state, not a failure).
     :raises ValueError: when the subgraph does not return every requested
-        address; the message lists the missing ones.
+        address (the message lists the missing ones), or when the resolved
+        mechs collectively yield no on-chain metadata hashes.
     """
     if not addresses:
         return []
     quoted = ",".join(f'"{addr.lower()}"' for addr in addresses)
-    data = _post_graphql(subgraph_url, _MECHES_QUERY % {"addrs": quoted})
+    data = _post_graphql(subgraph_url, _MECHES_QUERY.format(addrs=quoted))
 
     meches = data.get("meches") or []
     returned = {(mech.get("address") or "").lower() for mech in meches}
@@ -294,6 +317,11 @@ def resolve_mech_tools(addresses: list[str], subgraph_url: str) -> list[str]:
         manifests = (mech.get("service") or {}).get("metadata") or []
         if manifests and manifests[0].get("metadata"):
             metadata_hashes.add(manifests[0]["metadata"])
+
+    if not metadata_hashes:
+        raise ValueError(
+            "subgraph returned all addresses but none have on-chain metadata"
+        )
 
     tools: set[str] = set()
     for metadata_hash in metadata_hashes:
@@ -322,7 +350,7 @@ def fetch_valid_tools() -> dict[str, list[str] | None]:
         log.warning("trader release resolution failed: %s", exc)
         return valid  # every deployment stays None
 
-    for deployment, (service, chain) in _DEPLOYMENT_CONFIG.items():
+    for deployment, (service, chain, _platform) in _DEPLOYMENTS.items():
         try:
             yaml_source = _http_get(
                 TRADER_SERVICE_YAML_URL.format(ref=ref, service=service)

--- a/benchmark/tool_usage.py
+++ b/benchmark/tool_usage.py
@@ -262,18 +262,35 @@ def resolve_mech_tools(addresses: list[str], subgraph_url: str) -> list[str]:
     a malformed IPFS manifest, so the caller can mark the deployment
     unavailable.
 
+    A subgraph response that omits any requested address (typo'd
+    ``valid_mechs`` entry, mech not yet indexed, address on the wrong chain,
+    etc.) is treated as a hard failure — silently unioning only the resolved
+    manifests would shrink the allow-list and look indistinguishable from a
+    real "no tools selectable" state on the daily report.
+
     :param addresses: mech contract addresses (the parsed ``valid_mechs``).
     :param subgraph_url: marketplace subgraph endpoint for the chain.
     :return: sorted union of advertised tool names; ``[]`` when ``addresses``
         is empty (a real "no mechs whitelisted" state, not a failure).
+    :raises ValueError: when the subgraph does not return every requested
+        address; the message lists the missing ones.
     """
     if not addresses:
         return []
     quoted = ",".join(f'"{addr.lower()}"' for addr in addresses)
     data = _post_graphql(subgraph_url, _MECHES_QUERY % {"addrs": quoted})
 
+    meches = data.get("meches") or []
+    returned = {(mech.get("address") or "").lower() for mech in meches}
+    requested = {addr.lower() for addr in addresses}
+    missing = requested - returned
+    if missing:
+        raise ValueError(
+            "subgraph did not return mech address(es): " + ", ".join(sorted(missing))
+        )
+
     metadata_hashes: set[str] = set()
-    for mech in data.get("meches") or []:
+    for mech in meches:
         manifests = (mech.get("service") or {}).get("metadata") or []
         if manifests and manifests[0].get("metadata"):
             metadata_hashes.add(manifests[0]["metadata"])


### PR DESCRIPTION
## What

The trader no longer filters tools with a per-tool allow/deny list. It now selects any marketplace tool offered by the mechs in each deployment's `valid_mechs` whitelist (`trader_pearl/service.yaml` for omen, `polymarket_trader/service.yaml` for polymarket). The benchmark's "Tool Deployment Status" section and per-platform active-tool filter now resolve the selectable-tool set from `valid_mechs` instead of reading the old `IRRELEVANT_TOOLS` deny-list.

## How it resolves

`benchmark/tool_usage.py` `fetch_valid_tools()`:

- resolve the latest `valory-xyz/trader` release tag;
- read `valid_mechs` from each deployment's `service.yaml` at that tag;
- resolve each mech address via the marketplace subgraph (`meches` → on-chain metadata CID, gnosis/polygon) → IPFS manifest `tools[]`;
- return the per-deployment **union** of advertised tools.

Per-deployment failures degrade to `None` (renders `⚠️ unavailable`), never raised, so the daily report is never blocked by a flaky GitHub/subgraph/IPFS fetch. The deprecated `omenstrat QS` deployment is dropped. The resolution pattern mirrors `random-valory-scripts/mech/list_marketplace_tools.py`.

## Code

- **`tool_usage.py`** — rewrote the fetch layer (`latest_trader_ref`, `parse_valid_mechs`, `fetch_tools_for_metadata`, `resolve_mech_tools`, `fetch_valid_tools`).
- **`analyze.py`** — flipped the membership test from deny (`not in`) to allow (`in`) in `_active_tools_for_platform` and `section_tool_deployment_status`; renamed `disabled*` → `valid*` and `fetch_disabled_tools` → `fetch_valid_tools`.
- **tests** — rewrote `test_tool_usage.py` (all network monkeypatched, no real I/O) and inverted the `test_analyze.py` deployment-status fixtures.

## Verification

- 209 benchmark tests pass; lint suite green (`black-check isort-check flake8 mypy pylint darglint`).
- Live `fetch_valid_tools()` against trader `v0.38.7-rc1`:
  - **omenstrat Pearl** → `factual_research`, `prediction-request-reasoning-claude`, `resolve-market-jury-v1`, `resolve-market-reasoning-gpt-4.1`, `superforcaster`
  - **polystrat Pearl** → `factual_research`, `resolve-market-reasoning-gpt-4.1`, `superforcaster`

The prediction-side subset matches the values the earlier (never-merged) `VALID_TOOLS` spec expected; `resolve-*` tools are filtered out by the intersection since they are not benchmarked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)