### PR TITLE
feat(customs): split off superforcaster_polymarket_v1

### DIFF
--- a/benchmark/tools.py
+++ b/benchmark/tools.py
@@ -48,6 +48,13 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "superforcaster": ToolSpec(
         module="packages.valory.customs.superforcaster.superforcaster",
     ),
+    # valory/superforcaster_polymarket_v1
+    "superforcaster-polymarket-v1": ToolSpec(
+        module=(
+            "packages.valory.customs.superforcaster_polymarket_v1"
+            ".superforcaster_polymarket_v1"
+        ),
+    ),
     # napthaai/prediction_request_reasoning
     "prediction-request-reasoning": ToolSpec(
         module="packages.napthaai.customs.prediction_request_reasoning.prediction_request_reasoning",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -11,16 +11,16 @@
         "custom/valory/prediction_request/0.1.0": "bafybeic5mml6a3ovi63c7rcymmv2ot5pqgtvolhn5m5lhywcfpafphjk3i",
         "custom/valory/prepare_tx/0.1.0": "bafybeida74hcfsfgh644o27qlq2lmue5aj7kvjfsbjermwv42euyf525ya",
         "custom/valory/resolve_market/0.1.0": "bafybeigxgcjsvi2zovoxgz5ra7x7sqz5qfx3p5kxmhgftrr7fxonjmhspi",
-        "custom/valory/superforcaster/0.1.0": "bafybeic2ziubkeyjq6syiqcs2bq7o5og3n62q6c2fnvv2oysczpnjdl56m",
+        "custom/valory/superforcaster/0.1.0": "bafybeidkraklf5c6rkv6g7y7lqj2woy4j5u5dmupjez6mtjhdek3lzbmki",
         "custom/victorpolisetty/dalle_request/0.1.0": "bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e",
         "custom/victorpolisetty/gemini_request/0.1.0": "bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu",
         "custom/valory/factual_research/0.1.0": "bafybeidcxmqemvzm7cz2ydyjsmu53zflsqpcj2gpco5kwn3ldvf22rqx4i",
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiezdf24cnpdvf42yf3t5yebr2mciphbuf6j7ccwwghpatb4avdb4y",
         "custom/valory/superforcaster_full_search/0.1.0": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
         "custom/valory/superforcaster_calibrated_full_search/0.1.0": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
-        "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeiehni272ok633xpdh7m2y7v463zsrczcubvedfsjo4qigosyax374",
-        "agent/valory/mech_predict/0.1.0": "bafybeiad7ov5r2eqls2fxq2xnsu4dkgsiy4gyfbh6tdlieggjemedjes4i",
-        "service/valory/mech_predict/0.1.0": "bafybeicnb4h57v452fzc3km6ojlz4nwj5jju5stru7preuutcqknprzib4"
+        "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeibvm77sizmxtbhtqnxqbg5mwwi4m3sidd326fo7gfwuc2hriprade",
+        "agent/valory/mech_predict/0.1.0": "bafybeid4epxuu5mfenpvlrw6uiluk7muifypam6xhvfu3eunfdm4n6mepe",
+        "service/valory/mech_predict/0.1.0": "bafybeierloususbzhj24q6vdhp7fxlkl6q5rrkbxndswztsyf7rbqin6bu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -18,7 +18,7 @@
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiezdf24cnpdvf42yf3t5yebr2mciphbuf6j7ccwwghpatb4avdb4y",
         "custom/valory/superforcaster_full_search/0.1.0": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
         "custom/valory/superforcaster_calibrated_full_search/0.1.0": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
-        "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeibvm77sizmxtbhtqnxqbg5mwwi4m3sidd326fo7gfwuc2hriprade",
+        "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeiawfhy3w5aclmxm5zxebwd5l7paseqlgmihwbqfyhcdpn2kccgtrq",
         "agent/valory/mech_predict/0.1.0": "bafybeid4epxuu5mfenpvlrw6uiluk7muifypam6xhvfu3eunfdm4n6mepe",
         "service/valory/mech_predict/0.1.0": "bafybeierloususbzhj24q6vdhp7fxlkl6q5rrkbxndswztsyf7rbqin6bu"
     },

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -18,6 +18,7 @@
         "custom/valory/resolve_market_jury/0.1.0": "bafybeiezdf24cnpdvf42yf3t5yebr2mciphbuf6j7ccwwghpatb4avdb4y",
         "custom/valory/superforcaster_full_search/0.1.0": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
         "custom/valory/superforcaster_calibrated_full_search/0.1.0": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
+        "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeiehni272ok633xpdh7m2y7v463zsrczcubvedfsjo4qigosyax374",
         "agent/valory/mech_predict/0.1.0": "bafybeiad7ov5r2eqls2fxq2xnsu4dkgsiy4gyfbh6tdlieggjemedjes4i",
         "service/valory/mech_predict/0.1.0": "bafybeicnb4h57v452fzc3km6ojlz4nwj5jju5stru7preuutcqknprzib4"
     },

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -61,7 +61,7 @@ customs:
 - valory/prediction_langchain:0.1.0:bafybeifuxvvldtt7o5zmrgdscbqofnkgtmemv5yv5gxzeptnxsiymwvs6a
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
-- valory/superforcaster:0.1.0:bafybeic2ziubkeyjq6syiqcs2bq7o5og3n62q6c2fnvv2oysczpnjdl56m
+- valory/superforcaster:0.1.0:bafybeidkraklf5c6rkv6g7y7lqj2woy4j5u5dmupjez6mtjhdek3lzbmki
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeifssc6ed7itkvqot6qunlpd3prghwsf5dh26kin3xduci3sohulqq

--- a/packages/valory/customs/superforcaster/component.yaml
+++ b/packages/valory/customs/superforcaster/component.yaml
@@ -8,9 +8,9 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeifvbuxt54l5jsxextf6ru5yvimkfdg4gfkcsnmyvsyqcsgclg7vey
-  superforcaster.py: bafybeibfat4z2tdqvrjz6dukdz34oyb36j7bi5rqtgat42vxncai5hw6im
+  superforcaster.py: bafybeic7vbcjcq5jomciosjaez2nnktwsdlbf2ctakdrbh5nl7cgod5z6e
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
-  tests/test_superforcaster.py: bafybeigscr6ayqdkgchxxvygp25yzqlu6g6rkwg3fcbflxx2sbfpymgdqa
+  tests/test_superforcaster.py: bafybeiboaixfm4itoashxu5a4fshfe36plhnkk2tw3reznnoxz4yl7ovhm
 fingerprint_ignore_patterns: []
 entry_point: superforcaster.py
 callable: run
@@ -23,5 +23,7 @@ dependencies:
     version: ==0.25.2
   tiktoken:
     version: ==0.12.0
+  pydantic:
+    version: '>=2.0.0,<3.0.0'
   requests:
     version: ==2.32.5

--- a/packages/valory/customs/superforcaster/superforcaster.py
+++ b/packages/valory/customs/superforcaster/superforcaster.py
@@ -27,6 +27,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import openai
 import requests
+from openai import OpenAI
+from pydantic import BaseModel, Field, model_validator
 from tiktoken import encoding_for_model
 
 MechResponseWithKeys = Tuple[
@@ -41,6 +43,99 @@ N_MODEL_CALLS = 1
 DEFAULT_DELIVERY_RATE = 100
 
 
+# ---------------------------------------------------------------------------
+# Pydantic schema for OpenAI Structured Outputs
+# ---------------------------------------------------------------------------
+
+
+class PredictionResult(BaseModel):
+    """Superforecaster structured output.
+
+    The text fields carry the 7-step reasoning chain (facts → pros/cons →
+    aggregation + tentative → reflection → final). Only the four numeric
+    fields at the bottom are returned on-chain per the mech protocol.
+    """
+
+    facts: str = Field(
+        ...,
+        description=(
+            "Core factual points compiled from the sources and relevant "
+            "background. Specific, relevant, no conclusions about how a "
+            "fact influences the forecast."
+        ),
+    )
+    reasons_no: str = Field(
+        ...,
+        description=(
+            "Reasons why the answer might be NO. Rate the strength of each "
+            "reason on a scale of 1-10."
+        ),
+    )
+    reasons_yes: str = Field(
+        ...,
+        description=(
+            "Reasons why the answer might be YES. Rate the strength of each "
+            "reason on a scale of 1-10."
+        ),
+    )
+    aggregation: str = Field(
+        ...,
+        description=(
+            "Aggregate considerations. Weigh competing factors, apply the "
+            "CALIBRATION block (state a base rate and justify, adjust using "
+            "specific evidence, treat missing expected evidence as a NO signal), "
+            "adjust for news negativity / sensationalism bias. End by stating a "
+            "tentative probability in [0,1]."
+        ),
+    )
+    reflection: str = Field(
+        ...,
+        description=(
+            "Sanity checks and finalisation. Apply the three checks: "
+            "EVIDENCE BAR, CONFIDENCE COUPLING, NUMERIC QUESTIONS. Check for "
+            "over/underconfidence and forecasting biases. Highlight the key "
+            "factors informing the final forecast."
+        ),
+    )
+    p_yes: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Estimated probability that the event in the Question occurs.",
+    )
+    p_no: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Estimated probability that the event does NOT occur.",
+    )
+    confidence: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Confidence in the prediction (0 = lowest, 1 = highest).",
+    )
+    info_utility: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Utility of the information in the sources to inform the prediction "
+            "(0 = lowest, 1 = highest)."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _check_p_yes_p_no_sum(self) -> "PredictionResult":
+        """Validate that p_yes + p_no ≈ 1."""
+        if abs(self.p_yes + self.p_no - 1.0) > 0.01:
+            raise ValueError(
+                f"p_yes + p_no must equal 1 (got {self.p_yes} + {self.p_no} = "
+                f"{self.p_yes + self.p_no})"
+            )
+        return self
+
+
 def with_key_rotation(func: Callable) -> Callable:
     """
     Decorator that retries a function with API key rotation on failure.
@@ -51,16 +146,22 @@ def with_key_rotation(func: Callable) -> Callable:
     """
 
     @functools.wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> MechResponseWithKeys:
+    def wrapper(
+        *args: Any, **kwargs: Any
+    ) -> Union[MaxCostResponse, MechResponseWithKeys]:
         # this is expected to be a KeyChain object,
         # although it is not explicitly typed as such
         api_keys = kwargs["api_keys"]
         retries_left: Dict[str, int] = api_keys.max_retries()
 
-        def execute() -> MechResponseWithKeys:
+        def execute() -> Union[MaxCostResponse, MechResponseWithKeys]:
             """Retry the function with a new key."""
             try:
-                result: MechResponse = func(*args, **kwargs)
+                result = func(*args, **kwargs)
+                # Max-cost path returns a float; pass through without appending
+                # api_keys (tuple concatenation would fail).
+                if isinstance(result, float):
+                    return result
                 return result + (api_keys,)
             except openai.RateLimitError as e:
                 # try with a new key again
@@ -81,91 +182,38 @@ def with_key_rotation(func: Callable) -> Callable:
 
 
 class OpenAIClientManager:
-    """Client context manager for OpenAI."""
+    """Context manager that creates and closes a local OpenAI client."""
 
     def __init__(self, api_key: str):
-        """Initializes with API keys"""
+        """Initializes with API key."""
         self.api_key = api_key
-        self._client: Optional["OpenAIClient"] = None
+        self._client: Optional[OpenAI] = None
 
-    def __enter__(self) -> "OpenAIClient":
-        """Initializes and returns LLM client."""
-        self._client = OpenAIClient(api_key=self.api_key)
+    def __enter__(self) -> OpenAI:
+        """Initializes and returns the OpenAI client."""
+        self._client = OpenAI(api_key=self.api_key)
         return self._client
 
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
-        """Closes the LLM client"""
+        """Closes the OpenAI client."""
         if self._client is not None:
-            self._client.client.close()
+            self._client.close()
             self._client = None
-
-
-class Usage:
-    """Usage class."""
-
-    def __init__(
-        self,
-        prompt_tokens: Optional[Any] = None,
-        completion_tokens: Optional[Any] = None,
-    ):
-        """Initializes with prompt tokens and completion tokens."""
-        self.prompt_tokens = prompt_tokens
-        self.completion_tokens = completion_tokens
-
-
-class OpenAIResponse:
-    """Response class."""
-
-    def __init__(self, content: Optional[str] = None, usage: Optional[Usage] = None):
-        """Initializes with content and usage class."""
-        self.content = content
-        self.usage = Usage()
-
-
-class OpenAIClient:
-    """OpenAI Client"""
-
-    def __init__(self, api_key: str):
-        """Initializes with API keys and client."""
-        self.api_key = api_key
-        self.client = openai.OpenAI(api_key=self.api_key)
-
-    def completions(
-        self,
-        model: str,
-        messages: List = [],  # noqa: B006
-        timeout: Optional[Union[float, int]] = None,
-        temperature: Optional[float] = None,
-        top_p: Optional[float] = None,
-        n: Optional[int] = None,
-        stop: Any = None,
-        max_tokens: Optional[float] = None,
-    ) -> Optional[OpenAIResponse]:
-        """Generate a completion from the specified LLM provider using the given model and messages."""
-        response_provider = self.client.chat.completions.create(
-            model=model,
-            messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
-            n=1,
-            timeout=150,
-            stop=None,
-        )
-        response = OpenAIResponse()
-        response.content = response_provider.choices[0].message.content
-        response.usage.prompt_tokens = response_provider.usage.prompt_tokens
-        response.usage.completion_tokens = response_provider.usage.completion_tokens
-        return response
 
 
 def count_tokens(text: str, model: str) -> int:
     """Count the number of tokens in a text."""
-    enc = encoding_for_model(model)
+    try:
+        enc = encoding_for_model(model)
+    except KeyError:
+        from tiktoken import get_encoding
+
+        enc = get_encoding("o200k_base")
     return len(enc.encode(text))
 
 
 DEFAULT_OPENAI_SETTINGS = {
-    "max_tokens": 500,
+    "max_tokens": 4096,
     "limit_max_tokens": 4096,
     "temperature": 0,
 }
@@ -176,6 +224,8 @@ MAX_SOURCES = 5
 COMPLETION_RETRIES = 3
 COMPLETION_DELAY = 2
 
+
+SYSTEM_PROMPT = "You are a helpful assistant."
 
 PREDICTION_PROMPT = """
 You are an advanced AI system which has been finetuned to provide calibrated probabilistic
@@ -188,7 +238,6 @@ Question:
 {question}
 
 Today's date: {today}
-Your pretraining knowledge cutoff: October 2023
 
 We have retrieved the following information for this question:
 <background>{sources}</background>
@@ -196,20 +245,21 @@ We have retrieved the following information for this question:
 Recall the question you are forecasting:
 {question}
 
-Instructions:
-1. Compress key factual information from the sources, as well as useful background information
+Return a structured PredictionResult whose fields capture the following reasoning chain:
+
+1. `facts` — Compress key factual information from the sources, as well as useful background information
 which may not be in the sources, into a list of core factual points to reference. Aim for
 information which is specific, relevant, and covers the core considerations you'll use to make
 your forecast. For this step, do not draw any conclusions about how a fact will influence your
-answer or forecast. Place this section of your response in <facts></facts> tags.
+answer or forecast.
 
-2. Provide a few reasons why the answer might be no. Rate the strength of each reason on a
-scale of 1-10. Use <no></no> tags.
+2. `reasons_no` — Provide a few reasons why the answer might be no. Rate the strength of each reason on a
+scale of 1-10.
 
-3. Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
-scale of 1-10. Use <yes></yes> tags.
+3. `reasons_yes` — Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
+scale of 1-10.
 
-4. Aggregate your considerations. Do not summarize or repeat previous points; instead,
+4. `aggregation` — Aggregate your considerations. Do not summarize or repeat previous points; instead,
 investigate how the competing factors and mechanisms interact and weigh against each other.
 Factorize your thinking across (exhaustive, mutually exclusive) cases if and only if it would be
 beneficial to your reasoning. We have detected that you overestimate world conflict, drama,
@@ -217,13 +267,17 @@ violence, and crises due to news' negativity bias, which doesn't necessarily rep
 trends or base rates. Similarly, we also have detected you overestimate dramatic, shocking,
 or emotionally charged news due to news' sensationalism bias. Therefore adjust for news'
 negativity bias and sensationalism bias by considering reasons to why your provided sources
-might be biased or exaggerated. Think like a superforecaster. Use <thinking></thinking> tags
-for this section of your response.
+might be biased or exaggerated. Think like a superforecaster.
 
-5. Output an initial probability (prediction) as a single number between 0 and 1 given steps 1-4.
-Use <tentative></tentative> tags.
+CALIBRATION (mandatory before any probability):
+- State a base-rate probability for this event category and justify it.
+- Adjust from the base rate using specific evidence only.
+- Missing expected evidence (no announcement found, no confirmation) is a NO signal.
 
-6. Reflect on your answer, performing sanity checks and mentioning any additional knowledge
+End the `aggregation` field by stating an initial tentative probability (a single number between 0 and 1)
+given steps 1-4.
+
+5. `reflection` — Reflect on your tentative answer, performing sanity checks and mentioning any additional knowledge
 or background information which may be relevant. Check for over/underconfidence, improper
 treatment of conjunctive or disjunctive conditions (only if applicable), and other forecasting
 biases when reviewing your reasoning. Consider priors/base rates, and the extent to which
@@ -231,59 +285,83 @@ case-specific information justifies the deviation between your tentative forecas
 Recall that your performance will be evaluated according to the Brier score. Be precise with tail
 probabilities. Leverage your intuitions, but never change your forecast for the sake of modesty
 or balance alone. Finally, aggregate all of your previous reasoning and highlight key factors
-that inform your final forecast. Use <thinking></thinking> tags for this portion of your response.
+that inform your final forecast.
 
-7. Output your final prediction (a number between 0 and 1 with an asterisk at the beginning and
-end of the decimal) in <answer></answer> tags.
+BEFORE FINAL ANSWER — apply all three checks:
 
+1. EVIDENCE BAR: If sources confirm the event already occurred, high p_yes is fine.
+   If not: p_yes > 0.90 needs verified commitment (signed, awarded, published).
+   p_yes > 0.80 needs strong specific evidence, not plausibility or reputation.
+   Plans, proposals, and intentions are not completed actions.
 
-OUTPUT_FORMAT
-* Your output response must be only a single JSON object to be parsed by Python's "json.loads()".
-* The JSON must contain four fields: "p_yes", "p_no", "confidence", and "info_utility".
-* Each item in the JSON must have a value between 0 and 1.
+2. CONFIDENCE COUPLING: If confidence < 0.3, keep p_yes between 0.30-0.70.
+   If confidence < 0.5, keep p_yes between 0.20-0.80.
+
+3. NUMERIC QUESTIONS: For price/temperature/count thresholds, find the current
+   value and compare to the threshold. A large gap overrides sentiment or forecasts.
+
+6. `p_yes`, `p_no`, `confidence`, `info_utility` — the four numeric fields:
    - "p_yes": Estimated probability that the event in the "Question" occurs.
    - "p_no": Estimated probability that the event in the "Question" does not occur.
    - "confidence": A value between 0 and 1 indicating the confidence in the prediction. 0 indicates lowest
      confidence value; 1 maximum confidence value.
    - "info_utility": Utility of the information provided in "sources" to help you make the prediction.
      0 indicates lowest utility; 1 maximum utility.
-* The sum of "p_yes" and "p_no" must equal 1.
-* Output only the JSON object. Do not include any other contents in your response.
-* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
-* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
-* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
+   - Each value must be between 0 and 1.
+   - The sum of "p_yes" and "p_no" must equal 1.
 """
 
 
-def generate_prediction_with_retry(
-    client: "OpenAIClient",
+def _parse_completion(
+    client: OpenAI,
     model: str,
     messages: List[Dict[str, str]],
-    temperature: float,
-    max_tokens: int,
+    response_format: Any,
+    temperature: float = 0,
+    max_tokens: int = 4096,
     retries: int = COMPLETION_RETRIES,
     delay: int = COMPLETION_DELAY,
     counter_callback: Optional[Callable] = None,
 ) -> Tuple[Any, Optional[Callable]]:
-    """Attempt to generate a prediction with retries on failure."""
+    """Call OpenAI Structured Outputs and parse into a Pydantic model.
+
+    ``client.beta.chat.completions.parse()`` guarantees the response conforms
+    to the supplied Pydantic schema — no prompt-side JSON format instructions
+    or regex extraction required.
+
+    :param client: an initialised OpenAI client.
+    :param model: OpenAI model identifier.
+    :param messages: chat messages list (role + content dicts).
+    :param response_format: Pydantic model class used as the structured-output schema.
+    :param temperature: sampling temperature (0 = deterministic).
+    :param max_tokens: maximum tokens to generate.
+    :param retries: number of retry attempts on transient / validation failure.
+    :param delay: delay in seconds between retries.
+    :param counter_callback: optional callback tracking token usage.
+    :return: tuple of (parsed model instance, counter_callback).
+    :raises RuntimeError: if all retries exhausted without a successful parse.
+    """
     attempt = 0
     while attempt < retries:
         try:
-            response = client.completions(
+            response = client.beta.chat.completions.parse(
                 model=model,
                 messages=messages,
+                response_format=response_format,
                 temperature=temperature,
                 max_tokens=max_tokens,
-                n=1,
-                timeout=90,
-                stop=None,
+                timeout=150,
             )
 
-            if (
-                response
-                and response.content is not None
-                and counter_callback is not None
-            ):
+            parsed = response.choices[0].message.parsed
+
+            if parsed is None:
+                refusal = response.choices[0].message.refusal
+                raise ValueError(
+                    f"Model refused or returned unparseable output: {refusal}"
+                )
+
+            if counter_callback is not None:
                 counter_callback(
                     input_tokens=response.usage.prompt_tokens,
                     output_tokens=response.usage.completion_tokens,
@@ -291,13 +369,23 @@ def generate_prediction_with_retry(
                     token_counter=count_tokens,
                 )
 
-            content = response.content if response else None
-            return content, counter_callback
-        except Exception as e:
-            print(f"Attempt {attempt + 1} failed with error: {e}")
+            return parsed, counter_callback
+        except (
+            openai.APIConnectionError,
+            openai.RateLimitError,
+            openai.InternalServerError,
+            ValueError,
+        ) as e:
+            # Retry only transient failures and model-side issues:
+            #   - APIConnectionError (includes APITimeoutError) — network blips
+            #   - RateLimitError / InternalServerError — OpenAI-side retryable
+            #   - ValueError — covers pydantic ValidationError (e.g. p_yes+p_no
+            #     sum check) and the inline "Model refused…" raise above
+            print(f"[superforcaster] Attempt {attempt + 1} failed: {e}")
             time.sleep(delay)
             attempt += 1
-    raise Exception("Failed to generate prediction after retries")
+
+    raise RuntimeError("Failed to get structured LLM completion after retries")
 
 
 def fetch_additional_sources(question: Any, serper_api_key: Any) -> requests.Response:
@@ -436,26 +524,47 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
         )
         print(f"\n{prediction_prompt=}\n")
         messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "system", "content": SYSTEM_PROMPT},
             {"role": "user", "content": prediction_prompt},
         ]
         print("Getting prompt response...")
-        extracted_block, counter_callback = generate_prediction_with_retry(
+        prediction: PredictionResult
+        prediction, counter_callback = _parse_completion(
             client=llm_client,
             model=model,
             messages=messages,
+            response_format=PredictionResult,
             temperature=temperature,
             max_tokens=max_tokens,
-            retries=COMPLETION_RETRIES,
-            delay=COMPLETION_DELAY,
             counter_callback=counter_callback,
         )
 
-        used_params = {
+        print(f"[superforcaster] === FACTS ===\n{prediction.facts}")
+        print(f"[superforcaster] === REASONS_NO ===\n{prediction.reasons_no}")
+        print(f"[superforcaster] === REASONS_YES ===\n{prediction.reasons_yes}")
+        print(f"[superforcaster] === AGGREGATION ===\n{prediction.aggregation}")
+        print(f"[superforcaster] === REFLECTION ===\n{prediction.reflection}")
+        print(
+            f"[superforcaster] Result: p_yes={prediction.p_yes}, "
+            f"p_no={prediction.p_no}, confidence={prediction.confidence}, "
+            f"info_utility={prediction.info_utility}"
+        )
+
+        # On-chain result — only the four standard mech fields.
+        result = json.dumps(
+            {
+                "p_yes": prediction.p_yes,
+                "p_no": prediction.p_no,
+                "confidence": prediction.confidence,
+                "info_utility": prediction.info_utility,
+            }
+        )
+
+        used_params: Dict[str, Any] = {
             "model": model,
             "temperature": temperature,
             "max_tokens": max_tokens,
         }
         if return_source_content:
             used_params["source_content"] = captured_source_content
-        return extracted_block, prediction_prompt, None, counter_callback, used_params
+        return result, prediction_prompt, None, counter_callback, used_params

--- a/packages/valory/customs/superforcaster/tests/test_superforcaster.py
+++ b/packages/valory/customs/superforcaster/tests/test_superforcaster.py
@@ -17,7 +17,7 @@
 #
 # ------------------------------------------------------------------------------
 
-"""Unit tests for superforcaster: thread-safe client, offline tiktoken, and source_content."""
+"""Unit tests for superforcaster: thread-safe client, structured outputs, source_content."""
 
 import inspect
 import json
@@ -29,7 +29,8 @@ import pytest
 import packages.valory.customs.superforcaster.superforcaster as module
 from packages.valory.customs.superforcaster.superforcaster import (
     OpenAIClientManager,
-    generate_prediction_with_retry,
+    PredictionResult,
+    _parse_completion,
     run,
 )
 
@@ -37,20 +38,20 @@ from packages.valory.customs.superforcaster.superforcaster import (
 class TestOpenAIClientManager:
     """Verify OpenAIClientManager creates per-context clients without globals."""
 
-    def test_context_manager_returns_client_instance(self) -> None:
-        """__enter__ returns a fresh OpenAIClient, __exit__ closes it."""
+    def test_context_manager_returns_openai_client(self) -> None:
+        """__enter__ returns a fresh openai.OpenAI client, __exit__ closes it."""
         mgr = OpenAIClientManager(api_key="sk-test")
         with patch(
-            "packages.valory.customs.superforcaster.superforcaster.OpenAIClient"
-        ) as MockClient:
+            "packages.valory.customs.superforcaster.superforcaster.OpenAI"
+        ) as MockOpenAI:
             mock_instance = MagicMock()
-            MockClient.return_value = mock_instance
+            MockOpenAI.return_value = mock_instance
 
             with mgr as client:
                 assert client is mock_instance
-                MockClient.assert_called_once_with(api_key="sk-test")
+                MockOpenAI.assert_called_once_with(api_key="sk-test")
 
-            mock_instance.client.close.assert_called_once()
+            mock_instance.close.assert_called_once()
 
     def test_no_global_client_variable(self) -> None:
         """The module must not define a module-level 'client' variable."""
@@ -63,9 +64,9 @@ class TestOpenAIClientManager:
                         f"Module-level 'client' variable found at line {i}: {line}"
                     )
 
-    def test_generate_prediction_requires_client_param(self) -> None:
-        """generate_prediction_with_retry requires client as first param."""
-        params = list(inspect.signature(generate_prediction_with_retry).parameters)
+    def test_parse_completion_requires_client_param(self) -> None:
+        """_parse_completion requires client as first param."""
+        params = list(inspect.signature(_parse_completion).parameters)
         assert params[0] == "client"
 
 
@@ -86,8 +87,16 @@ FAKE_SERPER_RESPONSE = {
     ],
 }
 
-PREDICTION_JSON = json.dumps(
-    {"p_yes": 0.5, "p_no": 0.5, "confidence": 0.5, "info_utility": 0.5}
+FAKE_PREDICTION = PredictionResult(
+    facts="Fact 1. Fact 2.",
+    reasons_no="No 1 (strength 6). No 2 (strength 4).",
+    reasons_yes="Yes 1 (strength 5). Yes 2 (strength 3).",
+    aggregation="Base rate 0.5. Tentative: 0.5.",
+    reflection="Passes evidence bar.",
+    p_yes=0.5,
+    p_no=0.5,
+    confidence=0.5,
+    info_utility=0.5,
 )
 
 PREDICTION_PROMPT = (
@@ -110,6 +119,116 @@ def _make_mock_api_keys(return_source_content: str = "false") -> MagicMock:
     return mock
 
 
+def _mock_parse_response() -> MagicMock:
+    """Build a fake response object matching the beta.chat.completions.parse shape."""
+    return MagicMock(
+        choices=[MagicMock(message=MagicMock(parsed=FAKE_PREDICTION, refusal=None))],
+        usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+    )
+
+
+class TestStructuredOutputContract:
+    """Verify the tool uses OpenAI Structured Outputs and returns only the 4 on-chain fields."""
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_uses_beta_parse_with_prediction_result_schema(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """run() calls client.beta.chat.completions.parse with response_format=PredictionResult."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        run(
+            tool="superforcaster",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+
+        mock_client.beta.chat.completions.parse.assert_called_once()
+        kwargs = mock_client.beta.chat.completions.parse.call_args.kwargs
+        assert kwargs["response_format"] is PredictionResult
+        assert kwargs["model"] == "gpt-4.1-2025-04-14"
+        mock_client.chat.completions.create.assert_not_called()
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_returns_only_four_mech_fields_on_chain(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """The on-chain result JSON contains exactly p_yes/p_no/confidence/info_utility."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = run(
+            tool="superforcaster",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+
+        on_chain_json = result[0]
+        parsed = json.loads(on_chain_json)
+        assert set(parsed.keys()) == {"p_yes", "p_no", "confidence", "info_utility"}
+        assert "facts" not in parsed
+        assert "reasons_no" not in parsed
+        assert "aggregation" not in parsed
+        assert "reflection" not in parsed
+        assert parsed["p_yes"] == 0.5
+        assert parsed["p_no"] == 0.5
+
+
+class TestPredictionResultValidator:
+    """Pydantic sum validator rejects malformed probabilities."""
+
+    def test_valid_sum_accepted(self) -> None:
+        """p_yes + p_no = 1.0 is accepted."""
+        obj = PredictionResult(
+            facts="f",
+            reasons_no="n",
+            reasons_yes="y",
+            aggregation="a",
+            reflection="r",
+            p_yes=0.7,
+            p_no=0.3,
+            confidence=0.6,
+            info_utility=0.5,
+        )
+        assert obj.p_yes == 0.7
+
+    def test_sum_violation_rejected(self) -> None:
+        """p_yes + p_no outside 0.01 tolerance raises ValidationError."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            PredictionResult(
+                facts="f",
+                reasons_no="n",
+                reasons_yes="y",
+                aggregation="a",
+                reflection="r",
+                p_yes=0.7,
+                p_no=0.2,
+                confidence=0.6,
+                info_utility=0.5,
+            )
+
+
 class TestSuperforcasterSourceContent:
     """Verify superforcaster captures and replays source_content correctly."""
 
@@ -124,16 +243,13 @@ class TestSuperforcasterSourceContent:
         mock_fetch.return_value = mock_response
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         result = run(
             tool="superforcaster",
-            model="gpt-4o",
+            model="gpt-4.1-2025-04-14",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("true"),
             counter_callback=None,
@@ -151,17 +267,14 @@ class TestSuperforcasterSourceContent:
     ) -> None:
         """Replay with {'serper_response': ...} uses organic and peopleAlsoAsk."""
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         source_content = {"serper_response": FAKE_SERPER_RESPONSE}
         result = run(
             tool="superforcaster",
-            model="gpt-4o",
+            model="gpt-4.1-2025-04-14",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("true"),
             counter_callback=None,
@@ -185,16 +298,13 @@ class TestSuperforcasterSourceContent:
         mock_fetch.return_value = mock_response
 
         mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
+        mock_client.beta.chat.completions.parse.return_value = _mock_parse_response()
         mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
 
         result = run(
             tool="superforcaster",
-            model="gpt-4o",
+            model="gpt-4.1-2025-04-14",
             prompt=PREDICTION_PROMPT,
             api_keys=_make_mock_api_keys("false"),
             counter_callback=None,

--- a/packages/valory/customs/superforcaster_polymarket_v1/__init__.py
+++ b/packages/valory/customs/superforcaster_polymarket_v1/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the Superforcaster tool."""

--- a/packages/valory/customs/superforcaster_polymarket_v1/component.yaml
+++ b/packages/valory/customs/superforcaster_polymarket_v1/component.yaml
@@ -10,7 +10,7 @@ fingerprint:
   __init__.py: bafybeidr6ok7hgnywgtlggdajgklohlpaxnxmvpo2wn5fayq7fhzrr2sli
   superforcaster_polymarket_v1.py: bafybeidaidqvhcx7ltfuolniqityheydug45apzpy66bhwfymn2qpl245i
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
-  tests/test_superforcaster.py: bafybeibmpctuf3hjjbjhmbugrr74552pilpze7ysnlekznn3ygyl4fwqyq
+  tests/test_superforcaster.py: bafybeicexd4tvx4jzubxtj3k7z7filjlac74bhem4u2sto7ce5tsbm2jzu
 fingerprint_ignore_patterns: []
 entry_point: superforcaster_polymarket_v1.py
 callable: run

--- a/packages/valory/customs/superforcaster_polymarket_v1/component.yaml
+++ b/packages/valory/customs/superforcaster_polymarket_v1/component.yaml
@@ -1,0 +1,27 @@
+name: superforcaster_polymarket_v1
+author: valory
+version: 0.1.0
+type: custom
+description: A tool for making binary predictions on markets using the Serper API
+  and LLMs.
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  __init__.py: bafybeidr6ok7hgnywgtlggdajgklohlpaxnxmvpo2wn5fayq7fhzrr2sli
+  superforcaster_polymarket_v1.py: bafybeidaidqvhcx7ltfuolniqityheydug45apzpy66bhwfymn2qpl245i
+  tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
+  tests/test_superforcaster.py: bafybeibmpctuf3hjjbjhmbugrr74552pilpze7ysnlekznn3ygyl4fwqyq
+fingerprint_ignore_patterns: []
+entry_point: superforcaster_polymarket_v1.py
+callable: run
+params:
+  default_model: gpt-4.1-2025-04-14
+dependencies:
+  openai:
+    version: ==1.93.0
+  httpx:
+    version: ==0.25.2
+  tiktoken:
+    version: ==0.12.0
+  requests:
+    version: ==2.32.5

--- a/packages/valory/customs/superforcaster_polymarket_v1/component.yaml
+++ b/packages/valory/customs/superforcaster_polymarket_v1/component.yaml
@@ -10,7 +10,7 @@ fingerprint:
   __init__.py: bafybeidr6ok7hgnywgtlggdajgklohlpaxnxmvpo2wn5fayq7fhzrr2sli
   superforcaster_polymarket_v1.py: bafybeidaidqvhcx7ltfuolniqityheydug45apzpy66bhwfymn2qpl245i
   tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
-  tests/test_superforcaster.py: bafybeicexd4tvx4jzubxtj3k7z7filjlac74bhem4u2sto7ce5tsbm2jzu
+  tests/test_superforcaster.py: bafybeiecpixajbp4vxbt2uuu2etzrjguvcbm4jh2m5h4mhx4pgjb46qtg4
 fingerprint_ignore_patterns: []
 entry_point: superforcaster_polymarket_v1.py
 callable: run

--- a/packages/valory/customs/superforcaster_polymarket_v1/superforcaster_polymarket_v1.py
+++ b/packages/valory/customs/superforcaster_polymarket_v1/superforcaster_polymarket_v1.py
@@ -1,0 +1,461 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Contains the job definitions"""
+
+import functools
+import json
+import re
+import time
+from datetime import date
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import openai
+import requests
+from tiktoken import encoding_for_model
+
+MechResponseWithKeys = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]], Any
+]
+MechResponse = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]]
+]
+MaxCostResponse = float
+
+N_MODEL_CALLS = 1
+DEFAULT_DELIVERY_RATE = 100
+
+
+def with_key_rotation(func: Callable) -> Callable:
+    """
+    Decorator that retries a function with API key rotation on failure.
+
+    :param func: The function to be decorated.
+    :type func: Callable
+    :returns: Callable -- the wrapped function that handles retries with key rotation.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> MechResponseWithKeys:
+        # this is expected to be a KeyChain object,
+        # although it is not explicitly typed as such
+        api_keys = kwargs["api_keys"]
+        retries_left: Dict[str, int] = api_keys.max_retries()
+
+        def execute() -> MechResponseWithKeys:
+            """Retry the function with a new key."""
+            try:
+                result: MechResponse = func(*args, **kwargs)
+                return result + (api_keys,)
+            except openai.RateLimitError as e:
+                # try with a new key again
+                if retries_left["openai"] <= 0 and retries_left["openrouter"] <= 0:
+                    raise e
+                retries_left["openai"] -= 1
+                retries_left["openrouter"] -= 1
+                api_keys.rotate("openai")
+                api_keys.rotate("openrouter")
+                return execute()
+            except Exception as e:
+                return str(e), "", None, None, None, api_keys
+
+        mech_response = execute()
+        return mech_response
+
+    return wrapper
+
+
+class OpenAIClientManager:
+    """Client context manager for OpenAI."""
+
+    def __init__(self, api_key: str):
+        """Initializes with API keys"""
+        self.api_key = api_key
+        self._client: Optional["OpenAIClient"] = None
+
+    def __enter__(self) -> "OpenAIClient":
+        """Initializes and returns LLM client."""
+        self._client = OpenAIClient(api_key=self.api_key)
+        return self._client
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Closes the LLM client"""
+        if self._client is not None:
+            self._client.client.close()
+            self._client = None
+
+
+class Usage:
+    """Usage class."""
+
+    def __init__(
+        self,
+        prompt_tokens: Optional[Any] = None,
+        completion_tokens: Optional[Any] = None,
+    ):
+        """Initializes with prompt tokens and completion tokens."""
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+
+class OpenAIResponse:
+    """Response class."""
+
+    def __init__(self, content: Optional[str] = None, usage: Optional[Usage] = None):
+        """Initializes with content and usage class."""
+        self.content = content
+        self.usage = Usage()
+
+
+class OpenAIClient:
+    """OpenAI Client"""
+
+    def __init__(self, api_key: str):
+        """Initializes with API keys and client."""
+        self.api_key = api_key
+        self.client = openai.OpenAI(api_key=self.api_key)
+
+    def completions(
+        self,
+        model: str,
+        messages: List = [],  # noqa: B006
+        timeout: Optional[Union[float, int]] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        n: Optional[int] = None,
+        stop: Any = None,
+        max_tokens: Optional[float] = None,
+    ) -> Optional[OpenAIResponse]:
+        """Generate a completion from the specified LLM provider using the given model and messages."""
+        response_provider = self.client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            n=1,
+            timeout=150,
+            stop=None,
+        )
+        response = OpenAIResponse()
+        response.content = response_provider.choices[0].message.content
+        response.usage.prompt_tokens = response_provider.usage.prompt_tokens
+        response.usage.completion_tokens = response_provider.usage.completion_tokens
+        return response
+
+
+def count_tokens(text: str, model: str) -> int:
+    """Count the number of tokens in a text."""
+    enc = encoding_for_model(model)
+    return len(enc.encode(text))
+
+
+DEFAULT_OPENAI_SETTINGS = {
+    "max_tokens": 500,
+    "limit_max_tokens": 4096,
+    "temperature": 0,
+}
+DEFAULT_OPENAI_MODEL = "gpt-4.1-2025-04-14"
+ALLOWED_TOOLS = ["superforcaster-polymarket-v1"]
+ALLOWED_MODELS = [DEFAULT_OPENAI_MODEL]
+MAX_SOURCES = 5
+COMPLETION_RETRIES = 3
+COMPLETION_DELAY = 2
+
+
+PREDICTION_PROMPT = """
+You are an advanced AI system which has been finetuned to provide calibrated probabilistic
+forecasts under uncertainty, with your performance evaluated according to the Brier score. When
+forecasting, do not treat 0.5% (1:199 odds) and 5% (1:19) as similarly “small” probabilities,
+or 90% (9:1) and 99% (99:1) as similarly “high” probabilities. As the odds show, they are
+markedly different, so output your probabilities accordingly.
+
+Question:
+{question}
+
+Today's date: {today}
+Your pretraining knowledge cutoff: October 2023
+
+We have retrieved the following information for this question:
+<background>{sources}</background>
+
+Recall the question you are forecasting:
+{question}
+
+Instructions:
+1. Compress key factual information from the sources, as well as useful background information
+which may not be in the sources, into a list of core factual points to reference. Aim for
+information which is specific, relevant, and covers the core considerations you'll use to make
+your forecast. For this step, do not draw any conclusions about how a fact will influence your
+answer or forecast. Place this section of your response in <facts></facts> tags.
+
+2. Provide a few reasons why the answer might be no. Rate the strength of each reason on a
+scale of 1-10. Use <no></no> tags.
+
+3. Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
+scale of 1-10. Use <yes></yes> tags.
+
+4. Aggregate your considerations. Do not summarize or repeat previous points; instead,
+investigate how the competing factors and mechanisms interact and weigh against each other.
+Factorize your thinking across (exhaustive, mutually exclusive) cases if and only if it would be
+beneficial to your reasoning. We have detected that you overestimate world conflict, drama,
+violence, and crises due to news' negativity bias, which doesn't necessarily represent overall
+trends or base rates. Similarly, we also have detected you overestimate dramatic, shocking,
+or emotionally charged news due to news' sensationalism bias. Therefore adjust for news'
+negativity bias and sensationalism bias by considering reasons to why your provided sources
+might be biased or exaggerated. Think like a superforecaster. Use <thinking></thinking> tags
+for this section of your response.
+
+5. Output an initial probability (prediction) as a single number between 0 and 1 given steps 1-4.
+Use <tentative></tentative> tags.
+
+6. Reflect on your answer, performing sanity checks and mentioning any additional knowledge
+or background information which may be relevant. Check for over/underconfidence, improper
+treatment of conjunctive or disjunctive conditions (only if applicable), and other forecasting
+biases when reviewing your reasoning. Consider priors/base rates, and the extent to which
+case-specific information justifies the deviation between your tentative forecast and the prior.
+Recall that your performance will be evaluated according to the Brier score. Be precise with tail
+probabilities. Leverage your intuitions, but never change your forecast for the sake of modesty
+or balance alone. Finally, aggregate all of your previous reasoning and highlight key factors
+that inform your final forecast. Use <thinking></thinking> tags for this portion of your response.
+
+7. Output your final prediction (a number between 0 and 1 with an asterisk at the beginning and
+end of the decimal) in <answer></answer> tags.
+
+
+OUTPUT_FORMAT
+* Your output response must be only a single JSON object to be parsed by Python's "json.loads()".
+* The JSON must contain four fields: "p_yes", "p_no", "confidence", and "info_utility".
+* Each item in the JSON must have a value between 0 and 1.
+   - "p_yes": Estimated probability that the event in the "Question" occurs.
+   - "p_no": Estimated probability that the event in the "Question" does not occur.
+   - "confidence": A value between 0 and 1 indicating the confidence in the prediction. 0 indicates lowest
+     confidence value; 1 maximum confidence value.
+   - "info_utility": Utility of the information provided in "sources" to help you make the prediction.
+     0 indicates lowest utility; 1 maximum utility.
+* The sum of "p_yes" and "p_no" must equal 1.
+* Output only the JSON object. Do not include any other contents in your response.
+* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
+* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
+* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
+"""
+
+
+def generate_prediction_with_retry(
+    client: "OpenAIClient",
+    model: str,
+    messages: List[Dict[str, str]],
+    temperature: float,
+    max_tokens: int,
+    retries: int = COMPLETION_RETRIES,
+    delay: int = COMPLETION_DELAY,
+    counter_callback: Optional[Callable] = None,
+) -> Tuple[Any, Optional[Callable]]:
+    """Attempt to generate a prediction with retries on failure."""
+    attempt = 0
+    while attempt < retries:
+        try:
+            response = client.completions(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                n=1,
+                timeout=90,
+                stop=None,
+            )
+
+            if (
+                response
+                and response.content is not None
+                and counter_callback is not None
+            ):
+                counter_callback(
+                    input_tokens=response.usage.prompt_tokens,
+                    output_tokens=response.usage.completion_tokens,
+                    model=model,
+                    token_counter=count_tokens,
+                )
+
+            content = response.content if response else None
+            return content, counter_callback
+        except Exception as e:
+            print(f"Attempt {attempt + 1} failed with error: {e}")
+            time.sleep(delay)
+            attempt += 1
+    raise Exception("Failed to generate prediction after retries")
+
+
+def fetch_additional_sources(question: Any, serper_api_key: Any) -> requests.Response:
+    """Fetches additional sources for the given question using the Serper API."""
+    url = "https://google.serper.dev/search"
+    payload = json.dumps({"q": question})
+    headers = {
+        "X-API-KEY": serper_api_key,
+        "Content-Type": "application/json",
+    }
+
+    response = requests.request("POST", url, headers=headers, data=payload)
+
+    return response
+
+
+def format_sources_data(organic_data: Any, misc_data: Any) -> str:
+    """Formats organic search results and "People Also Ask" data into a human-readable string."""
+    sources = ""
+
+    if len(organic_data) > 0:
+        print("Adding organic data...")
+
+        sources = """
+        Organic Results:
+        """
+
+        for item in organic_data:
+            sources += f"""{item.get('position', 'N/A')}. **Title:** {item.get("title", 'N/A')}
+            - **Link:** [{item.get("link", '#')}]({item.get("link", '#')})
+            - **Snippet:** {item.get("snippet", 'N/A')}
+            """
+
+    if len(misc_data) > 0:
+        print("Adding misc data...")
+
+        sources += "People Also Ask:\n"
+
+        counter = 1
+        for item in misc_data:
+            sources += f"""{counter}. **Question:** {item.get("question", 'N/A')}
+            - **Link:** [{item.get("link", '#')}]({item.get("link", '#')})
+            - **Snippet:** {item.get("snippet", 'N/A')}
+            """
+            counter += 1
+
+    return sources
+
+
+def extract_question(prompt: str) -> str:
+    """Uses regexp to extract question from the prompt"""
+    # Match from 'question "' to '" and the `yes`' to handle nested quotes
+    pattern = r'question\s+"(.+?)"\s+and\s+the\s+`yes`'
+    try:
+        question = re.findall(pattern, prompt, re.DOTALL)[0]
+    except Exception as e:
+        print(f"Error extracting question: {e}")
+        question = prompt
+    return question
+
+
+@with_key_rotation
+def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
+    """Run the task"""
+    tool = kwargs["tool"]
+    if tool not in ALLOWED_TOOLS:
+        raise ValueError(f"Tool {tool} is not supported.")
+
+    model = kwargs.get("model")
+    if model is None:
+        raise ValueError("Model not supplied.")
+
+    delivery_rate = int(kwargs.get("delivery_rate", DEFAULT_DELIVERY_RATE))
+    counter_callback: Optional[Callable[..., Any]] = kwargs.get(
+        "counter_callback", None
+    )
+    if delivery_rate == 0:
+        if not counter_callback:
+            raise ValueError(
+                "A delivery rate of `0` was passed, but no counter callback was given to calculate the max cost with."
+            )
+
+        max_cost = counter_callback(
+            max_cost=True,
+            models_calls=(model,) * N_MODEL_CALLS,
+        )
+        return max_cost
+
+    openai_api_key = kwargs["api_keys"]["openai"]
+    source_content = kwargs.get("source_content", None)
+    return_source_content = (
+        kwargs["api_keys"].get("return_source_content", "false") == "true"
+    )
+    source_content_mode = kwargs["api_keys"].get("source_content_mode", "cleaned")
+    if source_content_mode not in ("cleaned", "raw"):
+        raise ValueError(
+            f"Invalid source_content_mode: {source_content_mode!r}. Must be 'cleaned' or 'raw'."
+        )
+    with OpenAIClientManager(openai_api_key) as llm_client:
+        max_tokens = kwargs.get("max_tokens", DEFAULT_OPENAI_SETTINGS["max_tokens"])
+        temperature = kwargs.get("temperature", DEFAULT_OPENAI_SETTINGS["temperature"])
+        prompt = kwargs["prompt"]
+
+        today = date.today()
+        d = today.strftime("%d/%m/%Y")
+
+        question = extract_question(prompt)
+
+        if source_content is not None:
+            print("Using provided source content (cached replay)...")
+            captured_source_content = source_content
+            serper_data = source_content.get("serper_response", source_content)
+            organic_data = serper_data.get("organic", [])[:MAX_SOURCES]
+            misc_data = serper_data.get("peopleAlsoAsk", [])
+            sources = format_sources_data(organic_data, misc_data)
+        else:
+            serper_api_key = kwargs["api_keys"]["serperapi"]
+            print("Fetching additional sources...")
+            serper_response = fetch_additional_sources(question, serper_api_key)
+            sources_data = serper_response.json()
+            # mode tag included for consistency across tools; content is identical
+            # regardless of mode since Serper returns structured JSON, not HTML
+            captured_source_content = {
+                "mode": source_content_mode,
+                "serper_response": sources_data,
+            }
+            print(f"Additional sources fetched: {sources_data}")
+            organic_data = sources_data.get("organic", [])[:MAX_SOURCES]
+            misc_data = sources_data.get("peopleAlsoAsk", [])
+            print("Formating sources...")
+            sources = format_sources_data(organic_data, misc_data)
+
+        print("Updating prompt...")
+        prediction_prompt = PREDICTION_PROMPT.format(
+            question=question, today=d, sources=sources
+        )
+        print(f"\n{prediction_prompt=}\n")
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": prediction_prompt},
+        ]
+        print("Getting prompt response...")
+        extracted_block, counter_callback = generate_prediction_with_retry(
+            client=llm_client,
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            retries=COMPLETION_RETRIES,
+            delay=COMPLETION_DELAY,
+            counter_callback=counter_callback,
+        )
+
+        used_params = {
+            "model": model,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        if return_source_content:
+            used_params["source_content"] = captured_source_content
+        return extracted_block, prediction_prompt, None, counter_callback, used_params

--- a/packages/valory/customs/superforcaster_polymarket_v1/tests/__init__.py
+++ b/packages/valory/customs/superforcaster_polymarket_v1/tests/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for superforcaster custom package."""

--- a/packages/valory/customs/superforcaster_polymarket_v1/tests/test_superforcaster.py
+++ b/packages/valory/customs/superforcaster_polymarket_v1/tests/test_superforcaster.py
@@ -112,6 +112,28 @@ def _make_mock_api_keys(return_source_content: str = "false") -> MagicMock:
     return mock
 
 
+def _install_mock_client(mock_client_mgr: MagicMock) -> MagicMock:
+    """Wire OpenAIClientManager to return a client whose completions() yields PREDICTION_JSON.
+
+    The wrapper's call path is `OpenAIClient.completions(...)`, so the response
+    must be configured on `mock_client.completions.return_value` — not on
+    `mock_client.chat.completions.create` (which is the raw OpenAI SDK path the
+    wrapper hides).
+
+    :param mock_client_mgr: the patched OpenAIClientManager mock.
+    :return: the inner mock_client wired into the manager's __enter__.
+    """
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = PREDICTION_JSON
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 5
+    mock_client.completions.return_value = mock_response
+    mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+    mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_client
+
+
 class TestSuperforcasterSourceContent:
     """Verify superforcaster captures and replays source_content correctly."""
 
@@ -121,17 +143,10 @@ class TestSuperforcasterSourceContent:
         self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
     ) -> None:
         """Live run wraps Serper response in {'serper_response': ...}."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = FAKE_SERPER_RESPONSE
-        mock_fetch.return_value = mock_response
-
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
-        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        mock_serper = MagicMock()
+        mock_serper.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_serper
+        _install_mock_client(mock_client_mgr)
 
         result = run(
             tool="superforcaster-polymarket-v1",
@@ -141,6 +156,7 @@ class TestSuperforcasterSourceContent:
             counter_callback=None,
         )
 
+        assert result[0] == PREDICTION_JSON
         used_params = result[4]
         assert "source_content" in used_params
         assert "mode" in used_params["source_content"]
@@ -152,13 +168,7 @@ class TestSuperforcasterSourceContent:
         self, mock_client_mgr: MagicMock
     ) -> None:
         """Replay with {'serper_response': ...} uses organic and peopleAlsoAsk."""
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
-        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        _install_mock_client(mock_client_mgr)
 
         source_content = {"serper_response": FAKE_SERPER_RESPONSE}
         result = run(
@@ -170,7 +180,7 @@ class TestSuperforcasterSourceContent:
             source_content=source_content,
         )
 
-        # Verify the prompt contains the organic result
+        assert result[0] == PREDICTION_JSON
         prediction_prompt = result[1]
         assert "Test Result" in prediction_prompt
         assert "Test snippet content" in prediction_prompt
@@ -182,17 +192,10 @@ class TestSuperforcasterSourceContent:
         self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
     ) -> None:
         """When return_source_content is false, source_content is not in used_params."""
-        mock_response = MagicMock()
-        mock_response.json.return_value = FAKE_SERPER_RESPONSE
-        mock_fetch.return_value = mock_response
-
-        mock_client = MagicMock()
-        mock_client.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
-            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
-        )
-        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
-        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        mock_serper = MagicMock()
+        mock_serper.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_serper
+        _install_mock_client(mock_client_mgr)
 
         result = run(
             tool="superforcaster-polymarket-v1",
@@ -202,5 +205,6 @@ class TestSuperforcasterSourceContent:
             counter_callback=None,
         )
 
+        assert result[0] == PREDICTION_JSON
         used_params = result[4]
         assert "source_content" not in used_params

--- a/packages/valory/customs/superforcaster_polymarket_v1/tests/test_superforcaster.py
+++ b/packages/valory/customs/superforcaster_polymarket_v1/tests/test_superforcaster.py
@@ -69,7 +69,9 @@ class TestOpenAIClientManager:
         assert params[0] == "client"
 
 
-SF_MODULE = "packages.valory.customs.superforcaster_polymarket_v1.superforcaster_polymarket_v1"
+SF_MODULE = (
+    "packages.valory.customs.superforcaster_polymarket_v1.superforcaster_polymarket_v1"
+)
 
 FAKE_SERPER_RESPONSE = {
     "searchParameters": {"q": "test query", "type": "search"},

--- a/packages/valory/customs/superforcaster_polymarket_v1/tests/test_superforcaster.py
+++ b/packages/valory/customs/superforcaster_polymarket_v1/tests/test_superforcaster.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Unit tests for superforcaster: thread-safe client, offline tiktoken, and source_content."""
+
+import inspect
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import packages.valory.customs.superforcaster_polymarket_v1.superforcaster_polymarket_v1 as module
+from packages.valory.customs.superforcaster_polymarket_v1.superforcaster_polymarket_v1 import (
+    OpenAIClientManager,
+    generate_prediction_with_retry,
+    run,
+)
+
+
+class TestOpenAIClientManager:
+    """Verify OpenAIClientManager creates per-context clients without globals."""
+
+    def test_context_manager_returns_client_instance(self) -> None:
+        """__enter__ returns a fresh OpenAIClient, __exit__ closes it."""
+        mgr = OpenAIClientManager(api_key="sk-test")
+        with patch(
+            "packages.valory.customs.superforcaster_polymarket_v1.superforcaster_polymarket_v1.OpenAIClient"
+        ) as MockClient:
+            mock_instance = MagicMock()
+            MockClient.return_value = mock_instance
+
+            with mgr as client:
+                assert client is mock_instance
+                MockClient.assert_called_once_with(api_key="sk-test")
+
+            mock_instance.client.close.assert_called_once()
+
+    def test_no_global_client_variable(self) -> None:
+        """The module must not define a module-level 'client' variable."""
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        for i, line in enumerate(source.split("\n"), 1):
+            stripped = line.lstrip()
+            if stripped.startswith("client:") or stripped.startswith("client ="):
+                if not line.startswith(" ") and not line.startswith("\t"):
+                    pytest.fail(
+                        f"Module-level 'client' variable found at line {i}: {line}"
+                    )
+
+    def test_generate_prediction_requires_client_param(self) -> None:
+        """generate_prediction_with_retry requires client as first param."""
+        params = list(inspect.signature(generate_prediction_with_retry).parameters)
+        assert params[0] == "client"
+
+
+SF_MODULE = "packages.valory.customs.superforcaster_polymarket_v1.superforcaster_polymarket_v1"
+
+FAKE_SERPER_RESPONSE = {
+    "searchParameters": {"q": "test query", "type": "search"},
+    "organic": [
+        {
+            "title": "Test Result",
+            "link": "http://example.com/result",
+            "snippet": "Test snippet content",
+            "position": 1,
+        },
+    ],
+    "peopleAlsoAsk": [
+        {"question": "What is test?", "snippet": "A test answer."},
+    ],
+}
+
+PREDICTION_JSON = json.dumps(
+    {"p_yes": 0.5, "p_no": 0.5, "confidence": 0.5, "info_utility": 0.5}
+)
+
+PREDICTION_PROMPT = (
+    'With the given question "Will X happen?" '
+    "and the `yes` option represented by `Yes` and the `no` option represented by `No`, "
+    "what are the respective probabilities of `p_yes` and `p_no` occurring?"
+)
+
+
+def _make_mock_api_keys(return_source_content: str = "false") -> MagicMock:
+    """Create a mock KeyChain-like api_keys object."""
+    services = {
+        "openai": ["sk-test"],
+        "serperapi": ["serper-test"],
+        "return_source_content": [return_source_content],
+    }
+    mock = MagicMock()
+    mock.__getitem__ = lambda self, key: services[key][0]
+    mock.get = lambda key, default="": services.get(key, [default])[0]
+    return mock
+
+
+class TestSuperforcasterSourceContent:
+    """Verify superforcaster captures and replays source_content correctly."""
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_live_capture_wraps_serper_json(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """Live run wraps Serper response in {'serper_response': ...}."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
+            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+        )
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = run(
+            tool="superforcaster-polymarket-v1",
+            model="gpt-4o",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("true"),
+            counter_callback=None,
+        )
+
+        used_params = result[4]
+        assert "source_content" in used_params
+        assert "mode" in used_params["source_content"]
+        assert "serper_response" in used_params["source_content"]
+        assert used_params["source_content"]["serper_response"] == FAKE_SERPER_RESPONSE
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    def test_replay_with_serper_response_format(
+        self, mock_client_mgr: MagicMock
+    ) -> None:
+        """Replay with {'serper_response': ...} uses organic and peopleAlsoAsk."""
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
+            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+        )
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        source_content = {"serper_response": FAKE_SERPER_RESPONSE}
+        result = run(
+            tool="superforcaster-polymarket-v1",
+            model="gpt-4o",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("true"),
+            counter_callback=None,
+            source_content=source_content,
+        )
+
+        # Verify the prompt contains the organic result
+        prediction_prompt = result[1]
+        assert "Test Result" in prediction_prompt
+        assert "Test snippet content" in prediction_prompt
+        assert "What is test?" in prediction_prompt
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_flag_off_no_source_content(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """When return_source_content is false, source_content is not in used_params."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_response
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[MagicMock(message=MagicMock(content=PREDICTION_JSON))],
+            usage=MagicMock(prompt_tokens=10, completion_tokens=5),
+        )
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = run(
+            tool="superforcaster-polymarket-v1",
+            model="gpt-4o",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("false"),
+            counter_callback=None,
+        )
+
+        used_params = result[4]
+        assert "source_content" not in used_params

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeiad7ov5r2eqls2fxq2xnsu4dkgsiy4gyfbh6tdlieggjemedjes4i
+agent: valory/mech_predict:0.1.0:bafybeid4epxuu5mfenpvlrw6uiluk7muifypam6xhvfu3eunfdm4n6mepe
 number_of_agents: 1
 deployment:
   agent:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -75,6 +75,9 @@ PREDICTION_REQUEST_REASONING_CONFIG = _component_config(
 PREDICTION_URL_COT_CONFIG = _component_config("napthaai/customs/prediction_url_cot")
 DALLE_REQUEST_CONFIG = _component_config("victorpolisetty/customs/dalle_request")
 SUPERFORCASTER_CONFIG = _component_config("valory/customs/superforcaster")
+SUPERFORCASTER_POLYMARKET_V1_CONFIG = _component_config(
+    "valory/customs/superforcaster_polymarket_v1"
+)
 FACTUAL_RESEARCH_CONFIG = _component_config("valory/customs/factual_research")
 
 # Prompts
@@ -173,6 +176,13 @@ class TestSuperforcaster(BaseIsolatedToolTest):
     """Test Superforcaster."""
 
     component_yaml = SUPERFORCASTER_CONFIG
+    prompts = [PREDICTION_PROMPT]
+
+
+class TestSuperforcasterPolymarketV1(BaseIsolatedToolTest):
+    """Test Superforcaster (Polymarket v1, uncalibrated)."""
+
+    component_yaml = SUPERFORCASTER_POLYMARKET_V1_CONFIG
     prompts = [PREDICTION_PROMPT]
 
 


### PR DESCRIPTION
## Reasoning

- The **calibrated** superforcaster currently runs on Gnosis and performs well on **omenstrat**.
- The **uncalibrated** version currently runs in production on Polymarket and performs well on **polystrat**.
- We previously tried the calibrated version on polystrat, but it performed poorly — so it was reverted (`b22c7055`).

This PR preserves both production-validated variants under separate tool names so each strategy can keep running its winning model.

## Summary

- **Split**: Carve out the older uncalibrated `superforcaster` as a Polymarket-specific tool, `superforcaster_polymarket_v1` (tool name `superforcaster-polymarket-v1`) — this is the version currently winning on polystrat.
- **Restore**: Replace the `superforcaster` package with the calibrated implementation from commit `023b7524` (the version winning on omenstrat, previously reverted).
- Keep the newer Serper/LLMs description on `superforcaster/component.yaml`.
- Adds unit tests for the new package (mocked Serper + OpenAI; no network).
- Registers `superforcaster_polymarket_v1` in `packages.json` and re-locks all affected hashes.

## Hashes

- `custom/valory/superforcaster/0.1.0`: `bafybeidkraklf5c6rkv6g7y7lqj2woy4j5u5dmupjez6mtjhdek3lzbmki` (calibrated, with newer description)
- `custom/valory/superforcaster_polymarket_v1/0.1.0`: `bafybeibvm77sizmxtbhtqnxqbg5mwwi4m3sidd326fo7gfwuc2hriprade`

## Test plan

- [x] `uv run pytest packages/valory/customs/superforcaster/tests/ packages/valory/customs/superforcaster_polymarket_v1/tests/` — 16/16 pass
- [x] `uv run autonomy packages lock --check` — verification successful
- [x] `uv run tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint` — all OK

Robot Generated with Claude Code