### PR TITLE
fix(benchmark): decouple analyze from aea-heavy tournament import

### DIFF
--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -2255,7 +2255,7 @@ def load_active_tournament_cids(
     off the report.
 
     Delegates loading + schema validation to
-    :func:`benchmark.tournament.load_tournament_tools`, so non-dict
+    :func:`benchmark.tournament_tools.load_tournament_tools`, so non-dict
     JSON, empty CIDs, and missing files are rejected by the same rules
     the tournament runner uses (no second source of truth).
 

--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -42,7 +42,7 @@ from benchmark.scorer import (
     brier_sort_key,
 )
 from benchmark.tool_usage import deployments_for_platform, fetch_valid_tools
-from benchmark.tournament import TOURNAMENT_TOOLS_JSON, load_tournament_tools
+from benchmark.tournament_tools import TOURNAMENT_TOOLS_JSON, load_tournament_tools
 
 log = logging.getLogger(__name__)
 

--- a/benchmark/tests/test_tournament_tools_config.py
+++ b/benchmark/tests/test_tournament_tools_config.py
@@ -19,6 +19,9 @@
 """Tests for benchmark/tournament_tools.py:load_tournament_tools."""
 
 import json
+import subprocess
+import sys
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -95,3 +98,47 @@ def test_shipped_file_loads_and_is_nonempty() -> None:
     for tool_name, cid in result.items():
         assert isinstance(tool_name, str) and tool_name
         assert isinstance(cid, str) and cid.startswith("bafy")
+
+
+def test_analyze_imports_without_heavy_stack() -> None:
+    """benchmark.analyze imports with aea/yaml/dotenv blocked.
+
+    Regression guard for the bug this module split fixes: the
+    benchmark-flywheel CI job runs ``python -m benchmark.analyze`` in a
+    minimal env (``pip install requests scipy numpy``), so analyze must not
+    transitively import the open-autonomy / ``aea`` stack. We reproduce that
+    env in a subprocess by blocking ``aea``, ``yaml`` and ``dotenv`` from the
+    import system, then importing analyze. If a future change re-couples
+    analyze to ``benchmark.tournament`` (which pulls those in), this fails
+    here instead of in the next scheduled flywheel run.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    script = textwrap.dedent("""
+        import sys
+
+        _BLOCKED = ("aea", "yaml", "dotenv")
+
+        class _Blocker:
+            def find_spec(self, name, path=None, target=None):
+                if name.split(".")[0] in _BLOCKED:
+                    raise ModuleNotFoundError(f"blocked heavy dep: {name}")
+                return None
+
+        sys.meta_path.insert(0, _Blocker())
+
+        import benchmark.tournament_tools  # noqa: F401
+        import benchmark.analyze  # noqa: F401
+
+        print("IMPORT_OK")
+        """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert (
+        result.returncode == 0
+    ), f"analyze import pulled a blocked heavy dep:\n{result.stderr}"
+    assert "IMPORT_OK" in result.stdout

--- a/benchmark/tests/test_tournament_tools_config.py
+++ b/benchmark/tests/test_tournament_tools_config.py
@@ -16,13 +16,13 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-"""Tests for benchmark/tournament.py:load_tournament_tools."""
+"""Tests for benchmark/tournament_tools.py:load_tournament_tools."""
 
 import json
 from pathlib import Path
 
 import pytest
-from benchmark.tournament import TOURNAMENT_TOOLS_JSON, load_tournament_tools
+from benchmark.tournament_tools import TOURNAMENT_TOOLS_JSON, load_tournament_tools
 
 
 def test_loads_valid_file(tmp_path: Path) -> None:

--- a/benchmark/tournament.py
+++ b/benchmark/tournament.py
@@ -36,6 +36,11 @@ from benchmark.tools import (
     load_tool_run,
 )
 
+# load_tournament_tools lives in a dependency-free module so lightweight consumers
+# (e.g. benchmark.analyze in CI's minimal env) can read the tool→CID map without
+# importing the aea stack this module pulls in.
+from benchmark.tournament_tools import load_tournament_tools
+
 # isort treats `benchmark` as third-party (not in known_first_party=autonomy);
 # pylint treats it as first-party. The two views disagree on import order.
 # isort wins — silence pylint's complaint on the import that follows.
@@ -44,12 +49,6 @@ from dotenv import (  # type: ignore[import-not-found]  # pylint: disable=wrong-
 )
 
 from packages.valory.skills.task_execution.utils.apis import KeyChain
-
-# ---------------------------------------------------------------------------
-# Tournament tools — single source of truth (TOURNAMENT_IPFS_LOADER_SPEC §3.1)
-# ---------------------------------------------------------------------------
-
-TOURNAMENT_TOOLS_JSON = Path(__file__).resolve().parent / "tournament_tools.json"
 
 # Patterns that look like API keys / tokens (long hex, base64, sk-... etc.)
 _SECRET_RE = re.compile(
@@ -60,42 +59,6 @@ _SECRET_RE = re.compile(
 def _sanitize_error(error: str) -> str:
     """Redact potential secrets from error strings."""
     return _SECRET_RE.sub("REDACTED", error)
-
-
-def load_tournament_tools(path: Path = TOURNAMENT_TOOLS_JSON) -> dict[str, str]:
-    """Load the tournament tool→CID map from JSON.
-
-    :param path: path to tournament_tools.json. Defaults to the file shipped
-        alongside this module.
-    :return: dict mapping tool_name → IPFS CID.
-    :raises FileNotFoundError: if the file is missing.
-    :raises ValueError: if the file is malformed (not a dict[str, str]).
-    """
-    if not path.exists():
-        raise FileNotFoundError(
-            f"Tournament tools config not found: {path}. "
-            "Tournament cannot run without it."
-        )
-    try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"Tournament tools config is not valid JSON: {path}") from exc
-    if not isinstance(data, dict):
-        raise ValueError(
-            f"Tournament tools config must be a JSON object, got {type(data).__name__}: {path}"
-        )
-    for tool_name, cid in data.items():
-        if not isinstance(tool_name, str) or not isinstance(cid, str):
-            raise ValueError(
-                f"Tournament tools config must map str→str; "
-                f"got {tool_name!r}→{cid!r} in {path}"
-            )
-        if not tool_name or not cid:
-            raise ValueError(
-                f"Tournament tools config has empty tool_name or CID: "
-                f"{tool_name!r}→{cid!r} in {path}"
-            )
-    return data
 
 
 load_dotenv()

--- a/benchmark/tournament_tools.py
+++ b/benchmark/tournament_tools.py
@@ -1,0 +1,57 @@
+"""
+Tournament tool→CID map: the single source of truth, with zero heavy deps.
+
+This module deliberately imports only the standard library so that lightweight
+consumers (e.g. ``benchmark.analyze`` running in CI's minimal env) can read the
+tournament tool→CID map without dragging in the open-autonomy / ``aea`` stack
+that ``benchmark.tournament`` pulls in via ``ipfs_loader`` and ``KeyChain``.
+
+``benchmark.tournament`` re-imports ``load_tournament_tools`` from here.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Tournament tools — single source of truth (TOURNAMENT_IPFS_LOADER_SPEC §3.1)
+# ---------------------------------------------------------------------------
+
+TOURNAMENT_TOOLS_JSON = Path(__file__).resolve().parent / "tournament_tools.json"
+
+
+def load_tournament_tools(path: Path = TOURNAMENT_TOOLS_JSON) -> dict[str, str]:
+    """Load the tournament tool→CID map from JSON.
+
+    :param path: path to tournament_tools.json. Defaults to the file shipped
+        alongside this module.
+    :return: dict mapping tool_name → IPFS CID.
+    :raises FileNotFoundError: if the file is missing.
+    :raises ValueError: if the file is malformed (not a dict[str, str]).
+    """
+    if not path.exists():
+        raise FileNotFoundError(
+            f"Tournament tools config not found: {path}. "
+            "Tournament cannot run without it."
+        )
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Tournament tools config is not valid JSON: {path}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"Tournament tools config must be a JSON object, got {type(data).__name__}: {path}"
+        )
+    for tool_name, cid in data.items():
+        if not isinstance(tool_name, str) or not isinstance(cid, str):
+            raise ValueError(
+                f"Tournament tools config must map str→str; "
+                f"got {tool_name!r}→{cid!r} in {path}"
+            )
+        if not tool_name or not cid:
+            raise ValueError(
+                f"Tournament tools config has empty tool_name or CID: "
+                f"{tool_name!r}→{cid!r} in {path}"
+            )
+    return data


### PR DESCRIPTION
## Problem

The scheduled `benchmark-flywheel` run fails at import time: [run 26734025144](https://github.com/valory-xyz/mech-predict/actions/runs/26734025144/job/78786441488).

```
File "benchmark/analyze.py", line 45, in <module>
  from benchmark.tournament import TOURNAMENT_TOOLS_JSON, load_tournament_tools
File "benchmark/tournament.py", line 30, in <module>
  from benchmark.ipfs_loader import IpfsFetchError
File "benchmark/ipfs_loader.py", line 38, in <module>
  import yaml
ModuleNotFoundError: No module named 'yaml'
```

## Root cause

PR #294 added `from benchmark.tournament import …` to `analyze.py:45`. `tournament.py` imports `ipfs_loader`, `dotenv`, and `KeyChain` at module level, which transitively pulls in the whole open-autonomy / `aea` stack:

| import | drags in |
|---|---|
| `tournament.py:30` `from benchmark.ipfs_loader import IpfsFetchError` | `ipfs_loader` → `packages.valory…ipfs` → `aea` |
| `tournament.py:42` `from dotenv import load_dotenv` | `python-dotenv` |
| `tournament.py:46` `from packages.valory…apis import KeyChain` | `packages.valory…__init__` → `aea` |

The `benchmark` job deliberately runs in a minimal env (`pip install requests scipy numpy`, `benchmark_flywheel.yaml:71`) — no `uv`, no `aea`. Before #294 `analyze` never touched that stack, so the minimal install was sufficient. #294 silently coupled the lightweight job to the heavy stack, so every `python -m benchmark.analyze` now crashes before doing any work. (It passes locally only because `uv sync` installs the full project.)

Adding `pyyaml`/`python-dotenv` to the job is *not* a real fix — it just unmasks the next missing dep, `aea`.

## Fix

`analyze` only needs two trivial things from `tournament`: `TOURNAMENT_TOOLS_JSON` (a `Path` constant) and `load_tournament_tools` (a stdlib JSON reader). Neither needs `ipfs_loader`/`dotenv`/`KeyChain`/`aea`.

- New stdlib-only module `benchmark/tournament_tools.py` holds both.
- `analyze.py` and the config test import from there.
- `tournament.py` re-imports `load_tournament_tools` for its own internal use.

This restores the pre-#294 contract and keeps the benchmark job lightweight — no workflow change needed.

## Verification

- **CI-faithful repro** on the failing commit (isolated env, exactly `requests scipy numpy`): `import benchmark.analyze` now succeeds and `load_tournament_tools()` returns its 4 tools. Previously: `ModuleNotFoundError: yaml` → then `aea`.
- `benchmark.tournament` still imports fine in the full env.
- Tests: 37 passed (`test_tournament_tools_config.py` + tournament-related `test_analyze.py`, including the `load_tournament_tools` monkeypatch paths).
- Lint: black, isort, flake8, mypy, pylint, darglint all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)