### PR TITLE
feat(benchmark): surface every active tournament candidate as a standings table

### DIFF
--- a/benchmark/analyze.py
+++ b/benchmark/analyze.py
@@ -2390,49 +2390,102 @@ def _scope_tournament_to_active(
     return {**tvm_scores, "by_tool_version_mode": kept}
 
 
+def _prod_comparison_cell(
+    tool: str,
+    cand_cid: str,
+    t_brier: float | None,
+    scores_prod: dict[str, Any],
+    rm: dict[str, Any],
+) -> str:
+    """Render the ``vs Production`` cell for one tournament candidate.
+
+    The production baseline is the latest-tagged production CID for the
+    same tool. The comparison is informational, **not** a gate: when no
+    such baseline exists the cell says so and the row is still rendered by
+    the caller (a new tool with no production predecessor must stay
+    visible). A non-trivial Brier delta is tagged 🟢 (tournament better by
+    at least ``CALLOUT_DELTA``) or 🔴 (worse by at least ``CALLOUT_DELTA``);
+    deltas inside the noise band are left untagged.
+
+    :param tool: runtime tool name.
+    :param cand_cid: the candidate's tournament CID.
+    :param t_brier: the candidate's tournament Brier, or None when it has
+        no resolved markets yet.
+    :param scores_prod: production scores dict.
+    :param rm: release map.
+    :return: a markdown cell string (no surrounding pipes).
+    """
+    prod_cid = _most_recent_prod_cid(tool, scores_prod, rm)
+    if prod_cid is None:
+        return "— no prod baseline"
+    if prod_cid == cand_cid:
+        # Candidate has rolled out; comparing a version against itself is
+        # eval-pipeline noise, not a promotion signal.
+        return "— rolled out"
+    prod_tvm = scores_prod.get("by_tool_version_mode", {})
+    p_stats = prod_tvm.get(f"{tool} | {prod_cid} | production_replay") or {}
+    p_brier = p_stats.get("brier")
+    if p_brier is None or t_brier is None:
+        return "— no prod data"
+    prod_label = release_map.resolve(prod_cid, rm)
+    delta = t_brier - p_brier
+    if delta <= -CALLOUT_DELTA:
+        tag = " 🟢"
+    elif delta >= CALLOUT_DELTA:
+        tag = " 🔴"
+    else:
+        tag = ""
+    return f"`{prod_label}` {p_brier:.4f} · Δ {delta:+.4f}{tag}"
+
+
 def section_tournament_callouts(
     scores_prod: dict[str, Any],
     scores_tournament: dict[str, Any] | None,
     release_map_data: dict[str, Any] | None = None,
     active_cids: set[str] | None = None,
 ) -> str:
-    """Flag tool versions whose tournament Brier diverges from prod.
+    """Tabulate every active tournament candidate, all-time.
 
-    A row qualifies when the absolute Brier delta exceeds
-    ``CALLOUT_DELTA``. Negative deltas become promotion candidates
-    (tournament better); positive deltas become tournament regressions
-    (tournament worse — a warning before the version reaches production).
+    One row per candidate CID still under tournament evaluation, sorted by
+    Brier (best first). Every active candidate is surfaced — a production
+    baseline to compare against is rendered when one exists, but its
+    absence does **not** hide the row. A brand-new tool with no production
+    predecessor (e.g. a tournament-only variant) still appears, ranked by
+    its Brier and its skill against the market baseline. This is
+    deliberate: new tools that could beat the incumbents must be visible
+    before they have a production counterpart.
 
-    Tournament is **not** sample-size gated when ``active_cids`` is
-    provided: a candidate's all-time record is shown from its very first
-    resolved market and grows each day, with rows below ``CALLOUT_MIN_N``
-    carrying a ``⚠ low data`` marker so the reader (and the Slack summary)
-    can weight them accordingly.
+    Per row:
 
-    When ``active_cids`` is ``None`` (scoping unavailable — e.g.
-    ``tournament_tools.json`` failed to load) the ``CALLOUT_MIN_N`` gate
-    is re-applied as a hard floor so the degraded path stays bounded:
-    without scoping AND without the gate, every long-inactive low-n CID
-    would surface. The pairing ensures fail-open mode is strictly
-    quieter (not noisier) than the scoped path.
+    - ``BSS vs mkt`` — the candidate's Brier skill score against the
+      market-implied baseline (carried on every tournament row), so a
+      no-prod tool still has a real comparator.
+    - ``vs Production`` — the candidate's Brier against the **latest-tagged
+      production CID** for the same tool, tagged 🟢 (better by at least
+      ``CALLOUT_DELTA``) or 🔴 (worse by at least ``CALLOUT_DELTA``), or
+      left untagged inside the noise band. Renders an em-dash note when no
+      production baseline exists or the candidate has already rolled out.
 
-    When ``active_cids`` is provided, only candidates still in the
-    tournament (CIDs in ``tournament_tools.json``) are considered; promoted
-    or dropped candidates fall off.
+    Sample size is surfaced, never gating: a candidate with fewer than
+    ``CALLOUT_MIN_N`` resolved markets carries a ``⚠`` marker so the reader
+    (and the Slack summary) can weight it as still-accumulating.
 
-    The production baseline is the **specific production CID with the
-    latest release tag** for the same tool — not the tool-level
-    aggregate. That way a rollout scenario (v2 partially in prod,
-    tournament evaluating v2) compares against the right thing and
-    doesn't get washed out by older versions' numbers.
+    When ``active_cids`` is provided, only candidates whose CID is in it
+    (i.e. still listed in ``tournament_tools.json``) appear; promoted or
+    dropped CIDs fall off. When ``active_cids`` is ``None`` (scoping
+    unavailable — e.g. ``tournament_tools.json`` failed to load) the
+    ``CALLOUT_MIN_N`` gate is re-applied as a hard floor so the degraded,
+    unscoped path stays bounded rather than listing every long-inactive
+    low-n CID.
 
     :param scores_prod: production scores dict.
     :param scores_tournament: tournament scores dict, or None.
     :param release_map_data: optional pre-loaded release map.
     :param active_cids: CIDs still under tournament evaluation, or None
         when scoping is unavailable (fail-open: re-arms the
-        ``CALLOUT_MIN_N`` gate to keep callout volume bounded).
-    :return: markdown section, or empty string when no callouts qualify.
+        ``CALLOUT_MIN_N`` gate to keep volume bounded).
+    :return: markdown table section, or empty string when no active
+        candidate qualifies.
     """
     if not _has_tournament_data(scores_tournament):
         return ""
@@ -2442,86 +2495,59 @@ def section_tournament_callouts(
 
     assert scores_tournament is not None  # narrowed by _has_tournament_data
     tournament_tvm = scores_tournament.get("by_tool_version_mode", {})
-    prod_tvm = (scores_prod or {}).get("by_tool_version_mode", {})
 
-    # Callout tuple layout:
-    #   tool, cand_cid, cand_label, t_stats, prod_cid, prod_label, p_stats
-    Callout = tuple[str, str, str, dict[str, Any], str, str, dict[str, Any]]
-    promotions: list[Callout] = []
-    regressions: list[Callout] = []
+    # Row layout: (sort_brier, tool, rendered_markdown_row).
+    rows: list[tuple[float, str, str]] = []
 
     for key, t_stats in tournament_tvm.items():
         tool, cand_cid, mode = _parse_tvm_key(key)
         if mode != "tournament":
             continue
         if active_cids is None:
-            # Fail-open: scoping unavailable, so re-arm the min-n gate
-            # to keep callout volume bounded (matches pre-PR behavior
-            # for the degraded path).
-            if t_stats.get("n", 0) < CALLOUT_MIN_N:
+            # Fail-open: scoping unavailable, so re-arm the min-n gate to
+            # keep volume bounded (degraded path stays strictly quieter).
+            if t_stats.get("valid_n", 0) < CALLOUT_MIN_N:
                 continue
         elif cand_cid not in active_cids:
             # Candidate no longer under tournament evaluation.
             continue
+
+        valid_n = t_stats.get("valid_n", 0)
         t_brier = t_stats.get("brier")
-        if t_brier is None:
-            continue
-
-        prod_cid = _most_recent_prod_cid(tool, scores_prod or {}, release_map_data)
-        if prod_cid is None:
-            # Tournament-only tool — no prod baseline to compare against.
-            continue
-        if cand_cid == prod_cid:
-            # Candidate has rolled out; comparing two samples of the same
-            # version is eval-pipeline noise, not a promotion signal.
-            continue
-        p_stats = prod_tvm.get(f"{tool} | {prod_cid} | production_replay") or {}
-        p_brier = p_stats.get("brier")
-        if p_brier is None:
-            continue
-
+        low = " ⚠" if valid_n < CALLOUT_MIN_N else ""
+        brier_str = f"{t_brier:.4f}" if t_brier is not None else "—"
+        bss = t_stats.get("brier_skill_score")
+        bss_str = f"{bss:+.3f}" if bss is not None else "—"
         cand_label = release_map.resolve(cand_cid, release_map_data)
-        prod_label = release_map.resolve(prod_cid, release_map_data)
-
-        delta = t_brier - p_brier
-        entry: Callout = (
-            tool,
-            cand_cid,
-            cand_label,
-            t_stats,
-            prod_cid,
-            prod_label,
-            p_stats,
+        prod_cell = _prod_comparison_cell(
+            tool, cand_cid, t_brier, scores_prod or {}, release_map_data
         )
-        if delta <= -CALLOUT_DELTA:
-            promotions.append(entry)
-        elif delta >= CALLOUT_DELTA:
-            regressions.append(entry)
 
-    if not promotions and not regressions:
+        row = (
+            f"| {tool} | `{cand_label}` | {valid_n}{low} | {brier_str}"
+            f" | {bss_str} | {prod_cell} |"
+        )
+        # None Brier (no resolved markets yet) sorts last.
+        sort_brier = t_brier if t_brier is not None else float("inf")
+        rows.append((sort_brier, tool, row))
+
+    if not rows:
         return ""
 
-    def _bullet(entry: Callout) -> str:
-        tool, _cand_cid, cand_label, t_stats, _prod_cid, prod_label, p_stats = entry
-        delta = t_stats["brier"] - p_stats["brier"]
-        low = " ⚠ low data" if t_stats["n"] < CALLOUT_MIN_N else ""
-        return (
-            f"- `{tool}` `{cand_label}` (tournament, n={t_stats['n']}){low} Brier"
-            f" {t_stats['brier']:.4f} vs `{prod_label}` (production,"
-            f" n={p_stats['n']}) Brier {p_stats['brier']:.4f}. Δ {delta:+.4f}."
-        )
+    rows.sort(key=lambda r: (r[0], r[1]))
 
-    lines = ["## Tournament Callouts", ""]
-    if promotions:
-        lines.append("**Promotion candidates:**")
-        lines.append("")
-        lines.extend(_bullet(e) for e in promotions)
-        lines.append("")
-    if regressions:
-        lines.append("**Tournament regressions:**")
-        lines.append("")
-        lines.extend(_bullet(e) for e in regressions)
-    return "\n".join(lines).rstrip()
+    lines = [
+        "## Tournament Callouts",
+        "",
+        "_All active tournament candidates, all-time. Sorted by Brier"
+        f" (best first). n = resolved markets; ⚠ = n < {CALLOUT_MIN_N}"
+        " (still accumulating)._",
+        "",
+        "| Tool | Version | n | Brier | BSS vs mkt | vs Production |",
+        "|------|---------|--:|------:|----------:|---------------|",
+    ]
+    lines.extend(row for _, _, row in rows)
+    return "\n".join(lines)
 
 
 def generate_report(  # pylint: disable=too-many-statements

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -95,7 +95,15 @@ Rules:
 - Only include rows where min(n_b, n_c) ≥ {VERSION_DELTA_LOW_SAMPLE_STRICT} and direction is "regressed" or "improved". Never include rows marked ⚠ — the flagged samples are too small to be reliable.
 - Skip this section entirely if the Version Deltas section is absent or has no rows without ⚠.
 
-*Tournament callouts:* If the report has a "Tournament Callouts" section, list each callout as a single bullet: tool name, release-tag labels for both tournament and production versions (in backticks, e.g. `v0.17.2` and `v0.17.0`), tournament Brier + n, production Brier + n, Brier Δ. Lead promotion candidates with "promotion candidate:" and tournament regressions with "watch:". Tournament callouts are never sample-gated, so include every bullet — but if a bullet carries a `⚠ low data` marker, append " (low data, still accumulating)" to that bullet so the reader knows the sample is small and growing; never drop a low-data callout. Skip this section entirely only if no Tournament Callouts section is present in the report.
+*Tournament callouts:* REQUIRED — whenever the report contains a "## Tournament Callouts" heading you MUST output this section in full; never omit, shorten, or merge it, even when every row is a plain "candidate:" with no production comparison. (The ONLY time you skip it is when the report has no "## Tournament Callouts" heading at all.) The heading introduces a standings table of every active tournament candidate (one row per tool/version) with columns Tool, Version, n (resolved markets), Brier, BSS vs mkt, and vs Production. Output exactly ONE bullet per table row — never sample-gate, never drop a candidate. Choose each bullet's prefix by reading that row's "vs Production" cell:
+- 🟢 tag (tournament beats production) → "promotion candidate:" — give the tool, both version labels in backticks (tournament and production), tournament Brier + n, and production Brier + Δ.
+- 🔴 tag (tournament worse than production) → "watch:" — same fields.
+- any other cell ("— no prod baseline", "— no prod data", or "— rolled out") → "candidate:" — give the tool, version in backticks, Brier + n, and BSS vs mkt, then append the "vs Production" note verbatim so the reader knows why there is no Δ.
+Before writing, count the table's data rows (N) and output EXACTLY N bullets — one per row, none dropped or truncated. First scan ALL rows for 🟢/🔴 tags: those promotion/watch rows are the highest-value and must never be omitted, even when they sit at the bottom of the table (the table is sorted by Brier, so a 🟢 row can be last). Order: promotion candidates (🟢) first, then watches (🔴), then the remaining "candidate:" rows sorted by BSS vs mkt descending — this is a re-ordering of the table, not the table's own row order. If a row's n carries a `⚠` marker, keep the bullet and append " (low data, still accumulating)".
+
+Examples (copy this style exactly):
+• promotion candidate: `superforcaster` (tournament `v0.20.0` vs production `v0.18.2`) — tournament Brier `0.1847` (n=47) vs production `0.2832`, Δ `-0.0985` improved
+• candidate: `factual_research` `untagged@bafybeib` — Brier `0.0896` (n=34), BSS vs mkt `+0.285` — no prod data
 
 *Diagnostics:*
 If the report has a "Diagnostics Historical Comparison" section, for each tool that carries at least one row with a signed delta (not `insufficient data`, not `no prev window`), summarize up to two metrics with the largest movement. Use format: • `tool` — `metric` Current {ROLLING_WINDOW_DAYS}d `X.XXXX` (n=X), Δ vs All-Time `±X.XXXX direction`, Δ vs Prev {ROLLING_WINDOW_DAYS}d `±X.XXXX direction`. Skip the section if no tool has a signed delta.
@@ -112,6 +120,7 @@ Rules:
 - Wrap tool names, Brier scores, and Edge scores in backticks.
 - Slack mrkdwn only: *bold* (single asterisk), `code`. No **double asterisks**.
 - No greetings or preamble.
+- The *Tournament callouts:* section is mandatory whenever a "## Tournament Callouts" heading appears in the report — output one bullet per table row and never drop the section, even on short reports or when no row has a 🟢/🔴 production tag.
 - Edge over market: positive = tool beats market, negative = market beats tool. Read it as a system-level diagnostic — tools are still ranked by Brier.
 - "Accuracy" in the report means "Directional Accuracy" — it excludes predictions at exactly 0.5 (no signal).
 - Log Loss: like Brier but punishes confidently-wrong predictions harder.

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -1604,7 +1604,7 @@ class TestScopeTournamentToActive:
 
 
 class TestTournamentCallouts:
-    """Tests for section_tournament_callouts."""
+    """Tests for section_tournament_callouts (active-candidate standings)."""
 
     def test_empty_when_no_tournament_data(self) -> None:
         """Missing tournament scores returns empty string."""
@@ -1612,113 +1612,153 @@ class TestTournamentCallouts:
         assert section_tournament_callouts(prod, None) == ""
         assert section_tournament_callouts(prod, {"total_rows": 0}) == ""
 
-    def test_promotion_candidate_flagged(self) -> None:
-        """Tournament Brier meaningfully lower than production triggers a promotion bullet."""
+    def test_renders_standings_table(self) -> None:
+        """An active candidate renders as a row under the table header."""
         prod = _scores_with_tool("tool-a", 0.20, 1000)
         tourn = _tournament_scores_with_version("tool-a", "v2", 0.10, 50)
-        result = section_tournament_callouts(prod, tourn)
-        assert "Promotion candidates:" in result
+        result = section_tournament_callouts(prod, tourn, active_cids={"v2"})
+        assert "## Tournament Callouts" in result
+        assert "| Tool | Version | n | Brier | BSS vs mkt | vs Production |" in result
         assert "tool-a" in result
         assert "v2" in result
-        assert "Tournament regressions:" not in result
-        # n=50 is above CALLOUT_MIN_N, so no low-data marker.
-        assert "⚠ low data" not in result
 
-    def test_tournament_regression_flagged(self) -> None:
-        """Tournament Brier meaningfully higher than production triggers a regression bullet."""
+    def test_better_than_prod_tagged_green(self) -> None:
+        """A candidate beating prod by >= CALLOUT_DELTA is tagged 🟢 with its Δ."""
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.10, 50)
+        result = section_tournament_callouts(prod, tourn, active_cids={"v2"})
+        assert "🟢" in result
+        assert "🔴" not in result
+        assert "Δ -0.1000" in result  # 0.10 (tournament) - 0.20 (prod)
+
+    def test_worse_than_prod_tagged_red(self) -> None:
+        """A candidate worse than prod by >= CALLOUT_DELTA is tagged 🔴."""
         prod = _scores_with_tool("tool-a", 0.20, 1000)
         tourn = _tournament_scores_with_version("tool-a", "v2", 0.40, 50)
-        result = section_tournament_callouts(prod, tourn)
-        assert "Tournament regressions:" in result
-        assert "Promotion candidates:" not in result
-
-    def test_low_n_callout_shown_with_marker(self) -> None:
-        """Low-n tournament cells are flagged with a marker when scoping is on.
-
-        Tournament is not sample-gated while ``active_cids`` is
-        provided: a candidate's record shows from its first resolved
-        market with a ``⚠ low data`` marker so the reader (and the
-        Slack summary) can weight it.
-        """
-        prod = _scores_with_tool("tool-a", 0.20, 1000)
-        tourn = _tournament_scores_with_version("tool-a", "v2", 0.05, 10)
         result = section_tournament_callouts(prod, tourn, active_cids={"v2"})
-        assert "Promotion candidates:" in result
-        assert "⚠ low data" in result
-        assert "n=10" in result
+        assert "🔴" in result
+        assert "🟢" not in result
 
-    def test_low_n_regression_shown_with_marker(self) -> None:
-        """The low-data marker is added on the regression path too.
+    def test_within_delta_band_row_shown_untagged(self) -> None:
+        """A within-noise candidate is still surfaced, just without a 🟢/🔴 tag.
 
-        Companion to the promotion case above. ``_bullet`` adds the
-        marker unconditionally for both lists; a future refactor that
-        moved it inside the promotion branch would leave low-n
-        regressions reading as reliable. Asserts the marker appears
-        under the ``Tournament regressions:`` heading specifically.
+        Behaviour change from the callouts-only design: every active
+        candidate appears, but a delta inside ``CALLOUT_DELTA`` carries no
+        promotion/regression signal. The old design returned "" here.
         """
-        prod = _scores_with_tool("tool-a", 0.20, 1000)
-        tourn = _tournament_scores_with_version("tool-a", "v2", 0.40, 10)
-        result = section_tournament_callouts(prod, tourn, active_cids={"v2"})
-        assert "Promotion candidates:" not in result
-        regressions_section = result.split("Tournament regressions:")[1]
-        assert "⚠ low data" in regressions_section
-        assert "n=10" in regressions_section
-
-    def test_fail_open_reapplies_min_n_gate(self) -> None:
-        """When active_cids is None, CALLOUT_MIN_N gates the callout.
-
-        Without scoping (e.g. tournament_tools.json failed to load) the
-        report must stay bounded: a low-n row that would otherwise be
-        flagged with ``⚠ low data`` is suppressed entirely so the
-        degraded path is strictly quieter, not noisier.
-        """
-        prod = _scores_with_tool("tool-a", 0.20, 1000)
-        tourn = _tournament_scores_with_version("tool-a", "v2", 0.05, 10)
-        # active_cids=None → min-n gate fires → empty.
-        assert section_tournament_callouts(prod, tourn, active_cids=None) == ""
-
-    def test_scoped_to_active_cids(self) -> None:
-        """Active-CID scoping drops inactive rows; None disables scoping.
-
-        Three cases pin the ``is not None`` semantics the loader
-        depends on — empty set must not be treated the same as None,
-        otherwise a flip to truthy checks (``if active_cids:``) would
-        silently change behavior.
-        """
-        prod = _scores_with_tool("tool-a", 0.20, 1000)
-        tourn = _tournament_scores_with_version("tool-a", "v2", 0.05, 50)
-        # v2 no longer under evaluation → dropped.
-        assert section_tournament_callouts(prod, tourn, active_cids=set()) == ""
-        # v2 active → flagged.
-        result_scoped = section_tournament_callouts(prod, tourn, active_cids={"v2"})
-        assert "Promotion candidates:" in result_scoped
-        # None disables scoping; n=50 ≥ CALLOUT_MIN_N so the row still
-        # surfaces under fail-open. Pins the empty-set ≠ None distinction.
-        result_unscoped = section_tournament_callouts(prod, tourn, active_cids=None)
-        assert "Promotion candidates:" in result_unscoped
-
-    def test_suppressed_within_delta_band(self) -> None:
-        """Tournament vs production deltas within CALLOUT_DELTA are not flagged."""
         prod = _scores_with_tool("tool-a", 0.20, 1000)
         tourn = _tournament_scores_with_version("tool-a", "v2", 0.21, 100)
-        assert section_tournament_callouts(prod, tourn) == ""
+        result = section_tournament_callouts(prod, tourn, active_cids={"v2"})
+        assert "tool-a" in result
+        assert "🟢" not in result
+        assert "🔴" not in result
 
-    def test_same_cid_on_both_sides_is_skipped(self) -> None:
-        """After rollout, tournament and production share a CID; don't flag noise.
+    def test_tournament_only_tool_surfaced_without_prod(self) -> None:
+        """A candidate with no production predecessor still appears.
 
-        ``_most_recent_prod_cid`` returns the latest-tagged prod CID.
-        Once the candidate has rolled out, ``cand_cid == prod_cid`` and
-        the loop compares two samples of the same version — sampling
-        noise alone can exceed ``CALLOUT_DELTA`` at small n. The section
-        must suppress this, otherwise the rollout fix promised by this
-        PR is itself a regression.
+        The core of the standings redesign: a brand-new tool that has
+        never reached production is ranked by Brier and its skill against
+        the market baseline, shown with a "no prod baseline" note instead
+        of being dropped (the old design skipped it entirely).
+        """
+        prod = _scores_with_tool("tool-a", 0.20, 1000)  # unrelated prod tool
+        tourn = _tournament_scores_with_version("tool-b", "vnew", 0.12, 60)
+        result = section_tournament_callouts(prod, tourn, active_cids={"vnew"})
+        assert "tool-b" in result
+        assert "no prod baseline" in result
+        # BSS-vs-market (0.1 from the builder) is still surfaced.
+        assert "+0.100" in result
+
+    def test_low_n_marked_not_gated(self) -> None:
+        """Low resolved-n candidates are surfaced with a ⚠ marker (scoped path)."""
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.05, 10)
+        result = section_tournament_callouts(prod, tourn, active_cids={"v2"})
+        assert "⚠" in result
+        assert "| 10 ⚠ |" in result
+
+    def test_no_resolved_markets_renders_dashes(self) -> None:
+        """A candidate with no resolved markets degrades Brier/BSS to em-dash."""
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = {
+            "total_rows": 5,
+            "overall": {},
+            "by_tool_version_mode": {
+                "tool-a | vpending | tournament": {
+                    "n": 5,
+                    "valid_n": 0,
+                    "brier": None,
+                    "brier_skill_score": None,
+                },
+            },
+        }
+        result = section_tournament_callouts(prod, tourn, active_cids={"vpending"})
+        assert "tool-a" in result
+        assert "| — |" in result  # Brier/BSS cells degrade, no crash
+
+    def test_rolled_out_candidate_noted_not_dropped(self) -> None:
+        """A candidate whose CID == latest prod CID shows "rolled out", still listed.
+
+        Same-version comparison is pipeline noise, so no Δ/tag is emitted,
+        but the candidate stays visible (it's still in tournament_tools.json).
+        The old design dropped this row entirely.
         """
         shared_cid = "cid_v2"
         prod = _scores_with_tool("tool-a", 0.20, 1000, prod_cid=shared_cid)
-        # Tournament cell uses the same CID; Brier diverges enough to
-        # trigger a promotion bullet if the same-CID guard is missing.
         tourn = _tournament_scores_with_version("tool-a", shared_cid, 0.10, 50)
-        assert section_tournament_callouts(prod, tourn) == ""
+        result = section_tournament_callouts(prod, tourn, active_cids={shared_cid})
+        assert "rolled out" in result
+        assert "🟢" not in result
+
+    def test_fail_open_reapplies_min_n_gate(self) -> None:
+        """When active_cids is None, the min-n gate suppresses low-n rows.
+
+        Without scoping (e.g. tournament_tools.json failed to load) the
+        report must stay bounded, so the degraded path drops a low-n row
+        that would otherwise carry a ⚠ marker.
+        """
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.05, 10)
+        assert section_tournament_callouts(prod, tourn, active_cids=None) == ""
+
+    def test_scoping_distinguishes_empty_set_from_none(self) -> None:
+        """Empty set scopes to nothing; None disables scoping (high-n survives).
+
+        Pins the ``is not None`` semantics — a flip to truthy checks
+        (``if active_cids:``) would collapse the two cases.
+        """
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = _tournament_scores_with_version("tool-a", "v2", 0.05, 50)
+        # Empty set → v2 not active → no rows.
+        assert section_tournament_callouts(prod, tourn, active_cids=set()) == ""
+        # v2 active → surfaced.
+        assert "tool-a" in section_tournament_callouts(prod, tourn, active_cids={"v2"})
+        # None → fail-open; n=50 ≥ CALLOUT_MIN_N so the row survives.
+        assert "tool-a" in section_tournament_callouts(prod, tourn, active_cids=None)
+
+    def test_sorted_by_brier_best_first(self) -> None:
+        """Multiple candidates are ordered by Brier ascending."""
+        prod = _scores_with_tool("tool-a", 0.20, 1000)
+        tourn = {
+            "total_rows": 100,
+            "overall": {},
+            "by_tool_version_mode": {
+                "tool-worse | cidw | tournament": {
+                    "n": 50,
+                    "valid_n": 50,
+                    "brier": 0.30,
+                    "brier_skill_score": -0.1,
+                },
+                "tool-best | cidb | tournament": {
+                    "n": 50,
+                    "valid_n": 50,
+                    "brier": 0.12,
+                    "brier_skill_score": 0.2,
+                },
+            },
+        }
+        result = section_tournament_callouts(prod, tourn, active_cids={"cidw", "cidb"})
+        assert result.index("tool-best") < result.index("tool-worse")
 
 
 class TestGenerateReportWithTournamentFiles:
@@ -1840,8 +1880,8 @@ class TestGenerateReportWithTournamentFiles:
         assert "v1" in report
         assert "v2" in report
 
-    def test_callout_section_included_when_triggered(self) -> None:
-        """Promotion-worthy tournament data causes the callouts section to render."""
+    def test_callout_section_included_when_candidate_present(self) -> None:
+        """Any active tournament candidate causes the standings section to render."""
         prod = _scores_with_tool("tool-a", 0.20, 1000)
         tourn = _tournament_scores_with_version("tool-a", "v2", 0.10, 50)
         report = generate_report(
@@ -1853,8 +1893,13 @@ class TestGenerateReportWithTournamentFiles:
         )
         assert "## Tournament Callouts" in report
 
-    def test_callout_section_omitted_when_empty(self) -> None:
-        """Tournament data present but within delta band -> no callout section."""
+    def test_within_band_candidate_still_listed(self) -> None:
+        """A within-delta candidate is now surfaced (untagged), not omitted.
+
+        Behaviour change: the standings view lists every active candidate,
+        so tournament data inside the noise band still renders the section
+        (the old callouts-only design omitted it).
+        """
         prod = _scores_with_tool("tool-a", 0.20, 1000)
         tourn = _tournament_scores_with_version("tool-a", "v2", 0.21, 100)
         report = generate_report(
@@ -1864,7 +1909,10 @@ class TestGenerateReportWithTournamentFiles:
             include_tournament=True,
             scores_tournament=tourn,
         )
-        assert "## Tournament Callouts" not in report
+        assert "## Tournament Callouts" in report
+        callouts = report.split("## Tournament Callouts", 1)[1].split("\n## ", 1)[0]
+        assert "🟢" not in callouts
+        assert "🔴" not in callouts
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

The tournament report section only emitted **promotion/regression callouts** — a candidate was shown only when it had a production CID to diff against *and* the Brier delta cleared `CALLOUT_DELTA`. Consequences:

- Tournament-only tools (`superforcaster_calibrated_full_search`, `superforcaster_full_search`) with no production predecessor were **dropped entirely**, so a new tool that could beat the incumbents stayed invisible until promoted.
- **Omenstrat rendered no tournament section at all** on runs where no candidate had a qualifying production diff.

This reworks the section into a **standings table of every active candidate** in `tournament_tools.json`, all-time, sorted by Brier. The production comparison becomes an annotation, not a gate.

## Changes

### `analyze.py`
- `section_tournament_callouts` now renders **one row per active candidate** (scoped to `tournament_tools.json`), sorted by Brier ascending.
- **Production comparison is informational, not a gate.** The `vs Production` cell is tagged 🟢 (tournament better by ≥ `CALLOUT_DELTA`) / 🔴 (worse by ≥ `CALLOUT_DELTA`) against the latest-tagged prod CID, or an em-dash note (`— no prod baseline` / `— no prod data` / `— rolled out`) when there's nothing to diff. A no-prod tool still appears, ranked by **BSS vs market** (carried on every tournament row).
- **Sample size is surfaced, never gating** — `⚠` marker on `n < CALLOUT_MIN_N` resolved markets. The fail-open path (`active_cids=None`) keeps the min-n floor so the unscoped degraded path stays bounded.
- New `_prod_comparison_cell` helper isolates the vs-Production logic.

### `notify_slack.py`
- Rewrote the `*Tournament callouts:*` prompt for the table: a **REQUIRED** mandate, per-row bullet labels (`promotion candidate:` / `watch:` / `candidate:`), copy-this examples, and a completeness guard (output N bullets; scan all rows for 🟢/🔴 first so a bottom-of-table promotion is never dropped).

### tests
- Rewrote `TestTournamentCallouts` for the table format: tournament-only surfacing, within-band untagged rows, rolled-out note, no-resolved-markets em-dashes, sort order, fail-open/empty-set scoping.
- Updated the two report-level cases whose behaviour flips from *omitted* to *listed*.

## Verification

Rendered against the latest scheduled `benchmark-flywheel` run (2026-06-05). Both platforms now show all 4 active candidates; Omenstrat previously had no tournament section. Lint clean (black, isort, flake8, mypy, pylint, darglint); **293** benchmark tests pass.

Slack `--dry-run` against the real summarizer (`gpt-4.1-mini`): when the section is emitted it is now complete and correctly ordered (promotion first, all rows present). **Known limitation:** the LLM still intermittently omits the whole section on short reports (~50% on Polystrat — pre-existing; the old single-bullet format dropped it 0/4). Prompt tuning has hit diminishing returns on *presence*; a follow-up to render the bullets deterministically in `notify_slack.py` would guarantee inclusion. Flagged for discussion, not included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)