### PR TITLE
fix(benchmark): unify prompt-schema dispatch via ToolSpec family field

### DIFF
--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -1284,9 +1284,16 @@ def _default_family_system_prompt(candidate_module: Any) -> str:
     :param candidate_module: the imported candidate tool module.
     :return: the module's ``SYSTEM_PROMPT_FORECASTER`` or the generic fallback.
     """
-    return getattr(
-        candidate_module, "SYSTEM_PROMPT_FORECASTER", DEFAULT_REPLAY_SYSTEM_PROMPT
+    if hasattr(candidate_module, "SYSTEM_PROMPT_FORECASTER"):
+        return candidate_module.SYSTEM_PROMPT_FORECASTER
+    # Expected for *-sme; for any other default-family tool this likely means a
+    # missing/typo'd symbol, so make the substitution visible rather than silent.
+    log.warning(
+        "%s exports no SYSTEM_PROMPT_FORECASTER; replaying with the generic "
+        "system prompt. Expected for *-sme tools, suspicious otherwise.",
+        getattr(candidate_module, "__name__", candidate_module),
     )
+    return DEFAULT_REPLAY_SYSTEM_PROMPT
 
 
 def _baseline_family(tool_name: str) -> str:
@@ -1311,6 +1318,15 @@ def _baseline_family(tool_name: str) -> str:
     spec = TOOL_REGISTRY.get(tool_name)
     if spec is not None:
         return spec.family
+    # Unregistered name: the heuristic below is a guess. Warn so a misnamed or
+    # not-yet-registered tool is visible here rather than only as a silent
+    # ``Enriched 0/N`` drop downstream (the original bug's failure mode).
+    log.warning(
+        "Tool '%s' is not in TOOL_REGISTRY; guessing its prompt-schema family "
+        "from the name. Register it with an explicit family to avoid a silent "
+        "mis-route.",
+        tool_name,
+    )
     if tool_name.startswith("prediction-request-reasoning"):
         return "reasoning"
     if tool_name.startswith("prediction-request-rag") or tool_name.startswith(

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -344,23 +344,33 @@ def extract_prompt_components(
 ) -> Optional[dict[str, str]]:
     """Extract components from a formatted IPFS prompt, dispatching by tool.
 
+    Dispatch keys off :func:`_baseline_family` — the same registry-backed
+    classifier the replay path uses — so ``-v<n+1>`` siblings and other family
+    members (``superforcaster-polymarket-v1``, ``factual_research-v2``,
+    ``prediction-url-cot``) route to the right extractor instead of silently
+    falling through to the default ``prediction-online`` regexes. Sharing one
+    classifier across enrich (here) and replay is what prevents the drift that
+    previously left enrich parsing 0 rows for sibling baselines.
+
     :param formatted_prompt: the full IPFS prompt string.
     :param tool_name: tool name to determine extraction strategy.
     :return: dict of extracted components, or None if extraction fails.
     """
-    if tool_name.startswith("prediction-request-reasoning"):
+    family = _baseline_family(tool_name)
+
+    if family == "reasoning":
         return _extract_reasoning_prompt_components(formatted_prompt)
 
-    if tool_name.startswith("prediction-request-rag"):
+    if family == "rag":
         return _extract_rag_prompt_components(formatted_prompt)
 
-    if tool_name == "superforcaster":
+    if family == "superforcaster":
         return _extract_superforcaster_prompt_components(formatted_prompt)
 
-    if tool_name == "factual_research":
+    if family == "factual_research":
         return _extract_factual_research_prompt_components(formatted_prompt)
 
-    # Default: prediction-online format
+    # Default: prediction-online format (also covers *-sme)
     up_match = USER_PROMPT_RE.search(formatted_prompt)
     ai_match = ADDITIONAL_INFO_RE.search(formatted_prompt)
 
@@ -1255,28 +1265,34 @@ def _replay_reasoning_tool(
 
 
 def _baseline_family(tool_name: str) -> str:
-    """Classify a baseline tool by its prompt-attribute schema.
+    """Classify a tool by its prompt-schema family.
 
-    The replay path keys off this family to decide which symbols
-    (``PREDICTION_PROMPT`` / ``SYSTEM_PROMPT`` / ``ESTIMATE_USER`` / etc.)
-    to read from the candidate module. Widened from exact-name match so
-    ``-v<n+1>`` siblings (housekeeping default for ``p_yes``-shifting fixes)
-    route to the same family as their parent, and so tool families that
-    don't export ``SYSTEM_PROMPT_FORECASTER`` (superforcaster siblings,
-    prediction-url-cot, ``*-sme``) reach a branch that matches what their
-    module actually exposes.
+    The family decides both which symbols the replay path reads from the
+    candidate module (``PREDICTION_PROMPT`` / ``SYSTEM_PROMPT`` /
+    ``ESTIMATE_USER`` / …) and which regex extractor the enrich path
+    (:func:`extract_prompt_components`) uses. Both sites call this one helper
+    so they cannot drift — the asymmetry that previously let enrichment parse
+    0 rows for sibling baselines.
 
-    :param tool_name: tool name from the enriched rows.
+    ``benchmark.tools.TOOL_REGISTRY`` is the source of truth: every registered
+    tool carries an explicit ``family``. The name heuristic below is only a
+    fallback for a ``-v<n+1>`` sibling that has not been added to the registry
+    yet, so it routes to its parent's family rather than silently to default.
+
+    :param tool_name: tool name from the enriched rows / baseline.
     :return: one of ``"reasoning"``, ``"rag"``, ``"superforcaster"``,
         ``"factual_research"``, ``"default"``.
     """
+    spec = TOOL_REGISTRY.get(tool_name)
+    if spec is not None:
+        return spec.family
     if tool_name.startswith("prediction-request-reasoning"):
         return "reasoning"
     if tool_name.startswith("prediction-request-rag") or tool_name.startswith(
         "prediction-url-cot"
     ):
         return "rag"
-    if tool_name.startswith("superforcaster") or tool_name.endswith("-sme"):
+    if tool_name.startswith("superforcaster"):
         return "superforcaster"
     if tool_name.startswith("factual_research"):
         return "factual_research"
@@ -1376,7 +1392,12 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
         system_prompt = candidate_module.ESTIMATE_SYSTEM
     else:
         PREDICTION_PROMPT = candidate_module.PREDICTION_PROMPT
-        system_prompt = candidate_module.SYSTEM_PROMPT_FORECASTER
+        # Default-family tools format with user_prompt/additional_information.
+        # Most export SYSTEM_PROMPT_FORECASTER; *-sme tools do not, so fall
+        # back rather than AttributeError on import.
+        system_prompt = getattr(
+            candidate_module, "SYSTEM_PROMPT_FORECASTER", "You are a helpful assistant."
+        )
 
     if "claude" in model:
         api_key = os.environ.get("ANTHROPIC_API_KEY", "")

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -1264,6 +1264,31 @@ def _replay_reasoning_tool(
 # ---------------------------------------------------------------------------
 
 
+# Generic system prompt used when a default-family module exports no
+# SYSTEM_PROMPT_FORECASTER. Note: *-sme tools build a dynamic, question-specific
+# persona at request time (``get_sme_role`` in prediction_request_sme.py), which
+# isn't reproducible offline — so replayed SME p_yes is not strictly comparable
+# to deployed SME. The superforcaster branch already substitutes a static prompt
+# for the same reason; do NOT "fix" this by aliasing SME's generation prompt to
+# SYSTEM_PROMPT_FORECASTER, as that would silently shift benchmark semantics.
+DEFAULT_REPLAY_SYSTEM_PROMPT = "You are a helpful assistant."
+
+
+def _default_family_system_prompt(candidate_module: Any) -> str:
+    """Pick the system prompt for a default-family replay.
+
+    Most default-family tools export ``SYSTEM_PROMPT_FORECASTER``; ``*-sme``
+    tools do not, so fall back to a generic prompt rather than ``AttributeError``
+    on import.
+
+    :param candidate_module: the imported candidate tool module.
+    :return: the module's ``SYSTEM_PROMPT_FORECASTER`` or the generic fallback.
+    """
+    return getattr(
+        candidate_module, "SYSTEM_PROMPT_FORECASTER", DEFAULT_REPLAY_SYSTEM_PROMPT
+    )
+
+
 def _baseline_family(tool_name: str) -> str:
     """Classify a tool by its prompt-schema family.
 
@@ -1392,12 +1417,7 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
         system_prompt = candidate_module.ESTIMATE_SYSTEM
     else:
         PREDICTION_PROMPT = candidate_module.PREDICTION_PROMPT
-        # Default-family tools format with user_prompt/additional_information.
-        # Most export SYSTEM_PROMPT_FORECASTER; *-sme tools do not, so fall
-        # back rather than AttributeError on import.
-        system_prompt = getattr(
-            candidate_module, "SYSTEM_PROMPT_FORECASTER", "You are a helpful assistant."
-        )
+        system_prompt = _default_family_system_prompt(candidate_module)
 
     if "claude" in model:
         api_key = os.environ.get("ANTHROPIC_API_KEY", "")

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,7 @@ from benchmark.prompt_replay import (
     _prepare_output_dir,
     extract_prompt_components,
 )
+from benchmark.tools import TOOL_REGISTRY
 
 from packages.valory.customs.factual_research.factual_research import REFRAME_USER
 
@@ -342,14 +344,20 @@ class TestExtractFactualResearchPromptComponents:
 
 
 class TestBaselineFamily:
-    """`_baseline_family` classifies a tool name to its prompt-attribute schema.
+    """`_baseline_family` classifies a tool name to its prompt-schema family.
 
-    Direct unit test of the small pure helper the replay path uses to decide
-    which symbols (PREDICTION_PROMPT / SYSTEM_PROMPT / ESTIMATE_USER / ...)
-    to read from the candidate module. The widening from exact-name match
-    fixes the gap the #321 review flagged: previously several registered
-    tools fell into the `else` branch and crashed when their module didn't
-    export ``SYSTEM_PROMPT_FORECASTER``.
+    Direct unit test of the helper both ``prompt_replay`` dispatch sites use to
+    decide which symbols (PREDICTION_PROMPT / SYSTEM_PROMPT / ESTIMATE_USER /
+    ...) the replay path reads from a module and which regex extractor the
+    enrich path uses. Family is read from ``TOOL_REGISTRY`` (source of truth)
+    for registered tools, with a name heuristic only as a fallback for
+    not-yet-registered ``-v<n+1>`` siblings.
+
+    Note on history: before the registry field, the replay ``else`` branch
+    hard-imported from ``prediction_request`` (which *does* export
+    ``SYSTEM_PROMPT_FORECASTER``), so misrouted tools ran with the *wrong
+    prompt* — they did not crash on import. The defect was silent
+    mis-prompting, not an exception.
     """
 
     @pytest.mark.parametrize(
@@ -361,21 +369,22 @@ class TestBaselineFamily:
             # Rag family (PREDICTION_PROMPT + SYSTEM_PROMPT).
             ("prediction-request-rag", "rag"),
             ("prediction-request-rag-claude", "rag"),
-            # prediction-url-cot is rag-shaped — #321 review fix.
+            # prediction-url-cot is rag-shaped (<user_prompt> XML).
             ("prediction-url-cot", "rag"),
             ("prediction-url-cot-claude", "rag"),
-            # Superforcaster family (PREDICTION_PROMPT only).
+            # Superforcaster family (PREDICTION_PROMPT + Question/<background>).
             ("superforcaster", "superforcaster"),
-            # Existing -polymarket-v1 sibling — #321 review fix; would
-            # previously fall to `else` and crash on SYSTEM_PROMPT_FORECASTER.
             ("superforcaster-polymarket-v1", "superforcaster"),
-            # Hypothetical new-version siblings the housekeeping default
-            # produces: superforcaster -> superforcaster-v1 etc.
+            # Not-yet-registered new-version siblings route via the heuristic
+            # fallback to their parent's family.
             ("superforcaster-v1", "superforcaster"),
             ("superforcaster-polymarket-v2", "superforcaster"),
-            # SME tools also export only PREDICTION_PROMPT — #321 review fix.
-            ("prediction-offline-sme", "superforcaster"),
-            ("prediction-online-sme", "superforcaster"),
+            # SME exports only PREDICTION_PROMPT but it uses
+            # {user_prompt}/{additional_information} and ships no
+            # SYSTEM_PROMPT_FORECASTER — that is the *default* schema, not
+            # superforcaster (Ojus #321 review, comment 3364080538).
+            ("prediction-offline-sme", "default"),
+            ("prediction-online-sme", "default"),
             # factual_research family (ESTIMATE_USER + ESTIMATE_SYSTEM).
             ("factual_research", "factual_research"),
             ("factual_research-v1", "factual_research"),
@@ -391,19 +400,169 @@ class TestBaselineFamily:
     ) -> None:
         """Registered tools route to the schema their module actually exports.
 
-        Covers the three tools the #321 review caught falling into the wrong
-        branch (superforcaster-polymarket-v1, prediction-url-cot, *-sme) plus
-        hypothetical ``-v<n+1>`` siblings the housekeeping default produces.
+        Pins the families the #321 review flagged as mis-routed — SME to
+        ``default`` (not superforcaster), prediction-url-cot to ``rag`` — plus
+        not-yet-registered ``-v<n+1>`` siblings handled by the fallback.
 
         :param tool_name: tool name from the parametrize matrix.
         :param expected: family the helper should classify ``tool_name`` to.
         """
         assert _baseline_family(tool_name) == expected
 
-    def test_unknown_tool_falls_to_default(self) -> None:
-        """Unknown names fall to the default family.
+    def test_registry_is_source_of_truth_over_heuristic(self) -> None:
+        """A registered name returns its registry family, not the heuristic.
 
-        The existing ``else`` branch in replay() then handles them (or raises
-        on missing attributes downstream).
+        ``prediction-online-sme`` ends in ``-sme`` and the old heuristic mapped
+        that to ``superforcaster``; the registry entry says ``default`` and
+        must win. Guards against re-introducing the name heuristic as primary.
         """
+        assert TOOL_REGISTRY["prediction-online-sme"].family == "default"
+        assert _baseline_family("prediction-online-sme") == "default"
+
+    def test_unknown_tool_falls_to_default(self) -> None:
+        """Unknown, unregistered names fall to the default family."""
         assert _baseline_family("totally-made-up-name") == "default"
+
+
+def _sf_prompt(question: str = "Will X?", today: str = "2026-04-22") -> str:
+    """Minimal superforcaster IPFS prompt (Question/<background> layout)."""
+    return (
+        f"Question:\n{question}\n\nToday's date: {today}\n"
+        f"<background>Some background.</background>"
+    )
+
+
+def _rag_prompt(question: str = "Will X?") -> str:
+    """Minimal RAG-family IPFS prompt (XML-tagged, not backtick-fenced)."""
+    return (
+        f"<user_prompt>{question}</user_prompt>\n"
+        f"<additional_information>Some info.</additional_information>"
+    )
+
+
+def _default_prompt(question: str = "Will X?") -> str:
+    """Minimal prediction-online / SME IPFS prompt (backtick-fenced)."""
+    return (
+        f"USER_PROMPT:\n```\n{question}\n```\n\n"
+        f"ADDITIONAL_INFORMATION:\n```\nSome info.\n```"
+    )
+
+
+class TestExtractPromptComponentsDispatch:
+    """`extract_prompt_components` routes sibling baselines to the right extractor.
+
+    Regression guard for the #321 review's unresolved 🔴 (comment 3364080553):
+    the enrich-time dispatch used exact-name matches (`== "superforcaster"`,
+    `== "factual_research"`), so a sibling baseline like
+    ``superforcaster-polymarket-v1`` or ``factual_research-v2`` fell through to
+    the default backtick regex, returned None, and every row was silently
+    dropped (``Enriched 0/N``). Now both this and the replay path share
+    `_baseline_family`, so siblings parse.
+    """
+
+    def test_superforcaster_sibling_parses_not_none(self) -> None:
+        """A ``superforcaster-*`` baseline parses via the superforcaster extractor.
+
+        Under the old exact-match dispatch this hit the default backtick regex
+        and returned None — the 0/140 enrichment failure.
+        """
+        out = extract_prompt_components(
+            _sf_prompt(question="Will it rain?"),
+            tool_name="superforcaster-polymarket-v1",
+        )
+        assert out is not None
+        assert out["user_prompt"] == "Will it rain?"
+
+    def test_factual_research_sibling_parses_not_none(self) -> None:
+        """A ``factual_research-*`` baseline parses via the FR extractor."""
+        out = extract_prompt_components(
+            _fr_prompt(question="Will it snow?", today="2026-04-22", briefing="B"),
+            tool_name="factual_research-v2",
+        )
+        assert out is not None
+        assert out["user_prompt"] == "Will it snow?"
+
+    def test_url_cot_parses_via_rag_extractor(self) -> None:
+        """``prediction-url-cot`` is rag-shaped, not default backtick format."""
+        out = extract_prompt_components(
+            _rag_prompt(question="Will it hail?"),
+            tool_name="prediction-url-cot",
+        )
+        assert out is not None
+        assert out["user_prompt"] == "Will it hail?"
+
+    def test_sme_parses_via_default_extractor(self) -> None:
+        """``*-sme`` is default-schema: backtick USER_PROMPT, not superforcaster."""
+        out = extract_prompt_components(
+            _default_prompt(question="Will it freeze?"),
+            tool_name="prediction-online-sme",
+        )
+        assert out is not None
+        assert out["user_prompt"] == "Will it freeze?"
+
+
+# Per-family contract the replay path relies on: which module attribute holds
+# the user-facing template and which kwargs format() it. Mirrors the dispatch
+# in replay() — keep in sync.
+_FAMILY_TEMPLATE = {
+    "rag": ("PREDICTION_PROMPT", {"USER_PROMPT": "q", "ADDITIONAL_INFORMATION": "a"}),
+    "superforcaster": (
+        "PREDICTION_PROMPT",
+        {"question": "q", "today": "t", "sources": "s"},
+    ),
+    "factual_research": (
+        "ESTIMATE_USER",
+        {"question": "q", "today": "t", "briefing": "b"},
+    ),
+    "default": (
+        "PREDICTION_PROMPT",
+        {"user_prompt": "q", "additional_information": "a"},
+    ),
+}
+
+
+class TestRegistryFamilyFormatRoundTrip:
+    """Every registered tool's module satisfies its declared family's contract.
+
+    Closes the #321 review test-gap (comment 3364080586): ``TestBaselineFamily``
+    only checked the string→family mapping, never that the chosen family's
+    ``.format(**kwargs)`` actually succeeds against the real module. That gap is
+    why the SME ``KeyError`` (comment 3364080538) stayed green — SME was routed
+    to superforcaster, whose ``format(question=, today=, sources=)`` blows up on
+    SME's ``{user_prompt}``/``{additional_information}`` template. This test
+    imports each module and runs the round-trip, so a mis-declared family fails.
+    """
+
+    @pytest.mark.parametrize("tool_name", sorted(TOOL_REGISTRY))
+    def test_family_template_formats_with_family_kwargs(self, tool_name: str) -> None:
+        """The family's template attr exists and formats with the family kwargs.
+
+        :param tool_name: a registered tool name.
+        """
+        spec = TOOL_REGISTRY[tool_name]
+        module = importlib.import_module(spec.module)
+
+        if spec.family == "reasoning":
+            # Two-stage: assert the symbols replay reads all exist.
+            for attr in (
+                "PREDICTION_PROMPT",
+                "REASONING_PROMPT",
+                "parser_reasoning_response",
+                "SYSTEM_PROMPT",
+            ):
+                assert hasattr(module, attr), f"{tool_name} missing {attr}"
+            return
+
+        attr, kwargs = _FAMILY_TEMPLATE[spec.family]
+        template = getattr(module, attr)
+        # Must not raise KeyError/IndexError on the family's kwargs.
+        template.format(**kwargs)
+
+    def test_default_family_system_prompt_is_optional(self) -> None:
+        """SME (default family) ships no SYSTEM_PROMPT_FORECASTER; replay tolerates it.
+
+        Pins the getattr fallback in replay() so default-family tools without
+        the forecaster system prompt don't AttributeError on import.
+        """
+        module = importlib.import_module(TOOL_REGISTRY["prediction-online-sme"].module)
+        assert not hasattr(module, "SYSTEM_PROMPT_FORECASTER")

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -431,6 +431,27 @@ class TestBaselineFamily:
         """Unknown, unregistered names fall to the default family."""
         assert _baseline_family("totally-made-up-name") == "default"
 
+    def test_unregistered_name_warns(self, caplog: Any) -> None:
+        """An unregistered tool warns that its family is being guessed.
+
+        Makes a misnamed / not-yet-registered tool visible at classify time
+        rather than only as a silent ``Enriched 0/N`` drop downstream.
+
+        :param caplog: pytest log-capture fixture.
+        """
+        with caplog.at_level("WARNING"):
+            _baseline_family("totally-made-up-name")
+        assert "not in TOOL_REGISTRY" in caplog.text
+
+    def test_registered_name_does_not_warn(self, caplog: Any) -> None:
+        """A registered tool resolves from the registry with no warning.
+
+        :param caplog: pytest log-capture fixture.
+        """
+        with caplog.at_level("WARNING"):
+            _baseline_family("superforcaster")
+        assert "not in TOOL_REGISTRY" not in caplog.text
+
 
 def _sf_prompt(question: str = "Will X?", today: str = "2026-04-22") -> str:
     """Minimal superforcaster IPFS prompt (Question/<background> layout)."""
@@ -617,7 +638,16 @@ class TestDefaultFamilySystemPrompt:
         module = SimpleNamespace(SYSTEM_PROMPT_FORECASTER="Custom forecaster prompt.")
         assert _default_family_system_prompt(module) == "Custom forecaster prompt."
 
-    def test_falls_back_when_absent(self) -> None:
-        """When the symbol is missing (e.g. SME), the generic fallback is used."""
+    def test_falls_back_when_absent(self, caplog: Any) -> None:
+        """When the symbol is missing (e.g. SME), the generic fallback is used.
+
+        The substitution is logged at WARNING so a missing/typo'd symbol on a
+        non-SME default-family tool is visible.
+
+        :param caplog: pytest log-capture fixture.
+        """
         module = SimpleNamespace()
-        assert _default_family_system_prompt(module) == DEFAULT_REPLAY_SYSTEM_PROMPT
+        with caplog.at_level("WARNING"):
+            result = _default_family_system_prompt(module)
+        assert result == DEFAULT_REPLAY_SYSTEM_PROMPT
+        assert "SYSTEM_PROMPT_FORECASTER" in caplog.text

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -6,11 +6,14 @@ from __future__ import annotations
 import importlib
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from benchmark.prompt_replay import (
+    DEFAULT_REPLAY_SYSTEM_PROMPT,
     _baseline_family,
+    _default_family_system_prompt,
     _extract_factual_research_prompt_components,
     _load_and_filter_rows,
     _log_replay_summary,
@@ -353,11 +356,12 @@ class TestBaselineFamily:
     for registered tools, with a name heuristic only as a fallback for
     not-yet-registered ``-v<n+1>`` siblings.
 
-    Note on history: before the registry field, the replay ``else`` branch
-    hard-imported from ``prediction_request`` (which *does* export
-    ``SYSTEM_PROMPT_FORECASTER``), so misrouted tools ran with the *wrong
-    prompt* — they did not crash on import. The defect was silent
-    mis-prompting, not an exception.
+    Note on history: the prior defect differed by branch. Tools misrouted into
+    the old ``else``/default branch hard-imported from ``prediction_request``
+    (which *does* export ``SYSTEM_PROMPT_FORECASTER``), so they ran with the
+    *wrong prompt* — silent mis-prompting, no exception. The superforcaster
+    branch was harsher: SME routed there hit a format-time ``KeyError`` (see
+    ``TestRegistryFamilyFormatRoundTrip``), crashing the whole replay.
     """
 
     @pytest.mark.parametrize(
@@ -366,9 +370,13 @@ class TestBaselineFamily:
             # Reasoning family (two-stage).
             ("prediction-request-reasoning", "reasoning"),
             ("prediction-request-reasoning-claude", "reasoning"),
+            # Not-yet-registered reasoning sibling → heuristic fallback.
+            ("prediction-request-reasoning-v2", "reasoning"),
             # Rag family (PREDICTION_PROMPT + SYSTEM_PROMPT).
             ("prediction-request-rag", "rag"),
             ("prediction-request-rag-claude", "rag"),
+            # Not-yet-registered rag sibling → heuristic fallback.
+            ("prediction-request-rag-v2", "rag"),
             # prediction-url-cot is rag-shaped (<user_prompt> XML).
             ("prediction-url-cot", "rag"),
             ("prediction-url-cot-claude", "rag"),
@@ -448,6 +456,17 @@ def _default_prompt(question: str = "Will X?") -> str:
     )
 
 
+def _reasoning_prompt(question: str = "Will X?") -> str:
+    """Minimal two-stage reasoning IPFS prompt (reasoning ////  prediction)."""
+    reasoning_half = (
+        f"Here is the user's question: {question}\n"
+        f"Here is some additional information "
+        f"<additional_information>Some info.</additional_information>"
+    )
+    prediction_half = f"<user_input>{question}</user_input>"
+    return f"{reasoning_half}////{prediction_half}"
+
+
 class TestExtractPromptComponentsDispatch:
     """`extract_prompt_components` routes sibling baselines to the right extractor.
 
@@ -500,24 +519,43 @@ class TestExtractPromptComponentsDispatch:
         assert out is not None
         assert out["user_prompt"] == "Will it freeze?"
 
+    def test_reasoning_parses_via_two_stage_extractor(self) -> None:
+        """Reasoning baselines parse via the ``////``-split extractor."""
+        out = extract_prompt_components(
+            _reasoning_prompt(question="Will it thaw?"),
+            tool_name="prediction-request-reasoning",
+        )
+        assert out is not None
+        assert out["user_prompt"] == "Will it thaw?"
+        assert out["user_input"] == "Will it thaw?"
 
-# Per-family contract the replay path relies on: which module attribute holds
-# the user-facing template and which kwargs format() it. Mirrors the dispatch
-# in replay() — keep in sync.
-_FAMILY_TEMPLATE = {
-    "rag": ("PREDICTION_PROMPT", {"USER_PROMPT": "q", "ADDITIONAL_INFORMATION": "a"}),
-    "superforcaster": (
-        "PREDICTION_PROMPT",
-        {"question": "q", "today": "t", "sources": "s"},
-    ),
-    "factual_research": (
-        "ESTIMATE_USER",
-        {"question": "q", "today": "t", "briefing": "b"},
-    ),
-    "default": (
-        "PREDICTION_PROMPT",
-        {"user_prompt": "q", "additional_information": "a"},
-    ),
+
+# Per-family contract the replay path relies on: which module attribute(s) hold
+# the user-facing template(s) and which kwargs format() them. Each family maps
+# to a list so multi-template families (reasoning: PREDICTION_PROMPT +
+# REASONING_PROMPT) are covered. Mirrors the dispatch in replay() — keep in sync.
+_FAMILY_TEMPLATES = {
+    "reasoning": [
+        ("PREDICTION_PROMPT", {"USER_INPUT": "q", "REASONING": "r"}),
+        ("REASONING_PROMPT", {"USER_PROMPT": "q", "ADDITIONAL_INFOMATION": "a"}),
+    ],
+    "rag": [("PREDICTION_PROMPT", {"USER_PROMPT": "q", "ADDITIONAL_INFORMATION": "a"})],
+    "superforcaster": [
+        ("PREDICTION_PROMPT", {"question": "q", "today": "t", "sources": "s"}),
+    ],
+    "factual_research": [
+        ("ESTIMATE_USER", {"question": "q", "today": "t", "briefing": "b"}),
+    ],
+    "default": [
+        ("PREDICTION_PROMPT", {"user_prompt": "q", "additional_information": "a"}),
+    ],
+}
+
+# Non-template symbols the replay path reads per family (beyond the templates
+# above). Checked for existence so a missing symbol fails loudly here.
+_FAMILY_EXTRA_SYMBOLS = {
+    "reasoning": ("parser_reasoning_response", "SYSTEM_PROMPT"),
+    "rag": ("SYSTEM_PROMPT",),
 }
 
 
@@ -535,28 +573,24 @@ class TestRegistryFamilyFormatRoundTrip:
 
     @pytest.mark.parametrize("tool_name", sorted(TOOL_REGISTRY))
     def test_family_template_formats_with_family_kwargs(self, tool_name: str) -> None:
-        """The family's template attr exists and formats with the family kwargs.
+        """The family's template(s) exist and format with the family kwargs.
+
+        Every template the replay path formats is exercised — including both
+        stages of the reasoning family — so a placeholder added to a template
+        without a matching family kwarg fails here instead of at replay time.
 
         :param tool_name: a registered tool name.
         """
         spec = TOOL_REGISTRY[tool_name]
         module = importlib.import_module(spec.module)
 
-        if spec.family == "reasoning":
-            # Two-stage: assert the symbols replay reads all exist.
-            for attr in (
-                "PREDICTION_PROMPT",
-                "REASONING_PROMPT",
-                "parser_reasoning_response",
-                "SYSTEM_PROMPT",
-            ):
-                assert hasattr(module, attr), f"{tool_name} missing {attr}"
-            return
+        for attr, kwargs in _FAMILY_TEMPLATES[spec.family]:
+            template = getattr(module, attr)
+            # Must not raise KeyError/IndexError on the family's kwargs.
+            template.format(**kwargs)
 
-        attr, kwargs = _FAMILY_TEMPLATE[spec.family]
-        template = getattr(module, attr)
-        # Must not raise KeyError/IndexError on the family's kwargs.
-        template.format(**kwargs)
+        for attr in _FAMILY_EXTRA_SYMBOLS.get(spec.family, ()):
+            assert hasattr(module, attr), f"{tool_name} missing {attr}"
 
     def test_default_family_system_prompt_is_optional(self) -> None:
         """SME (default family) ships no SYSTEM_PROMPT_FORECASTER; replay tolerates it.
@@ -566,3 +600,24 @@ class TestRegistryFamilyFormatRoundTrip:
         """
         module = importlib.import_module(TOOL_REGISTRY["prediction-online-sme"].module)
         assert not hasattr(module, "SYSTEM_PROMPT_FORECASTER")
+
+
+class TestDefaultFamilySystemPrompt:
+    """`_default_family_system_prompt` — the testable system-prompt selector.
+
+    Positive coverage for the getattr fallback (Ojus #321 review, comment on
+    prompt_replay.py:1399): asserting the attribute is *absent* on SME doesn't
+    prove the fallback string is actually returned. If someone reverts the
+    helper to a hard ``candidate_module.SYSTEM_PROMPT_FORECASTER`` access, the
+    second case below raises AttributeError and this test fails.
+    """
+
+    def test_uses_forecaster_prompt_when_present(self) -> None:
+        """When the module exports SYSTEM_PROMPT_FORECASTER, that value is used."""
+        module = SimpleNamespace(SYSTEM_PROMPT_FORECASTER="Custom forecaster prompt.")
+        assert _default_family_system_prompt(module) == "Custom forecaster prompt."
+
+    def test_falls_back_when_absent(self) -> None:
+        """When the symbol is missing (e.g. SME), the generic fallback is used."""
+        module = SimpleNamespace()
+        assert _default_family_system_prompt(module) == DEFAULT_REPLAY_SYSTEM_PROMPT

--- a/benchmark/tools.py
+++ b/benchmark/tools.py
@@ -25,28 +25,46 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class ToolSpec:
-    """Specification for a prediction tool."""
+    """Specification for a prediction tool.
+
+    ``family`` is the single source of truth for prompt-schema dispatch. It
+    decides both (a) which attribute symbols the replay path reads from the
+    tool's module (``PREDICTION_PROMPT`` / ``SYSTEM_PROMPT`` / ``ESTIMATE_USER``
+    / …) and the kwargs it formats them with, and (b) which regex extractor the
+    enrich path uses to parse the IPFS prompt. Both ``prompt_replay`` dispatch
+    sites read this field via ``_baseline_family`` so they cannot drift.
+
+    It is required (no default) on purpose: a silent wrong default is exactly
+    the failure mode that left enrichment parsing 0 rows for sibling baselines.
+    A new ``-v<n+1>`` variant must declare the same family as its parent.
+    """
 
     module: str
+    family: str
 
 
 TOOL_REGISTRY: dict[str, ToolSpec] = {
     # valory/prediction_request
     "prediction-online": ToolSpec(
         module="packages.valory.customs.prediction_request.prediction_request",
+        family="default",
     ),
     "prediction-offline": ToolSpec(
         module="packages.valory.customs.prediction_request.prediction_request",
+        family="default",
     ),
     "claude-prediction-online": ToolSpec(
         module="packages.valory.customs.prediction_request.prediction_request",
+        family="default",
     ),
     "claude-prediction-offline": ToolSpec(
         module="packages.valory.customs.prediction_request.prediction_request",
+        family="default",
     ),
     # valory/superforcaster
     "superforcaster": ToolSpec(
         module="packages.valory.customs.superforcaster.superforcaster",
+        family="superforcaster",
     ),
     # valory/superforcaster_polymarket_v1
     "superforcaster-polymarket-v1": ToolSpec(
@@ -54,38 +72,52 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
             "packages.valory.customs.superforcaster_polymarket_v1"
             ".superforcaster_polymarket_v1"
         ),
+        family="superforcaster",
     ),
     # napthaai/prediction_request_reasoning
     "prediction-request-reasoning": ToolSpec(
         module="packages.napthaai.customs.prediction_request_reasoning.prediction_request_reasoning",
+        family="reasoning",
     ),
     "prediction-request-reasoning-claude": ToolSpec(
         module="packages.napthaai.customs.prediction_request_reasoning.prediction_request_reasoning",
+        family="reasoning",
     ),
     # napthaai/prediction_request_rag
     "prediction-request-rag": ToolSpec(
         module="packages.napthaai.customs.prediction_request_rag.prediction_request_rag",
+        family="rag",
     ),
     "prediction-request-rag-claude": ToolSpec(
         module="packages.napthaai.customs.prediction_request_rag.prediction_request_rag",
+        family="rag",
     ),
-    # napthaai/prediction_url_cot
+    # napthaai/prediction_url_cot — rag-shaped (PREDICTION_PROMPT + SYSTEM_PROMPT,
+    # <user_prompt> XML layout), NOT the default backtick format.
     "prediction-url-cot": ToolSpec(
         module="packages.napthaai.customs.prediction_url_cot.prediction_url_cot",
+        family="rag",
     ),
     "prediction-url-cot-claude": ToolSpec(
         module="packages.napthaai.customs.prediction_url_cot.prediction_url_cot",
+        family="rag",
     ),
     # valory/factual_research
     "factual_research": ToolSpec(
         module="packages.valory.customs.factual_research.factual_research",
+        family="factual_research",
     ),
-    # nickcom007/prediction_request_sme
+    # nickcom007/prediction_request_sme — default schema: PREDICTION_PROMPT uses
+    # {user_prompt}/{additional_information} and the module exports no
+    # SYSTEM_PROMPT_FORECASTER. (It is NOT superforcaster-shaped despite
+    # exporting only PREDICTION_PROMPT.)
     "prediction-offline-sme": ToolSpec(
         module="packages.nickcom007.customs.prediction_request_sme.prediction_request_sme",
+        family="default",
     ),
     "prediction-online-sme": ToolSpec(
         module="packages.nickcom007.customs.prediction_request_sme.prediction_request_sme",
+        family="default",
     ),
 }
 

--- a/benchmark/tools.py
+++ b/benchmark/tools.py
@@ -13,7 +13,7 @@ import platform
 import threading
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Optional, TYPE_CHECKING
+from typing import Any, Callable, Literal, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from packages.valory.skills.task_execution.utils.apis import KeyChain
@@ -21,6 +21,13 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Tool registry
 # ---------------------------------------------------------------------------
+
+# Closed set of prompt-schema families. Typed as a Literal so a registry typo
+# (e.g. ``family="reasonning"``) is a mypy error rather than a silent route to
+# the default branch — the exact silent-misroute class this field exists to kill.
+FamilyName = Literal[
+    "reasoning", "rag", "superforcaster", "factual_research", "default"
+]
 
 
 @dataclass(frozen=True)
@@ -40,7 +47,7 @@ class ToolSpec:
     """
 
     module: str
-    family: str
+    family: FamilyName
 
 
 TOOL_REGISTRY: dict[str, ToolSpec] = {


### PR DESCRIPTION
## Why

`benchmark-replay` was failing with `FileNotFoundError: benchmark/results/ci_replay/baseline.jsonl` (e.g. [run 27194342892](https://github.com/valory-xyz/mech-predict/actions/runs/27194342892), [run 27219601862](https://github.com/valory-xyz/mech-predict/actions/runs/27219601862), PR #333 / the `factual_research-v2` branch). That error is a cascade — the real failure is upstream: enrichment logged `Enriched 0/140 rows`, so replay wrote no `baseline.jsonl` and the report step crashed.

Root cause: the two prompt-schema dispatch sites disagreed.

- **Replay** classified tools via `_baseline_family` (`startswith`).
- **Enrich** (`extract_prompt_components`) used **exact** name matches: `== "superforcaster"`, `== "factual_research"`.

So a sibling baseline — `superforcaster-polymarket-v1`, `factual_research-v2`, `prediction-url-cot` — was not equal to the bare name, fell through to the default `prediction-online` backtick regex, which doesn't match a `Question:/<background>` (superforcaster) or multi-section (factual_research) prompt → `extract_prompt_components` returned `None` → every row silently dropped.

This exact drift, plus a related cluster, was flagged by **@OjusWiZard** during the #321 review and merged unresolved. This PR resolves all five of his unresolved threads:

- 🔴 [`3364080553`](https://github.com/valory-xyz/mech-predict/pull/321#discussion_r3364080553) — extraction dispatch not widened to match `_baseline_family` (the `0/140` bug).
- 🔴 [`3364080538`](https://github.com/valory-xyz/mech-predict/pull/321#discussion_r3364080538) — `*-sme` routed to the superforcaster family crashes the whole replay with `KeyError` (SME's `PREDICTION_PROMPT` uses `{user_prompt}`/`{additional_information}`, not `question/today/sources`).
- 🟢 [`3364080568`](https://github.com/valory-xyz/mech-predict/pull/321#discussion_r3364080568) — prefer a `ToolSpec` field over name heuristics, feeding both dispatch sites from one source.
- 🟡 [`3364080571`](https://github.com/valory-xyz/mech-predict/pull/321#discussion_r3364080571) — docstring rationale was factually wrong ("crash on `SYSTEM_PROMPT_FORECASTER`"); the real prior defect was silent mis-prompting.
- 🟡 [`3364080586`](https://github.com/valory-xyz/mech-predict/pull/321#discussion_r3364080586) — `TestBaselineFamily` only checked the string→family mapping, never the `.format(**kwargs)` round-trip, which is why the SME `KeyError` stayed green.

## What

- Add a **required** `family` field to `ToolSpec` (`benchmark/tools.py`) as the single source of truth for prompt-schema dispatch. No default — a silent wrong default is exactly the failure mode here.
- `_baseline_family` now reads `TOOL_REGISTRY[name].family`; the name heuristic remains only as a fallback for a not-yet-registered `-v<n+1>` sibling. `extract_prompt_components` dispatches off `_baseline_family`, so enrich and replay can no longer drift.
- Reclassify `prediction-{offline,online}-sme` as `family="default"` (their schema is `{user_prompt}`/`{additional_information}` and they export no `SYSTEM_PROMPT_FORECASTER`), and add a `getattr(..., "SYSTEM_PROMPT_FORECASTER", "You are a helpful assistant.")` fallback in the default replay branch so those tools don't `AttributeError` on import.
- Tests: add `TestExtractPromptComponentsDispatch` (sibling baselines parse, not `None`) and `TestRegistryFamilyFormatRoundTrip` (imports every registered module and runs the family's `.format(**kwargs)` — would now catch the SME `KeyError`). Correct the factually-wrong docstrings.

> [!NOTE]
> `family` is required, so any future new-version `ToolSpec` entry (e.g. `superforcaster-polymarket-v2`, `factual_research-v2`) must declare the same family as its parent. Worth a line in CLAUDE.md's tool-improvement housekeeping table — flagging rather than editing it here.

## Test plan

- [x] `benchmark/tests/` — 923 passed
- [x] `black-check`, `isort-check`, `flake8`, `mypy`, `pylint`, `darglint` clean
- [x] Round-trip test imports all registered modules and formats each family's template without `KeyError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)