### PR TITLE
chore: add superforcaster split version to aea config

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -19,8 +19,8 @@
         "custom/valory/superforcaster_full_search/0.1.0": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
         "custom/valory/superforcaster_calibrated_full_search/0.1.0": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
         "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeiawfhy3w5aclmxm5zxebwd5l7paseqlgmihwbqfyhcdpn2kccgtrq",
-        "agent/valory/mech_predict/0.1.0": "bafybeid4epxuu5mfenpvlrw6uiluk7muifypam6xhvfu3eunfdm4n6mepe",
-        "service/valory/mech_predict/0.1.0": "bafybeierloususbzhj24q6vdhp7fxlkl6q5rrkbxndswztsyf7rbqin6bu"
+        "agent/valory/mech_predict/0.1.0": "bafybeiawjaelunykl5a54ncrt4lzju7b2rdstrhezixyvcpliwik66f3da",
+        "service/valory/mech_predict/0.1.0": "bafybeiati2getulfjl5xiacrzv246javxb45yvwilv6ofqcbba2ym52dyu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -62,6 +62,7 @@ customs:
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
 - valory/superforcaster:0.1.0:bafybeidkraklf5c6rkv6g7y7lqj2woy4j5u5dmupjez6mtjhdek3lzbmki
+- valory/superforcaster_polymarket_v1:0.1.0:bafybeiawfhy3w5aclmxm5zxebwd5l7paseqlgmihwbqfyhcdpn2kccgtrq
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeifssc6ed7itkvqot6qunlpd3prghwsf5dh26kin3xduci3sohulqq

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeid4epxuu5mfenpvlrw6uiluk7muifypam6xhvfu3eunfdm4n6mepe
+agent: valory/mech_predict:0.1.0:bafybeiawjaelunykl5a54ncrt4lzju7b2rdstrhezixyvcpliwik66f3da
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
Was missed in https://github.com/valory-xyz/mech-predict/pull/297