### PR TITLE
test(ci): benchmark-only probe — verify integration_tests skips

### DIFF
--- a/benchmark/CI_GATE_PROBE.md
+++ b/benchmark/CI_GATE_PROBE.md
@@ -1,0 +1,6 @@
+# CI gate probe
+
+Throwaway file. Its only purpose is a **benchmark-only** diff to verify that
+the `detect_changes` job (added in #295) emits `run_integration=false` and the
+live `integration_tests` suite is **skipped** while `All checks passed` stays
+green. Safe to delete; this PR is not meant to be merged.


### PR DESCRIPTION
## What

Throwaway PR to verify the gate added in #295. The diff touches **only `benchmark/`** (a single new `CI_GATE_PROBE.md`), so:

- `detect_changes` should emit `run_integration=false`
- `integration_tests` should be **skipped** (not failed)
- `All checks passed` should still go **green**

**Not for merge** — will be closed once the gate behaviour is confirmed. The probe file is safe to delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)