### PR TITLE
chore(ci): replace tool-improvement Actions Variables with workflow_dispatch inputs

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -38,6 +38,11 @@ on:
         description: 'Trailing-window length (days) for the Current/Prev rolling comparison sections'
         required: false
         default: '7'
+      run_triage:
+        description: 'Run the tool-improvement triage step at the end (default: true). Cron always runs it; manual dispatch can flip it off to skip the step.'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   # -----------------------------------------------------------------------
@@ -300,23 +305,23 @@ jobs:
       # benchmark-data artifact). The hashFiles() gate is defensive: if
       # either rolling file is missing (because the scorer step failed)
       # we skip triage rather than open a noisy issue against half-data.
-      # ENABLE_TOOL_IMPROVEMENT is opt-in: the step runs only when the
-      # repo var is explicitly 'true'. This keeps the default state
-      # silent (no live dispatch) until the operator deliberately
-      # promotes from observer -> dry-run -> live by flipping repo vars.
+      # Triage runs by default. The `run_triage` workflow_dispatch input
+      # lets a human dispatch flip it off (run_triage=false). Cron-
+      # triggered runs send an empty string for the input, so the
+      # `!= 'false'` semantics fire the step on cron as the YAML
+      # `default: true` advertises. No repo-level Actions Variables
+      # are required. (The script still accepts --dry-run for local
+      # debugging; we don't expose it as a workflow input because
+      # mech-predict-test is the right place to validate behaviour
+      # without filing real issues.)
       - name: Tool-improvement triage (Polystrat)
-        if: always() && !cancelled() && (vars.ENABLE_TOOL_IMPROVEMENT == 'true') && hashFiles('benchmark/results/rolling_scores_polymarket.json') != '' && hashFiles('benchmark/results/prev_rolling_scores_polymarket.json') != ''
+        if: always() && !cancelled() && (github.event.inputs.run_triage != 'false') && hashFiles('benchmark/results/rolling_scores_polymarket.json') != '' && hashFiles('benchmark/results/prev_rolling_scores_polymarket.json') != ''
         env:
           GH_TOKEN: ${{ secrets.TOOL_IMPROVEMENT_GH_TOKEN || github.token }}
           GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
-          DRY_RUN_FLAG=""
-          if [ "${{ vars.TOOL_IMPROVEMENT_DRY_RUN }}" = "true" ]; then
-            DRY_RUN_FLAG="--dry-run"
-          fi
           python -m benchmark.tool_improvement_triage \
-            --repo "${{ github.repository }}" \
-            $DRY_RUN_FLAG
+            --repo "${{ github.repository }}"
 
       # Daily log files uploaded separately for archival
       - name: Upload daily log archive


### PR DESCRIPTION
## Summary

Replaces the two repo-level Actions Variables introduced by #304 (`vars.ENABLE_TOOL_IMPROVEMENT` + `vars.TOOL_IMPROVEMENT_DRY_RUN`) with a **single** `workflow_dispatch` boolean input named after what the script actually does:

| Old (removed) | New |
|---|---|
| `vars.ENABLE_TOOL_IMPROVEMENT` | `run_triage` input (`default: true`) |
| `vars.TOOL_IMPROVEMENT_DRY_RUN` | **dropped from workflow** (`--dry-run` argparse flag stays in the script for local debugging) |

## Why

- Variables on `valory-xyz/*` need admin/maintainer access to flip, which adds an out-of-band setup step easy to forget when merging (today's manual dispatch by @LOCKhart07 — run `26812718445` — hit this; triage step skipped because the variable was unset)
- `workflow_dispatch` inputs are more discoverable: anyone with dispatch permission sees the knob in the Run-workflow form, named clearly after the script
- Dry-run-as-workflow-input was justified in the original PR #304 rollout plan as "validate the issue body before going live", but: the body is deterministic from JSON fixtures, the python `build_issue_body()` is unit-tested, and `mech-predict-test` (mocked workflow + fixtures) is the right place to validate end-to-end without polluting the production tracker

## Posture change (deliberate, please confirm)

**This PR flips triage from opt-in to opt-out.** PR #304 deliberately made triage silent-by-default (observer → dry-run → live, gated on a repo var). This PR makes the daily cron run triage **live by default**, filing real issues. The only workflow knob is `run_triage` (defaults true) — a kill-switch, not an enable-switch.

The rationale: end-to-end validation already happened on `mech-predict-test` (mocked benchmark-flywheel workflow, fixtures committed, real GitHub issues #1–#7 verified across open/duplicate-suppression/close-to-rearm/level_floor-cooldown paths). Keeping the workflow gated on a repo var means an opaque out-of-band setup step that nobody remembers to do after merge. Flipping to default-on, with `run_triage=false` as the kill-switch, makes the safe state the visible default.

## Behaviour table

| Trigger | `run_triage` | Triage step |
|---|---|---|
| cron (daily 02:30 UTC) | empty (treated as `true` via `!= 'false'`) | **runs live** (real issues filed) |
| manual dispatch, default | `true` | runs live |
| manual dispatch | `false` | **skipped** |

Cron sends an empty string for `workflow_dispatch` inputs, so the gate uses `!= 'false'` semantics: empty → not `'false'` → step runs. This matches the YAML `default: true`.

## Operator action required BEFORE merge (or the first cron after merge will fail)

Because cron runs live by default, the first regression-trigger will call `gh issue create --label tool-improvement`. If the label doesn't exist, that call fails with rc=1 ("could not add label") and the step exits non-zero (CI goes red). The label must be created **before** the first cron run after this lands:

```bash
gh label create tool-improvement \
  --description "Tool-quality regression flagged by daily benchmark; routes to tool-improvement-agent" \
  --color "1d76db" \
  --repo valory-xyz/mech-predict
```

I can do this as part of merging if I have label-write on `valory-xyz/mech-predict`; otherwise a maintainer needs to do it.

## Test plan

- [x] CI green (linter_checks + lock_check)
- [x] End-to-end on `jmoreira-valory/mech-predict-test` — issues #1, #2 (regression open + duplicate suppress + close-to-rearm), #7 (level_floor open + cooldown after close)
- [ ] Label created on `valory-xyz/mech-predict`
- [ ] First cron run after merge files a real issue (or stays silent if no regression that day)
- [ ] Manual dispatch with `run_triage=false` → `Tool-improvement triage (Polystrat)` step shows `skipped`