### PR TITLE
chore(deps): drop pip>=24.0 from runtime deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ dependencies = [
     "prometheus-client>=0.23.1,<0.24",
     "pebble==5.1.3",
     "python-dotenv==0.21.1",
-    "pip>=24.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -2717,7 +2717,6 @@ dependencies = [
     { name = "openfactverification-kongzii" },
     { name = "pandas" },
     { name = "pebble" },
-    { name = "pip" },
     { name = "prometheus-client" },
     { name = "py-ecc" },
     { name = "pypdf" },
@@ -2783,7 +2782,6 @@ requires-dist = [
     { name = "openfactverification-kongzii", specifier = ">=0.1.0,<0.2" },
     { name = "pandas", specifier = ">=2.1.1,<3" },
     { name = "pebble", specifier = "==5.1.3" },
-    { name = "pip", specifier = ">=24.0" },
     { name = "prometheus-client", specifier = ">=0.23.1,<0.24" },
     { name = "py-ecc", specifier = ">=8,<10" },
     { name = "pypdf", specifier = ">=3.9.0,<7" },
@@ -3721,15 +3719,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c3/28/ec0fc38107fc32536908034e990c47914c57cd7c5a3ece4d8d8f7ffd7e27/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4a6c9fa44005fa37a91ebfc95d081e8079757d2e904b27103f4f5fa6f0bf78c0", size = 5355404, upload-time = "2026-04-01T14:46:06.33Z" },
     { url = "https://files.pythonhosted.org/packages/5e/8b/51b0eddcfa2180d60e41f06bd6d0a62202b20b59c68f5a132e615b75aecf/pillow-12.2.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25373b66e0dd5905ed63fa3cae13c82fbddf3079f2c8bf15c6fb6a35586324c1", size = 6002215, upload-time = "2026-04-01T14:46:08.83Z" },
     { url = "https://files.pythonhosted.org/packages/bc/60/5382c03e1970de634027cee8e1b7d39776b778b81812aaf45b694dfe9e28/pillow-12.2.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bfa9c230d2fe991bed5318a5f119bd6780cda2915cca595393649fc118ab895e", size = 7080946, upload-time = "2026-04-01T14:46:11.734Z" },
-]
-
-[[package]]
-name = "pip"
-version = "26.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pip is a build/install tool and shouldn't be in the app's runtime dependency list. Mirrors the cleanup done in meme-ooorr commit `11acfdad1` per #436 rule.

`uv lock` removed the corresponding entry from `uv.lock`. No `tox.ini` change (the tox-internal `pip` in liccheck/freeze envs is a separate dep). No `autonomy packages lock` change — package hashes are unaffected.

## Test plan

- [ ] CI green (check-dependencies, tests, liccheck)
- [ ] `uv sync` produces a working venv
- [ ] `autonomy --version` still works (sanity check for the jmoreira bug from market-resolver `aabf26b2`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)