### PR TITLE
feat(triage): replace Brier-band re-arm with flat N-day cooldown after close

### DIFF
--- a/benchmark/tests/test_tool_improvement_triage.py
+++ b/benchmark/tests/test_tool_improvement_triage.py
@@ -34,7 +34,6 @@ from types import SimpleNamespace
 from typing import Any, Dict
 
 import pytest
-
 from benchmark.tool_improvement_triage import (
     BRIER_LEVEL_THRESHOLD,
     BRIER_REGRESSION_THRESHOLD,
@@ -1167,6 +1166,8 @@ class TestCooldownStatusLogging:
         lets the issue fire. The fix mirrors the gate's predicate exactly
         (``last_close >= cutoff``) so the log and the decision can never
         disagree on a tool the operator is consulting the log about.
+
+        :param caplog: pytest log capture fixture.
         """
         # 43 hours ago with N=1 -> outside the gate window (gate fires),
         # but age.days == 1 -> floored-day status would have said ACTIVE.

--- a/benchmark/tests/test_tool_improvement_triage.py
+++ b/benchmark/tests/test_tool_improvement_triage.py
@@ -34,8 +34,8 @@ from types import SimpleNamespace
 from typing import Any, Dict
 
 import pytest
+
 from benchmark.tool_improvement_triage import (
-    BRIER_LEVEL_RE_ARM,
     BRIER_LEVEL_THRESHOLD,
     BRIER_REGRESSION_THRESHOLD,
     RECENT_CLOSE_DAYS,
@@ -775,160 +775,13 @@ class TestLevelFloorIssueBody:
         assert "factual_research" in body
 
 
-def _prior_level_floor_state(*tools: str) -> Dict[str, Any]:
-    """Prior state where each tool's last open_issue carried trigger=level_floor."""
-    # The cooldown reads the dedicated ``trigger`` field (not ``reason``)
-    # because ``reason`` gets clobbered with ``duplicate_suppressed``
-    # every day the GitHub issue is open. Simulating an open-then-closed
-    # level issue means injecting the ``trigger`` marker the live
-    # pipeline would have set when it first opened.
-    return {
-        "by_tool": {
-            t: {
-                "issue_open": False,
-                "reason": "duplicate_suppressed",
-                "trigger": "level_floor",
-            }
-            for t in tools
-        }
-    }
+class TestLevelFloorAndRegressionCoverage:
+    """Closes the test gap @OjusWiZard flagged on the missing_log_loss branches."""
 
-
-def _state_from_decisions(decisions: list) -> Dict[str, Any]:
-    """Build a prior_state dict from triage() output (mimics write_state)."""
-    return {
-        "by_tool": {
-            d["tool"]: {
-                "decision": d["decision"],
-                "reason": d["reason"],
-                "trigger": d.get("trigger"),
-                "issue_open": d["issue_open"],
-            }
-            for d in decisions
-        }
-    }
-
-
-class TestLevelFloorCooldown:
-    """A closed level_floor issue stays suppressed until Brier drops below the re-arm band."""
-
-    def test_closed_level_floor_suppressed_while_brier_above_rearm(self) -> None:
-        """Live open_now=[] + brier still above 0.22 -> cooldown, no re-open."""
-        # Prior state: level_floor issue was open and is now closed (so
-        # open_now=[]). Brier is still above the re-arm band -> must NOT
-        # reopen.
-        prior = _prior_level_floor_state("a")
-        d = triage(
-            _scores(a=_stats(brier=0.260, log_loss=0.610)),
-            _scores(a=_stats(brier=0.260, log_loss=0.610)),
-            prior,
-            open_now=[],
-        )
-        assert d[0]["decision"] == "silent"
-        assert d[0]["reason"] == "level_floor_cooldown"
-        assert d[0]["trigger"] == "level_floor"
-        # Cooldown is a local suppression after the GitHub issue closed,
-        # so issue_open=False (no live issue exists). The trigger marker
-        # carries the cooldown state across runs.
-        assert d[0]["issue_open"] is False
-
-    def test_closed_level_floor_re_arms_below_band(self) -> None:
-        """Brier dropped below BRIER_LEVEL_RE_ARM -> cooldown lifts and tool can re-fire later."""
-        # Brier below 0.22 today + below the level floor + no
-        # regression -> silent/no_regression, cooldown effectively
-        # over.
-        prior = _prior_level_floor_state("a")
-        d = triage(
-            _scores(a=_stats(brier=0.150, log_loss=0.580)),
-            _scores(a=_stats(brier=0.160, log_loss=0.610)),
-            prior,
-            open_now=[],
-        )
-        assert d[0]["decision"] == "silent"
-        assert d[0]["reason"] == "no_regression"
-
-    def test_cooldown_does_not_block_regression_reason(self) -> None:
-        """Hysteresis applies to level_floor only; regression-reason re-fires immediately."""
-        # Same tool had a closed level_floor issue, but today it
-        # genuinely regresses (delta > 0.040 + sign agreement) -> the
-        # cooldown must not stop a regression dispatch.
-        prior = _prior_level_floor_state("a")
-        d = triage(
-            _scores(a=_stats(brier=0.260, log_loss=0.700)),
-            _scores(a=_stats(brier=0.210, log_loss=0.610)),
-            prior,
-            open_now=[],
-        )
-        assert d[0]["decision"] == "open_issue"
-        assert d[0]["reason"] == "regression"
-
-    def test_cooldown_constant_below_threshold(self) -> None:
-        """The re-arm constant must sit strictly below the level threshold."""
-        assert BRIER_LEVEL_RE_ARM < BRIER_LEVEL_THRESHOLD
-
-    def test_cooldown_survives_duplicate_suppressed_lifecycle(self) -> None:
-        """End-to-end lifecycle: open -> N days suppressed -> close -> still cooldown.
-
-        @OjusWiZard test_tool_improvement_triage.py:727 thread: the previous
-        cooldown test injected reason=level_floor directly, skipping the
-        duplicate_suppressed overwrite that happens on every real day the
-        issue is open. This test runs the actual day-by-day state machine
-        to prove the trigger marker survives the entire suppressed period.
-        """
-        # Day 1: Brier 0.30, no prior state -> open level_floor issue
-        cur = _scores(a=_stats(brier=0.300, log_loss=0.620))
-        prev = _scores(a=_stats(brier=0.295, log_loss=0.610))
-        d1 = triage(cur, prev, {}, open_now=[])
-        assert d1[0]["decision"] == "open_issue"
-        assert d1[0]["trigger"] == "level_floor"
-        state = _state_from_decisions(d1)
-
-        # Days 2..8: GitHub issue is open, Brier still 0.30. Every day
-        # triage writes reason=duplicate_suppressed. The trigger marker
-        # must persist through ALL of these writes.
-        for _ in range(7):
-            dN = triage(cur, prev, state, open_now=["a"])
-            assert dN[0]["decision"] == "silent"
-            assert dN[0]["reason"] == "duplicate_suppressed"
-            assert dN[0]["trigger"] == "level_floor"  # the load-bearing claim
-            state = _state_from_decisions(dN)
-
-        # Day 9: operator closes the GitHub issue as wontfix.
-        # Brier is still 0.30 (above 0.22 re-arm band). The cooldown must
-        # engage and stop a new issue from firing.
-        d9 = triage(cur, prev, state, open_now=[])
-        assert d9[0]["decision"] == "silent"
-        assert d9[0]["reason"] == "level_floor_cooldown"
-        assert d9[0]["trigger"] == "level_floor"
-
-    def test_cooldown_holds_in_hysteresis_band(self) -> None:
-        """Brier in (BRIER_LEVEL_RE_ARM, BRIER_LEVEL_THRESHOLD] keeps cooldown alive.
-
-        Without the cooldown check running before the no_regression guard,
-        a Brier in this band exits via no_regression (above_level is False)
-        and silently clears the marker. This test forces the band traversal.
-        """
-        prior = _prior_level_floor_state("a")
-        # Brier 0.230 sits inside (0.22, 0.25] -> above_level=False, no
-        # regression, but cooldown must still fire.
-        d = triage(
-            _scores(a=_stats(brier=0.230, log_loss=0.600)),
-            _scores(a=_stats(brier=0.225, log_loss=0.595)),
-            prior,
-            open_now=[],
-        )
-        assert d[0]["decision"] == "silent"
-        assert d[0]["reason"] == "level_floor_cooldown"
-        assert d[0]["trigger"] == "level_floor"
-
-
-class TestLevelFloorReArmAndRegressionCoverage:
-    """Closes the test gap @OjusWiZard flagged on the re-arm + missing_log_loss branches."""
-
-    def test_open_now_empty_re_arms_level_floor(self) -> None:
-        """Re-arm path for reason=level_floor (no prior level cooldown, no regression)."""
-        # No prior state -> no cooldown. Brier above 0.25, no
-        # regression -> level_floor fires.
+    def test_open_now_empty_fires_level_floor(self) -> None:
+        """Re-fire path for reason=level_floor (no prior cooldown, no regression)."""
+        # No prior state, no closed_issues -> no cooldown. Brier above
+        # 0.25, no regression -> level_floor fires.
         d = triage(
             _scores(a=_stats(brier=0.270, log_loss=0.610)),
             _scores(a=_stats(brier=0.265, log_loss=0.610)),
@@ -1037,14 +890,15 @@ _NOW = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc)
 class TestRecentlyClosedSilence:
     """Issues closed within RECENT_CLOSE_DAYS silence any re-fire of the same pair.
 
-    Stacks ON TOP of the existing Brier-band re-arm: even when the re-arm
-    would have allowed a fire (e.g. regression bypass), the recently-closed
-    silence wins. Tests exercise both triggers + the "no trigger" pass-through.
+    Replaces the previous Brier-band re-arm hysteresis: a partial fix that
+    leaves the Brier above ``BRIER_LEVEL_THRESHOLD`` is allowed to re-fire
+    after the window elapses. Tests exercise both triggers + the "no
+    trigger" pass-through.
     """
 
     def test_recently_closed_above_level_silenced(self) -> None:
         """Tool would fire level_floor but closed within window -> silent."""
-        closed = _closed_triples(("a", "polymarket"), days_ago=1)
+        closed = _closed_triples(("a", "polymarket"), days_ago=0)
         d = triage(
             _scores(a=_stats(brier=0.300, log_loss=0.620)),
             _scores(a=_stats(brier=0.295, log_loss=0.610)),
@@ -1059,8 +913,8 @@ class TestRecentlyClosedSilence:
         assert d[0]["issue_open"] is False
 
     def test_recently_closed_regression_silenced(self) -> None:
-        """Regression delta crossed but closed recently -> silent (cooldown wins over re-arm bypass)."""
-        closed = _closed_triples(("a", "polymarket"), days_ago=2)
+        """Regression delta crossed but closed recently -> silent."""
+        closed = _closed_triples(("a", "polymarket"), days_ago=0)
         d = triage(
             _scores(a=_stats(brier=0.270, log_loss=0.700)),
             _scores(a=_stats(brier=0.210, log_loss=0.610)),
@@ -1075,7 +929,7 @@ class TestRecentlyClosedSilence:
 
     def test_recently_closed_but_no_trigger_passes_through(self) -> None:
         """No trigger fires -> cooldown gate is irrelevant; standard no_regression."""
-        closed = _closed_triples(("a", "polymarket"), days_ago=1)
+        closed = _closed_triples(("a", "polymarket"), days_ago=0)
         d = triage(
             _scores(a=_stats(brier=0.180, log_loss=0.580)),
             _scores(a=_stats(brier=0.180, log_loss=0.580)),
@@ -1136,27 +990,24 @@ class TestRecentlyClosedSilence:
         assert RECENT_CLOSE_DAYS > 0
 
 
-class TestStaleClosedMarkerReset:
-    """A close older than RECENT_CLOSE_DAYS clears the level_cooldown marker.
+class TestCloseOlderThanWindow:
+    """Closes older than ``RECENT_CLOSE_DAYS`` are out of cooldown -> tool can re-fire.
 
-    Without reset, a level_floor marker stored in state would silence a tool
-    indefinitely once the Brier sat in the re-arm band [0.22, 0.25]. The
-    reset lets the loop re-evaluate a still-bad tool as a fresh issue once
-    engineers have had the silence window to act.
+    This is the dead-zone fix: under the previous Brier-band re-arm a partial
+    fix that left the Brier above ``BRIER_LEVEL_THRESHOLD`` could silence a
+    tool forever. The flat N-day cooldown elapses on its own.
     """
 
-    def test_stale_close_clears_marker_so_tool_re_fires(self) -> None:
-        """Closed > N days ago + Brier in re-arm band -> marker reset, level_floor fires."""
-        # Pre-fix this scenario was silenced forever by the re-arm: prior
-        # state has trigger=level_floor, Brier=0.260 sits above re-arm
-        # 0.22 and above level threshold 0.25, no regression delta. The
-        # re-arm marker would have held silent forever.
-        prior = {"by_tool": {"a": {"trigger": "level_floor", "issue_open": False}}}
+    def test_old_close_does_not_silence_above_level_tool(self) -> None:
+        """Closed > N days ago + Brier still above threshold -> level_floor fires fresh."""
+        # The same scenario that under the old re-arm marker would have
+        # been silenced indefinitely: Brier 0.260 (above threshold), no
+        # regression, but the close is outside the cooldown window.
         closed = _closed_triples(("a", "polymarket"), days_ago=RECENT_CLOSE_DAYS + 2)
         d = triage(
             _scores(a=_stats(brier=0.260, log_loss=0.610)),
             _scores(a=_stats(brier=0.260, log_loss=0.610)),
-            prior,
+            {},
             open_now=[],
             closed_issues=closed,
             now=_NOW,
@@ -1164,14 +1015,10 @@ class TestStaleClosedMarkerReset:
         assert d[0]["decision"] == "open_issue"
         assert d[0]["reason"] == "level_floor"
 
-    def test_stale_close_does_not_silence_recent_close_via_recently_closed(
-        self,
-    ) -> None:
-        """A pair with BOTH a stale and a recent close -> recent close wins (silenced)."""
-        # Tool was closed 10 days ago AND again 2 days ago. The most
-        # recent close is within the window -> silenced.
-        old = _closed_triples(("a", "polymarket"), days_ago=10)
-        new = _closed_triples(("a", "polymarket"), days_ago=2)
+    def test_most_recent_close_wins_when_both_old_and_new_exist(self) -> None:
+        """A pair with BOTH an old and a recent close -> recent close drives the cooldown."""
+        old = _closed_triples(("a", "polymarket"), days_ago=RECENT_CLOSE_DAYS + 9)
+        new = _closed_triples(("a", "polymarket"), days_ago=0)
         d = triage(
             _scores(a=_stats(brier=0.300, log_loss=0.620)),
             _scores(a=_stats(brier=0.295, log_loss=0.610)),
@@ -1183,46 +1030,127 @@ class TestStaleClosedMarkerReset:
         assert d[0]["decision"] == "silent"
         assert d[0]["reason"] == "recently_closed"
 
-    def test_recent_close_preserves_marker(self) -> None:
-        """A close WITHIN the window does NOT mark the level_cooldown marker stale."""
-        # The recently_closed silence already fires (silencing in band as
-        # well), but the test pins down that the marker reset only fires
-        # for stale closes -- not every close. Distinguished by: the
-        # decision uses "recently_closed", not "level_floor_cooldown".
-        prior = {"by_tool": {"a": {"trigger": "level_floor", "issue_open": False}}}
-        closed = _closed_triples(("a", "polymarket"), days_ago=1)
-        d = triage(
-            _scores(a=_stats(brier=0.260, log_loss=0.610)),
-            _scores(a=_stats(brier=0.260, log_loss=0.610)),
-            prior,
-            open_now=[],
-            closed_issues=closed,
-            now=_NOW,
-        )
-        # Brier 0.260 is above level threshold, so trigger fires;
-        # recently_closed silences it. The level_cooldown reset is NOT
-        # exercised because the close is recent (within window).
-        assert d[0]["decision"] == "silent"
-        assert d[0]["reason"] == "recently_closed"
-
-    def test_stale_close_clears_marker_then_no_trigger_falls_through(self) -> None:
-        """Stale close + benign Brier -> marker cleared, no spurious silence."""
-        # If the reset cleared the marker INCORRECTLY (e.g. set
-        # level_cooldown wrong polarity), this tool would either be
-        # silenced as level_floor_cooldown or fire spuriously. The
-        # expected path is plain no_regression silence.
-        prior = {"by_tool": {"a": {"trigger": "level_floor", "issue_open": False}}}
+    def test_old_close_with_benign_brier_silent_no_regression(self) -> None:
+        """Old close + benign Brier -> standard no_regression silence, no spurious gate fires."""
         closed = _closed_triples(("a", "polymarket"), days_ago=RECENT_CLOSE_DAYS + 5)
         d = triage(
             _scores(a=_stats(brier=0.180, log_loss=0.580)),
             _scores(a=_stats(brier=0.180, log_loss=0.580)),
-            prior,
+            {},
             open_now=[],
             closed_issues=closed,
             now=_NOW,
         )
         assert d[0]["decision"] == "silent"
         assert d[0]["reason"] == "no_regression"
+
+
+class TestCooldownStatusLogging:
+    """Per-tool cooldown status is logged as INFO so the operator can see why a tool is (or isn't) firing."""
+
+    def test_active_cooldown_logs_active(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A tool with a close within the window logs cooldown ACTIVE."""
+        closed = _closed_triples(("a", "polymarket"), days_ago=0)
+        with caplog.at_level(logging.INFO, logger="benchmark.tool_improvement_triage"):
+            triage(
+                _scores(a=_stats(brier=0.300, log_loss=0.620)),
+                _scores(a=_stats(brier=0.295, log_loss=0.610)),
+                {},
+                open_now=[],
+                closed_issues=closed,
+                now=_NOW,
+            )
+        matches = [
+            r.getMessage()
+            for r in caplog.records
+            if "cooldown ACTIVE" in r.getMessage()
+        ]
+        assert len(matches) == 1
+        assert "'a'" in matches[0]
+        assert "'polymarket'" in matches[0]
+        assert f"N={RECENT_CLOSE_DAYS}" in matches[0]
+
+    def test_elapsed_cooldown_logs_elapsed(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A tool whose close is past the window logs cooldown ELAPSED."""
+        closed = _closed_triples(("a", "polymarket"), days_ago=RECENT_CLOSE_DAYS + 2)
+        with caplog.at_level(logging.INFO, logger="benchmark.tool_improvement_triage"):
+            triage(
+                _scores(a=_stats(brier=0.180, log_loss=0.580)),
+                _scores(a=_stats(brier=0.180, log_loss=0.580)),
+                {},
+                open_now=[],
+                closed_issues=closed,
+                now=_NOW,
+            )
+        matches = [
+            r.getMessage()
+            for r in caplog.records
+            if "cooldown ELAPSED" in r.getMessage()
+        ]
+        assert len(matches) == 1
+        assert "'a'" in matches[0]
+
+    def test_no_close_history_no_log(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A tool with no recent close history produces no cooldown log line."""
+        with caplog.at_level(logging.INFO, logger="benchmark.tool_improvement_triage"):
+            triage(
+                _scores(a=_stats(brier=0.180, log_loss=0.580)),
+                _scores(a=_stats(brier=0.180, log_loss=0.580)),
+                {},
+                open_now=[],
+                closed_issues=[],
+                now=_NOW,
+            )
+        assert not any(
+            "cooldown ACTIVE" in r.getMessage() or "cooldown ELAPSED" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_ancient_close_outside_horizon_not_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A close far past the log horizon (2*N+7 days) produces no log noise."""
+        closed = _closed_triples(
+            ("a", "polymarket"), days_ago=2 * RECENT_CLOSE_DAYS + 30
+        )
+        with caplog.at_level(logging.INFO, logger="benchmark.tool_improvement_triage"):
+            triage(
+                _scores(a=_stats(brier=0.180, log_loss=0.580)),
+                _scores(a=_stats(brier=0.180, log_loss=0.580)),
+                {},
+                open_now=[],
+                closed_issues=closed,
+                now=_NOW,
+            )
+        assert not any(
+            "cooldown ACTIVE" in r.getMessage() or "cooldown ELAPSED" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_retired_tool_with_close_not_logged(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A tool not in current rolling scores (retired) doesn't log a cooldown line."""
+        # closed_issues references "b" but cur only has "a" -> the cur_tools
+        # gate keeps the retired tool's log line out.
+        closed = _closed_triples(("b", "polymarket"), days_ago=0)
+        with caplog.at_level(logging.INFO, logger="benchmark.tool_improvement_triage"):
+            triage(
+                _scores(a=_stats(brier=0.180, log_loss=0.580)),
+                _scores(a=_stats(brier=0.180, log_loss=0.580)),
+                {},
+                open_now=[],
+                closed_issues=closed,
+                now=_NOW,
+            )
+        assert not any(
+            "'b'" in r.getMessage() and "cooldown" in r.getMessage()
+            for r in caplog.records
+        )
 
 
 class TestMainExitCode:

--- a/benchmark/tests/test_tool_improvement_triage.py
+++ b/benchmark/tests/test_tool_improvement_triage.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import json
 import logging
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Dict
@@ -38,6 +38,7 @@ from benchmark.tool_improvement_triage import (
     BRIER_LEVEL_RE_ARM,
     BRIER_LEVEL_THRESHOLD,
     BRIER_REGRESSION_THRESHOLD,
+    RECENT_CLOSE_DAYS,
     RELIABILITY_FLOOR,
     VALID_N_PER_WINDOW_FLOOR,
     _load_json,
@@ -1014,6 +1015,214 @@ class TestLevelFloorReArmAndRegressionCoverage:
         row = payload["by_tool"]["a"]
         assert row["decision"] == "reliability_collapse"
         assert row["delta_brier"] is None
+
+
+def _closed_triples(*pairs: Any, days_ago: int) -> Any:
+    """Helper: build a `(tool, platform, closed_at)` list for ``triage(closed_issues=...)``.
+
+    :param pairs: (tool, platform) tuples to time-stamp identically.
+    :param days_ago: how many days ago each close happened (used to land
+        inside or outside the RECENT_CLOSE_DAYS window).
+    :return: list of (tool, platform, closed_at) triples.
+    """
+    closed_at = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc) - timedelta(
+        days=days_ago
+    )
+    return [(t, p, closed_at) for t, p in pairs]
+
+
+_NOW = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class TestRecentlyClosedSilence:
+    """Issues closed within RECENT_CLOSE_DAYS silence any re-fire of the same pair.
+
+    Stacks ON TOP of the existing Brier-band re-arm: even when the re-arm
+    would have allowed a fire (e.g. regression bypass), the recently-closed
+    silence wins. Tests exercise both triggers + the "no trigger" pass-through.
+    """
+
+    def test_recently_closed_above_level_silenced(self) -> None:
+        """Tool would fire level_floor but closed within window -> silent."""
+        closed = _closed_triples(("a", "polymarket"), days_ago=1)
+        d = triage(
+            _scores(a=_stats(brier=0.300, log_loss=0.620)),
+            _scores(a=_stats(brier=0.295, log_loss=0.610)),
+            {},
+            open_now=[],
+            closed_issues=closed,
+            now=_NOW,
+        )
+        assert d[0]["decision"] == "silent"
+        assert d[0]["reason"] == "recently_closed"
+        assert d[0]["trigger"] == "level_floor"
+        assert d[0]["issue_open"] is False
+
+    def test_recently_closed_regression_silenced(self) -> None:
+        """Regression delta crossed but closed recently -> silent (cooldown wins over re-arm bypass)."""
+        closed = _closed_triples(("a", "polymarket"), days_ago=2)
+        d = triage(
+            _scores(a=_stats(brier=0.270, log_loss=0.700)),
+            _scores(a=_stats(brier=0.210, log_loss=0.610)),
+            {},
+            open_now=[],
+            closed_issues=closed,
+            now=_NOW,
+        )
+        assert d[0]["decision"] == "silent"
+        assert d[0]["reason"] == "recently_closed"
+        assert d[0]["trigger"] == "regression"
+
+    def test_recently_closed_but_no_trigger_passes_through(self) -> None:
+        """No trigger fires -> cooldown gate is irrelevant; standard no_regression."""
+        closed = _closed_triples(("a", "polymarket"), days_ago=1)
+        d = triage(
+            _scores(a=_stats(brier=0.180, log_loss=0.580)),
+            _scores(a=_stats(brier=0.180, log_loss=0.580)),
+            {},
+            open_now=[],
+            closed_issues=closed,
+            now=_NOW,
+        )
+        assert d[0]["decision"] == "silent"
+        assert d[0]["reason"] == "no_regression"
+
+    def test_recently_closed_filtered_by_platform(self) -> None:
+        """Close on `(tool, platform_A)` must not silence `(tool, platform_B)`."""
+        closed = _closed_triples(("a", "omen"), days_ago=1)
+        d = triage(
+            _scores(a=_stats(brier=0.300, log_loss=0.620)),
+            _scores(a=_stats(brier=0.295, log_loss=0.610)),
+            {},
+            platform="polymarket",
+            open_now=[],
+            closed_issues=closed,
+            now=_NOW,
+        )
+        assert d[0]["decision"] == "open_issue"
+        assert d[0]["reason"] == "level_floor"
+
+    def test_closed_issues_none_applies_no_cooldown(self) -> None:
+        """Gh failure path: closed_issues=None -> no cooldown, fires normally."""
+        d = triage(
+            _scores(a=_stats(brier=0.300, log_loss=0.620)),
+            _scores(a=_stats(brier=0.295, log_loss=0.610)),
+            {},
+            open_now=[],
+            closed_issues=None,
+            now=_NOW,
+        )
+        assert d[0]["decision"] == "open_issue"
+        assert d[0]["reason"] == "level_floor"
+
+    def test_close_exactly_at_window_boundary_silenced(self) -> None:
+        """Close on the exact RECENT_CLOSE_DAYS boundary is still recent (>= cutoff)."""
+        closed = _closed_triples(("a", "polymarket"), days_ago=RECENT_CLOSE_DAYS)
+        d = triage(
+            _scores(a=_stats(brier=0.300, log_loss=0.620)),
+            _scores(a=_stats(brier=0.295, log_loss=0.610)),
+            {},
+            open_now=[],
+            closed_issues=closed,
+            now=_NOW,
+        )
+        # Boundary uses >= so the close at exactly N days ago still silences.
+        assert d[0]["decision"] == "silent"
+        assert d[0]["reason"] == "recently_closed"
+
+    def test_recent_close_days_constant_is_positive(self) -> None:
+        """RECENT_CLOSE_DAYS must be a positive integer or the gate becomes a no-op."""
+        assert isinstance(RECENT_CLOSE_DAYS, int)
+        assert RECENT_CLOSE_DAYS > 0
+
+
+class TestStaleClosedMarkerReset:
+    """A close older than RECENT_CLOSE_DAYS clears the level_cooldown marker.
+
+    Without reset, a level_floor marker stored in state would silence a tool
+    indefinitely once the Brier sat in the re-arm band [0.22, 0.25]. The
+    reset lets the loop re-evaluate a still-bad tool as a fresh issue once
+    engineers have had the silence window to act.
+    """
+
+    def test_stale_close_clears_marker_so_tool_re_fires(self) -> None:
+        """Closed > N days ago + Brier in re-arm band -> marker reset, level_floor fires."""
+        # Pre-fix this scenario was silenced forever by the re-arm: prior
+        # state has trigger=level_floor, Brier=0.260 sits above re-arm
+        # 0.22 and above level threshold 0.25, no regression delta. The
+        # re-arm marker would have held silent forever.
+        prior = {"by_tool": {"a": {"trigger": "level_floor", "issue_open": False}}}
+        closed = _closed_triples(("a", "polymarket"), days_ago=RECENT_CLOSE_DAYS + 2)
+        d = triage(
+            _scores(a=_stats(brier=0.260, log_loss=0.610)),
+            _scores(a=_stats(brier=0.260, log_loss=0.610)),
+            prior,
+            open_now=[],
+            closed_issues=closed,
+            now=_NOW,
+        )
+        assert d[0]["decision"] == "open_issue"
+        assert d[0]["reason"] == "level_floor"
+
+    def test_stale_close_does_not_silence_recent_close_via_recently_closed(
+        self,
+    ) -> None:
+        """A pair with BOTH a stale and a recent close -> recent close wins (silenced)."""
+        # Tool was closed 10 days ago AND again 2 days ago. The most
+        # recent close is within the window -> silenced.
+        old = _closed_triples(("a", "polymarket"), days_ago=10)
+        new = _closed_triples(("a", "polymarket"), days_ago=2)
+        d = triage(
+            _scores(a=_stats(brier=0.300, log_loss=0.620)),
+            _scores(a=_stats(brier=0.295, log_loss=0.610)),
+            {},
+            open_now=[],
+            closed_issues=old + new,
+            now=_NOW,
+        )
+        assert d[0]["decision"] == "silent"
+        assert d[0]["reason"] == "recently_closed"
+
+    def test_recent_close_preserves_marker(self) -> None:
+        """A close WITHIN the window does NOT mark the level_cooldown marker stale."""
+        # The recently_closed silence already fires (silencing in band as
+        # well), but the test pins down that the marker reset only fires
+        # for stale closes -- not every close. Distinguished by: the
+        # decision uses "recently_closed", not "level_floor_cooldown".
+        prior = {"by_tool": {"a": {"trigger": "level_floor", "issue_open": False}}}
+        closed = _closed_triples(("a", "polymarket"), days_ago=1)
+        d = triage(
+            _scores(a=_stats(brier=0.260, log_loss=0.610)),
+            _scores(a=_stats(brier=0.260, log_loss=0.610)),
+            prior,
+            open_now=[],
+            closed_issues=closed,
+            now=_NOW,
+        )
+        # Brier 0.260 is above level threshold, so trigger fires;
+        # recently_closed silences it. The level_cooldown reset is NOT
+        # exercised because the close is recent (within window).
+        assert d[0]["decision"] == "silent"
+        assert d[0]["reason"] == "recently_closed"
+
+    def test_stale_close_clears_marker_then_no_trigger_falls_through(self) -> None:
+        """Stale close + benign Brier -> marker cleared, no spurious silence."""
+        # If the reset cleared the marker INCORRECTLY (e.g. set
+        # level_cooldown wrong polarity), this tool would either be
+        # silenced as level_floor_cooldown or fire spuriously. The
+        # expected path is plain no_regression silence.
+        prior = {"by_tool": {"a": {"trigger": "level_floor", "issue_open": False}}}
+        closed = _closed_triples(("a", "polymarket"), days_ago=RECENT_CLOSE_DAYS + 5)
+        d = triage(
+            _scores(a=_stats(brier=0.180, log_loss=0.580)),
+            _scores(a=_stats(brier=0.180, log_loss=0.580)),
+            prior,
+            open_now=[],
+            closed_issues=closed,
+            now=_NOW,
+        )
+        assert d[0]["decision"] == "silent"
+        assert d[0]["reason"] == "no_regression"
 
 
 class TestMainExitCode:

--- a/benchmark/tests/test_tool_improvement_triage.py
+++ b/benchmark/tests/test_tool_improvement_triage.py
@@ -41,6 +41,7 @@ from benchmark.tool_improvement_triage import (
     RECENT_CLOSE_DAYS,
     RELIABILITY_FLOOR,
     VALID_N_PER_WINDOW_FLOOR,
+    _closed_issue_pairs,
     _load_json,
     _open_issue,
     _open_issue_tools,
@@ -870,16 +871,19 @@ class TestLevelFloorAndRegressionCoverage:
         assert row["delta_brier"] is None
 
 
-def _closed_triples(*pairs: Any, days_ago: int) -> Any:
+def _closed_triples(*pairs: Any, days_ago: int = 0, hours_ago: int = 0) -> Any:
     """Helper: build a `(tool, platform, closed_at)` list for ``triage(closed_issues=...)``.
 
     :param pairs: (tool, platform) tuples to time-stamp identically.
     :param days_ago: how many days ago each close happened (used to land
         inside or outside the RECENT_CLOSE_DAYS window).
+    :param hours_ago: additional hours offset for fractional-day testing
+        (e.g. ``hours_ago=43`` lands the close in the ``(1d, 2d)`` band that
+        exercises the gate-vs-log status agreement on N=1).
     :return: list of (tool, platform, closed_at) triples.
     """
     closed_at = datetime(2026, 6, 6, 12, 0, 0, tzinfo=timezone.utc) - timedelta(
-        days=days_ago
+        days=days_ago, hours=hours_ago
     )
     return [(t, p, closed_at) for t, p in pairs]
 
@@ -1151,6 +1155,164 @@ class TestCooldownStatusLogging:
             "'b'" in r.getMessage() and "cooldown" in r.getMessage()
             for r in caplog.records
         )
+
+    def test_fractional_band_log_status_matches_gate(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Log status must agree with the gate in the (N, N+1)-day band.
+
+        Regression guard for the gate-vs-log mismatch flagged in PR #329
+        review: with N=1, a close ~43h ago lands in the (1d, 2d) band where
+        ``age.days == 1`` would falsely say ACTIVE while the gate actually
+        lets the issue fire. The fix mirrors the gate's predicate exactly
+        (``last_close >= cutoff``) so the log and the decision can never
+        disagree on a tool the operator is consulting the log about.
+        """
+        # 43 hours ago with N=1 -> outside the gate window (gate fires),
+        # but age.days == 1 -> floored-day status would have said ACTIVE.
+        closed = _closed_triples(("a", "polymarket"), hours_ago=43)
+        with caplog.at_level(logging.INFO, logger="benchmark.tool_improvement_triage"):
+            decisions = triage(
+                _scores(a=_stats(brier=0.300, log_loss=0.620)),
+                _scores(a=_stats(brier=0.295, log_loss=0.610)),
+                {},
+                open_now=[],
+                closed_issues=closed,
+                now=_NOW,
+            )
+        # Gate fires the issue (close is past the N=1 window).
+        assert decisions[0]["decision"] == "open_issue"
+        assert decisions[0]["reason"] == "level_floor"
+        # Log must agree: ELAPSED, not ACTIVE.
+        log_lines = [
+            r.getMessage() for r in caplog.records if "cooldown" in r.getMessage()
+        ]
+        assert len(log_lines) == 1
+        assert "cooldown ELAPSED" in log_lines[0]
+        assert "cooldown ACTIVE" not in log_lines[0]
+
+
+class TestClosedIssuePairs:
+    """``_closed_issue_pairs`` backtick title + ``closedAt`` parsing + gh-error fallback.
+
+    Mirrors :class:`TestOpenIssueToolsParser` for the closed-issue sibling
+    which adds ``closedAt`` ISO parsing on top of the title-regex flow. These
+    are the fail-open paths the cooldown design leans on.
+    """
+
+    def test_parses_tool_platform_and_closed_at(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """(tool, platform, closed_at) triples are extracted with timezone-aware UTC."""
+        stdout = (
+            '[{"title": "[tool-improvement] `superforcaster`: Brier '
+            'regression on polymarket W-1", "closedAt": "2026-06-05T10:30:00Z"},'
+            ' {"title": "[tool-improvement] `factual_research`: Brier '
+            'above level on omen W-1", "closedAt": "2026-06-04T08:15:00Z"}]'
+        )
+        result = SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.subprocess.run",
+            lambda *a, **k: result,
+        )
+        triples = _closed_issue_pairs("r/r", "tool-improvement")
+        assert triples is not None
+        assert len(triples) == 2
+        assert triples[0][0] == "superforcaster"
+        assert triples[0][1] == "polymarket"
+        assert triples[0][2] == datetime(2026, 6, 5, 10, 30, 0, tzinfo=timezone.utc)
+        assert triples[1][0] == "factual_research"
+        assert triples[1][1] == "omen"
+
+    def test_skips_title_without_backticks(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A label-matching issue filed manually (no backticks) is skipped + warned."""
+        stdout = (
+            '[{"title": "[tool-improvement] superforcaster bad on polymarket",'
+            ' "closedAt": "2026-06-05T10:30:00Z"}]'
+        )
+        result = SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.subprocess.run",
+            lambda *a, **k: result,
+        )
+        with caplog.at_level(logging.WARNING):
+            assert _closed_issue_pairs("r/r", "tool-improvement") == []
+        assert any(
+            "did not match the expected format" in r.message for r in caplog.records
+        )
+
+    def test_skips_unparseable_closed_at(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A malformed ``closedAt`` field is skipped + warned (cooldown stays fail-open)."""
+        stdout = (
+            '[{"title": "[tool-improvement] `superforcaster`: Brier '
+            'above level on polymarket W-1", "closedAt": "not-a-date"}]'
+        )
+        result = SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.subprocess.run",
+            lambda *a, **k: result,
+        )
+        with caplog.at_level(logging.WARNING):
+            assert _closed_issue_pairs("r/r", "tool-improvement") == []
+        assert any("unparseable closedAt" in r.message for r in caplog.records)
+
+    def test_gh_error_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-zero gh exit yields ``None`` so the caller skips the cooldown gate."""
+        # Distinct from "success with zero closed issues" which returns [].
+        result = SimpleNamespace(returncode=4, stdout="", stderr="auth required")
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.subprocess.run",
+            lambda *a, **k: result,
+        )
+        assert _closed_issue_pairs("r/r", "tool-improvement") is None
+
+    def test_gh_timeout_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``subprocess.TimeoutExpired`` is caught and returns ``None`` (fail-open)."""
+
+        def fake_run(*_a: Any, **_k: Any) -> Any:
+            raise subprocess.TimeoutExpired(cmd="gh", timeout=30)
+
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.subprocess.run", fake_run
+        )
+        assert _closed_issue_pairs("r/r", "tool-improvement") is None
+
+    def test_gh_oserror_returns_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``OSError`` (gh binary missing) is caught and returns ``None`` (fail-open)."""
+
+        def fake_run(*_a: Any, **_k: Any) -> Any:
+            raise OSError("gh: command not found")
+
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.subprocess.run", fake_run
+        )
+        assert _closed_issue_pairs("r/r", "tool-improvement") is None
+
+    def test_gh_invalid_json_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Unparseable JSON on stdout yields ``None`` so cooldown stays fail-open."""
+        result = SimpleNamespace(returncode=0, stdout="not json", stderr="")
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.subprocess.run",
+            lambda *a, **k: result,
+        )
+        assert _closed_issue_pairs("r/r", "tool-improvement") is None
+
+    def test_gh_success_zero_issues_returns_empty_list(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Successful gh with no closed issues yields ``[]`` (no cooldown anywhere)."""
+        result = SimpleNamespace(returncode=0, stdout="[]", stderr="")
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.subprocess.run",
+            lambda *a, **k: result,
+        )
+        assert _closed_issue_pairs("r/r", "tool-improvement") == []
 
 
 class TestMainExitCode:

--- a/benchmark/tool_improvement_triage.py
+++ b/benchmark/tool_improvement_triage.py
@@ -83,6 +83,14 @@ BRIER_LEVEL_THRESHOLD = 0.25
 # would re-fire on the next run -- the level trigger is a standing
 # condition, unlike the regression trigger whose delta self-limits.
 BRIER_LEVEL_RE_ARM = 0.22
+# Time-based silence applied to every closed ``tool-improvement`` issue:
+# any new fire for the same ``(tool, platform)`` is suppressed for this many
+# days after the most recent close (merge OR manual), regardless of trigger.
+# Stacked ON TOP of the Brier-band re-arm above, never replacing it. After
+# the window elapses, the level_cooldown marker is also cleared for that
+# tool so a still-bad tool can fire as a fresh issue rather than staying
+# silenced forever by a stale re-arm marker.
+RECENT_CLOSE_DAYS = 5
 VALID_N_PER_WINDOW_FLOOR = 105
 RELIABILITY_FLOOR = 0.80
 ROLLING_WINDOW_DAYS = 7
@@ -171,12 +179,134 @@ def _open_issue_tools(repo: str, label: str) -> Optional[List[Tuple[str, str]]]:
     return pairs
 
 
+def _closed_issue_pairs(
+    repo: str, label: str
+) -> Optional[List[Tuple[str, str, datetime]]]:
+    """Return `(tool, platform, closed_at)` triples for closed tool-improvement issues.
+
+    Caller buckets the result by ``closed_at`` against ``RECENT_CLOSE_DAYS``:
+    issues within the window drive the recently-closed silence, issues older
+    than the window mark the level_cooldown marker stale (re-arm reset).
+
+    Returns ``None`` on transient gh-CLI failure so callers can skip the
+    cooldown rather than open a noisy issue against a half-resolved state.
+
+    :param repo: GitHub ``owner/repo`` slug.
+    :param label: issue label to filter on (e.g. ``"tool-improvement"``).
+    :return: list of ``(tool, platform, closed_at)`` triples, or ``None`` on
+        gh error. ``closed_at`` is a timezone-aware UTC ``datetime``.
+    """
+    cmd = [
+        "gh",
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--label",
+        label,
+        "--state",
+        "closed",
+        "--json",
+        "title,closedAt",
+        "--limit",
+        "1000",
+    ]
+    try:
+        r = subprocess.run(cmd, check=False, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        log.warning(
+            "gh issue list (closed) failed (%s); skipping recently-closed cooldown",
+            exc,
+        )
+        return None
+    if r.returncode != 0:
+        log.warning(
+            "gh issue list (closed) rc=%d stderr=%r; "
+            "skipping recently-closed cooldown",
+            r.returncode,
+            r.stderr[:200],
+        )
+        return None
+    try:
+        rows = json.loads(r.stdout or "[]")
+    except ValueError as exc:
+        log.warning(
+            "gh issue list (closed) returned unparseable JSON (%s); "
+            "skipping recently-closed cooldown",
+            exc,
+        )
+        return None
+    triples: List[Tuple[str, str, datetime]] = []
+    for row in rows:
+        title = row.get("title") or ""
+        m = _TITLE_RE.search(title)
+        if not m:
+            log.warning(
+                "closed tool-improvement issue title did not match the expected "
+                "format; skipping (no suppression): %r",
+                title[:120],
+            )
+            continue
+        closed_at_raw = row.get("closedAt") or ""
+        try:
+            closed_at = datetime.fromisoformat(closed_at_raw.replace("Z", "+00:00"))
+        except ValueError:
+            log.warning(
+                "closed tool-improvement issue has unparseable closedAt=%r; "
+                "skipping",
+                closed_at_raw,
+            )
+            continue
+        triples.append((m.group(1), m.group(2), closed_at))
+    return triples
+
+
+def _bucket_closed_by_age(
+    closed_issues: Optional[List[Tuple[str, str, datetime]]],
+    platform: str,
+    cutoff: datetime,
+) -> Tuple[set, set]:
+    """Bucket ``closed_issues`` for ``platform`` by whether the close is recent.
+
+    Per ``(tool, platform)`` we keep only the most recent close timestamp so a
+    long-lived tool with several historical closes doesn't appear stale just
+    because an old close exists.
+
+    :param closed_issues: list of ``(tool, platform, closed_at)`` triples from
+        the live gh query, or ``None`` if the query was skipped / failed.
+    :param platform: the platform under triage; entries on other platforms are
+        ignored.
+    :param cutoff: datetimes ``>= cutoff`` are considered recent; older closes
+        are considered stale.
+    :return: ``(recently_closed, stale_closed)`` sets of tool names.
+    """
+    if closed_issues is None:
+        return set(), set()
+    most_recent: Dict[Tuple[str, str], datetime] = {}
+    for tool_name, tool_platform, closed_at in closed_issues:
+        if tool_platform != platform:
+            continue
+        existing = most_recent.get((tool_name, tool_platform))
+        if existing is None or closed_at > existing:
+            most_recent[(tool_name, tool_platform)] = closed_at
+    recently: set = set()
+    stale: set = set()
+    for (tool_name, _), closed_at in most_recent.items():
+        if closed_at >= cutoff:
+            recently.add(tool_name)
+        else:
+            stale.add(tool_name)
+    return recently, stale
+
+
 def triage(
     cur: Dict[str, Any],
     prev: Dict[str, Any],
     prior_state: Dict[str, Any],
     platform: str = "polymarket",
     open_now: Optional[List[Any]] = None,
+    closed_issues: Optional[List[Tuple[str, str, datetime]]] = None,
+    now: Optional[datetime] = None,
 ) -> List[Dict[str, Any]]:
     """Apply the gate cascade to ``cur`` vs ``prev`` and return one decision dict per tool."""
     # ``open_now`` may be a list of bare tool names (legacy single-
@@ -188,7 +318,8 @@ def triage(
     # when provided; falls back to ``prior_state`` only when the caller
     # did not run the live query. Closing the GitHub issue therefore
     # re-arms the trigger on the next run regardless of state-file
-    # content -- with one exception, the level_floor cooldown below.
+    # content -- subject to the level_floor cooldown + recently-closed
+    # silence below.
     if open_now is not None:
         prior_open = {}
         for entry in open_now:
@@ -203,6 +334,19 @@ def triage(
             t: v.get("issue_open", False)
             for t, v in (prior_state.get("by_tool") or {}).items()
         }
+    # Recently-closed silence: any issue closed within the last
+    # RECENT_CLOSE_DAYS suppresses re-fire of the same (tool, platform)
+    # regardless of trigger. Tools whose most recent close is older than
+    # the window appear in ``stale_closed_set`` and have their stored
+    # ``level_floor`` cooldown marker cleared below (so a still-bad tool
+    # can fire fresh once the silence window has elapsed).
+    # ``closed_issues=None`` (caller skipped the query) means we apply no
+    # silence and no marker reset -- same fail-open principle as
+    # ``open_now=None``.
+    cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=RECENT_CLOSE_DAYS)
+    recently_closed_set, stale_closed_set = _bucket_closed_by_age(
+        closed_issues, platform, cutoff
+    )
     # Hysteresis cooldown: a tool whose most recent open_issue carried
     # trigger="level_floor" remains suppressed (from the state file)
     # until its current Brier drops below BRIER_LEVEL_RE_ARM. Read from
@@ -211,10 +355,13 @@ def triage(
     # issue is open, but ``trigger`` carries the original signal that
     # caused the issue to open and survives the entire suppressed period
     # (and the cooldown period after the issue is closed).
+    # Marker is reset when the tool's most recent close was more than
+    # RECENT_CLOSE_DAYS ago: a stale re-arm marker should not silence a
+    # tool indefinitely once the time-based window has elapsed.
     level_cooldown = {
         t
         for t, v in (prior_state.get("by_tool") or {}).items()
-        if v.get("trigger") == "level_floor"
+        if v.get("trigger") == "level_floor" and t not in stale_closed_set
     }
     decisions: List[Dict[str, Any]] = []
     for tool in sorted((cur.get("by_tool") or {}).keys()):
@@ -274,6 +421,28 @@ def triage(
                 d.update(decision="silent", reason="sign_disagreement")
                 decisions.append(d)
                 continue
+        # Recently-closed silence: a tool whose issue closed within the last
+        # RECENT_CLOSE_DAYS is silenced regardless of trigger (regression OR
+        # level_floor) and regardless of how it closed (merge OR manual).
+        # Stacks ON TOP of the Brier-band re-arm below: even if the re-arm
+        # would have allowed a fire (e.g. genuine regression bypass), we
+        # honour the operator's "give engineers room before the next page"
+        # invariant. Gated on prior_open being false because while the
+        # issue is still open the duplicate_suppressed path below owns the
+        # suppression.
+        if (
+            (regressed or above_level)
+            and not prior_open.get(tool)
+            and tool in recently_closed_set
+        ):
+            d.update(
+                decision="silent",
+                reason="recently_closed",
+                trigger="regression" if regressed else "level_floor",
+                issue_open=False,
+            )
+            decisions.append(d)
+            continue
         # Level-floor hysteresis (checked BEFORE the no_regression guard
         # so a Brier in the (BRIER_LEVEL_RE_ARM, BRIER_LEVEL_THRESHOLD]
         # band actually keeps the cooldown alive instead of falling
@@ -584,6 +753,13 @@ def main() -> int:
     open_now = _open_issue_tools(args.repo, args.label)
     if open_now:
         log.info("triage open issues on GitHub: %s", sorted(open_now))
+    closed_issues = _closed_issue_pairs(args.repo, args.label)
+    if closed_issues:
+        log.info(
+            "triage closed-issue history (last %d shown): %s",
+            min(10, len(closed_issues)),
+            sorted((t, p, c.strftime("%Y-%m-%d")) for t, p, c in closed_issues[:10]),
+        )
 
     all_decisions: List[Dict[str, Any]] = []
     n_opened = n_failed = n_collapse = n_silent = 0
@@ -591,7 +767,14 @@ def main() -> int:
         cur = _load_json(RESULTS_DIR / f"rolling_scores_{platform}.json")
         prev = _load_json(RESULTS_DIR / f"prev_rolling_scores_{platform}.json")
         platform_scores = _load_json(RESULTS_DIR / f"scores_{platform}.json")
-        decisions = triage(cur, prev, state, platform=platform, open_now=open_now)
+        decisions = triage(
+            cur,
+            prev,
+            state,
+            platform=platform,
+            open_now=open_now,
+            closed_issues=closed_issues,
+        )
         all_decisions.extend(decisions)
 
         for d in decisions:

--- a/benchmark/tool_improvement_triage.py
+++ b/benchmark/tool_improvement_triage.py
@@ -315,6 +315,8 @@ def _log_cooldown_status(
     :param n_days: the ``RECENT_CLOSE_DAYS`` value in effect.
     """
     horizon = timedelta(days=2 * n_days + 7)
+    cooldown = timedelta(days=n_days)
+    cutoff = now_dt - cooldown
     cur_tool_set = set(cur_tools)
     for tool_name, last_close in sorted(most_recent_close.items()):
         if tool_name not in cur_tool_set:
@@ -322,14 +324,17 @@ def _log_cooldown_status(
         age = now_dt - last_close
         if age > horizon:
             continue
-        days_since = age.days
-        status = "ACTIVE" if days_since <= n_days else "ELAPSED"
+        # Mirror the gate's predicate exactly (``last_close >= cutoff``) so
+        # the log never says ACTIVE on a close the gate is about to let
+        # fire. Floored ``age.days`` is fine for the human-readable count
+        # but must not drive the status decision.
+        status = "ACTIVE" if last_close >= cutoff else "ELAPSED"
         log.info(
             "cooldown %s: tool=%r platform=%r closed %d day(s) ago (N=%d)",
             status,
             tool_name,
             platform,
-            days_since,
+            age.days,
             n_days,
         )
 
@@ -447,15 +452,15 @@ def triage(
                 d.update(decision="silent", reason="sign_disagreement")
                 decisions.append(d)
                 continue
+        # Trigger label is shared by the recently-closed silence below, the
+        # duplicate_suppressed path, and the open_issue path; compute once.
+        trigger = "regression" if regressed else "level_floor"
         # Recently-closed silence: a tool whose issue closed within the last
         # RECENT_CLOSE_DAYS is silenced regardless of trigger (regression OR
         # level_floor) and regardless of how it closed (merge OR manual).
-        # Stacks ON TOP of the Brier-band re-arm below: even if the re-arm
-        # would have allowed a fire (e.g. genuine regression bypass), we
-        # honour the operator's "give engineers room before the next page"
-        # invariant. Gated on prior_open being false because while the
-        # issue is still open the duplicate_suppressed path below owns the
-        # suppression.
+        # Gives engineers room before the next page after a close. Gated on
+        # prior_open being false because while the issue is still open the
+        # duplicate_suppressed path below owns the suppression.
         if (
             (regressed or above_level)
             and not prior_open.get(tool)
@@ -464,7 +469,7 @@ def triage(
             d.update(
                 decision="silent",
                 reason="recently_closed",
-                trigger="regression" if regressed else "level_floor",
+                trigger=trigger,
                 issue_open=False,
             )
             decisions.append(d)
@@ -477,7 +482,6 @@ def triage(
         # this tool (regression or level signal), stay silent. The
         # ``trigger`` field records the original signal for state-file
         # bookkeeping and analytics.
-        trigger = "regression" if regressed else "level_floor"
         if prior_open.get(tool):
             d.update(
                 decision="silent",
@@ -746,13 +750,15 @@ def main() -> int:
     now = datetime.now(timezone.utc)
     window_iso = _window_iso(now)
     state = _load_json(args.state)
-    # Live source-of-truth for duplicate-issue suppression: a tool whose
-    # issue is currently open on GitHub stays silent; one whose issue was
-    # closed (PR merged or human dismissed) re-arms the trigger
-    # immediately on the next run. The state file is consulted only as a
-    # fallback when the live gh query fails (returns None); it is also
-    # the source of the level_floor cooldown band so a closed level
-    # issue does not re-fire while the Brier is still in the band.
+    # Live sources-of-truth for the two close-related gates:
+    #  * ``open_now`` (open issues on GitHub) drives the duplicate-issue
+    #    suppression. The state file is consulted only as a fallback when
+    #    the gh query fails (returns ``None``).
+    #  * ``closed_issues`` (recently closed issues on GitHub) drives the
+    #    ``RECENT_CLOSE_DAYS`` cooldown silence. Same fail-open principle:
+    #    a transient gh failure skips the cooldown rather than refile.
+    # The state file is no longer consulted for cooldown bookkeeping; the
+    # gate runs entirely off the live gh closed-list result.
     open_now = _open_issue_tools(args.repo, args.label)
     if open_now:
         log.info("triage open issues on GitHub: %s", sorted(open_now))
@@ -777,6 +783,7 @@ def main() -> int:
             platform=platform,
             open_now=open_now,
             closed_issues=closed_issues,
+            now=now,
         )
         all_decisions.extend(decisions)
 

--- a/benchmark/tool_improvement_triage.py
+++ b/benchmark/tool_improvement_triage.py
@@ -48,10 +48,17 @@ cascade:
 Duplicate-issue suppression: once a tool has an open ``tool-improvement``
 issue on GitHub, the triage stays silent for that tool. ``prior_open``
 is seeded from the live ``gh issue list`` query at the start of
-``main()`` rather than from yesterday's state file alone, so a PR that
-fixes the issue (closing it) re-arms the trigger immediately; a PR
-still under review keeps the tool quiet for as long as the issue
-remains open.
+``main()`` rather than from yesterday's state file alone; a PR that
+fixes the issue (closing it) re-arms the trigger after the
+``RECENT_CLOSE_DAYS`` cooldown elapses, and a PR still under review
+keeps the tool quiet for as long as the issue remains open.
+
+Recently-closed cooldown: any ``(tool, platform)`` with a close in the
+last ``RECENT_CLOSE_DAYS`` days is silenced regardless of trigger. The
+log line per tool with a close in the recent past explicitly states
+whether the cooldown is ACTIVE or has ELAPSED, so an operator can see
+why a known-bad tool isn't firing today (or why it is firing again
+after a recent close).
 
 For each ``open_issue`` decision, the script calls ``gh issue create``
 with the ``tool-improvement`` label. The label routes the issue to
@@ -76,21 +83,14 @@ from typing import Any, Dict, List, Optional, Tuple
 ENABLED_PLATFORMS = ["polymarket"]
 BRIER_REGRESSION_THRESHOLD = 0.040
 BRIER_LEVEL_THRESHOLD = 0.25
-# Hysteresis floor for level_floor re-arm: a tool that previously
-# opened a level_floor issue stays suppressed (even after the GitHub
-# issue is closed) until its Brier drops below this band. Without it,
-# closing a level_floor issue with the Brier still above the trigger
-# would re-fire on the next run -- the level trigger is a standing
-# condition, unlike the regression trigger whose delta self-limits.
-BRIER_LEVEL_RE_ARM = 0.22
 # Time-based silence applied to every closed ``tool-improvement`` issue:
 # any new fire for the same ``(tool, platform)`` is suppressed for this many
 # days after the most recent close (merge OR manual), regardless of trigger.
-# Stacked ON TOP of the Brier-band re-arm above, never replacing it. After
-# the window elapses, the level_cooldown marker is also cleared for that
-# tool so a still-bad tool can fire as a fresh issue rather than staying
-# silenced forever by a stale re-arm marker.
-RECENT_CLOSE_DAYS = 5
+# Replaces the previous Brier-band re-arm hysteresis: a partial fix that
+# leaves the Brier above ``BRIER_LEVEL_THRESHOLD`` is allowed to re-fire
+# the day after the window elapses, rather than being silenced forever by
+# a stuck cooldown marker (the dead-zone failure mode of the re-arm band).
+RECENT_CLOSE_DAYS = 1
 VALID_N_PER_WINDOW_FLOOR = 105
 RELIABILITY_FLOOR = 0.80
 ROLLING_WINDOW_DAYS = 7
@@ -184,9 +184,9 @@ def _closed_issue_pairs(
 ) -> Optional[List[Tuple[str, str, datetime]]]:
     """Return `(tool, platform, closed_at)` triples for closed tool-improvement issues.
 
-    Caller buckets the result by ``closed_at`` against ``RECENT_CLOSE_DAYS``:
-    issues within the window drive the recently-closed silence, issues older
-    than the window mark the level_cooldown marker stale (re-arm reset).
+    Caller buckets the result by ``closed_at`` against ``RECENT_CLOSE_DAYS``
+    to drive the recently-closed silence (issues within the window suppress
+    re-fire of the same ``(tool, platform)``).
 
     Returns ``None`` on transient gh-CLI failure so callers can skip the
     cooldown rather than open a noisy issue against a half-resolved state.
@@ -261,42 +261,77 @@ def _closed_issue_pairs(
     return triples
 
 
-def _bucket_closed_by_age(
+def _most_recent_close_per_tool(
     closed_issues: Optional[List[Tuple[str, str, datetime]]],
     platform: str,
-    cutoff: datetime,
-) -> Tuple[set, set]:
-    """Bucket ``closed_issues`` for ``platform`` by whether the close is recent.
+) -> Dict[str, datetime]:
+    """Return ``{tool: most_recent_close_at}`` for ``platform``.
 
     Per ``(tool, platform)`` we keep only the most recent close timestamp so a
-    long-lived tool with several historical closes doesn't appear stale just
-    because an old close exists.
+    long-lived tool with several historical closes is summarised by its
+    latest close (the one that governs the cooldown window).
 
     :param closed_issues: list of ``(tool, platform, closed_at)`` triples from
         the live gh query, or ``None`` if the query was skipped / failed.
     :param platform: the platform under triage; entries on other platforms are
         ignored.
-    :param cutoff: datetimes ``>= cutoff`` are considered recent; older closes
-        are considered stale.
-    :return: ``(recently_closed, stale_closed)`` sets of tool names.
+    :return: mapping from tool name to its most recent close ``datetime``
+        (timezone-aware UTC). Empty dict if ``closed_issues`` is ``None`` or
+        has no entries for ``platform``.
     """
     if closed_issues is None:
-        return set(), set()
-    most_recent: Dict[Tuple[str, str], datetime] = {}
+        return {}
+    most_recent: Dict[str, datetime] = {}
     for tool_name, tool_platform, closed_at in closed_issues:
         if tool_platform != platform:
             continue
-        existing = most_recent.get((tool_name, tool_platform))
+        existing = most_recent.get(tool_name)
         if existing is None or closed_at > existing:
-            most_recent[(tool_name, tool_platform)] = closed_at
-    recently: set = set()
-    stale: set = set()
-    for (tool_name, _), closed_at in most_recent.items():
-        if closed_at >= cutoff:
-            recently.add(tool_name)
-        else:
-            stale.add(tool_name)
-    return recently, stale
+            most_recent[tool_name] = closed_at
+    return most_recent
+
+
+def _log_cooldown_status(
+    most_recent_close: Dict[str, datetime],
+    cur_tools: List[str],
+    platform: str,
+    now_dt: datetime,
+    n_days: int,
+) -> None:
+    """Log per-tool cooldown status for any current tool with a recent close.
+
+    For each tool present in the current rolling scores AND in
+    ``most_recent_close``, emit one INFO log line stating whether the
+    ``RECENT_CLOSE_DAYS`` cooldown is ACTIVE or has ELAPSED. The status is
+    bounded to closes within ``2 * n_days + 7`` days so the operator sees the
+    transition without permanent log noise from ancient closes.
+
+    :param most_recent_close: ``{tool: closed_at}`` from
+        :func:`_most_recent_close_per_tool` for the current platform.
+    :param cur_tools: tool names present in today's rolling scores; the log is
+        scoped to these so retired tools don't add noise.
+    :param platform: platform under triage (rendered in the log message).
+    :param now_dt: reference "now" used to compute days-since-close.
+    :param n_days: the ``RECENT_CLOSE_DAYS`` value in effect.
+    """
+    horizon = timedelta(days=2 * n_days + 7)
+    cur_tool_set = set(cur_tools)
+    for tool_name, last_close in sorted(most_recent_close.items()):
+        if tool_name not in cur_tool_set:
+            continue
+        age = now_dt - last_close
+        if age > horizon:
+            continue
+        days_since = age.days
+        status = "ACTIVE" if days_since <= n_days else "ELAPSED"
+        log.info(
+            "cooldown %s: tool=%r platform=%r closed %d day(s) ago (N=%d)",
+            status,
+            tool_name,
+            platform,
+            days_since,
+            n_days,
+        )
 
 
 def triage(
@@ -316,10 +351,9 @@ def triage(
     # ``A`` does not suppress the same tool on platform ``B``.
     # Suppression source-of-truth: ``open_now`` (the live gh result)
     # when provided; falls back to ``prior_state`` only when the caller
-    # did not run the live query. Closing the GitHub issue therefore
-    # re-arms the trigger on the next run regardless of state-file
-    # content -- subject to the level_floor cooldown + recently-closed
-    # silence below.
+    # did not run the live query. Closing the GitHub issue re-arms the
+    # trigger after the ``RECENT_CLOSE_DAYS`` cooldown elapses (or
+    # immediately if the cooldown is already past).
     if open_now is not None:
         prior_open = {}
         for entry in open_now:
@@ -336,33 +370,25 @@ def triage(
         }
     # Recently-closed silence: any issue closed within the last
     # RECENT_CLOSE_DAYS suppresses re-fire of the same (tool, platform)
-    # regardless of trigger. Tools whose most recent close is older than
-    # the window appear in ``stale_closed_set`` and have their stored
-    # ``level_floor`` cooldown marker cleared below (so a still-bad tool
-    # can fire fresh once the silence window has elapsed).
+    # regardless of trigger. Replaces the previous Brier-band re-arm
+    # hysteresis: a partial fix that leaves the Brier above
+    # ``BRIER_LEVEL_THRESHOLD`` is allowed to re-fire the day after the
+    # window elapses, rather than being silenced forever by a stuck
+    # cooldown marker (the dead-zone failure mode of the re-arm band).
     # ``closed_issues=None`` (caller skipped the query) means we apply no
-    # silence and no marker reset -- same fail-open principle as
-    # ``open_now=None``.
-    cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=RECENT_CLOSE_DAYS)
-    recently_closed_set, stale_closed_set = _bucket_closed_by_age(
-        closed_issues, platform, cutoff
-    )
-    # Hysteresis cooldown: a tool whose most recent open_issue carried
-    # trigger="level_floor" remains suppressed (from the state file)
-    # until its current Brier drops below BRIER_LEVEL_RE_ARM. Read from
-    # the dedicated ``trigger`` field, NOT from ``reason``: ``reason``
-    # gets clobbered with ``duplicate_suppressed`` every day the GitHub
-    # issue is open, but ``trigger`` carries the original signal that
-    # caused the issue to open and survives the entire suppressed period
-    # (and the cooldown period after the issue is closed).
-    # Marker is reset when the tool's most recent close was more than
-    # RECENT_CLOSE_DAYS ago: a stale re-arm marker should not silence a
-    # tool indefinitely once the time-based window has elapsed.
-    level_cooldown = {
-        t
-        for t, v in (prior_state.get("by_tool") or {}).items()
-        if v.get("trigger") == "level_floor" and t not in stale_closed_set
+    # silence -- same fail-open principle as ``open_now=None``.
+    now_dt = now or datetime.now(timezone.utc)
+    cutoff = now_dt - timedelta(days=RECENT_CLOSE_DAYS)
+    most_recent_close = _most_recent_close_per_tool(closed_issues, platform)
+    recently_closed_set = {
+        tool_name
+        for tool_name, last_close in most_recent_close.items()
+        if last_close >= cutoff
     }
+    cur_tools = list((cur.get("by_tool") or {}).keys())
+    _log_cooldown_status(
+        most_recent_close, cur_tools, platform, now_dt, RECENT_CLOSE_DAYS
+    )
     decisions: List[Dict[str, Any]] = []
     for tool in sorted((cur.get("by_tool") or {}).keys()):
         c = cur["by_tool"][tool]
@@ -443,37 +469,14 @@ def triage(
             )
             decisions.append(d)
             continue
-        # Level-floor hysteresis (checked BEFORE the no_regression guard
-        # so a Brier in the (BRIER_LEVEL_RE_ARM, BRIER_LEVEL_THRESHOLD]
-        # band actually keeps the cooldown alive instead of falling
-        # through to no_regression and silently clearing the marker).
-        # Gated on prior_open being false: cooldown is a "stay-silent
-        # AFTER close" mechanism; while the issue is still open, the
-        # duplicate_suppressed path below owns the suppression. Regression
-        # bypasses the cooldown so a genuinely regressing tool still fires.
-        in_cooldown = (
-            not regressed
-            and not prior_open.get(tool)
-            and tool in level_cooldown
-            and bc >= BRIER_LEVEL_RE_ARM
-        )
-        if in_cooldown:
-            d.update(
-                decision="silent",
-                reason="level_floor_cooldown",
-                trigger="level_floor",
-                issue_open=False,
-            )
-            decisions.append(d)
-            continue
         if not regressed and not above_level:
             d.update(decision="silent", reason="no_regression")
             decisions.append(d)
             continue
         # Duplicate-issue suppression: if an issue is already open for
-        # this tool (regression or level signal), stay silent. Preserve
-        # the original ``trigger`` field across the suppressed period so
-        # the cooldown above can read it after the issue closes.
+        # this tool (regression or level signal), stay silent. The
+        # ``trigger`` field records the original signal for state-file
+        # bookkeeping and analytics.
         trigger = "regression" if regressed else "level_floor"
         if prior_open.get(tool):
             d.update(


### PR DESCRIPTION
## Why

The previous level_floor hysteresis (`BRIER_LEVEL_RE_ARM=0.22` floor, `BRIER_LEVEL_THRESHOLD=0.25` ceiling) created a **dead zone**: a partial fix that left the Brier in `(0.22, 0.25]` silenced the tool forever, because the cooldown marker only cleared when the Brier dropped strictly below 0.22 — which a partially-effective fix may never achieve.

Concrete failure mode:
- Day 1: Brier 0.30 → fires `level_floor` issue
- Day 8: PR merges, issue closes, marker stored as `trigger=level_floor`
- Day 9+: Brier stuck at 0.29 → `bc >= BRIER_LEVEL_RE_ARM` keeps the cooldown alive forever
- Engineer never hears about it again even though the tool is still bad

## What

- **Removed** `BRIER_LEVEL_RE_ARM`, the `level_cooldown` set construction, the `in_cooldown` block, and the `stale_closed_set` bookkeeping.
- **Kept** the recently-closed silence from the prior approach but as the **only** post-close gate.
- `RECENT_CLOSE_DAYS = 1` (module-level constant, same pattern as `BRIER_LEVEL_THRESHOLD` / `VALID_N_PER_WINDOW_FLOOR`). Any close within the window silences re-fire of the same `(tool, platform)`; the day after the window the tool re-evaluates from scratch.
- **New helper** `_log_cooldown_status`: one INFO line per tool with a close in the last `2*N + 7` days, stating whether the cooldown is `ACTIVE` or has `ELAPSED`, plus days-since-close and current `N`. Bounded so ancient closes don't add noise.

## How the new cooldown reads in logs

```
INFO cooldown ACTIVE:  tool='superforcaster' platform='polymarket' closed 0 day(s) ago (N=1)
INFO cooldown ELAPSED: tool='factual_research' platform='polymarket' closed 3 day(s) ago (N=1)
```

The operator can see why a known-bad tool isn't firing today (ACTIVE), and why it is firing again after the window (ELAPSED).

## Tests

- 77/77 pass (`pytest benchmark/tests/test_tool_improvement_triage.py`).
- Removed 6 obsolete `TestLevelFloorCooldown` tests + 4 obsolete `TestStaleClosedMarkerReset` tests (re-arm semantics gone).
- Added 5 new `TestCooldownStatusLogging` tests: ACTIVE / ELAPSED / no close history / outside log horizon / retired tool.
- `TestRecentlyClosedSilence` and `TestCloseOlderThanWindow` cover the cooldown gate end-to-end.

## Lint

isort + black + flake8 (F-series) + pylint (E+F) clean on both touched files.
