### PR TITLE
feat: tool-improvement housekeeping rules + tool_lineage.json ledger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,10 +226,10 @@ Pick exactly ONE based on the size of the change:
 
 | Path | When | What you DO NOT do |
 | --- | --- | --- |
-| **In place** — edit `packages/{author}/customs/<tool>/<tool>.py` | Small bugfix: output clamp, parsing fix, one-line prompt tweak, typo, dead-branch removal. Pre-lint diff ≤ 30 LOC. Does NOT touch the prompt's `system`/`user` template structure or the tool's high-level reasoning flow. | Do NOT touch `tool_lineage.json`. Do NOT rename. Do NOT create a new sibling directory. |
-| **New version** — create `packages/{author}/customs/<base>_v<n+1>/<base>_v<n+1>.py` | Significant change: prompt rewrite, mechanism swap, new business logic, new evidence source, different model class. | Do NOT delete or modify the existing `<tool>` source — the previous variant keeps running alongside the new one. |
+| **In place** — edit `packages/{author}/customs/<tool>/<tool>.py` | Output-preserving fixes only: typos, comments, dead-branch removal, refactors with identical behaviour, parsing/error-handling on previously-crashing inputs. Pre-lint diff ≤ 30 LOC. | Do NOT touch `tool_lineage.json`. Do NOT rename. Do NOT create a new sibling directory. Do NOT edit the prompt text or any code that can shift `p_yes` on a normal input. |
+| **New version** — create `packages/{author}/customs/<base>_v<n+1>/<base>_v<n+1>.py` | Anything that can change the probability distribution: any prompt edit (even one line), output clamp/calibration, mechanism swap, new evidence source, model swap, new business logic. | Do NOT delete or modify the existing `<tool>` source — the previous variant keeps running alongside the new one. |
 
-If unsure: default to **in place** for smaller changes, **new version** for anything that crosses a paragraph boundary in the prompt or rewires the call graph.
+If unsure: default to **new version**. If you cannot show the edit leaves outputs bit-identical on the existing benchmark, treat it as a new version.
 
 #### Naming convention (new-version path)
 
@@ -247,7 +247,7 @@ Examples:
 | `superforcaster-v2` | `superforcaster` | `superforcaster`, `superforcaster-v2` | 2 | `superforcaster-v3` |
 | `superforcaster-polymarket-v1` | `superforcaster-polymarket` | `superforcaster-polymarket-v1` | 1 | `superforcaster-polymarket-v2` |
 
-Directory uses `_` (Python module convention); the registered tool name uses `-` (trader-visible convention).
+Directory uses `_` (Python module convention). New variants' registered tool names use `-` (trader-visible convention); some legacy tools (e.g. `factual_research`, `close_market`, `superforcaster_full_search`) use `_` — keep their existing form rather than renaming.
 
 #### The `tool_lineage.json` ledger
 
@@ -259,9 +259,7 @@ Lives at the repo root. The `tools` field is a **dictionary keyed by tool name**
   "tools": {
     "superforcaster-v3": {
       "parent": "superforcaster-v2",
-      "reason": "<one-line why, e.g. 'prompt rewrite to add low-p_yes evidence bar'>",
-      "pr": "<URL of the PR introducing this variant>",
-      "deployed": false
+      "reason": "<one-line why, e.g. 'prompt rewrite to add low-p_yes evidence bar'>"
     }
   }
 }
@@ -269,11 +267,11 @@ Lives at the repo root. The `tools` field is a **dictionary keyed by tool name**
 
 Field semantics:
 
-- The dictionary key is the tool name. Must match `^[a-z][a-z0-9_-]*$` and equal `<base>-v<n+1>` per the naming convention.
+- The dictionary key is the tool name. Must match `^[a-z][a-z0-9._-]*$` and equal `<base>-v<n+1>` per the naming convention (legacy underscored names are grandfathered).
 - `parent` — the tool named in the issue (the one that triggered this version), or `null` for a tool introduced from scratch. Lets readers walk back the lineage.
 - `reason` — one human-readable line. NOT the hypothesis (that goes in the PR body); just the housekeeping reason.
-- `pr` — URL of this PR. Use `"PENDING"` as a placeholder if appending before `gh pr create`; replace with the real URL in the same commit.
-- `deployed` — defaults to `false`. `false` = variant ships in source but NOT routed to live traders. Promotion to live traffic is a separate human PR on `agent-deployments`; that PR flips this to `true`. The automation never sets `deployed: true`.
+
+PR-of-introduction is intentionally omitted — `git log -- packages/{author}/customs/<dir>/component.yaml` is authoritative. Deployment status is intentionally omitted — it drifts; query the marketplace subgraph + IPFS manifests to get live truth.
 
 Add exactly ONE entry per new variant. Do not modify or remove existing entries.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,15 +216,105 @@ Configure in `.1env` or `.agentenv`:
 
 ## Important Patterns
 
-### Adding a New Tool
+### Tool-improvement housekeeping rules
 
-1. Create package structure in `packages/{author}/customs/{tool_name}/`
-2. Implement `run(**kwargs)` function with proper signature
-3. Use `@with_key_rotation` decorator if calling rate-limited APIs
-4. Add tool metadata to `component.yaml`
-5. Add IPFS hash to `TOOLS_TO_PACKAGE_HASH` mapping
-6. Update package hashes: `autonomy packages lock`
-7. Test with `scripts/test_tool.py`
+When modifying an existing prediction tool (e.g. in response to a `tool-improvement`-labelled issue), follow these rules. They are scoped to **housekeeping** only — file paths, naming, the `tool_lineage.json` ledger, side effects. They do NOT cover investigation, hypothesis-forming, or whether a change is warranted (that logic lives in the `tool-improvement-agent` pipeline in the `agent-skills` repo).
+
+#### In place vs new version
+
+Pick exactly ONE based on the size of the change:
+
+| Path | When | What you DO NOT do |
+| --- | --- | --- |
+| **In place** — edit `packages/{author}/customs/<tool>/<tool>.py` | Small bugfix: output clamp, parsing fix, one-line prompt tweak, typo, dead-branch removal. Pre-lint diff ≤ 30 LOC. Does NOT touch the prompt's `system`/`user` template structure or the tool's high-level reasoning flow. | Do NOT touch `tool_lineage.json`. Do NOT rename. Do NOT create a new sibling directory. |
+| **New version** — create `packages/{author}/customs/<base>_v<n+1>/<base>_v<n+1>.py` | Significant change: prompt rewrite, mechanism swap, new business logic, new evidence source, different model class. | Do NOT delete or modify the existing `<tool>` source — the previous variant keeps running alongside the new one. |
+
+If unsure: default to **in place** for smaller changes, **new version** for anything that crosses a paragraph boundary in the prompt or rewires the call graph.
+
+#### Naming convention (new-version path)
+
+To compute the new tool name from the `<tool>` named in the issue:
+
+1. Strip a trailing `-v<digits>` from `<tool>` to get `<base>`. Bare names with no suffix are implicit `-v0`.
+2. Find the largest `n` such that `<base>-v<n>` exists in either `benchmark/tools.py:TOOL_REGISTRY` keys or `tool_lineage.json` `tools` keys.
+3. New name is `<base>-v<n+1>`.
+
+Examples:
+
+| `<tool>` (from issue) | `<base>` | Existing | `n` | New name |
+| --- | --- | --- | --- | --- |
+| `superforcaster` | `superforcaster` | `superforcaster` | 0 | `superforcaster-v1` |
+| `superforcaster-v2` | `superforcaster` | `superforcaster`, `superforcaster-v2` | 2 | `superforcaster-v3` |
+| `superforcaster-polymarket-v1` | `superforcaster-polymarket` | `superforcaster-polymarket-v1` | 1 | `superforcaster-polymarket-v2` |
+
+Directory uses `_` (Python module convention); the registered tool name uses `-` (trader-visible convention).
+
+#### The `tool_lineage.json` ledger
+
+Lives at the repo root. The `tools` field is a **dictionary keyed by tool name**, so lookup is O(1) and "does this name already exist?" is a trivial `name in tools` check. Updated **only** on the new-version path (in-place edits leave it untouched).
+
+```json
+{
+  "version": 1,
+  "tools": {
+    "superforcaster-v3": {
+      "parent": "superforcaster-v2",
+      "reason": "<one-line why, e.g. 'prompt rewrite to add low-p_yes evidence bar'>",
+      "pr": "<URL of the PR introducing this variant>",
+      "deployed": false
+    }
+  }
+}
+```
+
+Field semantics:
+
+- The dictionary key is the tool name. Must match `^[a-z][a-z0-9_-]*$` and equal `<base>-v<n+1>` per the naming convention.
+- `parent` — the tool named in the issue (the one that triggered this version), or `null` for a tool introduced from scratch. Lets readers walk back the lineage.
+- `reason` — one human-readable line. NOT the hypothesis (that goes in the PR body); just the housekeeping reason.
+- `pr` — URL of this PR. Use `"PENDING"` as a placeholder if appending before `gh pr create`; replace with the real URL in the same commit.
+- `deployed` — defaults to `false`. `false` = variant ships in source but NOT routed to live traders. Promotion to live traffic is a separate human PR on `agent-deployments`; that PR flips this to `true`. The automation never sets `deployed: true`.
+
+Add exactly ONE entry per new variant. Do not modify or remove existing entries.
+
+#### File side effects, by path
+
+**In-place path:**
+
+| File | Action |
+| --- | --- |
+| `packages/{author}/customs/<tool>/<tool>.py` | edit |
+| `packages/{author}/customs/<tool>/component.yaml` | re-fingerprinted by `autonomy packages lock` |
+| `packages/packages.json` | CID bumped by `autonomy packages lock` |
+| `benchmark/tournament_tools.json[<tool>]` | bump to new CID (value swap; key unchanged) |
+| `tool_lineage.json` | **untouched** |
+| `benchmark/tools.py:TOOL_REGISTRY` | **untouched** |
+
+**New-version path:**
+
+| File | Action |
+| --- | --- |
+| `packages/{author}/customs/<tool>/` | **untouched** — previous variant keeps running |
+| `packages/{author}/customs/<base>_v<n+1>/<base>_v<n+1>.py` | NEW — copy previous tool's source as starting point, then apply the change |
+| `packages/{author}/customs/<base>_v<n+1>/component.yaml` | NEW — generated by `autonomy packages lock` |
+| `packages/{author}/customs/<base>_v<n+1>/__init__.py` | NEW — copy from previous tool's `__init__.py` |
+| `packages/packages.json` | CID added by `autonomy packages lock` |
+| `benchmark/tools.py:TOOL_REGISTRY` | ADD entry mapping `<base>-v<n+1>` → new module path |
+| `benchmark/tournament_tools.json` | ADD entry `<base>-v<n+1>` → new CID. Previous entry left in place. |
+| `tool_lineage.json` | ADD one entry to `tools` (schema above) |
+
+#### Adding a new tool from scratch (not an update)
+
+If you are adding a tool that has no predecessor (a brand-new tool, not a variant of an existing one), the flow is the same as the new-version path above, except:
+
+- `tool_lineage.json` gets an entry where `parent` is `null`.
+- The new tool's name does not need a `-v<N>` suffix on first introduction — `superforcaster` is fine; the suffix only appears when a variant of it is later spawned.
+
+#### Out-of-scope reminders
+
+- Do NOT run `autonomy push-all`. Publishing bytes to IPFS is a human step before merging.
+- Do NOT modify `agent-deployments`. Routing a CID to live traffic is a separate human PR.
+- Do NOT delete old variants. The previous version keeps running until a human explicitly retires it.
 
 ### API Key Management
 

--- a/benchmark/tool_improvement_triage.py
+++ b/benchmark/tool_improvement_triage.py
@@ -467,6 +467,8 @@ This issue records the {signal}, not a diagnosis. The cause has not been identif
 Artifact: {artifact_url}
 
 Download with `gh run download <run-id> --name benchmark-data`. The artifact contains the daily JSONL logs and `results/scores_{platform}.json`. Reproduce the headline number from the raw rows before forming any hypothesis.
+
+If your investigation concludes that a code change is warranted, **before editing anything** read the [Tool-improvement housekeeping rules](../blob/main/CLAUDE.md#tool-improvement-housekeeping-rules) section of `CLAUDE.md` at the repo root. It is the canonical reference for: in-place edit vs new-version spawn decision, naming convention, the `tool_lineage.json` ledger, and the side-effect file list.
 """
 
 

--- a/tool_lineage.json
+++ b/tool_lineage.json
@@ -1,0 +1,186 @@
+{
+  "version": 1,
+  "_doc": "Ledger of tool variants, keyed by tool name. See CLAUDE.md section 'Tool-improvement housekeeping rules' for the canonical schema and update rule.",
+  "tools": {
+    "superforcaster-polymarket-v1": {
+      "parent": "superforcaster",
+      "reason": "Carve out the older uncalibrated superforcaster as a Polymarket-specific tool, leaving the original superforcaster untouched.",
+      "pr": 297,
+      "deployed": true
+    },
+    "claude-prediction-offline": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 177,
+      "deployed": true
+    },
+    "claude-prediction-online": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 177,
+      "deployed": true
+    },
+    "close_market": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 177,
+      "deployed": false
+    },
+    "corcel-completion": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 252,
+      "deployed": false
+    },
+    "corcel-prediction": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 252,
+      "deployed": false
+    },
+    "dall-e-2": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 239,
+      "deployed": false
+    },
+    "dall-e-3": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 239,
+      "deployed": false
+    },
+    "factual_research": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 118,
+      "deployed": true
+    },
+    "gemini-2.0-flash": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 228,
+      "deployed": false
+    },
+    "gemini-2.0-flash-lite": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 228,
+      "deployed": false
+    },
+    "gemini-completion": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 252,
+      "deployed": false
+    },
+    "gemini-prediction": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 252,
+      "deployed": false
+    },
+    "native_transfer": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 201,
+      "deployed": false
+    },
+    "prediction-langchain": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 231,
+      "deployed": false
+    },
+    "prediction-offline": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 177,
+      "deployed": true
+    },
+    "prediction-offline-sme": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 177,
+      "deployed": true
+    },
+    "prediction-online": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 177,
+      "deployed": true
+    },
+    "prediction-online-sme": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 177,
+      "deployed": true
+    },
+    "prediction-request-rag": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 164,
+      "deployed": true
+    },
+    "prediction-request-rag-claude": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 164,
+      "deployed": true
+    },
+    "prediction-request-reasoning": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 188,
+      "deployed": true
+    },
+    "prediction-request-reasoning-claude": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 188,
+      "deployed": true
+    },
+    "prediction-url-cot": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 208,
+      "deployed": false
+    },
+    "prediction-url-cot-claude": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 208,
+      "deployed": false
+    },
+    "resolve-market-jury-v1": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 157,
+      "deployed": true
+    },
+    "resolve-market-reasoning-gpt-4.1": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 164,
+      "deployed": true
+    },
+    "superforcaster": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 260,
+      "deployed": true
+    },
+    "superforcaster_calibrated_full_search": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 290,
+      "deployed": false
+    },
+    "superforcaster_full_search": {
+      "parent": null,
+      "reason": "Original tool, baseline entry.",
+      "pr": 290,
+      "deployed": false
+    }
+  }
+}

--- a/tool_lineage.json
+++ b/tool_lineage.json
@@ -4,183 +4,123 @@
   "tools": {
     "superforcaster-polymarket-v1": {
       "parent": "superforcaster",
-      "reason": "Carve out the older uncalibrated superforcaster as a Polymarket-specific tool, leaving the original superforcaster untouched.",
-      "pr": 297,
-      "deployed": true
+      "reason": "Carve out the older uncalibrated superforcaster as a Polymarket-specific tool, leaving the original superforcaster untouched."
     },
     "claude-prediction-offline": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 177,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "claude-prediction-online": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 177,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "close_market": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 177,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "corcel-completion": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 252,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "corcel-prediction": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 252,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "dall-e-2": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 239,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "dall-e-3": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 239,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "factual_research": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 118,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "gemini-2.0-flash": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 228,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "gemini-2.0-flash-lite": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 228,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "gemini-completion": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 252,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "gemini-prediction": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 252,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "native_transfer": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 201,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "prediction-langchain": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 231,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "prediction-offline": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 177,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "prediction-offline-sme": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 177,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "prediction-online": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 177,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "prediction-online-sme": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 177,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "prediction-request-rag": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 164,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "prediction-request-rag-claude": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 164,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "prediction-request-reasoning": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 188,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "prediction-request-reasoning-claude": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 188,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "prediction-url-cot": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 208,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "prediction-url-cot-claude": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 208,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "resolve-market-jury-v1": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 157,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "resolve-market-reasoning-gpt-4.1": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 164,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "superforcaster": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 260,
-      "deployed": true
+      "reason": "Original tool, baseline entry."
     },
     "superforcaster_calibrated_full_search": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 290,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     },
     "superforcaster_full_search": {
       "parent": null,
-      "reason": "Original tool, baseline entry.",
-      "pr": 290,
-      "deployed": false
+      "reason": "Original tool, baseline entry."
     }
   }
 }


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — new `Tool-improvement housekeeping rules` section: the canonical reference for the in-place vs new-version path decision, the `<base>-v<n+1>` naming convention, the `tool_lineage.json` schema, and the side-effect file list per path.
- **tool_lineage.json** — new 30-entry ledger covering every tool sourced from `packages/*/customs/*`. Schema is intentionally minimal: keyed by tool name, fields `parent` + `reason` only.
- **benchmark/tool_improvement_triage.py** — triage-issue body now points investigators at the housekeeping-rules section in `CLAUDE.md` before any code edit.

## In-place vs new-version (tightened in `b6fb2eb3`)

| Path | When | Default-on-doubt |
|---|---|---|
| **In place** | Output-preserving fixes only: typos, dead-branch removal, refactors with identical behaviour, parsing on previously-crashing inputs. Pre-lint diff ≤ 30 LOC. | — |
| **New version** | Anything that can change the probability distribution: any prompt edit (even one line), output clamp/calibration, mechanism swap, new evidence source, model swap, new business logic. | ✅ default on doubt |

If you cannot show the edit leaves outputs bit-identical on the existing benchmark, treat it as a new version.

## Ledger schema (minimal — review-driven)

```json
{
  "version": 1,
  "tools": {
    "<tool-name>": {
      "parent": "<predecessor-or-null>",
      "reason": "<one-line why>"
    }
  }
}
```

- Key regex: `^[a-z][a-z0-9._-]*$` (legacy underscored names like `factual_research` are grandfathered).
- `parent` = the tool named in the issue (or `null` for a from-scratch tool).
- `reason` = one human-readable line; not the hypothesis (that lives in the PR body).
- **`pr` is intentionally omitted** — `git log -- packages/<dir>/component.yaml` is authoritative.
- **`deployed` is intentionally omitted** — it drifts; live truth = marketplace subgraph + IPFS manifest scan (same path the trader takes: subgraph → metadata CID → IPFS → `.tools`).

## Review history

Six review comments addressed in `b6fb2eb3`:

| # | Reviewer | Change |
|---|---|---|
| 3342511707 | LOCKhart07 | Tightened in-place rule; default-on-doubt flipped to new-version. |
| 3342532995 | LOCKhart07 | Dropped `pr` field; `git log` is the pointer. |
| 3342541013 | LOCKhart07 | Dropped `deployed` field; query marketplace + IPFS for live truth. |
| 3342564570 | LOCKhart07 | URL/int contradiction resolved by dropping `pr` entirely. |
| 3342564576 | LOCKhart07 | Key regex now allows `.` (`gemini-2.0-flash` et al.). |
| 3342564580 | LOCKhart07 | Naming rule softened to acknowledge legacy underscored names. |

## Test plan

- [x] Schema check: `python3 -c "import json; json.load(open('tool_lineage.json'))"` parses cleanly.
- [x] Verify all 30 keys match the new regex `^[a-z][a-z0-9._-]*$`.
- [ ] Read the CLAUDE.md housekeeping section end-to-end; confirm the side-effect tables match current file paths.
- [ ] Spot-check that the in-place vs new-version rule matches the team's mental model on a couple of recent PRs (e.g. #297 should clearly be new-version per the new rule).

## Companion PR

[valory-xyz/agent-skills#149](https://github.com/valory-xyz/agent-skills/pull/149) — points the `tool-improvement-agent`'s pipeline + CLAUDE.md + oa-tool-edit skill at this housekeeping section instead of duplicating the rules in agent-skills.