### PR TITLE
feat(benchmark): decouple candidate-tool from baseline-tool in /benchmark replay

### DIFF
--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -25,6 +25,10 @@ on:
         description: 'PR number to post results on (optional)'
         required: false
         default: ''
+      candidate_tool:
+        description: 'Candidate tool whose code runs against the baseline rows (default: same as tool, i.e. in-place edit)'
+        required: false
+        default: ''
 
 jobs:
   replay:
@@ -66,6 +70,7 @@ jobs:
           INPUT_SAMPLE: ${{ github.event.inputs.sample }}
           INPUT_SEED: ${{ github.event.inputs.seed }}
           INPUT_PR: ${{ github.event.inputs.pr }}
+          INPUT_CANDIDATE_TOOL: ${{ github.event.inputs.candidate_tool }}
           ACTOR: ${{ github.actor }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENT_USER: ${{ github.event.comment.user.login }}
@@ -76,12 +81,14 @@ jobs:
             SAMPLE="$INPUT_SAMPLE"
             SEED="$INPUT_SEED"
             PR="$INPUT_PR"
+            CANDIDATE_TOOL="$INPUT_CANDIDATE_TOOL"
             TRIGGERED_BY="$ACTOR"
           else
             TOOL=$(echo "$COMMENT_BODY" | awk '{print $2}')
             PHASE=$(echo "$COMMENT_BODY" | grep -oP '(?<=--phase )\S+' || echo "prediction-only")
             SAMPLE=$(echo "$COMMENT_BODY" | grep -oP '(?<=--sample )\d+' || echo "50")
             SEED=$(echo "$COMMENT_BODY" | grep -oP '(?<=--seed )\d+' || echo "42")
+            CANDIDATE_TOOL=$(echo "$COMMENT_BODY" | grep -oP '(?<=--candidate-tool )\S+' || echo "")
             PR="$ISSUE_NUMBER"
             TRIGGERED_BY="$COMMENT_USER"
           fi
@@ -91,15 +98,22 @@ jobs:
             echo "::error::Invalid tool name: '$TOOL'. Must match [a-z0-9_-]+"
             exit 1
           fi
+          # Same whitelist on candidate-tool when provided (defense-in-depth
+          # against shell-injection via attacker-controlled comment body).
+          if [ -n "$CANDIDATE_TOOL" ] && ! echo "$CANDIDATE_TOOL" | grep -qP '^[a-z0-9_-]+$'; then
+            echo "::error::Invalid candidate-tool name: '$CANDIDATE_TOOL'. Must match [a-z0-9_-]+"
+            exit 1
+          fi
 
           echo "tool=$TOOL" >> "$GITHUB_OUTPUT"
           echo "phase=$PHASE" >> "$GITHUB_OUTPUT"
           echo "sample=$SAMPLE" >> "$GITHUB_OUTPUT"
           echo "seed=$SEED" >> "$GITHUB_OUTPUT"
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
+          echo "candidate_tool=$CANDIDATE_TOOL" >> "$GITHUB_OUTPUT"
           echo "triggered_by=$TRIGGERED_BY" >> "$GITHUB_OUTPUT"
 
-          echo "Tool: $TOOL, Phase: $PHASE, Sample: $SAMPLE, Seed: $SEED, PR: $PR"
+          echo "Tool: $TOOL, Phase: $PHASE, Sample: $SAMPLE, Seed: $SEED, PR: $PR, Candidate: ${CANDIDATE_TOOL:-<same as tool>}"
 
       # Checkout — PR head for issue_comment, current branch for workflow_dispatch
       - name: Checkout PR head
@@ -162,11 +176,20 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.BENCHMARK_OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.BENCHMARK_ANTHROPIC_API_KEY }}
+          CANDIDATE_TOOL: ${{ steps.parse.outputs.candidate_tool }}
         run: |
+          # New-version PRs pass --candidate-tool so candidate code runs on
+          # the baseline's W-2 rows; in-place edits leave it empty so replay
+          # imports from the same tool as the enriched-row filter.
+          CANDIDATE_ARG=""
+          if [ -n "$CANDIDATE_TOOL" ]; then
+            CANDIDATE_ARG="--candidate-tool $CANDIDATE_TOOL"
+          fi
           uv run python -m benchmark.prompt_replay replay \
             --dataset benchmark/results/ci_enriched/dataset.jsonl \
             --output-dir benchmark/results/ci_replay/ \
-            --phase "${{ steps.parse.outputs.phase }}"
+            --phase "${{ steps.parse.outputs.phase }}" \
+            $CANDIDATE_ARG
 
       # Compute metrics and post comment (only if PR number is set)
       - name: Post benchmark report

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import argparse
 import base64
 import hashlib
+import importlib
 import json
 import logging
 import os
@@ -1257,6 +1258,7 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
     output_dir: Path,
     model: str,
     phase: str = "prediction-only",
+    candidate_tool: Optional[str] = None,
 ) -> None:
     """Replay enriched rows through current prompt template vs production baseline.
 
@@ -1266,6 +1268,14 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
     :param output_dir: directory for baseline.jsonl + candidate.jsonl output.
     :param model: LLM model identifier.
     :param phase: replay phase — "prediction-only", "reasoning-only", or "both".
+    :param candidate_tool: tool name whose module supplies the prompt templates
+        being replayed. Defaults to the baseline tool from the enriched rows
+        (in-place edit path: same name, edited code). Set to a different name
+        for new-version PRs (e.g. baseline=superforcaster, candidate=
+        superforcaster-v1) so the candidate's code runs against the baseline's
+        W-2 rows. The candidate must share the baseline's prompt-attribute
+        schema (PREDICTION_PROMPT / ESTIMATE_USER / etc.) and be registered in
+        benchmark.tools.TOOL_REGISTRY.
     """
     # Load enriched dataset first to detect tool
     sampled: list[dict[str, Any]] = load_jsonl(dataset)
@@ -1285,51 +1295,53 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
             log.warning("Could not load filter stats from %s: %s", stats_path, exc)
 
     tool_name = sampled[0]["tool_name"]
+    # Candidate defaults to baseline (in-place edits: same name, edited code).
+    # When set, the candidate's code is replayed against the baseline's W-2
+    # rows so new-version PRs (e.g. superforcaster -> superforcaster-v1) get a
+    # meaningful Brier delta against the parent on the same evidence + ground
+    # truth.
+    candidate_tool_name = candidate_tool or tool_name
     is_reasoning_tool = tool_name.startswith("prediction-request-reasoning")
     is_rag_tool = tool_name.startswith("prediction-request-rag")
     is_superforcaster = tool_name == "superforcaster"
     is_factual_research = tool_name == "factual_research"
 
-    # Import prompt templates from the appropriate tool module
+    # Resolve the candidate's module via TOOL_REGISTRY so new-version tools get
+    # replay support without growing the if/elif cascade below — only the
+    # baseline's family decides which attribute names we pull from the module.
+    from benchmark.tools import TOOL_REGISTRY  # pylint: disable=import-outside-toplevel
+
+    if candidate_tool_name not in TOOL_REGISTRY:
+        raise ValueError(
+            f"--candidate-tool '{candidate_tool_name}' is not registered in "
+            f"benchmark/tools.py TOOL_REGISTRY. Add a ToolSpec entry pointing "
+            f"at the candidate's module before running replay."
+        )
+    candidate_module = importlib.import_module(
+        TOOL_REGISTRY[candidate_tool_name].module
+    )
+
+    # Pull prompt templates from the candidate module per the baseline family's
+    # attribute schema. New-version tools must mirror the parent's symbols.
     if is_reasoning_tool:
-        from packages.napthaai.customs.prediction_request_reasoning.prediction_request_reasoning import (  # pylint: disable=import-outside-toplevel
-            PREDICTION_PROMPT,
-            REASONING_PROMPT,
-            SYSTEM_PROMPT,
-            parser_reasoning_response,
-        )
-
-        system_prompt = SYSTEM_PROMPT
+        PREDICTION_PROMPT = candidate_module.PREDICTION_PROMPT
+        REASONING_PROMPT = candidate_module.REASONING_PROMPT
+        parser_reasoning_response = candidate_module.parser_reasoning_response
+        system_prompt = candidate_module.SYSTEM_PROMPT
     elif is_rag_tool:
-        from packages.napthaai.customs.prediction_request_rag.prediction_request_rag import (  # pylint: disable=import-outside-toplevel
-            PREDICTION_PROMPT,
-            SYSTEM_PROMPT,
-        )
-
-        system_prompt = SYSTEM_PROMPT
+        PREDICTION_PROMPT = candidate_module.PREDICTION_PROMPT
+        system_prompt = candidate_module.SYSTEM_PROMPT
     elif is_superforcaster:
-        from packages.valory.customs.superforcaster.superforcaster import (  # pylint: disable=import-outside-toplevel
-            PREDICTION_PROMPT,
-        )
-
+        PREDICTION_PROMPT = candidate_module.PREDICTION_PROMPT
         system_prompt = "You are a helpful assistant."
     elif is_factual_research:
         # Replay only the ESTIMATE step; REFRAME + SYNTHESIS are upstream and
         # use cached evidence. ESTIMATE_USER takes (question, today, briefing).
-        from packages.valory.customs.factual_research.factual_research import (  # pylint: disable=import-outside-toplevel
-            ESTIMATE_SYSTEM,
-            ESTIMATE_USER,
-        )
-
-        PREDICTION_PROMPT = ESTIMATE_USER
-        system_prompt = ESTIMATE_SYSTEM
+        PREDICTION_PROMPT = candidate_module.ESTIMATE_USER
+        system_prompt = candidate_module.ESTIMATE_SYSTEM
     else:
-        from packages.valory.customs.prediction_request.prediction_request import (  # pylint: disable=import-outside-toplevel
-            PREDICTION_PROMPT,
-            SYSTEM_PROMPT_FORECASTER,
-        )
-
-        system_prompt = SYSTEM_PROMPT_FORECASTER
+        PREDICTION_PROMPT = candidate_module.PREDICTION_PROMPT
+        system_prompt = candidate_module.SYSTEM_PROMPT_FORECASTER
 
     if "claude" in model:
         api_key = os.environ.get("ANTHROPIC_API_KEY", "")
@@ -1662,6 +1674,20 @@ def main() -> None:
             "(default: prediction-only)"
         ),
     )
+    replay_parser.add_argument(
+        "--candidate-tool",
+        type=str,
+        default=None,
+        help=(
+            "Tool name whose code is replayed (default: same as the baseline "
+            "tool stamped on the enriched rows). Set this for new-version PRs "
+            "(e.g. baseline=superforcaster, candidate=superforcaster-v1) so "
+            "the candidate's code runs against the baseline's W-2 rows on the "
+            "same evidence + ground truth. Must be registered in "
+            "benchmark/tools.py TOOL_REGISTRY and mirror the baseline's "
+            "prompt-attribute schema."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1680,6 +1706,7 @@ def main() -> None:
             output_dir=args.output_dir,
             model=args.model,
             phase=args.phase,
+            candidate_tool=args.candidate_tool,
         )
 
 

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -56,6 +56,7 @@ from benchmark.datasets.fetch_production import (
     parse_tool_response,
 )
 from benchmark.io import load_jsonl
+from benchmark.tools import TOOL_REGISTRY
 
 # ---------------------------------------------------------------------------
 # Logging
@@ -1253,6 +1254,35 @@ def _replay_reasoning_tool(
 # ---------------------------------------------------------------------------
 
 
+def _baseline_family(tool_name: str) -> str:
+    """Classify a baseline tool by its prompt-attribute schema.
+
+    The replay path keys off this family to decide which symbols
+    (``PREDICTION_PROMPT`` / ``SYSTEM_PROMPT`` / ``ESTIMATE_USER`` / etc.)
+    to read from the candidate module. Widened from exact-name match so
+    ``-v<n+1>`` siblings (housekeeping default for ``p_yes``-shifting fixes)
+    route to the same family as their parent, and so tool families that
+    don't export ``SYSTEM_PROMPT_FORECASTER`` (superforcaster siblings,
+    prediction-url-cot, ``*-sme``) reach a branch that matches what their
+    module actually exposes.
+
+    :param tool_name: tool name from the enriched rows.
+    :return: one of ``"reasoning"``, ``"rag"``, ``"superforcaster"``,
+        ``"factual_research"``, ``"default"``.
+    """
+    if tool_name.startswith("prediction-request-reasoning"):
+        return "reasoning"
+    if tool_name.startswith("prediction-request-rag") or tool_name.startswith(
+        "prediction-url-cot"
+    ):
+        return "rag"
+    if tool_name.startswith("superforcaster") or tool_name.endswith("-sme"):
+        return "superforcaster"
+    if tool_name.startswith("factual_research"):
+        return "factual_research"
+    return "default"
+
+
 def replay(  # pylint: disable=too-many-statements,too-many-locals
     dataset: Path,
     output_dir: Path,
@@ -1301,21 +1331,26 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
     # meaningful Brier delta against the parent on the same evidence + ground
     # truth.
     candidate_tool_name = candidate_tool or tool_name
-    is_reasoning_tool = tool_name.startswith("prediction-request-reasoning")
-    is_rag_tool = tool_name.startswith("prediction-request-rag")
-    is_superforcaster = tool_name == "superforcaster"
-    is_factual_research = tool_name == "factual_research"
 
-    # Resolve the candidate's module via TOOL_REGISTRY so new-version tools get
-    # replay support without growing the if/elif cascade below — only the
-    # baseline's family decides which attribute names we pull from the module.
-    from benchmark.tools import TOOL_REGISTRY  # pylint: disable=import-outside-toplevel
+    family = _baseline_family(tool_name)
+    is_reasoning_tool = family == "reasoning"
+    is_rag_tool = family == "rag"
+    is_superforcaster = family == "superforcaster"
+    is_factual_research = family == "factual_research"
 
+    # Two registry checks split so the error message points at the right knob:
+    # the baseline comes from the enriched rows (no user-facing flag), the
+    # candidate comes from `--candidate-tool` (which may equal the baseline).
+    if tool_name not in TOOL_REGISTRY:
+        raise ValueError(
+            f"Baseline tool '{tool_name}' (from enriched rows) is not registered "
+            f"in benchmark/tools.py TOOL_REGISTRY."
+        )
     if candidate_tool_name not in TOOL_REGISTRY:
         raise ValueError(
             f"--candidate-tool '{candidate_tool_name}' is not registered in "
-            f"benchmark/tools.py TOOL_REGISTRY. Add a ToolSpec entry pointing "
-            f"at the candidate's module before running replay."
+            f"benchmark/tools.py TOOL_REGISTRY. Add a ToolSpec entry pointing at "
+            f"the candidate's module before running replay."
         )
     candidate_module = importlib.import_module(
         TOOL_REGISTRY[candidate_tool_name].module

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -7,7 +7,9 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
 from benchmark.prompt_replay import (
+    _baseline_family,
     _extract_factual_research_prompt_components,
     _load_and_filter_rows,
     _log_replay_summary,
@@ -337,3 +339,71 @@ class TestExtractFactualResearchPromptComponents:
         assert out["user_prompt"] == "Q?"
         assert out["today"] == "2026-04-22"
         assert out["additional_information"] == "B"
+
+
+class TestBaselineFamily:
+    """`_baseline_family` classifies a tool name to its prompt-attribute schema.
+
+    Direct unit test of the small pure helper the replay path uses to decide
+    which symbols (PREDICTION_PROMPT / SYSTEM_PROMPT / ESTIMATE_USER / ...)
+    to read from the candidate module. The widening from exact-name match
+    fixes the gap the #321 review flagged: previously several registered
+    tools fell into the `else` branch and crashed when their module didn't
+    export ``SYSTEM_PROMPT_FORECASTER``.
+    """
+
+    @pytest.mark.parametrize(
+        "tool_name,expected",
+        [
+            # Reasoning family (two-stage).
+            ("prediction-request-reasoning", "reasoning"),
+            ("prediction-request-reasoning-claude", "reasoning"),
+            # Rag family (PREDICTION_PROMPT + SYSTEM_PROMPT).
+            ("prediction-request-rag", "rag"),
+            ("prediction-request-rag-claude", "rag"),
+            # prediction-url-cot is rag-shaped — #321 review fix.
+            ("prediction-url-cot", "rag"),
+            ("prediction-url-cot-claude", "rag"),
+            # Superforcaster family (PREDICTION_PROMPT only).
+            ("superforcaster", "superforcaster"),
+            # Existing -polymarket-v1 sibling — #321 review fix; would
+            # previously fall to `else` and crash on SYSTEM_PROMPT_FORECASTER.
+            ("superforcaster-polymarket-v1", "superforcaster"),
+            # Hypothetical new-version siblings the housekeeping default
+            # produces: superforcaster -> superforcaster-v1 etc.
+            ("superforcaster-v1", "superforcaster"),
+            ("superforcaster-polymarket-v2", "superforcaster"),
+            # SME tools also export only PREDICTION_PROMPT — #321 review fix.
+            ("prediction-offline-sme", "superforcaster"),
+            ("prediction-online-sme", "superforcaster"),
+            # factual_research family (ESTIMATE_USER + ESTIMATE_SYSTEM).
+            ("factual_research", "factual_research"),
+            ("factual_research-v1", "factual_research"),
+            # Default family (PREDICTION_PROMPT + SYSTEM_PROMPT_FORECASTER).
+            ("prediction-online", "default"),
+            ("prediction-offline", "default"),
+            ("claude-prediction-online", "default"),
+            ("claude-prediction-offline", "default"),
+        ],
+    )
+    def test_classifies_registered_tools_to_their_actual_schema(
+        self, tool_name: str, expected: str
+    ) -> None:
+        """Registered tools route to the schema their module actually exports.
+
+        Covers the three tools the #321 review caught falling into the wrong
+        branch (superforcaster-polymarket-v1, prediction-url-cot, *-sme) plus
+        hypothetical ``-v<n+1>`` siblings the housekeeping default produces.
+
+        :param tool_name: tool name from the parametrize matrix.
+        :param expected: family the helper should classify ``tool_name`` to.
+        """
+        assert _baseline_family(tool_name) == expected
+
+    def test_unknown_tool_falls_to_default(self) -> None:
+        """Unknown names fall to the default family.
+
+        The existing ``else`` branch in replay() then handles them (or raises
+        on missing attributes downstream).
+        """
+        assert _baseline_family("totally-made-up-name") == "default"


### PR DESCRIPTION
## Why

Today `/benchmark <tool>` filters W-2 rows by `tool_name` AND imports the candidate code from the same tool's module. That works for in-place edits (same name, edited code) but blocks new-version PRs: any `p_yes`-changing fix must create a new tool (e.g. `superforcaster` → `superforcaster-v1`) per `CLAUDE.md`'s tool-improvement housekeeping rules, and a new tool has zero W-2 rows — so the cached replay can't produce a Brier delta against the parent.

## What

Add `--candidate-tool` to `benchmark.prompt_replay replay` (and to the benchmark-replay workflow's slash-command + `workflow_dispatch` inputs). When set, replay imports the candidate's code via `TOOL_REGISTRY` while still filtering W-2 by the baseline name. Same rows, same evidence, same ground truth — only the code producing `p_yes` differs.

Example:

    /benchmark superforcaster --sample 100 --candidate-tool superforcaster-v1

→ Brier delta = `superforcaster-v1` code's `p_yes` vs `superforcaster`'s recorded `p_yes`, on the same N rows. Default behavior (no flag) is unchanged: candidate defaults to the baseline (in-place edit path).

Also retires the 5-branch hardcoded `from packages...import` cascade in `replay()` — new prediction tools registered in `benchmark/tools.py:TOOL_REGISTRY` now get replay support for free, with the baseline's `tool_name` still deciding which attribute schema (`PREDICTION_PROMPT` / `ESTIMATE_USER` / `SYSTEM_PROMPT` / etc.) to read from the candidate module.

## Test plan

- [x] `benchmark/tests/` (880 tests) green
- [x] Lint pipeline (isort, black, flake8, mypy, pylint, darglint) clean on the changed files
- [ ] Existing `/benchmark <tool>` invocations on in-place-edit PRs still work (candidate defaults to baseline)
- [ ] `/benchmark <tool> --candidate-tool <new-tool>` produces a non-zero Brier delta when the candidate module differs from the baseline
- [ ] Invalid `--candidate-tool` name (not in `TOOL_REGISTRY`) raises with a clear error
- [ ] Shell-injection guard rejects malicious `--candidate-tool` names (same `[a-z0-9_-]+` whitelist as `--tool`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)