### PR TITLE
tool-improvement(factual_research-v2): inject trader-forwarded Polymarket resolution rules

### DIFF
--- a/benchmark/runner.py
+++ b/benchmark/runner.py
@@ -23,6 +23,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import requests
 from benchmark.datasets.fetch_production import classify_category, parse_tool_response
 from benchmark.io import load_existing_ids as load_existing_row_ids
 from benchmark.io import load_jsonl as load_dataset
@@ -83,6 +84,7 @@ def run_single(
     model: str,
     api_keys: KeyChain,
     timeout: int = TASK_DEADLINE,
+    request_context: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run one tool on one question and return parsed result.
 
@@ -92,6 +94,9 @@ def run_single(
     :param model: LLM model identifier.
     :param api_keys: KeyChain with API credentials.
     :param timeout: per-tool timeout in seconds.
+    :param request_context: optional mech request_context dict (market_id,
+        type, …) mirroring what the trader sends in production. Forwarded to
+        tools that read it (e.g. factual_research-v2); omitted when None.
     :return: dict with p_yes, p_no, confidence, prediction_parse_status,
         latency_s, error.
     """
@@ -106,6 +111,8 @@ def run_single(
         "counter_callback": None,
         "delivery_rate": 100,
     }
+    if request_context is not None:
+        kwargs["request_context"] = request_context
 
     start = time.monotonic()
     use_alarm = _can_use_sigalrm()
@@ -158,6 +165,103 @@ def run_single(
 # ---------------------------------------------------------------------------
 # Build output row
 # ---------------------------------------------------------------------------
+
+
+POLYMARKET_GAMMA_URL = "https://gamma-api.polymarket.com"
+POLYMARKET_PLATFORM = "polymarket"
+GAMMA_TIMEOUT = 15
+
+
+def _fetch_polymarket_description(condition_id: str) -> str | None:
+    """Fetch a Polymarket market's resolution rules (Gamma ``description``).
+
+    The benchmark stands in for the trader here: in production the trader
+    fetches the resolution rules from Gamma and forwards them on the mech
+    request (trader PR #989), and ``factual_research-v2`` only reads them. To
+    reproduce that input under replay we fetch the same text by ``condition_id``
+    and return ONLY the description — never prices, volume, or liquidity.
+
+    Returns None on any failure (network error, non-200, no match, condition-id
+    mismatch, or an empty/missing description), exactly mirroring the tool's
+    production fallback to v1 behaviour.
+
+    :param condition_id: CTF condition id hex (``0x…``); a leading ``poly_``
+        prefix is stripped.
+    :return: the resolution-rules text, or None.
+    """
+    cid = condition_id.strip()
+    if cid.startswith("poly_"):
+        cid = cid[len("poly_") :]
+    if not cid:
+        return None
+
+    # Gamma's default query hides closed markets, so a resolved (benchmark)
+    # market needs closed=true; an open (production) market is returned by the
+    # default query. Try open first, then closed — the rules are identical.
+    for params in ({"condition_ids": cid}, {"condition_ids": cid, "closed": "true"}):
+        try:
+            resp = requests.get(
+                f"{POLYMARKET_GAMMA_URL}/markets",
+                params=params,
+                timeout=GAMMA_TIMEOUT,
+            )
+            if resp.status_code != 200:
+                continue
+            markets = resp.json()
+        except Exception as exc:  # noqa: BLE001 — any failure → degrade to v1
+            log.warning("Gamma description fetch failed for %s: %s", cid, exc)
+            continue
+
+        if not markets:
+            continue
+        market = markets[0] if isinstance(markets, list) else markets
+
+        # Only trust a response that echoes back the exact condition id asked
+        # for; a mismatch means the filter was ignored and the rules would
+        # belong to some other market.
+        returned_cid = str(market.get("conditionId", "")).lower()
+        if not returned_cid or returned_cid != cid.lower():
+            continue
+
+        description = (market.get("description") or "").strip()
+        if description:
+            return description
+
+    return None
+
+
+def build_request_context(dataset_row: dict[str, Any]) -> dict[str, Any] | None:
+    """Build a mech-style request_context from a dataset row.
+
+    Mirrors the trader's ``Bet.to_request_context()`` so tools that read it in
+    production (e.g. factual_research-v2) receive the same input under replay:
+    ``market_id`` + ``type``, plus the Polymarket resolution rules under
+    ``description`` (Omen rows carry none). The description is taken from the
+    row when present, else fetched from Gamma the way the trader would. NO
+    market price/liquidity is ever included — those tools must never see odds.
+    Returns None when the row lacks a market id or platform.
+
+    :param dataset_row: one dataset row with ``market_id`` and ``platform``
+        (optionally a pre-baked ``description``).
+    :return: request_context dict, or None.
+    """
+    market_id = dataset_row.get("market_id")
+    platform = dataset_row.get("platform")
+    if not market_id or not platform:
+        return None
+
+    context: dict[str, Any] = {"market_id": market_id, "type": platform}
+
+    if platform == POLYMARKET_PLATFORM:
+        # Prefer a pre-baked description (deterministic, offline); otherwise
+        # simulate the trader and fetch it from Gamma.
+        description = dataset_row.get("description") or _fetch_polymarket_description(
+            str(market_id)
+        )
+        if description:
+            context["description"] = description
+
+    return context
 
 
 def build_output_row(
@@ -277,6 +381,7 @@ def replay(
                     model=model,
                     api_keys=api_keys,
                     timeout=timeout,
+                    request_context=build_request_context(row),
                 )
 
                 output_row = build_output_row(row, tool_name, model, result)

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -565,7 +565,13 @@ _FAMILY_TEMPLATES = {
         ("PREDICTION_PROMPT", {"question": "q", "today": "t", "sources": "s"}),
     ],
     "factual_research": [
-        ("ESTIMATE_USER", {"question": "q", "today": "t", "briefing": "b"}),
+        # ``resolution_rules`` is required by factual_research-v2 (Polymarket
+        # rules block) and tolerated as an unused placeholder by the parent
+        # + v1 templates, so one fixture covers all three.
+        (
+            "ESTIMATE_USER",
+            {"question": "q", "today": "t", "briefing": "b", "resolution_rules": "r"},
+        ),
     ],
     "default": [
         ("PREDICTION_PROMPT", {"user_prompt": "q", "additional_information": "a"}),

--- a/benchmark/tests/test_runner.py
+++ b/benchmark/tests/test_runner.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Unit tests for benchmark/runner.py request_context construction.
+
+These cover the trader-simulation logic: building a mech-style request_context
+from a dataset row, including the Polymarket resolution-rules fetch that the
+benchmark performs in the trader's place (factual_research-v2 only reads the
+forwarded ``description``; it never contacts Polymarket).
+"""
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from benchmark.runner import _fetch_polymarket_description, build_request_context
+
+RUNNER = "benchmark.runner"
+
+# A Gamma `/markets` object. Deliberately carries price/volume/liquidity fields
+# so the tests can prove only the description is extracted — these are exactly
+# the "odds" the prediction tools must never see.
+FAKE_GAMMA_MARKET = {
+    "conditionId": "0xabc123",
+    "question": "Will X ship?",
+    "description": "RULES_SENTINEL: resolves YES if X ships before 2026-01-01.",
+    "endDate": "2026-01-01T00:00:00Z",
+    "outcomePrices": '["0.82", "0.18"]',
+    "lastTradePrice": 0.82,
+    "volume": "1234567",
+    "liquidity": "98765",
+}
+
+_PRICE_TOKENS = (
+    "0.82",
+    "0.18",
+    "outcomePrices",
+    "lastTradePrice",
+    "volume",
+    "liquidity",
+    "1234567",
+    "98765",
+)
+
+
+def _mock_gamma_response(status: int = 200, payload: Any = None) -> MagicMock:
+    """Build a mock requests.Response for a Gamma query."""
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = [] if payload is None else payload
+    return resp
+
+
+class TestFetchPolymarketDescription:
+    """Tests for _fetch_polymarket_description — the trader-simulation fetch."""
+
+    @patch(f"{RUNNER}.requests.get")
+    def test_extracts_only_description(self, mock_get: MagicMock) -> None:
+        """A successful fetch returns ONLY the description text, no prices."""
+        mock_get.return_value = _mock_gamma_response(payload=[FAKE_GAMMA_MARKET])
+
+        out = _fetch_polymarket_description("0xABC123")
+
+        assert out == FAKE_GAMMA_MARKET["description"]
+        for token in _PRICE_TOKENS:
+            assert token not in out
+
+    @patch(f"{RUNNER}.requests.get")
+    def test_strips_poly_prefix_before_query(self, mock_get: MagicMock) -> None:
+        """A `poly_` prefix is stripped so Gamma gets the bare condition id."""
+        mock_get.return_value = _mock_gamma_response(payload=[FAKE_GAMMA_MARKET])
+
+        _fetch_polymarket_description("poly_0xabc123")
+
+        assert mock_get.call_args.kwargs["params"]["condition_ids"] == "0xabc123"
+
+    @patch(f"{RUNNER}.requests.get")
+    def test_condition_id_mismatch_returns_none(self, mock_get: MagicMock) -> None:
+        """A response echoing a different conditionId is rejected."""
+        wrong = dict(FAKE_GAMMA_MARKET, conditionId="0xdeadbeef")
+        mock_get.return_value = _mock_gamma_response(payload=[wrong])
+
+        assert _fetch_polymarket_description("0xabc123") is None
+
+    @patch(f"{RUNNER}.requests.get")
+    def test_empty_description_returns_none(self, mock_get: MagicMock) -> None:
+        """A market with no resolution text yields None."""
+        nodesc = dict(FAKE_GAMMA_MARKET, description="")
+        mock_get.return_value = _mock_gamma_response(payload=[nodesc])
+
+        assert _fetch_polymarket_description("0xabc123") is None
+
+    @patch(f"{RUNNER}.requests.get")
+    def test_non_200_returns_none(self, mock_get: MagicMock) -> None:
+        """A non-200 status degrades to None."""
+        mock_get.return_value = _mock_gamma_response(
+            status=503, payload=[FAKE_GAMMA_MARKET]
+        )
+
+        assert _fetch_polymarket_description("0xabc123") is None
+
+    @patch(f"{RUNNER}.requests.get")
+    def test_network_error_returns_none(self, mock_get: MagicMock) -> None:
+        """A raised request exception degrades to None, never propagates."""
+        mock_get.side_effect = Exception("boom")
+
+        assert _fetch_polymarket_description("0xabc123") is None
+
+    @patch(f"{RUNNER}.requests.get")
+    def test_falls_back_to_closed_query(self, mock_get: MagicMock) -> None:
+        """An empty open-market result retries with closed=true (resolved)."""
+        mock_get.side_effect = [
+            _mock_gamma_response(payload=[]),  # open query → nothing
+            _mock_gamma_response(payload=[FAKE_GAMMA_MARKET]),  # closed → hit
+        ]
+
+        out = _fetch_polymarket_description("0xabc123")
+
+        assert out == FAKE_GAMMA_MARKET["description"]
+        assert mock_get.call_count == 2
+        assert mock_get.call_args_list[0].kwargs["params"].get("closed") is None
+        assert mock_get.call_args_list[1].kwargs["params"].get("closed") == "true"
+
+
+class TestBuildRequestContext:
+    """Tests for build_request_context — dataset row → mech request_context."""
+
+    def test_returns_none_without_market_id(self) -> None:
+        """A row missing the market id yields no context."""
+        assert build_request_context({"platform": "polymarket"}) is None
+
+    def test_returns_none_without_platform(self) -> None:
+        """A row missing the platform yields no context."""
+        assert build_request_context({"market_id": "0xabc"}) is None
+
+    @patch(f"{RUNNER}._fetch_polymarket_description")
+    def test_omen_carries_id_and_type_no_fetch(self, mock_fetch: MagicMock) -> None:
+        """An Omen row gets id + type only and never hits Gamma."""
+        ctx = build_request_context({"market_id": "0xfpmm", "platform": "omen"})
+
+        assert ctx == {"market_id": "0xfpmm", "type": "omen"}
+        mock_fetch.assert_not_called()
+
+    @patch(f"{RUNNER}._fetch_polymarket_description")
+    def test_polymarket_prefers_prebaked_description(
+        self, mock_fetch: MagicMock
+    ) -> None:
+        """A row carrying a description uses it and skips the network."""
+        ctx = build_request_context(
+            {
+                "market_id": "0xabc",
+                "platform": "polymarket",
+                "description": "pre-baked rules",
+            }
+        )
+
+        assert ctx == {
+            "market_id": "0xabc",
+            "type": "polymarket",
+            "description": "pre-baked rules",
+        }
+        mock_fetch.assert_not_called()
+
+    @patch(f"{RUNNER}._fetch_polymarket_description")
+    def test_polymarket_fetches_when_absent(self, mock_fetch: MagicMock) -> None:
+        """A polymarket row without a description fetches it by market_id."""
+        mock_fetch.return_value = "fetched rules"
+
+        ctx = build_request_context({"market_id": "0xabc", "platform": "polymarket"})
+
+        assert ctx == {
+            "market_id": "0xabc",
+            "type": "polymarket",
+            "description": "fetched rules",
+        }
+        mock_fetch.assert_called_once_with("0xabc")
+
+    @patch(f"{RUNNER}._fetch_polymarket_description")
+    def test_polymarket_omits_description_when_fetch_fails(
+        self, mock_fetch: MagicMock
+    ) -> None:
+        """A failed fetch leaves the context without a description (v1 fallback)."""
+        mock_fetch.return_value = None
+
+        ctx = build_request_context({"market_id": "0xabc", "platform": "polymarket"})
+
+        assert ctx == {"market_id": "0xabc", "type": "polymarket"}

--- a/benchmark/tools.py
+++ b/benchmark/tools.py
@@ -84,6 +84,10 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
     "factual_research-v1": ToolSpec(
         module="packages.valory.customs.factual_research_v1.factual_research_v1",
     ),
+    # valory/factual_research_v2
+    "factual_research-v2": ToolSpec(
+        module="packages.valory.customs.factual_research_v2.factual_research_v2",
+    ),
     # nickcom007/prediction_request_sme
     "prediction-offline-sme": ToolSpec(
         module="packages.nickcom007.customs.prediction_request_sme.prediction_request_sme",

--- a/benchmark/tournament_tools.json
+++ b/benchmark/tournament_tools.json
@@ -1,7 +1,7 @@
 {
   "factual_research": "bafybeib7askinfzv5yolxxqojbqnmpygrg3lbxnwc77grr3nzuopha5era",
   "factual_research-v1": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
-  "factual_research-v2": "bafybeieggijzfxddrxkmot5t2ycn5jqvdioib7eaxcg6dy4nrog7vgdxji",
+  "factual_research-v2": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
   "superforcaster": "bafybeic2ziubkeyjq6syiqcs2bq7o5og3n62q6c2fnvv2oysczpnjdl56m",
   "superforcaster_full_search": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
   "superforcaster_calibrated_full_search": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe"

--- a/benchmark/tournament_tools.json
+++ b/benchmark/tournament_tools.json
@@ -1,6 +1,7 @@
 {
   "factual_research": "bafybeib7askinfzv5yolxxqojbqnmpygrg3lbxnwc77grr3nzuopha5era",
   "factual_research-v1": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
+  "factual_research-v2": "bafybeidzquaagyfnermmi6qcgdtq7bwxzvnp37mnpvboj53hl3cdcgkeju",
   "superforcaster": "bafybeic2ziubkeyjq6syiqcs2bq7o5og3n62q6c2fnvv2oysczpnjdl56m",
   "superforcaster_full_search": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
   "superforcaster_calibrated_full_search": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe"

--- a/benchmark/tournament_tools.json
+++ b/benchmark/tournament_tools.json
@@ -1,7 +1,7 @@
 {
   "factual_research": "bafybeib7askinfzv5yolxxqojbqnmpygrg3lbxnwc77grr3nzuopha5era",
   "factual_research-v1": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
-  "factual_research-v2": "bafybeidzquaagyfnermmi6qcgdtq7bwxzvnp37mnpvboj53hl3cdcgkeju",
+  "factual_research-v2": "bafybeieggijzfxddrxkmot5t2ycn5jqvdioib7eaxcg6dy4nrog7vgdxji",
   "superforcaster": "bafybeic2ziubkeyjq6syiqcs2bq7o5og3n62q6c2fnvv2oysczpnjdl56m",
   "superforcaster_full_search": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
   "superforcaster_calibrated_full_search": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe"

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -20,6 +20,7 @@
         "custom/valory/superforcaster_calibrated_full_search/0.1.0": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
         "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeiawfhy3w5aclmxm5zxebwd5l7paseqlgmihwbqfyhcdpn2kccgtrq",
         "custom/valory/factual_research_v1/0.1.0": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
+        "custom/valory/factual_research_v2/0.1.0": "bafybeidzquaagyfnermmi6qcgdtq7bwxzvnp37mnpvboj53hl3cdcgkeju",
         "agent/valory/mech_predict/0.1.0": "bafybeidln7xkyowihe4co6wqqjgk4atd5ys54cukpzzvny2ftt6wsfbzjm",
         "service/valory/mech_predict/0.1.0": "bafybeidqstj6s6oa7put2ew4chwpbod5a5ogxce2qtdwuxpxuc4kan3su4"
     },

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -20,7 +20,7 @@
         "custom/valory/superforcaster_calibrated_full_search/0.1.0": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
         "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeiawfhy3w5aclmxm5zxebwd5l7paseqlgmihwbqfyhcdpn2kccgtrq",
         "custom/valory/factual_research_v1/0.1.0": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
-        "custom/valory/factual_research_v2/0.1.0": "bafybeidzquaagyfnermmi6qcgdtq7bwxzvnp37mnpvboj53hl3cdcgkeju",
+        "custom/valory/factual_research_v2/0.1.0": "bafybeieggijzfxddrxkmot5t2ycn5jqvdioib7eaxcg6dy4nrog7vgdxji",
         "agent/valory/mech_predict/0.1.0": "bafybeidln7xkyowihe4co6wqqjgk4atd5ys54cukpzzvny2ftt6wsfbzjm",
         "service/valory/mech_predict/0.1.0": "bafybeidqstj6s6oa7put2ew4chwpbod5a5ogxce2qtdwuxpxuc4kan3su4"
     },

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -20,7 +20,7 @@
         "custom/valory/superforcaster_calibrated_full_search/0.1.0": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
         "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeiawfhy3w5aclmxm5zxebwd5l7paseqlgmihwbqfyhcdpn2kccgtrq",
         "custom/valory/factual_research_v1/0.1.0": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
-        "custom/valory/factual_research_v2/0.1.0": "bafybeieggijzfxddrxkmot5t2ycn5jqvdioib7eaxcg6dy4nrog7vgdxji",
+        "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "agent/valory/mech_predict/0.1.0": "bafybeidln7xkyowihe4co6wqqjgk4atd5ys54cukpzzvny2ftt6wsfbzjm",
         "service/valory/mech_predict/0.1.0": "bafybeidqstj6s6oa7put2ew4chwpbod5a5ogxce2qtdwuxpxuc4kan3su4"
     },

--- a/packages/valory/customs/factual_research_v2/__init__.py
+++ b/packages/valory/customs/factual_research_v2/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2024-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the Factual Research tool."""

--- a/packages/valory/customs/factual_research_v2/component.yaml
+++ b/packages/valory/customs/factual_research_v2/component.yaml
@@ -14,7 +14,7 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibrhuo2o5tu43vxc7a7uvniee52emt2erbmc32r4krcftc2gm3h2q
-  factual_research_v2.py: bafybeidtv6caw74bffgo4vqjvuxdbq6g57ednz5cuy4vrzlorz66rdcczm
+  factual_research_v2.py: bafybeigm2vjv6dnsumuogfd4dr25xvt5q5vfg3ty7ffgkqp3pj5ljazdqa
   tests/__init__.py: bafybeibu5izhcixkot5uv2k6uwj736qcpvdbepyk2ardyrhhc6vmhvgwnu
   tests/test_factual_research.py: bafybeifttpfzt7ouj7jippvjblwotjpdqsc6dxq47ozmwerxsculjxua44
 fingerprint_ignore_patterns: []

--- a/packages/valory/customs/factual_research_v2/component.yaml
+++ b/packages/valory/customs/factual_research_v2/component.yaml
@@ -14,9 +14,9 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeibrhuo2o5tu43vxc7a7uvniee52emt2erbmc32r4krcftc2gm3h2q
-  factual_research_v2.py: bafybeigm2vjv6dnsumuogfd4dr25xvt5q5vfg3ty7ffgkqp3pj5ljazdqa
+  factual_research_v2.py: bafybeiam63jkt7r6en33q6whib5dj4qth7xyengmkgxsbt4p737m7xo72e
   tests/__init__.py: bafybeibu5izhcixkot5uv2k6uwj736qcpvdbepyk2ardyrhhc6vmhvgwnu
-  tests/test_factual_research.py: bafybeifttpfzt7ouj7jippvjblwotjpdqsc6dxq47ozmwerxsculjxua44
+  tests/test_factual_research.py: bafybeibqb67w3aprzqoniuwndeidnjr67eowhn3wyc2mqt6njxds2hib2a
 fingerprint_ignore_patterns: []
 entry_point: factual_research_v2.py
 callable: run

--- a/packages/valory/customs/factual_research_v2/component.yaml
+++ b/packages/valory/customs/factual_research_v2/component.yaml
@@ -1,0 +1,39 @@
+name: factual_research_v2
+author: valory
+version: 0.1.0
+type: custom
+description: A tool for making binary predictions on markets. Returns the standard
+  mech prediction output (p_yes, p_no, confidence, info_utility). Variant of factual_research-v1
+  that, for Polymarket markets, reads the resolution rules the trader forwards in
+  the request context (request_context.description) and injects them into the reframe
+  and estimate stages, so sub-questions and the probability target the exact resolution
+  criteria. Only the resolution rules are used - no price/odds/volume is ever forwarded
+  - the tool never contacts Polymarket itself, and it falls back to v1 behaviour when
+  no resolution rules are present.
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  __init__.py: bafybeibrhuo2o5tu43vxc7a7uvniee52emt2erbmc32r4krcftc2gm3h2q
+  factual_research_v2.py: bafybeidtv6caw74bffgo4vqjvuxdbq6g57ednz5cuy4vrzlorz66rdcczm
+  tests/__init__.py: bafybeibu5izhcixkot5uv2k6uwj736qcpvdbepyk2ardyrhhc6vmhvgwnu
+  tests/test_factual_research.py: bafybeifttpfzt7ouj7jippvjblwotjpdqsc6dxq47ozmwerxsculjxua44
+fingerprint_ignore_patterns: []
+entry_point: factual_research_v2.py
+callable: run
+params:
+  default_model: gpt-4.1-2025-04-14
+dependencies:
+  openai:
+    version: ==1.93.0
+  tiktoken:
+    version: ==0.12.0
+  pydantic:
+    version: '>=2.0.0,<3.0.0'
+  requests:
+    version: ==2.32.5
+  readability-lxml:
+    version: ==0.8.1
+  lxml_html_clean:
+    version: ==0.4.4
+  markdownify:
+    version: ==1.2.2

--- a/packages/valory/customs/factual_research_v2/factual_research_v2.py
+++ b/packages/valory/customs/factual_research_v2/factual_research_v2.py
@@ -640,9 +640,11 @@ def _search_serper(
 
 # Maximum words to keep per scraped page
 _MAX_PAGE_WORDS = 400
-# Maximum words to keep from trader-forwarded Polymarket resolution rules;
-# mech requests are permissionless so this cap must hold regardless of caller.
-_MAX_RESOLUTION_RULES_WORDS = 500
+# Maximum characters to keep from trader-forwarded Polymarket resolution rules.
+# Matches the trader's MAX_REQUEST_CONTEXT_DESCRIPTION_LEN (5000, trader #989) so
+# honest within-limit rules are never clipped; the cap only bites the
+# permissionless path, where a requester can bypass the trader's bound entirely.
+_MAX_RESOLUTION_RULES_CHARS = 5000
 # Image / junk patterns to strip from HTML before extraction
 _IMG_TAG_PATTERN = re.compile(r"<img[^>]*>", re.IGNORECASE)
 _SCRIPT_STYLE_PATTERN = re.compile(
@@ -789,9 +791,8 @@ def _extract_resolution_rules(request_context: Any) -> Optional[str]:
     description = description.strip()
     if not description:
         return None
-    words = description.split()
-    if len(words) > _MAX_RESOLUTION_RULES_WORDS:
-        description = " ".join(words[:_MAX_RESOLUTION_RULES_WORDS]) + " [...]"
+    if len(description) > _MAX_RESOLUTION_RULES_CHARS:
+        description = description[:_MAX_RESOLUTION_RULES_CHARS] + " […]"
     return description
 
 

--- a/packages/valory/customs/factual_research_v2/factual_research_v2.py
+++ b/packages/valory/customs/factual_research_v2/factual_research_v2.py
@@ -1,0 +1,1142 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2024-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Factual Research tool — edge generation via narrow factual inquiry.
+
+Philosophy
+----------
+Mechs produce *edges*, not predictions.  This tool answers narrow, factual
+questions by gathering verifiable evidence from the open web and returning
+cited, state-of-the-world facts.  A downstream (non-mech) layer converts
+facts into a probability — the mech itself never sees prices, odds, or
+"likelihood".
+
+Pipeline (3 structured-output LLM calls):
+    1. **Reframe** — decompose the incoming prompt into narrow, verifiable,
+       factual sub-questions with date anchors.
+    2. **Gather** — web-search each sub-question via Serper; blocked domains
+       (Polymarket, Twitter/X, prediction sites) are excluded.
+    3. **Synthesise** — produce a factual briefing that answers each
+       sub-question with citations.
+    4. **Estimate** — a *separate* LLM call converts the factual briefing
+       into the standard ``{p_yes, p_no, confidence, info_utility}`` output
+       required by the mech protocol.
+
+What v2 adds over factual_research-v1
+-------------------------------------
+For Polymarket markets, the mech request carries a ``request_context`` dict
+(built by the trader) whose ``description`` field holds the market's
+**resolution rules** — the authoritative criteria for how the market resolves
+YES/NO. The trader fetches that text from the Gamma API and forwards it on the
+request (see trader PR #989); v2 simply READS it and injects it into the
+**Reframe** step (so sub-questions target the exact resolution criteria) and the
+**Estimate** step (so the probability maps to the real resolution condition
+rather than a loose reading of the question).
+
+The tool itself never contacts Polymarket — fetching is the trader's job — so no
+price/odds/volume signal can leak in: the trader forwards only the resolution
+text, preserving the "facts, not odds" philosophy. v2 degrades to exact v1
+behaviour whenever no resolution rules are present (Omen markets, which omit the
+field, or any request without a ``description``).
+
+All LLM calls use OpenAI **Structured Outputs**
+(``client.beta.chat.completions.parse``) with Pydantic models, so responses
+are guaranteed to conform to the expected schema — no fragile JSON-in-prompt
+parsing needed.
+
+Hard guardrails (enforced in every system prompt for steps 1-3):
+    • Never output a probability in the research phase.
+    • Never reference prices, odds, or betting lines.
+    • Never search Polymarket, Twitter/X, or prediction sites.
+    • Only report verifiable, cited facts.
+"""
+
+import functools
+import json
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import openai
+import requests
+from markdownify import markdownify as md
+from openai import OpenAI
+from pydantic import BaseModel, Field, model_validator
+from readability import Document as ReadabilityDocument
+from tiktoken import encoding_for_model
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas for OpenAI Structured Outputs
+# ---------------------------------------------------------------------------
+
+
+class SubQuestions(BaseModel):
+    """Output of the reframing step — narrow factual sub-questions."""
+
+    sub_questions: List[str] = Field(
+        ...,
+        description=(
+            "3-6 narrow, verifiable, factual sub-questions derived from the "
+            "original prompt.  Cover current status, competitors, historical "
+            "base rates, expert signals, obstacles, and timelines where relevant.  "
+            "No predictions or probabilities."
+        ),
+    )
+
+
+class SourceReference(BaseModel):
+    """A single cited source."""
+
+    title: str = Field(..., description="Title of the source article or page.")
+    url: str = Field(..., description="URL of the source.")
+
+
+class SubAnswer(BaseModel):
+    """A factual answer to one sub-question, with sources."""
+
+    question: str = Field(..., description="The factual sub-question that was asked.")
+    answer: str = Field(
+        ...,
+        description=(
+            "The factual answer supported by evidence.  "
+            "Say 'Insufficient evidence' if the evidence is lacking."
+        ),
+    )
+    sources: List[SourceReference] = Field(
+        default_factory=list,
+        description="Up to 2 sources that support the answer.",
+        max_length=2,
+    )
+
+
+class FactualBriefing(BaseModel):
+    """Output of the synthesis step — cited factual answers + summary."""
+
+    sub_answers: List[SubAnswer] = Field(
+        ...,
+        description="Concise factual answers for each sub-question (1-3 sentences each).",
+    )
+    summary: str = Field(
+        ...,
+        description=(
+            "A 3-6 sentence factual summary synthesising the key "
+            "state-of-the-world facts relevant to the original question.  "
+            "No predictions or probabilities."
+        ),
+    )
+    sources: List[SourceReference] = Field(
+        default_factory=list,
+        description="Most relevant sources relied upon (max 6).",
+        max_length=6,
+    )
+    info_utility: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="How useful the gathered evidence was (0 = useless, 1 = highly useful).",
+    )
+
+
+class PredictionResult(BaseModel):
+    """Standard mech prediction output — p_yes, p_no, confidence, info_utility + reasoning."""
+
+    reasoning: str = Field(
+        ...,
+        description=(
+            "Step-by-step reasoning that explains the probability estimate.  "
+            "Reference specific facts from the briefing.  Mention base rates, "
+            "key risk factors, and competing signals.  2-4 paragraphs."
+        ),
+    )
+    p_yes: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Estimated probability that the event occurs.",
+    )
+    p_no: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Estimated probability that the event does NOT occur.",
+    )
+    confidence: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Confidence in the prediction (0 = lowest, 1 = highest).",
+    )
+    info_utility: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Utility of the information gathered to inform the prediction.",
+    )
+
+    @model_validator(mode="after")
+    def _check_p_yes_p_no_sum(self) -> "PredictionResult":
+        """Validate that p_yes + p_no ≈ 1."""
+        if abs(self.p_yes + self.p_no - 1.0) > 0.01:
+            raise ValueError(
+                f"p_yes + p_no must equal 1 (got {self.p_yes} + {self.p_no} = "
+                f"{self.p_yes + self.p_no})"
+            )
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Mech-protocol types
+# ---------------------------------------------------------------------------
+
+MechResponseWithKeys = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]], Any
+]
+MechResponse = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]]
+]
+MaxCostResponse = float
+
+# 3 LLM calls: reframe → synthesise → estimate
+N_MODEL_CALLS = 3
+DEFAULT_DELIVERY_RATE = 100
+
+
+# ---------------------------------------------------------------------------
+# Key-rotation decorator (same pattern as other mech tools)
+# ---------------------------------------------------------------------------
+
+
+def with_key_rotation(func: Callable) -> Callable:
+    """Decorator that retries a function with API key rotation on failure."""
+
+    @functools.wraps(func)
+    def wrapper(
+        *args: Any, **kwargs: Any
+    ) -> Union[MaxCostResponse, MechResponseWithKeys]:
+        api_keys = kwargs["api_keys"]
+        retries_left: Dict[str, int] = api_keys.max_retries()
+
+        def execute() -> Union[MaxCostResponse, MechResponseWithKeys]:
+            """Retry the function with a new key."""
+            try:
+                result = func(*args, **kwargs)
+                # Max-cost path returns a float; pass through without
+                # appending api_keys (tuple concatenation would fail).
+                if isinstance(result, float):
+                    return result
+                return result + (api_keys,)
+            except (
+                openai.RateLimitError,
+                openai.AuthenticationError,
+                openai.PermissionDeniedError,
+            ) as e:
+                # Rotate on rate limits AND on auth/permission failures: a revoked
+                # key is as unusable as a throttled one, and rotating it out is
+                # the decorator's whole job.
+                if retries_left["openai"] <= 0 and retries_left["openrouter"] <= 0:
+                    raise e
+                retries_left["openai"] -= 1
+                retries_left["openrouter"] -= 1
+                api_keys.rotate("openai")
+                api_keys.rotate("openrouter")
+                return execute()
+            except Exception as e:
+                error_json = json.dumps(
+                    {
+                        "p_yes": None,
+                        "p_no": None,
+                        "confidence": 0.0,
+                        "info_utility": 0.0,
+                        "error": str(e),
+                    }
+                )
+                return error_json, "", None, None, None, api_keys
+
+        return execute()
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
+# OpenAI client helpers
+# ---------------------------------------------------------------------------
+
+
+class OpenAIClientManager:
+    """Context manager that creates and closes a local OpenAI client."""
+
+    def __init__(self, api_key: str):
+        """Initializes with API key."""
+        self.api_key = api_key
+        self._client: Optional[OpenAI] = None
+
+    def __enter__(self) -> OpenAI:
+        """Initializes and returns the OpenAI client."""
+        self._client = OpenAI(api_key=self.api_key)
+        return self._client
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Closes the OpenAI client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+
+def count_tokens(text: str, model: str) -> int:
+    """Count the number of tokens in *text* for the given *model*."""
+    try:
+        enc = encoding_for_model(model)
+    except KeyError:
+        from tiktoken import get_encoding
+
+        enc = get_encoding("o200k_base")
+    return len(enc.encode(text))
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_OPENAI_SETTINGS = {
+    "max_tokens": 2000,
+    "limit_max_tokens": 8192,
+    "temperature": 0,
+}
+DEFAULT_OPENAI_MODEL = "gpt-4.1-2025-04-14"
+ALLOWED_TOOLS = ["factual_research-v2"]
+ALLOWED_MODELS = [DEFAULT_OPENAI_MODEL]
+COMPLETION_RETRIES = 3
+COMPLETION_DELAY = 2
+
+# Domains that must never appear in search queries or results.
+BLOCKED_DOMAINS = [
+    "polymarket.com",
+    "twitter.com",
+    "x.com",
+    "predictit.org",
+    "metaculus.com",
+    "manifold.markets",
+    "kalshi.com",
+    "betfair.com",
+    "smarkets.com",
+    "oddschecker.com",
+    "bovada.lv",
+]
+
+
+# ---------------------------------------------------------------------------
+# Prompt templates
+# ---------------------------------------------------------------------------
+#
+# factual_research-v1 hypothesis (issue #314): on earnings/revenue-threshold
+# markets the estimate stage anchored p_yes on a STALE prior-period figure
+# carried in the briefing (e.g. Dell ISG $10.3B / HPE Cloud&AI $6.3B, both a
+# year old) and collapsed to a confident wrong NO, ignoring the forward/current
+# evidence (raised guidance, YoY growth, segment expansion) present in the same
+# briefing. The freshness guard below (SYNTHESIS_USER figure-period preservation
+# + ESTIMATE_SYSTEM/ESTIMATE_USER STEP 0 resolution-period freshness check)
+# disrupts that anchoring at the gate-visible estimate stage.
+
+REFRAME_SYSTEM = (
+    "You are a factual-research assistant. You decompose questions into "
+    "narrow, verifiable, factual sub-questions. You NEVER predict, estimate "
+    "probabilities, or reference prediction markets, odds, or prices."
+)
+
+REFRAME_USER = """Decompose the following question into narrow, verifiable, factual sub-questions.
+
+RULES
+1. Strip any "will … happen?" phrasing. Replace it with objective status checks:
+   - "Has X completed milestone Y as of today?"
+   - "What are the remaining steps / failure modes for X?"
+   - "List objective milestones remaining before date D."
+2. Each sub-question must be answerable with publicly verifiable facts.
+3. Add a date anchor ("as of {today}") wherever useful.
+4. Cover DIVERSE angles so the downstream estimator sees a full picture.
+   Consider these categories (use whichever are relevant):
+   A. Current status — what has already happened or been announced?
+   B. Competing alternatives / rival actors — who else could win or block this?
+   C. Historical base rates — how often do events like this succeed/fail?
+   D. Expert or official signals — what have credible authorities said?
+   E. Remaining obstacles or risk factors — what could still derail or enable this?
+   F. Timeline & deadlines — what key dates constrain the outcome?
+5. Output between 3 and 6 sub-questions. Prefer more when the topic is complex.
+
+INPUT QUESTION:
+\"\"\"{question}\"\"\"
+{resolution_rules}
+Today's date: {today}
+"""
+
+SYNTHESIS_SYSTEM = (
+    "You are a factual-research analyst. You answer questions using ONLY "
+    "verifiable, cited evidence. You NEVER output probabilities, predictions, "
+    "or reference prediction markets, odds, or prices."
+)
+
+SYNTHESIS_USER = """Produce a factual briefing that answers each sub-question below using the gathered evidence.
+
+ORIGINAL QUESTION:
+\"\"\"{question}\"\"\"
+
+SUB-QUESTIONS:
+{sub_questions}
+
+Today's date: {today}
+
+EVIDENCE GATHERED:
+{evidence}
+
+INSTRUCTIONS:
+1. For each sub-question, write a CONCISE factual answer (1-3 sentences max).
+   - If evidence is insufficient, say "Insufficient evidence".
+   - Explicitly note when *expected evidence is missing* (e.g. no official filing, no confirmation, no action).
+   - Cite at most 2 sources per sub-answer.
+2. Write a Factual Summary (2-4 sentences) synthesising the key state-of-the-world facts.
+   - Report what is verifiably true *and what has not yet happened*.
+   - Do NOT predict outcomes or imply likelihood.
+3. List only the most relevant sources (max 6 total).
+4. Rate how useful the evidence was (info_utility, 0-1).
+   - High info_utility means the evidence is informative, not that it supports success.
+5. Be concise throughout — every token counts.
+6. Attach the as-of period to EVERY numeric figure you report (the quarter/year the
+   figure actually measures, not the date it was published) — e.g.
+   "Cloud & AI revenue was $6.3B [Q1 FY2026]". When the question concerns a later
+   period, also report the most recent forward guidance / growth rate for that period.
+   NEVER present a prior-period figure as if it were the current or resolving period's value.
+"""
+
+ESTIMATE_SYSTEM = """You are an expert probability estimator. You receive a factual briefing and must convert it into a calibrated probability estimate.
+Your performance is evaluated by the Brier score.
+
+Calibration rules:
+• Figure freshness (MANDATORY for quantitative threshold questions): every figure has an as-of period (the quarter/year it measures). Match it against the period the question resolves on before using it. A figure from an EARLIER period than the question resolves on is STALE — it describes a trend, not the resolving value. Never compare a stale prior-period figure against the threshold and collapse to a confident tail; that is the single biggest source of overconfident misses. For a not-yet-reported metric, project forward from the latest baseline using the growth signals in the briefing (raised guidance, year-over-year growth, segment expansion, order backlog) — these are genuine signals on "above threshold" markets, not noise.
+• Absence of expected evidence is a NO signal ONLY when that evidence would normally exist by now given the event's timeline. For future-dated events where the deadline is still weeks or months out, absence of recent news is neutral, not negative — the normal state of the world is "nothing has happened yet".
+• High info_utility does NOT imply high probability.
+• Multi-step processes involving institutions, politics, or coordination rarely justify extreme probabilities.
+• You cannot compensate for low confidence by pushing probabilities to the extremes. Uncertainty must be expressed in the probability itself, near the base rate.
+
+Tail discipline (SYMMETRIC — applies equally to YES and NO extremes):
+• Probabilities above 90% or below 10% require evidence that the opposing outcome is effectively eliminated (e.g. explicit disqualification, deadline already missed, confirmed announcement).
+• Probabilities above 80% or below 20% require strong historical precedents under similar conditions.
+• When confidence is low, extreme probabilities are rarely justified.
+• If you find yourself tempted to output p_yes < 0.05 or p_yes > 0.95 on a future event with any remaining path to the other outcome, step back toward the base rate.
+"""
+
+ESTIMATE_USER = """Relying exclusively on the factual briefing provided below, assess the probability that the event in the original question will occur.
+
+ORIGINAL QUESTION:
+\"\"\"{question}\"\"\"
+{resolution_rules}
+Today's date: {today}
+
+FACTUAL BRIEFING:
+{briefing}
+
+INSTRUCTIONS:
+
+STEP 0 — Resolution-period freshness check (MANDATORY for any quantitative threshold)
+a. State the exact period the question resolves on (e.g. "Q1 FY2027", "the quarter ending May 2026", "calendar 2026").
+b. For EVERY numeric figure in the briefing you might use, write its own as-of period — the quarter/year the figure measures, not the date it was published.
+c. Label a figure STALE if its as-of period predates the question's resolution period. A prior-period figure is NOT the value the question resolves on; never treat last quarter's or last year's number as the current one.
+d. If the resolving figure is not yet reported (a forecasting task), do NOT anchor on the stale figure. Project it forward from the most recent baseline using the growth signals in the briefing (raised guidance, year-over-year growth, segment expansion, backlog). Treat the stale figure as the trend's starting point, not the answer — and do not emit a confident NO on an "above threshold" market merely because a stale figure sits below the threshold.
+
+STEP 1 — Base rate anchor (MANDATORY)
+a. Identify the event category (e.g. regulatory approval, election outcome, product launch, treaty, court decision).
+b. State an explicit base-rate probability for events of this type.
+   - Use historical data if available.
+   - If not, use a conservative implied base rate and justify it.
+c. This base rate is your starting point.
+
+STEP 2 — Evidence evaluation
+a. List the key YES signals (facts that materially increase probability).
+b. List the key NO signals, including:
+   - Explicit negative evidence
+   - Missing evidence that would normally be expected by this stage
+c. Weigh signal strength relative to the base rate.
+   - Weak, procedural, or intention-based evidence should cause only small updates.
+
+STEP 3 — Synthesis
+a. Update from the base rate IN PROPORTION to the strength of your evidence.
+   - Weak, procedural, or intention-based signals: update by at most ±0.10 from the base rate.
+   - One strong signal: update by at most ±0.20.
+   - Multiple independent strong signals pointing the same way: update further, but see Step 4.
+b. If evidence is mixed or thin, stay close to the base rate.
+c. "No recent news about a future event" is NOT itself strong evidence against it.
+d. Do NOT collapse to extreme tails (<0.1 or >0.9) without MULTIPLE INDEPENDENT STRONG signals.
+e. Do NOT default away from uncertainty without justification.
+
+STEP 4 — Output constraints
+• p_yes + p_no must equal 1.
+• Tail caps are SYMMETRIC: treat p_yes < 0.10 with the same burden of proof as p_yes > 0.90.
+• If confidence < 0.5, probabilities above 70% or below 30% require strong justification.
+• If confidence < 0.3, probabilities should remain within [0.2, 0.8].
+• It is valid for info_utility to be high while p_yes is extreme in EITHER direction — but extreme + high-confidence requires multiple independent strong signals.
+
+OUTPUT:
+1. Provide detailed reasoning (2-4 paragraphs).
+2. Then output p_yes, p_no, confidence, and info_utility.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Structured-output completion helper
+# ---------------------------------------------------------------------------
+
+
+def _parse_completion(
+    client: OpenAI,
+    model: str,
+    messages: List[Dict[str, str]],
+    response_format: Any,
+    temperature: float = 0,
+    max_tokens: int = 2000,
+    retries: int = COMPLETION_RETRIES,
+    delay: int = COMPLETION_DELAY,
+    counter_callback: Optional[Callable] = None,
+) -> Tuple[Any, Optional[Callable]]:
+    """Call OpenAI with Structured Outputs and parse into a Pydantic model.
+
+    Uses ``client.beta.chat.completions.parse()`` which guarantees the
+    response conforms to the supplied Pydantic schema — no fragile
+    JSON-in-prompt parsing or regex extraction needed.
+
+    :param client: The OpenAI client instance.
+    :type client: OpenAI
+    :param model: The OpenAI model name to use.
+    :type model: str
+    :param messages: List of message dicts with 'role' and 'content' keys.
+    :type messages: List[Dict[str, str]]
+    :param response_format: Pydantic model class for structured output parsing.
+    :type response_format: Any
+    :param temperature: Sampling temperature (0 = deterministic).
+    :type temperature: float
+    :param max_tokens: Maximum tokens to generate in the completion.
+    :type max_tokens: int
+    :param retries: Number of retry attempts on failure.
+    :type retries: int
+    :param delay: Delay in seconds between retries.
+    :type delay: int
+    :param counter_callback: Optional callback for tracking token usage.
+    :type counter_callback: Optional[Callable]
+
+    :return: Tuple of (parsed_model_instance, counter_callback).
+    :rtype: Tuple[Any, Optional[Callable]]
+    """
+
+    attempt = 0
+    while attempt < retries:
+        try:
+            response = client.beta.chat.completions.parse(
+                model=model,
+                messages=messages,
+                response_format=response_format,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                timeout=150,
+            )
+
+            parsed = response.choices[0].message.parsed
+
+            if parsed is None:
+                refusal = response.choices[0].message.refusal
+                raise ValueError(
+                    f"Model refused or returned unparseable output: {refusal}"
+                )
+
+            if counter_callback is not None:
+                counter_callback(
+                    input_tokens=response.usage.prompt_tokens,
+                    output_tokens=response.usage.completion_tokens,
+                    model=model,
+                    token_counter=count_tokens,
+                )
+
+            return parsed, counter_callback
+        except (
+            openai.APIConnectionError,
+            openai.RateLimitError,
+            openai.InternalServerError,
+            ValueError,
+        ) as e:
+            # Retry only transient failures and model-side issues:
+            #   - APIConnectionError (includes APITimeoutError) — network blips
+            #   - RateLimitError / InternalServerError — OpenAI-side retryable
+            #   - ValueError — covers pydantic ValidationError (e.g. p_yes+p_no
+            #     sum check) and the inline "Model refused…" raise above
+            # Programming bugs (AttributeError, KeyError, BadRequestError, etc.)
+            # are intentionally not caught so they surface immediately.
+            print(f"[factual_research] Attempt {attempt + 1} failed: {e}")
+            time.sleep(delay)
+            attempt += 1
+
+    raise RuntimeError("Failed to get structured LLM completion after retries")
+
+
+# ---------------------------------------------------------------------------
+# Web-search helpers (Serper API)
+# ---------------------------------------------------------------------------
+
+
+def _search_serper(
+    query: str, api_key: str, num_results: int = 5
+) -> List[Dict[str, str]]:
+    """Run a Google search via Serper; results from blocked domains are dropped."""
+    url = "https://google.serper.dev/search"
+    payload = {"q": query}
+    headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
+
+    response = requests.post(url, headers=headers, json=payload, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    results: List[Dict[str, str]] = []
+    for item in data.get("organic", []):
+        link = item.get("link", "")
+        if any(blocked in link for blocked in BLOCKED_DOMAINS):
+            continue
+        results.append(
+            {
+                "title": item.get("title", ""),
+                "link": link,
+                "snippet": item.get("snippet", ""),
+            }
+        )
+        if len(results) >= num_results:
+            break
+
+    # Also grab "People Also Ask" snippets if present
+    for paa in data.get("peopleAlsoAsk", []):
+        link = paa.get("link", "")
+        if any(blocked in link for blocked in BLOCKED_DOMAINS):
+            continue
+        results.append(
+            {
+                "title": paa.get("question", ""),
+                "link": link,
+                "snippet": paa.get("snippet", ""),
+            }
+        )
+
+    return results
+
+
+# Maximum words to keep per scraped page
+_MAX_PAGE_WORDS = 400
+# Image / junk patterns to strip from HTML before extraction
+_IMG_TAG_PATTERN = re.compile(r"<img[^>]*>", re.IGNORECASE)
+_SCRIPT_STYLE_PATTERN = re.compile(
+    r"<(script|style|noscript)[^>]*>.*?</\1>", re.IGNORECASE | re.DOTALL
+)
+
+
+def _clean_html(html: str, max_words: int = _MAX_PAGE_WORDS) -> Optional[str]:
+    """Extract main text from HTML via readability + markdownify.
+
+    :param html: Raw HTML string.
+    :type html: str
+    :param max_words: Maximum number of words to keep.
+    :type max_words: int
+
+    :return: Cleaned text content, or None on failure.
+    :rtype: Optional[str]
+    """
+    cleaned = _SCRIPT_STYLE_PATTERN.sub("", html)
+    cleaned = _IMG_TAG_PATTERN.sub("", cleaned)
+    article_html = ReadabilityDocument(cleaned).summary()
+    text = md(article_html, heading_style="ATX", strip=["img", "figure"])
+    if not text or not text.strip():
+        return None
+    words = text.split()
+    if len(words) > max_words:
+        text = " ".join(words[:max_words]) + " […]"
+    return text.strip()
+
+
+def _fetch_page_content(
+    url: str,
+    mode: str = "cleaned",
+    max_words: int = _MAX_PAGE_WORDS,
+    timeout: int = 10,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Fetch a URL and return (cleaned_text, raw_or_cleaned_for_capture).
+
+    :param url: The URL to fetch.
+    :type url: str
+    :param mode: ``"cleaned"`` stores extracted text; ``"raw"`` stores HTML.
+    :type mode: str
+    :param max_words: Maximum number of words to keep.
+    :type max_words: int
+    :param timeout: Request timeout in seconds.
+    :type timeout: int
+
+    :return: Tuple of (cleaned text for pipeline, content to store for replay).
+    :rtype: Tuple[Optional[str], Optional[str]]
+    """
+    try:
+        resp = requests.get(
+            url,
+            timeout=timeout,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; MechBot/1.0)"},
+        )
+        if resp.status_code != 200:
+            return None, None
+        content_type = resp.headers.get("Content-Type", "")
+        if "text/html" not in content_type:
+            return None, None
+
+        html = resp.text
+        text = _clean_html(html, max_words=max_words)
+        if not text:
+            return None, None
+
+        capture = html if mode == "raw" else text
+        return text, capture
+    except Exception as e:
+        print(f"[factual_research] Failed to fetch {url}: {e}")
+        return None, None
+
+
+def _format_evidence(all_results: List[Dict[str, str]]) -> str:
+    """Turn search-result dicts into a numbered evidence block."""
+    if not all_results:
+        return "(no evidence gathered)"
+    lines: List[str] = []
+    for idx, item in enumerate(all_results, 1):
+        content = item.get("content", "")
+        if content:
+            lines.append(
+                f"{idx}. [{item['title']}]({item['link']})\n"
+                f"   Snippet: {item['snippet']}\n"
+                f"   Content: {content}"
+            )
+        else:
+            lines.append(
+                f"{idx}. [{item['title']}]({item['link']})\n" f"   {item['snippet']}"
+            )
+    return "\n\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Prompt extraction helper
+# ---------------------------------------------------------------------------
+
+
+def _extract_question(prompt: str) -> str:
+    """Extract the core question from the mech prompt envelope."""
+    pattern = r'question\s+"(.+?)"\s+and\s+the\s+`yes`'
+    try:
+        return re.findall(pattern, prompt, re.DOTALL)[0]
+    except (IndexError, TypeError):
+        return prompt.strip()
+
+
+# ---------------------------------------------------------------------------
+# Resolution-rules helpers
+# ---------------------------------------------------------------------------
+#
+# The mech request for a Polymarket market carries a ``request_context`` dict
+# (built by the trader's ``Bet.to_request_context()``) whose ``description``
+# field holds the market's resolution rules. The trader fetches that text from
+# the Gamma API and forwards it on the request (trader PR #989); the tool simply
+# reads it. Omen requests omit the field, so they degrade to v1 behaviour.
+#
+# Only the resolution *rules* ever reach an LLM — the trader forwards no
+# price/odds/volume signal, so none can leak into the research or estimate
+# prompts.
+
+
+def _extract_resolution_rules(request_context: Any) -> Optional[str]:
+    """Read the resolution rules the trader passed in the request context.
+
+    The trader fetches a Polymarket market's resolution description and forwards
+    it as ``request_context["description"]`` (Omen requests omit the field).
+    Returns the stripped rules text, or ``None`` when the context is missing,
+    not a dict, or carries no usable description — so the caller degrades to
+    exact v1 behaviour.
+
+    :param request_context: The ``request_context`` kwarg from the mech request.
+    :type request_context: Any
+
+    :return: The resolution-rules text, or ``None``.
+    :rtype: Optional[str]
+    """
+    if not isinstance(request_context, dict):
+        return None
+    description = request_context.get("description")
+    if not isinstance(description, str):
+        return None
+    description = description.strip()
+    return description or None
+
+
+def _format_resolution_block(description: Optional[str]) -> str:
+    """Render resolution rules into a prompt block.
+
+    :param description: Resolution-rules text from
+        :func:`_extract_resolution_rules`.
+    :type description: Optional[str]
+
+    :return: A prompt-ready block, or "" when no rules are present.
+    :rtype: str
+    """
+    if not description:
+        return ""
+    return (
+        "\nMARKET RESOLUTION RULES (the authoritative criteria for how this "
+        f'market resolves YES vs NO):\n"""{description}"""\n'
+        "Treat these rules as the precise definition of what counts as a YES "
+        "resolution; align your work with this exact condition, not a loose "
+        "reading of the question.\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry-point
+# ---------------------------------------------------------------------------
+
+
+@with_key_rotation
+def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
+    """Run the Factual Research tool.
+
+    Pipeline
+    --------
+    1. Reframe the incoming prompt into narrow factual sub-questions
+       (structured output → ``SubQuestions``).
+    2. Search the web for each sub-question via Serper (no prediction sites).
+    3. Synthesise a cited factual briefing from the evidence
+       (structured output → ``FactualBriefing``).
+    4. Convert the factual briefing into the standard mech prediction format
+       (structured output → ``PredictionResult``).
+
+    :param kwargs: Keyword arguments including 'tool', 'model', 'prompt',
+        'api_keys', 'delivery_rate', 'counter_callback', 'temperature'.
+    :type kwargs: Any
+
+    :return: Either max_cost (float) if delivery_rate==0, or MechResponse tuple
+        (result_json, full_prompt, None, counter_callback).
+    :rtype: Union[MaxCostResponse, MechResponse]
+    """
+    tool = kwargs["tool"]
+    if tool not in ALLOWED_TOOLS:
+        raise ValueError(f"Tool {tool} is not supported.")
+
+    model = kwargs.get("model")
+    if model is None:
+        raise ValueError("Model not supplied.")
+
+    delivery_rate = int(kwargs.get("delivery_rate", DEFAULT_DELIVERY_RATE))
+    counter_callback: Optional[Callable[..., Any]] = kwargs.get(
+        "counter_callback", None
+    )
+
+    if delivery_rate == 0:
+        if not counter_callback:
+            raise ValueError(
+                "A delivery rate of `0` was passed, but no counter callback "
+                "was given to calculate the max cost with."
+            )
+        max_cost = counter_callback(
+            max_cost=True,
+            models_calls=(model,) * N_MODEL_CALLS,
+        )
+        return max_cost
+
+    # -- API keys --
+    openai_api_key = kwargs["api_keys"]["openai"]
+    source_content: Optional[Dict[str, Any]] = kwargs.get("source_content", None)
+    return_source_content = (
+        kwargs["api_keys"].get("return_source_content", "false") == "true"
+    )
+    source_content_mode = kwargs["api_keys"].get("source_content_mode", "cleaned")
+    if source_content_mode not in ("cleaned", "raw"):
+        raise ValueError(
+            f"Invalid source_content_mode: {source_content_mode!r}. "
+            "Must be 'cleaned' or 'raw'."
+        )
+
+    with OpenAIClientManager(openai_api_key) as llm_client:
+        temperature = kwargs.get("temperature", DEFAULT_OPENAI_SETTINGS["temperature"])
+        prompt = kwargs["prompt"]
+
+        today = date.today().strftime("%Y-%m-%d")
+        question = _extract_question(prompt)
+
+        # ---------------------------------------------------------------
+        # Step 0 — Polymarket resolution rules (v2 evidence source)
+        # ---------------------------------------------------------------
+        # For Polymarket markets the trader fetches the resolution rules and
+        # forwards them in request_context["description"]; we read them (never
+        # prices) and inject them into the reframe + estimate prompts.
+        # Non-Polymarket / missing → "" → exact v1 behaviour.
+        resolution_description = _extract_resolution_rules(
+            kwargs.get("request_context")
+        )
+        resolution_rules = _format_resolution_block(resolution_description)
+        if resolution_description:
+            print(
+                "[factual_research] Loaded Polymarket resolution rules "
+                f"({len(resolution_description)} chars)."
+            )
+
+        # ---------------------------------------------------------------
+        # Step 1 — Reframe into factual sub-questions  (Structured Output)
+        # ---------------------------------------------------------------
+        print("[factual_research] Step 1: Reframing prompt into factual sub-questions…")
+        reframe_messages = [
+            {"role": "system", "content": REFRAME_SYSTEM},
+            {
+                "role": "user",
+                "content": REFRAME_USER.format(
+                    question=question, today=today, resolution_rules=resolution_rules
+                ),
+            },
+        ]
+
+        sub_q_result: SubQuestions
+        sub_q_result, counter_callback = _parse_completion(
+            client=llm_client,
+            model=model,
+            messages=reframe_messages,
+            response_format=SubQuestions,
+            temperature=0,
+            max_tokens=600,
+            counter_callback=counter_callback,
+        )
+
+        sub_questions = sub_q_result.sub_questions
+        if not sub_questions:
+            sub_questions = [question]
+
+        print(f"[factual_research] Sub-questions: {sub_questions}")
+
+        # ---------------------------------------------------------------
+        # Step 2 — Search the web for each sub-question
+        # ---------------------------------------------------------------
+        print("[factual_research] Step 2: Searching for evidence…")
+        all_evidence: List[Dict[str, str]] = []
+        seen_links: set = set()
+
+        captured_source_content: Dict[str, Any] = {}
+
+        if source_content is not None:
+            # Cached replay mode: use pre-fetched content instead of live search
+            print("[factual_research] Using provided source_content (cached replay).")
+            captured_source_content = source_content
+            for item in source_content.get("serper_results", []):
+                all_evidence.append(item)
+            # Attach scraped page content from cache
+            mode = source_content.get("mode", "cleaned")
+            pages = source_content.get("pages", {})
+            for ev in all_evidence:
+                cached = pages.get(ev["link"])
+                if cached is None:
+                    continue
+                if mode == "raw":
+                    text = _clean_html(cached)
+                    if text:
+                        ev["content"] = text
+                else:
+                    ev["content"] = cached
+        else:
+            serper_api_key = kwargs["api_keys"]["serperapi"]
+            with ThreadPoolExecutor(max_workers=6) as pool:
+                futures = {
+                    pool.submit(_search_serper, sq, serper_api_key, num_results=3): sq
+                    for sq in sub_questions
+                }
+                for fut in as_completed(futures):
+                    sq = futures[fut]
+                    try:
+                        for r in fut.result():
+                            if r["link"] not in seen_links:
+                                seen_links.add(r["link"])
+                                all_evidence.append(r)
+                    except Exception as e:
+                        print(f"[factual_research] Search failed for '{sq}': {e}")
+
+            # Snapshot serper results before scraping mutates items
+            serper_results_snapshot = [
+                {k: v for k, v in ev.items() if k != "content"} for ev in all_evidence
+            ]
+
+            # Scrape actual page content for the top results
+            MAX_PAGES_TO_SCRAPE = 6
+            captured_pages: Dict[str, str] = {}
+            items_to_scrape = all_evidence[:MAX_PAGES_TO_SCRAPE]
+            with ThreadPoolExecutor(max_workers=6) as pool:
+                future_to_item = {
+                    pool.submit(
+                        _fetch_page_content,
+                        item["link"],
+                        mode=source_content_mode,
+                    ): item
+                    for item in items_to_scrape
+                }
+                scraped = 0
+                for scrape_fut in as_completed(future_to_item):
+                    item = future_to_item[scrape_fut]
+                    try:
+                        text, capture = scrape_fut.result()
+                        if text:
+                            item["content"] = text
+                            scraped += 1
+                        if capture:
+                            captured_pages[item["link"]] = capture
+                    except Exception as e:
+                        print(
+                            f"[factual_research] Scrape failed for '{item['link']}': {e}"
+                        )
+            print(f"[factual_research] Scraped {scraped}/{len(all_evidence)} pages.")
+
+            # Capture source content for replay
+            captured_source_content = {
+                "mode": source_content_mode,
+                "serper_results": serper_results_snapshot,
+                "pages": captured_pages,
+            }
+
+        # Cap evidence so we don't blow the synthesis context window
+        MAX_EVIDENCE_ITEMS = 20
+        if len(all_evidence) > MAX_EVIDENCE_ITEMS:
+            all_evidence = all_evidence[:MAX_EVIDENCE_ITEMS]
+
+        # Hard-trim evidence to stay within a reasonable token budget. Drop
+        # trailing (least-relevant, Serper orders by relevance) items until
+        # the joined text fits. Item-level trimming avoids uneven tokens-per-
+        # char across URL-heavy vs prose sections and never cuts mid-item.
+        MAX_EVIDENCE_TOKENS = 3000
+        original_count = len(all_evidence)
+        evidence_text = _format_evidence(all_evidence)
+        while all_evidence and count_tokens(evidence_text, model) > MAX_EVIDENCE_TOKENS:
+            all_evidence.pop()
+            evidence_text = _format_evidence(all_evidence)
+        if len(all_evidence) < original_count:
+            evidence_text += "\n\n[… evidence truncated …]"
+
+        print(
+            f"[factual_research] Gathered {len(all_evidence)} evidence items ({count_tokens(evidence_text, model)} tokens)."
+        )
+
+        # ---------------------------------------------------------------
+        # Step 3 — Synthesise factual briefing  (Structured Output)
+        # ---------------------------------------------------------------
+        print("[factual_research] Step 3: Synthesising factual briefing…")
+        numbered_sqs = "\n".join(
+            f"  {i}. {sq}" for i, sq in enumerate(sub_questions, 1)
+        )
+        synthesis_messages = [
+            {"role": "system", "content": SYNTHESIS_SYSTEM},
+            {
+                "role": "user",
+                "content": SYNTHESIS_USER.format(
+                    question=question,
+                    sub_questions=numbered_sqs,
+                    today=today,
+                    evidence=evidence_text,
+                ),
+            },
+        ]
+
+        briefing: FactualBriefing
+        briefing, counter_callback = _parse_completion(
+            client=llm_client,
+            model=model,
+            messages=synthesis_messages,
+            response_format=FactualBriefing,
+            temperature=temperature,
+            max_tokens=4096,
+            counter_callback=counter_callback,
+        )
+
+        briefing_text = briefing.model_dump_json(indent=2)
+        print(f"[factual_research] Briefing summary: {briefing.summary[:200]}…")
+        print(f"[factual_research] === FULL BRIEFING ===\n{briefing_text}")
+        print("[factual_research] === END BRIEFING ===")
+
+        # ---------------------------------------------------------------
+        # Step 4 — Convert briefing → prediction  (Structured Output)
+        # ---------------------------------------------------------------
+        print(
+            "[factual_research] Step 4: Estimating probability from factual briefing…"
+        )
+
+        estimate_messages = [
+            {"role": "system", "content": ESTIMATE_SYSTEM},
+            {
+                "role": "user",
+                "content": ESTIMATE_USER.format(
+                    question=question,
+                    today=today,
+                    briefing=briefing_text,
+                    resolution_rules=resolution_rules,
+                ),
+            },
+        ]
+
+        prediction: PredictionResult
+        prediction, counter_callback = _parse_completion(
+            client=llm_client,
+            model=model,
+            messages=estimate_messages,
+            response_format=PredictionResult,
+            temperature=temperature,
+            max_tokens=4096,
+            counter_callback=counter_callback,
+        )
+
+        print(f"[factual_research] === REASONING ===\n{prediction.reasoning}")
+        print("[factual_research] === END REASONING ===")
+        print(
+            f"[factual_research] Result: p_yes={prediction.p_yes}, "
+            f"p_no={prediction.p_no}, confidence={prediction.confidence}, "
+            f"info_utility={prediction.info_utility}"
+        )
+
+        # Final JSON string in the standard mech format
+        result = json.dumps(
+            {
+                "p_yes": prediction.p_yes,
+                "p_no": prediction.p_no,
+                "confidence": prediction.confidence,
+                "info_utility": prediction.info_utility,
+            }
+        )
+
+        # Full prompt trail for audit / transparency
+        full_prompt_used = (
+            f"--- REFRAME ---\n{json.dumps(reframe_messages, indent=2)}\n\n"
+            f"--- SUB-QUESTIONS ---\n{sub_q_result.model_dump_json(indent=2)}\n\n"
+            f"--- EVIDENCE ---\n{evidence_text}\n\n"
+            f"--- SYNTHESIS ---\n{json.dumps(synthesis_messages, indent=2)}\n\n"
+            f"--- BRIEFING ---\n{briefing_text}\n\n"
+            f"--- ESTIMATE ---\n{json.dumps(estimate_messages, indent=2)}\n\n"
+            f"--- REASONING ---\n{prediction.reasoning}"
+        )
+
+        used_params: Dict[str, Any] = {
+            "model": model,
+            "temperature": temperature,
+        }
+        if return_source_content:
+            used_params["source_content"] = captured_source_content
+
+        return result, full_prompt_used, None, counter_callback, used_params

--- a/packages/valory/customs/factual_research_v2/factual_research_v2.py
+++ b/packages/valory/customs/factual_research_v2/factual_research_v2.py
@@ -640,6 +640,9 @@ def _search_serper(
 
 # Maximum words to keep per scraped page
 _MAX_PAGE_WORDS = 400
+# Maximum words to keep from trader-forwarded Polymarket resolution rules;
+# mech requests are permissionless so this cap must hold regardless of caller.
+_MAX_RESOLUTION_RULES_WORDS = 500
 # Image / junk patterns to strip from HTML before extraction
 _IMG_TAG_PATTERN = re.compile(r"<img[^>]*>", re.IGNORECASE)
 _SCRIPT_STYLE_PATTERN = re.compile(
@@ -784,7 +787,12 @@ def _extract_resolution_rules(request_context: Any) -> Optional[str]:
     if not isinstance(description, str):
         return None
     description = description.strip()
-    return description or None
+    if not description:
+        return None
+    words = description.split()
+    if len(words) > _MAX_RESOLUTION_RULES_WORDS:
+        description = " ".join(words[:_MAX_RESOLUTION_RULES_WORDS]) + " [...]"
+    return description
 
 
 def _format_resolution_block(description: Optional[str]) -> str:
@@ -800,11 +808,9 @@ def _format_resolution_block(description: Optional[str]) -> str:
     if not description:
         return ""
     return (
-        "\nMARKET RESOLUTION RULES (the authoritative criteria for how this "
-        f'market resolves YES vs NO):\n"""{description}"""\n'
-        "Treat these rules as the precise definition of what counts as a YES "
-        "resolution; align your work with this exact condition, not a loose "
-        "reading of the question.\n"
+        "\nMARKET RESOLUTION RULES:\n"
+        "The following is the market's stated resolution criteria; use it to "
+        f'interpret what the question is asking:\n"""{description}"""\n'
     )
 
 

--- a/packages/valory/customs/factual_research_v2/tests/__init__.py
+++ b/packages/valory/customs/factual_research_v2/tests/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for the factual_research tool."""

--- a/packages/valory/customs/factual_research_v2/tests/test_factual_research.py
+++ b/packages/valory/customs/factual_research_v2/tests/test_factual_research.py
@@ -1,0 +1,1029 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Unit tests for factual_research_v2: helpers, source_content, and thread safety."""
+
+import json
+from pathlib import Path
+from typing import Any, List, Tuple
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import packages.valory.customs.factual_research_v2.factual_research_v2 as module
+from packages.valory.customs.factual_research_v2.factual_research_v2 import (
+    BLOCKED_DOMAINS,
+    FactualBriefing,
+    OpenAIClientManager,
+    PredictionResult,
+    SourceReference,
+    SubAnswer,
+    SubQuestions,
+    _clean_html,
+    _extract_question,
+    _extract_resolution_rules,
+    _fetch_page_content,
+    _format_evidence,
+    _format_resolution_block,
+    _parse_completion,
+    _search_serper,
+    run,
+)
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+FR_MODULE = "packages.valory.customs.factual_research_v2.factual_research_v2"
+
+PREDICTION_PROMPT = (
+    'With the given question "Will X happen by 2025?" '
+    "and the `yes` option represented by `Yes` and the `no` option represented by `No`, "
+    "what are the respective probabilities of `p_yes` and `p_no` occurring?"
+)
+
+SIMPLE_HTML = """
+<html><head><title>Test</title></head>
+<body>
+<script>var x = 1;</script>
+<style>.foo { color: red; }</style>
+<img src="foo.png">
+<p>This is the main article content with enough words to test extraction.</p>
+</body></html>
+"""
+
+FAKE_SERPER_RESPONSE = {
+    "organic": [
+        {
+            "title": "Clean Result",
+            "link": "https://example.com/clean",
+            "snippet": "A clean snippet.",
+        },
+        {
+            "title": "Polymarket Result",
+            "link": "https://polymarket.com/market/123",
+            "snippet": "Should be filtered.",
+        },
+        {
+            "title": "Twitter Result",
+            "link": "https://twitter.com/user/status/456",
+            "snippet": "Should be filtered.",
+        },
+        {
+            "title": "Another Clean",
+            "link": "https://reuters.com/article",
+            "snippet": "Reuters snippet.",
+        },
+    ],
+    "peopleAlsoAsk": [
+        {
+            "question": "What about X?",
+            "link": "https://example.com/paa",
+            "snippet": "PAA answer.",
+        },
+        {
+            "question": "X on Metaculus?",
+            "link": "https://metaculus.com/question/789",
+            "snippet": "Should be filtered.",
+        },
+    ],
+}
+
+
+def _make_mock_api_keys(
+    return_source_content: str = "false",
+    source_content_mode: str = "cleaned",
+) -> MagicMock:
+    """Create a mock KeyChain-like api_keys object."""
+    services = {
+        "openai": "sk-test",
+        "serperapi": "serper-test",
+        "return_source_content": return_source_content,
+        "source_content_mode": source_content_mode,
+        "openrouter": "",
+    }
+    mock = MagicMock()
+    mock.__getitem__ = lambda self, key: services[key]
+    mock.get = lambda key, default="": services.get(key, default)
+    mock.max_retries = lambda: {"openai": 0, "openrouter": 0}
+    return mock
+
+
+def _make_mock_parse_completion() -> List[Tuple[Any, None]]:
+    """Return an explicit side_effect list for the 3 _parse_completion calls.
+
+    The pipeline calls _parse_completion exactly 3 times in this order:
+    reframe → synthesise → estimate. Using a static list instead of a
+    counter-based dispatcher makes the test fail loudly if the pipeline
+    ever reorders or adds a call, instead of silently returning the wrong
+    model.
+
+    :return: side_effect list of (parsed_model, None) tuples for the 3 calls.
+    """
+    sub_q = SubQuestions(sub_questions=["What is the status of X?"])
+    briefing = FactualBriefing(
+        sub_answers=[
+            SubAnswer(
+                question="What is the status of X?",
+                answer="X is in progress.",
+                sources=[SourceReference(title="Source", url="https://example.com")],
+            )
+        ],
+        summary="X is ongoing with no major obstacles.",
+        sources=[SourceReference(title="Source", url="https://example.com")],
+        info_utility=0.7,
+    )
+    prediction = PredictionResult(
+        reasoning="Based on the evidence, X is likely.",
+        p_yes=0.6,
+        p_no=0.4,
+        confidence=0.7,
+        info_utility=0.8,
+    )
+    return [
+        (sub_q, None),
+        (briefing, None),
+        (prediction, None),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Group 1: Pure helper functions
+# ---------------------------------------------------------------------------
+
+
+class TestExtractQuestion:
+    """Tests for _extract_question."""
+
+    def test_mech_envelope_format(self) -> None:
+        """Standard mech prompt format extracts the question."""
+        result = _extract_question(PREDICTION_PROMPT)
+        assert result == "Will X happen by 2025?"
+
+    def test_plain_string(self) -> None:
+        """Non-mech prompt returns the string as-is, stripped."""
+        result = _extract_question("  some plain question  ")
+        assert result == "some plain question"
+
+    def test_empty_string(self) -> None:
+        """Empty string returns empty."""
+        result = _extract_question("")
+        assert result == ""
+
+
+class TestFormatEvidence:
+    """Tests for _format_evidence."""
+
+    def test_empty_list(self) -> None:
+        """Empty list returns sentinel string."""
+        assert _format_evidence([]) == "(no evidence gathered)"
+
+    def test_with_content(self) -> None:
+        """Items with content key include Content line."""
+        items = [
+            {
+                "title": "Article",
+                "link": "https://example.com",
+                "snippet": "A snippet",
+                "content": "Full article text",
+            }
+        ]
+        result = _format_evidence(items)
+        assert "Content: Full article text" in result
+        assert "Snippet: A snippet" in result
+        assert "[Article](https://example.com)" in result
+
+    def test_without_content(self) -> None:
+        """Items without content only show snippet."""
+        items = [
+            {"title": "Article", "link": "https://example.com", "snippet": "A snippet"}
+        ]
+        result = _format_evidence(items)
+        assert "Content:" not in result
+        assert "A snippet" in result
+
+
+class TestCleanHtml:
+    """Tests for _clean_html."""
+
+    def test_strips_scripts_and_extracts_text(self) -> None:
+        """HTML with scripts/styles produces clean text."""
+        result = _clean_html(SIMPLE_HTML)
+        assert result is not None
+        assert "var x = 1" not in result
+        assert "color: red" not in result
+        assert "main article content" in result
+
+    def test_truncates_to_max_words(self) -> None:
+        """Long content gets truncated."""
+        long_html = "<html><body><p>" + " ".join(["word"] * 500) + "</p></body></html>"
+        result = _clean_html(long_html, max_words=10)
+        assert result is not None
+        assert "[…]" in result
+        # Should have roughly 10 words before truncation marker
+        words_before = result.split("[…]")[0].split()
+        assert len(words_before) <= 11  # allow slight variance from markdown
+
+    def test_returns_none_for_empty(self) -> None:
+        """Empty body returns None."""
+        result = _clean_html("<html><body></body></html>")
+        # readability may extract something minimal; if it does, that's OK
+        # but truly empty content should be None
+        if result is not None:
+            assert result.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# Group 2: _search_serper domain filtering
+# ---------------------------------------------------------------------------
+
+
+class TestSearchSerper:
+    """Tests for _search_serper domain filtering."""
+
+    @patch(f"{FR_MODULE}.requests.post")
+    def test_filters_blocked_domains(self, mock_post: MagicMock) -> None:
+        """Blocked domains (polymarket, twitter, etc.) are dropped."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        results = _search_serper("test query", "api-key", num_results=5)
+
+        links = [r["link"] for r in results]
+        for domain in BLOCKED_DOMAINS:
+            assert not any(
+                domain in link for link in links
+            ), f"Blocked domain {domain} found in results"
+
+    @patch(f"{FR_MODULE}.requests.post")
+    def test_includes_clean_organic_and_paa(self, mock_post: MagicMock) -> None:
+        """Clean organic and PAA results are included."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        results = _search_serper("test query", "api-key", num_results=5)
+
+        links = [r["link"] for r in results]
+        assert "https://example.com/clean" in links
+        assert "https://reuters.com/article" in links
+        assert "https://example.com/paa" in links
+
+    @patch(f"{FR_MODULE}.requests.post")
+    def test_respects_num_results_for_organic(self, mock_post: MagicMock) -> None:
+        """Organic results are capped at num_results."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = FAKE_SERPER_RESPONSE
+        mock_response.raise_for_status = MagicMock()
+        mock_post.return_value = mock_response
+
+        results = _search_serper("test query", "api-key", num_results=1)
+
+        # Only 1 organic (Clean Result), but PAA still appended
+        organic_links = [
+            r["link"] for r in results if r["link"] != "https://example.com/paa"
+        ]
+        assert len(organic_links) == 1
+
+
+# ---------------------------------------------------------------------------
+# Group 3: _fetch_page_content modes
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPageContent:
+    """Tests for _fetch_page_content cleaned/raw modes."""
+
+    @patch(f"{FR_MODULE}.requests.get")
+    def test_cleaned_mode(self, mock_get: MagicMock) -> None:
+        """Cleaned mode returns (cleaned_text, cleaned_text)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"Content-Type": "text/html; charset=utf-8"}
+        mock_resp.text = SIMPLE_HTML
+        mock_get.return_value = mock_resp
+
+        text, capture = _fetch_page_content("https://example.com", mode="cleaned")
+
+        assert text is not None
+        assert capture is not None
+        assert text == capture  # cleaned mode: both are the same
+        assert "main article content" in text
+
+    @patch(f"{FR_MODULE}.requests.get")
+    def test_raw_mode(self, mock_get: MagicMock) -> None:
+        """Raw mode returns (cleaned_text, raw_html)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"Content-Type": "text/html; charset=utf-8"}
+        mock_resp.text = SIMPLE_HTML
+        mock_get.return_value = mock_resp
+
+        text, capture = _fetch_page_content("https://example.com", mode="raw")
+
+        assert text is not None
+        assert capture is not None
+        assert text != capture  # text is cleaned, capture is raw HTML
+        assert "<script>" in capture or "<p>" in capture  # raw HTML preserved
+        assert "main article content" in text
+
+    @patch(f"{FR_MODULE}.requests.get")
+    def test_non_html_returns_none(self, mock_get: MagicMock) -> None:
+        """Non-HTML content-type returns (None, None)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.headers = {"Content-Type": "application/pdf"}
+        mock_get.return_value = mock_resp
+
+        text, capture = _fetch_page_content("https://example.com/file.pdf")
+        assert text is None
+        assert capture is None
+
+    @patch(f"{FR_MODULE}.requests.get")
+    def test_non_200_returns_none(self, mock_get: MagicMock) -> None:
+        """Non-200 status returns (None, None)."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_resp.headers = {"Content-Type": "text/html"}
+        mock_get.return_value = mock_resp
+
+        text, capture = _fetch_page_content("https://example.com/missing")
+        assert text is None
+        assert capture is None
+
+
+# ---------------------------------------------------------------------------
+# Group 4: run() source_content integration
+# ---------------------------------------------------------------------------
+
+
+class TestRunSourceContent:
+    """Verify source_content capture, replay, and mode handling in run()."""
+
+    @patch(f"{FR_MODULE}._parse_completion")
+    @patch(f"{FR_MODULE}._search_serper")
+    @patch(f"{FR_MODULE}._fetch_page_content")
+    @patch(f"{FR_MODULE}.OpenAIClientManager")
+    def test_live_capture_includes_mode_and_pages(
+        self,
+        mock_mgr: MagicMock,
+        mock_fetch: MagicMock,
+        mock_serper: MagicMock,
+        mock_parse: MagicMock,
+    ) -> None:
+        """Live run with return_source_content=true captures mode, serper_results, pages."""
+        mock_client = MagicMock()
+        mock_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_serper.return_value = [
+            {"title": "R1", "link": "https://example.com/1", "snippet": "S1"},
+        ]
+        mock_fetch.return_value = ("Cleaned text", "Cleaned text")
+        mock_parse.side_effect = _make_mock_parse_completion()
+
+        result = run(
+            tool="factual_research-v2",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("true", "cleaned"),
+            counter_callback=None,
+            delivery_rate=100,
+        )
+
+        used_params = result[4]
+        assert "source_content" in used_params
+        sc = used_params["source_content"]
+        assert sc["mode"] == "cleaned"
+        assert "serper_results" in sc
+        assert "pages" in sc
+        # serper_results should NOT contain 'content' key (bug 3 fix)
+        for item in sc["serper_results"]:
+            assert "content" not in item
+
+    @patch(f"{FR_MODULE}._parse_completion")
+    @patch(f"{FR_MODULE}.OpenAIClientManager")
+    def test_replay_uses_cached_source_content(
+        self,
+        mock_mgr: MagicMock,
+        mock_parse: MagicMock,
+    ) -> None:
+        """Replay with source_content skips serper, uses cached evidence."""
+        mock_client = MagicMock()
+        mock_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        mock_parse.side_effect = _make_mock_parse_completion()
+
+        cached = {
+            "mode": "cleaned",
+            "serper_results": [
+                {"title": "Cached", "link": "https://cached.com/1", "snippet": "CS"},
+            ],
+            "pages": {"https://cached.com/1": "Cached page text"},
+        }
+
+        with patch(f"{FR_MODULE}._search_serper") as mock_serper:
+            result = run(
+                tool="factual_research-v2",
+                model="gpt-4.1-2025-04-14",
+                prompt=PREDICTION_PROMPT,
+                api_keys=_make_mock_api_keys("true"),
+                counter_callback=None,
+                delivery_rate=100,
+                source_content=cached,
+            )
+            mock_serper.assert_not_called()
+
+        # Result should be valid JSON
+        parsed = json.loads(result[0])
+        assert "p_yes" in parsed
+
+    @patch(f"{FR_MODULE}._parse_completion")
+    @patch(f"{FR_MODULE}._clean_html")
+    @patch(f"{FR_MODULE}.OpenAIClientManager")
+    def test_replay_raw_mode_recleans_html(
+        self,
+        mock_mgr: MagicMock,
+        mock_clean: MagicMock,
+        mock_parse: MagicMock,
+    ) -> None:
+        """Replay with mode=raw calls _clean_html on cached pages."""
+        mock_client = MagicMock()
+        mock_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        mock_parse.side_effect = _make_mock_parse_completion()
+        mock_clean.return_value = "Re-cleaned text"
+
+        cached = {
+            "mode": "raw",
+            "serper_results": [
+                {"title": "Raw", "link": "https://raw.com/1", "snippet": "RS"},
+            ],
+            "pages": {"https://raw.com/1": "<html><body>Raw HTML</body></html>"},
+        }
+
+        run(
+            tool="factual_research-v2",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("true"),
+            counter_callback=None,
+            delivery_rate=100,
+            source_content=cached,
+        )
+
+        mock_clean.assert_called_once_with("<html><body>Raw HTML</body></html>")
+
+    @patch(f"{FR_MODULE}._parse_completion")
+    @patch(f"{FR_MODULE}._search_serper")
+    @patch(f"{FR_MODULE}._fetch_page_content")
+    @patch(f"{FR_MODULE}.OpenAIClientManager")
+    def test_flag_off_no_source_content(
+        self,
+        mock_mgr: MagicMock,
+        mock_fetch: MagicMock,
+        mock_serper: MagicMock,
+        mock_parse: MagicMock,
+    ) -> None:
+        """When return_source_content=false, source_content is not in used_params."""
+        mock_client = MagicMock()
+        mock_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+        mock_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        mock_serper.return_value = [
+            {"title": "R1", "link": "https://example.com/1", "snippet": "S1"},
+        ]
+        mock_fetch.return_value = ("Cleaned", "Cleaned")
+        mock_parse.side_effect = _make_mock_parse_completion()
+
+        result = run(
+            tool="factual_research-v2",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("false"),
+            counter_callback=None,
+            delivery_rate=100,
+        )
+
+        used_params = result[4]
+        assert "source_content" not in used_params
+
+
+class TestParseCompletionRetry:
+    """Tests for _parse_completion retry logic."""
+
+    @patch(f"{FR_MODULE}.time.sleep")
+    def test_retries_then_succeeds(self, mock_sleep: MagicMock) -> None:
+        """Fail twice with retryable errors, succeed on the third attempt."""
+        mock_client = MagicMock()
+
+        # Build a successful response for the third attempt
+        mock_parsed = SubQuestions(sub_questions=["Q1", "Q2"])
+        mock_usage = MagicMock()
+        mock_usage.prompt_tokens = 10
+        mock_usage.completion_tokens = 20
+        mock_message = MagicMock()
+        mock_message.parsed = mock_parsed
+        mock_message.refusal = None
+        mock_choice = MagicMock()
+        mock_choice.message = mock_message
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        mock_response.usage = mock_usage
+
+        # ValueError is in the retryable set (covers pydantic ValidationError
+        # and the inline "Model refused…" raise).
+        mock_client.beta.chat.completions.parse.side_effect = [
+            ValueError("fail 1"),
+            ValueError("fail 2"),
+            mock_response,
+        ]
+
+        result, cb = _parse_completion(
+            client=mock_client,
+            model="gpt-4.1-2025-04-14",
+            messages=[{"role": "user", "content": "test"}],
+            response_format=SubQuestions,
+            retries=3,
+            delay=1,
+        )
+
+        assert mock_client.beta.chat.completions.parse.call_count == 3
+        assert result == mock_parsed
+        assert mock_sleep.call_count == 2
+
+    @patch(f"{FR_MODULE}.time.sleep")
+    def test_retries_exhausted_raises(self, mock_sleep: MagicMock) -> None:
+        """All retries fail with retryable errors; raises RuntimeError."""
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.side_effect = ValueError("nope")
+
+        with pytest.raises(RuntimeError, match="Failed to get structured LLM"):
+            _parse_completion(
+                client=mock_client,
+                model="gpt-4.1-2025-04-14",
+                messages=[{"role": "user", "content": "test"}],
+                response_format=SubQuestions,
+                retries=3,
+                delay=1,
+            )
+
+        assert mock_client.beta.chat.completions.parse.call_count == 3
+        assert mock_sleep.call_count == 3
+
+    @patch(f"{FR_MODULE}.time.sleep")
+    def test_non_retryable_exception_propagates(self, mock_sleep: MagicMock) -> None:
+        """Non-retryable exceptions (e.g. AttributeError) surface immediately."""
+        mock_client = MagicMock()
+        mock_client.beta.chat.completions.parse.side_effect = AttributeError("bug")
+
+        with pytest.raises(AttributeError, match="bug"):
+            _parse_completion(
+                client=mock_client,
+                model="gpt-4.1-2025-04-14",
+                messages=[{"role": "user", "content": "test"}],
+                response_format=SubQuestions,
+                retries=3,
+                delay=1,
+            )
+
+        # First failure should propagate — no retries, no sleeps.
+        assert mock_client.beta.chat.completions.parse.call_count == 1
+        assert mock_sleep.call_count == 0
+
+
+class TestNoGlobalClient:
+    """Verify the module does not use a global client variable."""
+
+    def test_no_module_level_client(self) -> None:
+        """The module must not define a module-level 'client' variable."""
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        for i, line in enumerate(source.split("\n"), 1):
+            stripped = line.lstrip()
+            if stripped.startswith("client:") or stripped.startswith("client ="):
+                if not line.startswith(" ") and not line.startswith("\t"):
+                    pytest.fail(
+                        f"Module-level 'client' variable found at line {i}: {line}"
+                    )
+
+    def test_client_manager_uses_local_state(self) -> None:
+        """Verify OpenAIClientManager stores client on self, not module global."""
+        with patch(f"{FR_MODULE}.OpenAI") as MockOpenAI:
+            mock_instance = MagicMock()
+            MockOpenAI.return_value = mock_instance
+
+            mgr = OpenAIClientManager(api_key="sk-test")
+            with mgr as client:
+                assert client is mock_instance
+                assert mgr._client is mock_instance
+                MockOpenAI.assert_called_once_with(api_key="sk-test")
+
+            mock_instance.close.assert_called_once()
+            assert mgr._client is None
+
+
+# ---------------------------------------------------------------------------
+# Group 5: Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestRunEdgeCases:
+    """Edge case validation for run().
+
+    Note: run() is wrapped by @with_key_rotation which catches unhandled
+    exceptions and returns an error tuple (error_json, "", None, None, None,
+    api_keys), where error_json is a JSON string of the form
+    {"p_yes": null, "p_no": null, "confidence": 0.0, "info_utility": 0.0,
+     "error": "<message>"}.
+    """
+
+    @staticmethod
+    def _assert_error_envelope(result_first: str, expected_substring: str) -> None:
+        """Assert the error envelope contract.
+
+        The first tuple element must be a JSON envelope with null predictions,
+        zeroed scores, and the exception message under `error`.
+
+        :param result_first: first element of the run() return tuple.
+        :param expected_substring: substring that must appear in the `error` field.
+        """
+        parsed = json.loads(result_first)
+        assert parsed["p_yes"] is None
+        assert parsed["p_no"] is None
+        assert parsed["confidence"] == 0.0
+        assert parsed["info_utility"] == 0.0
+        assert expected_substring in parsed["error"]
+
+    def test_rejects_unknown_tool(self) -> None:
+        """Unknown tool returns error JSON with 'not supported'."""
+        result = run(
+            tool="bogus_tool",
+            model="gpt-4o",
+            prompt="test",
+            api_keys=_make_mock_api_keys(),
+        )
+        self._assert_error_envelope(result[0], "not supported")
+
+    def test_rejects_missing_model(self) -> None:
+        """Missing model returns error JSON with 'Model not supplied'."""
+        result = run(
+            tool="factual_research-v2",
+            prompt="test",
+            api_keys=_make_mock_api_keys(),
+        )
+        self._assert_error_envelope(result[0], "Model not supplied")
+
+    def test_invalid_source_content_mode(self) -> None:
+        """Invalid source_content_mode returns error JSON."""
+        result = run(
+            tool="factual_research-v2",
+            model="gpt-4o",
+            prompt="test",
+            api_keys=_make_mock_api_keys(source_content_mode="bogus"),
+            delivery_rate=100,
+        )
+        self._assert_error_envelope(result[0], "Invalid source_content_mode")
+
+    def test_delivery_rate_zero_returns_max_cost(self) -> None:
+        """delivery_rate=0 calls counter_callback with max_cost=True."""
+        mock_cb = MagicMock(return_value=42.0)
+
+        result = run(
+            tool="factual_research-v2",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys(),
+            delivery_rate=0,
+            counter_callback=mock_cb,
+        )
+
+        mock_cb.assert_called_once_with(
+            max_cost=True,
+            models_calls=("gpt-4.1-2025-04-14",) * 3,
+        )
+        assert result == 42.0
+
+
+# ---------------------------------------------------------------------------
+# Group 6: with_key_rotation decorator
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_error(cls: type, message: str = "simulated") -> Exception:
+    """Build an openai APIStatusError-family exception for tests.
+
+    Skips the real constructor (which requires a live httpx.Response) and
+    sets up just the attributes the decorator under test touches.
+
+    :param cls: the openai exception subclass to instantiate.
+    :param message: the `str(exc)` payload.
+    :return: an instance of `cls` usable as a raise target in tests.
+    """
+    err: Exception = cls.__new__(cls)  # type: ignore[call-overload]
+    Exception.__init__(err, message)
+    err.message = message  # type: ignore[attr-defined]
+    return err
+
+
+class TestWithKeyRotation:
+    """Direct tests for the @with_key_rotation decorator contract.
+
+    These pin behaviors that are easy to regress:
+    - success path returns a 6-tuple ending in api_keys
+    - max-cost float pass-through (no api_keys appended — tuple concat would fail)
+    - RateLimitError / AuthenticationError / PermissionDeniedError rotate the key
+    - unhandled exceptions are wrapped in the prediction-shaped error JSON
+    """
+
+    def test_success_appends_api_keys(self) -> None:
+        """Success tuple gets api_keys appended as last element."""
+        keys = _make_mock_api_keys()
+
+        @module.with_key_rotation
+        def fake(api_keys: Any) -> Tuple[Any, ...]:  # pylint: disable=unused-argument
+            return "ok", "prompt", None, None, None
+
+        result = fake(api_keys=keys)
+        assert result == ("ok", "prompt", None, None, None, keys)
+
+    def test_max_cost_float_passthrough(self) -> None:
+        """Float return (max-cost path) skips the api_keys append."""
+        keys = _make_mock_api_keys()
+
+        @module.with_key_rotation
+        def fake(api_keys: Any) -> float:  # pylint: disable=unused-argument
+            return 42.0
+
+        assert fake(api_keys=keys) == 42.0
+
+    @pytest.mark.parametrize(
+        "exc_cls",
+        [
+            module.openai.RateLimitError,
+            module.openai.AuthenticationError,
+            module.openai.PermissionDeniedError,
+        ],
+    )
+    def test_rotates_on_recoverable_error(self, exc_cls: type) -> None:
+        """Rate-limit, auth, and permission errors all rotate the key and retry."""
+        keys = _make_mock_api_keys()
+        keys.max_retries = lambda: {"openai": 1, "openrouter": 1}
+        keys.rotate = MagicMock()
+        call_count = {"n": 0}
+
+        @module.with_key_rotation
+        def fake(api_keys: Any) -> Tuple[Any, ...]:  # pylint: disable=unused-argument
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise _make_openai_error(exc_cls, "simulated")
+            return "ok", "", None, None, None
+
+        result = fake(api_keys=keys)
+        assert call_count["n"] == 2  # one failure + one success
+        assert keys.rotate.call_count == 2  # rotated both openai and openrouter
+        assert result[-1] is keys
+
+    def test_rotation_exhausted_raises(self) -> None:
+        """Recoverable exception is re-raised when retries are exhausted.
+
+        When both openai and openrouter retries are exhausted, the decorator
+        re-raises instead of wrapping into the error JSON — the framework
+        needs the raw exception to know the key pool is burned.
+        """
+        keys = _make_mock_api_keys()
+        keys.max_retries = lambda: {"openai": 0, "openrouter": 0}
+
+        @module.with_key_rotation
+        def fake(api_keys: Any) -> Tuple[Any, ...]:  # pylint: disable=unused-argument
+            raise _make_openai_error(module.openai.RateLimitError, "burned out")
+
+        with pytest.raises(module.openai.RateLimitError, match="burned out"):
+            fake(api_keys=keys)
+
+    def test_unhandled_exception_returns_parseable_error_json(self) -> None:
+        """Unhandled exceptions wrap into a prediction-shaped error JSON.
+
+        Non-openai exceptions (including `LengthFinishReasonError`, shaped
+        here as a `RuntimeError`) are wrapped into the prediction-shaped
+        error JSON. This is the contract the decorator added in PR 232 —
+        regressing it would resurface raw framework strings to on-chain
+        consumers.
+        """
+        keys = _make_mock_api_keys()
+
+        @module.with_key_rotation
+        def fake(api_keys: Any) -> Tuple[Any, ...]:  # pylint: disable=unused-argument
+            raise RuntimeError("simulated truncation")
+
+        result = fake(api_keys=keys)
+        parsed = json.loads(result[0])
+        assert parsed["p_yes"] is None
+        assert parsed["p_no"] is None
+        assert parsed["confidence"] == 0.0
+        assert parsed["info_utility"] == 0.0
+        assert "simulated truncation" in parsed["error"]
+        assert result[1:] == ("", None, None, None, keys)
+
+    def test_run_wrapped_unhandled_exception_returns_error_json(self) -> None:
+        """End-to-end regression for the LengthFinishReasonError path.
+
+        When the pipeline raises inside `_parse_completion` (simulating the
+        `LengthFinishReasonError` path), the decorator wraps the error
+        cleanly. This is the exact failure shape that caused the 24.4% prod
+        error rate before `max_tokens` was raised.
+        """
+        with patch(f"{FR_MODULE}._parse_completion") as mock_parse:
+            mock_parse.side_effect = RuntimeError("simulated truncation")
+            result = run(
+                tool="factual_research-v2",
+                model="gpt-4.1-2025-04-14",
+                prompt=PREDICTION_PROMPT,
+                api_keys=_make_mock_api_keys(),
+            )
+        parsed = json.loads(result[0])
+        assert parsed["p_yes"] is None
+        assert parsed["confidence"] == 0.0
+        assert "simulated truncation" in parsed["error"]
+
+
+# ---------------------------------------------------------------------------
+# Group: resolution rules (v2)
+# ---------------------------------------------------------------------------
+#
+# As of trader PR #989 the trader fetches the Polymarket resolution rules and
+# forwards them on the mech request as request_context["description"]. v2 only
+# READS that field — it never contacts Polymarket — so these tests pass the
+# rules in via request_context and prove they reach the right pipeline stages.
+
+# Sentinel substring standing in for real resolution-rules text.
+_RULES_SENTINEL = "RESOLVES_YES_IFF_SENTINEL"
+_RULES_TEXT = (
+    f"{_RULES_SENTINEL}: this market resolves YES if X ships before "
+    "2026-01-01, per the official changelog."
+)
+
+
+class TestExtractResolutionRules:
+    """Tests for _extract_resolution_rules — reading the trader's field."""
+
+    def test_returns_stripped_description(self) -> None:
+        """A polymarket context's description is returned, stripped."""
+        out = _extract_resolution_rules(
+            {
+                "type": "polymarket",
+                "market_id": "0xabc",
+                "description": f"  {_RULES_TEXT}  ",
+            }
+        )
+        assert out == _RULES_TEXT
+
+    def test_missing_description_returns_none(self) -> None:
+        """A context with no description (e.g. Omen) yields None."""
+        assert _extract_resolution_rules({"type": "omen", "market_id": "0x1"}) is None
+
+    def test_blank_description_returns_none(self) -> None:
+        """A whitespace-only description is treated as absent."""
+        assert _extract_resolution_rules({"description": "   "}) is None
+
+    def test_non_string_description_returns_none(self) -> None:
+        """A non-string description is ignored rather than crashing."""
+        assert _extract_resolution_rules({"description": 123}) is None
+
+    def test_non_dict_context_returns_none(self) -> None:
+        """A missing/!dict request_context degrades silently."""
+        assert _extract_resolution_rules(None) is None
+        assert _extract_resolution_rules("nonsense") is None
+
+
+class TestFormatResolutionBlock:
+    """Tests for _format_resolution_block — prompt rendering."""
+
+    def test_with_rules_includes_text_and_guidance(self) -> None:
+        """A populated block carries the rules and the alignment guidance."""
+        block = _format_resolution_block("Resolves YES if X.")
+
+        assert "Resolves YES if X." in block
+        assert "RESOLUTION RULES" in block
+        assert "precise definition of what counts as a YES" in block
+
+    def test_no_description_returns_empty(self) -> None:
+        """No description → empty string (so templates degrade cleanly)."""
+        assert _format_resolution_block("") == ""
+        assert _format_resolution_block(None) == ""
+
+
+class TestRunInjectsResolutionRules:
+    """End-to-end: resolution rules flow into the right pipeline stages."""
+
+    @staticmethod
+    def _capturing_parse(captured: list) -> Any:
+        """side_effect for _parse_completion: records messages, stages outputs."""
+        outputs = _make_mock_parse_completion()
+        state = {"i": 0}
+
+        def _side(*_args: Any, **kwargs: Any) -> Tuple[Any, None]:
+            captured.append(kwargs["messages"])
+            out = outputs[state["i"]]
+            state["i"] += 1
+            return out
+
+        return _side
+
+    @patch(f"{FR_MODULE}._fetch_page_content")
+    @patch(f"{FR_MODULE}._search_serper")
+    @patch(f"{FR_MODULE}.OpenAIClientManager")
+    @patch(f"{FR_MODULE}._parse_completion")
+    def test_rules_reach_reframe_and_estimate_not_synthesis(
+        self,
+        mock_parse: MagicMock,
+        mock_mgr: MagicMock,
+        mock_serper: MagicMock,
+        mock_fetch_page: MagicMock,
+    ) -> None:
+        """Rules from request_context land in reframe + estimate, not synthesis."""
+        mock_mgr.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        mock_serper.return_value = [
+            {"title": "R1", "link": "https://example.com/1", "snippet": "S1"},
+        ]
+        mock_fetch_page.return_value = ("Cleaned text", "Cleaned text")
+        captured: list = []
+        mock_parse.side_effect = self._capturing_parse(captured)
+
+        run(
+            tool="factual_research-v2",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+            delivery_rate=100,
+            request_context={
+                "type": "polymarket",
+                "market_id": "0xabc",
+                "description": _RULES_TEXT,
+            },
+        )
+
+        assert len(captured) == 3  # reframe, synthesis, estimate
+        reframe_user = captured[0][1]["content"]
+        synthesis_user = captured[1][1]["content"]
+        estimate_user = captured[2][1]["content"]
+
+        # Injected where intended …
+        assert _RULES_SENTINEL in reframe_user
+        assert _RULES_SENTINEL in estimate_user
+        # … and NOT into synthesis (which stays evidence-only by design).
+        assert _RULES_SENTINEL not in synthesis_user
+
+    @patch(f"{FR_MODULE}._fetch_page_content")
+    @patch(f"{FR_MODULE}._search_serper")
+    @patch(f"{FR_MODULE}.OpenAIClientManager")
+    @patch(f"{FR_MODULE}._parse_completion")
+    def test_omen_market_degrades_to_v1(
+        self,
+        mock_parse: MagicMock,
+        mock_mgr: MagicMock,
+        mock_serper: MagicMock,
+        mock_fetch_page: MagicMock,
+    ) -> None:
+        """An Omen request (no description) injects no rules block."""
+        mock_mgr.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        mock_serper.return_value = [
+            {"title": "R1", "link": "https://example.com/1", "snippet": "S1"},
+        ]
+        mock_fetch_page.return_value = ("Cleaned text", "Cleaned text")
+        captured: list = []
+        mock_parse.side_effect = self._capturing_parse(captured)
+
+        run(
+            tool="factual_research-v2",
+            model="gpt-4.1-2025-04-14",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+            delivery_rate=100,
+            request_context={"type": "omen", "market_id": "0xfpmm"},
+        )
+
+        for msgs in captured:
+            for msg in msgs:
+                assert "MARKET RESOLUTION RULES" not in msg["content"]

--- a/packages/valory/customs/factual_research_v2/tests/test_factual_research.py
+++ b/packages/valory/customs/factual_research_v2/tests/test_factual_research.py
@@ -912,6 +912,25 @@ class TestExtractResolutionRules:
         assert _extract_resolution_rules(None) is None
         assert _extract_resolution_rules("nonsense") is None
 
+    def test_at_cap_not_truncated(self) -> None:
+        """A description exactly at the char cap is returned verbatim.
+
+        Honest trader rules sit within MAX_REQUEST_CONTEXT_DESCRIPTION_LEN, so
+        the boundary case must never be clipped.
+        """
+        desc = "y" * module._MAX_RESOLUTION_RULES_CHARS
+        out = _extract_resolution_rules({"description": desc})
+        assert out == desc
+
+    def test_over_cap_truncated_with_sentinel(self) -> None:
+        """A description over the char cap is clipped and gets a sentinel."""
+        desc = "x" * (module._MAX_RESOLUTION_RULES_CHARS + 50)
+        out = _extract_resolution_rules({"description": desc})
+        assert out is not None
+        assert out.endswith(" […]")
+        # Kept body is exactly the cap; sentinel is the only extra text.
+        assert out == "x" * module._MAX_RESOLUTION_RULES_CHARS + " […]"
+
 
 class TestFormatResolutionBlock:
     """Tests for _format_resolution_block — prompt rendering."""

--- a/packages/valory/customs/factual_research_v2/tests/test_factual_research.py
+++ b/packages/valory/customs/factual_research_v2/tests/test_factual_research.py
@@ -922,7 +922,7 @@ class TestFormatResolutionBlock:
 
         assert "Resolves YES if X." in block
         assert "RESOLUTION RULES" in block
-        assert "precise definition of what counts as a YES" in block
+        assert "stated resolution criteria" in block
 
     def test_no_description_returns_empty(self) -> None:
         """No description → empty string (so templates degrade cleanly)."""

--- a/tool_lineage.json
+++ b/tool_lineage.json
@@ -42,6 +42,10 @@
       "parent": "factual_research",
       "reason": "Add an as-of-date freshness guard at the estimate stage so it stops anchoring p_yes on stale prior-period figures on earnings/revenue-threshold markets."
     },
+    "factual_research-v2": {
+      "parent": "factual_research-v1",
+      "reason": "For Polymarket markets, read the resolution rules the trader forwards in request_context['description'] (trader PR #989) and inject them into the reframe and estimate stages (rules only, no prices; the tool never fetches)."
+    },
     "gemini-2.0-flash": {
       "parent": null,
       "reason": "Original tool, baseline entry."


### PR DESCRIPTION
## What

New prediction tool **`factual_research-v2`** — a variant of `factual_research-v1` that, for Polymarket markets, feeds the market's **resolution rules** into the pipeline.

Stacked on `tool-improvement/factual_research-asof-date-anchoring` (PR #320), and the trader-side counterpart of [trader#989](https://github.com/valory-xyz/trader/pull/989).

## Why

`factual_research-v1` reframes and estimates against a loose reading of the question title. The actual YES/NO resolution criteria (Polymarket's market `description`) are often stricter and more specific than the title implies, so the estimator can target the wrong condition. Giving the pipeline the authoritative resolution rules lets the sub-questions and the probability map to exactly what resolves the market.

## How

The trader (trader#989) fetches each Polymarket market's resolution `description` from the Gamma API and forwards it on the mech request inside `request_context["description"]` (Omen bets leave it unset). **The tool only reads it — it never contacts Polymarket itself**, so no price/odds/volume signal can leak into the research or estimate prompts, preserving v1's "facts, not odds" philosophy.

- `_extract_resolution_rules(request_context)` — reads `request_context["description"]`; returns `None` for non-dict / missing / blank → exact v1 fallback.
- `_format_resolution_block(description)` — renders the rules into a prompt block injected into the **Reframe** and **Estimate** stages (deliberately **not** Synthesis, which stays evidence-only).
- Graceful degradation: Omen markets, or any request without rules, behave exactly like v1.

### Benchmark

The benchmark stands in for the trader so the feature is exercised under replay:
- `build_request_context` populates `description` for Polymarket rows — preferring a pre-baked `dataset_row["description"]` (deterministic/offline), else fetching from Gamma via `_fetch_polymarket_description` (poly_-prefix strip, condition-id echo validation, open→closed fallback, description-only extraction, graceful `None`).
- No market price/liquidity is ever included. `run_single` forwards `request_context` to tools that read it.

## Housekeeping

- `tool_lineage.json`: one entry, `parent = factual_research-v1`.
- `benchmark/tools.py`: `TOOL_REGISTRY` entry for `factual_research-v2`.
- `packages/packages.json`: CID added via `autonomy packages lock` (verification successful).
- `benchmark/tournament_tools.json`: `factual_research-v2` → its locked package CID added, enrolling the tool in tournament mode (the project's first-deployment path). The CID is deterministic from `autonomy packages lock`; the package bytes still need a human `autonomy push-all` to IPFS before the tournament can fetch and run the tool.

## Testing

- Tool tests: extract / format / end-to-end injection (rules reach reframe + estimate, not synthesis; Omen degrades to v1).
- New `benchmark/tests/test_runner.py`: `_fetch_polymarket_description` (prefix strip, mismatch reject, closed fallback, non-200 / network-error → None) and `build_request_context` (prebaked-vs-fetch, Omen no-fetch, fetch-fails fallback).
- **59 tests pass**; lint clean (black, isort, flake8, mypy, pylint, darglint).


## Tool code diff vs v1

The new tool is a copy of `factual_research-v1` plus the additions below — everything else (the 3-call reframe→synthesise→estimate pipeline, Serper search, scraping, key rotation, source_content replay) is byte-identical to v1.

<details>
<summary><code>factual_research_v1.py</code> → <code>factual_research_v2.py</code></summary>

```diff
diff --git a/packages/valory/customs/factual_research_v1/factual_research_v1.py b/packages/valory/customs/factual_research_v2/factual_research_v2.py
index 032ba2c4..f818b749 100644
--- a/packages/valory/customs/factual_research_v1/factual_research_v1.py
+++ b/packages/valory/customs/factual_research_v2/factual_research_v2.py
@@ -37,6 +37,23 @@ Pipeline (3 structured-output LLM calls):
        into the standard ``{p_yes, p_no, confidence, info_utility}`` output
        required by the mech protocol.
 
+What v2 adds over factual_research-v1
+-------------------------------------
+For Polymarket markets, the mech request carries a ``request_context`` dict
+(built by the trader) whose ``description`` field holds the market's
+**resolution rules** — the authoritative criteria for how the market resolves
+YES/NO. The trader fetches that text from the Gamma API and forwards it on the
+request (see trader PR #989); v2 simply READS it and injects it into the
+**Reframe** step (so sub-questions target the exact resolution criteria) and the
+**Estimate** step (so the probability maps to the real resolution condition
+rather than a loose reading of the question).
+
+The tool itself never contacts Polymarket — fetching is the trader's job — so no
+price/odds/volume signal can leak in: the trader forwards only the resolution
+text, preserving the "facts, not odds" philosophy. v2 degrades to exact v1
+behaviour whenever no resolution rules are present (Omen markets, which omit the
+field, or any request without a ``description``).
+
 All LLM calls use OpenAI **Structured Outputs**
 (``client.beta.chat.completions.parse``) with Pydantic models, so responses
 are guaranteed to conform to the expected schema — no fragile JSON-in-prompt
@@ -303,7 +320,7 @@ DEFAULT_OPENAI_SETTINGS = {
     "temperature": 0,
 }
 DEFAULT_OPENAI_MODEL = "gpt-4.1-2025-04-14"
-ALLOWED_TOOLS = ["factual_research-v1"]
+ALLOWED_TOOLS = ["factual_research-v2"]
 ALLOWED_MODELS = [DEFAULT_OPENAI_MODEL]
 COMPLETION_RETRIES = 3
 COMPLETION_DELAY = 2
@@ -364,7 +381,7 @@ RULES
 
 INPUT QUESTION:
 \"\"\"{question}\"\"\"
-
+{resolution_rules}
 Today's date: {today}
 """
 
@@ -427,7 +444,7 @@ ESTIMATE_USER = """Relying exclusively on the factual briefing provided below, a
 
 ORIGINAL QUESTION:
 \"\"\"{question}\"\"\"
-
+{resolution_rules}
 Today's date: {today}
 
 FACTUAL BRIEFING:
@@ -731,6 +748,66 @@ def _extract_question(prompt: str) -> str:
         return prompt.strip()
 
 
+# ---------------------------------------------------------------------------
+# Resolution-rules helpers
+# ---------------------------------------------------------------------------
+#
+# The mech request for a Polymarket market carries a ``request_context`` dict
+# (built by the trader's ``Bet.to_request_context()``) whose ``description``
+# field holds the market's resolution rules. The trader fetches that text from
+# the Gamma API and forwards it on the request (trader PR #989); the tool simply
+# reads it. Omen requests omit the field, so they degrade to v1 behaviour.
+#
+# Only the resolution *rules* ever reach an LLM — the trader forwards no
+# price/odds/volume signal, so none can leak into the research or estimate
+# prompts.
+
+
+def _extract_resolution_rules(request_context: Any) -> Optional[str]:
+    """Read the resolution rules the trader passed in the request context.
+
+    The trader fetches a Polymarket market's resolution description and forwards
+    it as ``request_context["description"]`` (Omen requests omit the field).
+    Returns the stripped rules text, or ``None`` when the context is missing,
+    not a dict, or carries no usable description — so the caller degrades to
+    exact v1 behaviour.
+
+    :param request_context: The ``request_context`` kwarg from the mech request.
+    :type request_context: Any
+
+    :return: The resolution-rules text, or ``None``.
+    :rtype: Optional[str]
+    """
+    if not isinstance(request_context, dict):
+        return None
+    description = request_context.get("description")
+    if not isinstance(description, str):
+        return None
+    description = description.strip()
+    return description or None
+
+
+def _format_resolution_block(description: Optional[str]) -> str:
+    """Render resolution rules into a prompt block.
+
+    :param description: Resolution-rules text from
+        :func:`_extract_resolution_rules`.
+    :type description: Optional[str]
+
+    :return: A prompt-ready block, or "" when no rules are present.
+    :rtype: str
+    """
+    if not description:
+        return ""
+    return (
+        "\nMARKET RESOLUTION RULES (the authoritative criteria for how this "
+        f'market resolves YES vs NO):\n"""{description}"""\n'
+        "Treat these rules as the precise definition of what counts as a YES "
+        "resolution; align your work with this exact condition, not a loose "
+        "reading of the question.\n"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Entry-point
 # ---------------------------------------------------------------------------
@@ -803,6 +880,23 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
         today = date.today().strftime("%Y-%m-%d")
         question = _extract_question(prompt)
 
+        # ---------------------------------------------------------------
+        # Step 0 — Polymarket resolution rules (v2 evidence source)
+        # ---------------------------------------------------------------
+        # For Polymarket markets the trader fetches the resolution rules and
+        # forwards them in request_context["description"]; we read them (never
+        # prices) and inject them into the reframe + estimate prompts.
+        # Non-Polymarket / missing → "" → exact v1 behaviour.
+        resolution_description = _extract_resolution_rules(
+            kwargs.get("request_context")
+        )
+        resolution_rules = _format_resolution_block(resolution_description)
+        if resolution_description:
+            print(
+                "[factual_research] Loaded Polymarket resolution rules "
+                f"({len(resolution_description)} chars)."
+            )
+
         # ---------------------------------------------------------------
         # Step 1 — Reframe into factual sub-questions  (Structured Output)
         # ---------------------------------------------------------------
@@ -811,7 +905,9 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
             {"role": "system", "content": REFRAME_SYSTEM},
             {
                 "role": "user",
-                "content": REFRAME_USER.format(question=question, today=today),
+                "content": REFRAME_USER.format(
+                    question=question, today=today, resolution_rules=resolution_rules
+                ),
             },
         ]
 
@@ -988,7 +1084,10 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
             {
                 "role": "user",
                 "content": ESTIMATE_USER.format(
-                    question=question, today=today, briefing=briefing_text
+                    question=question,
+                    today=today,
+                    briefing=briefing_text,
+                    resolution_rules=resolution_rules,
                 ),
             },
         ]
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)