### PR TITLE
fix(benchmark): full-pool enrich + row_id dedup + --platform filter

### DIFF
--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -17,6 +17,10 @@ on:
         description: 'Sample size per platform'
         required: false
         default: '50'
+      platform:
+        description: 'Restrict to a single platform (omen|polymarket; empty = all)'
+        required: false
+        default: ''
       seed:
         description: 'Random seed'
         required: false
@@ -68,6 +72,7 @@ jobs:
           INPUT_TOOL: ${{ github.event.inputs.tool }}
           INPUT_PHASE: ${{ github.event.inputs.phase }}
           INPUT_SAMPLE: ${{ github.event.inputs.sample }}
+          INPUT_PLATFORM: ${{ github.event.inputs.platform }}
           INPUT_SEED: ${{ github.event.inputs.seed }}
           INPUT_PR: ${{ github.event.inputs.pr }}
           INPUT_CANDIDATE_TOOL: ${{ github.event.inputs.candidate_tool }}
@@ -79,6 +84,7 @@ jobs:
             TOOL="$INPUT_TOOL"
             PHASE="$INPUT_PHASE"
             SAMPLE="$INPUT_SAMPLE"
+            PLATFORM="$INPUT_PLATFORM"
             SEED="$INPUT_SEED"
             PR="$INPUT_PR"
             CANDIDATE_TOOL="$INPUT_CANDIDATE_TOOL"
@@ -87,6 +93,7 @@ jobs:
             TOOL=$(echo "$COMMENT_BODY" | awk '{print $2}')
             PHASE=$(echo "$COMMENT_BODY" | grep -oP '(?<=--phase )\S+' || echo "prediction-only")
             SAMPLE=$(echo "$COMMENT_BODY" | grep -oP '(?<=--sample )\d+' || echo "50")
+            PLATFORM=$(echo "$COMMENT_BODY" | grep -oP '(?<=--platform )[a-z]+' || echo "")
             SEED=$(echo "$COMMENT_BODY" | grep -oP '(?<=--seed )\d+' || echo "42")
             CANDIDATE_TOOL=$(echo "$COMMENT_BODY" | grep -oP '(?<=--candidate-tool )\S+' || echo "")
             PR="$ISSUE_NUMBER"
@@ -104,16 +111,24 @@ jobs:
             echo "::error::Invalid candidate-tool name: '$CANDIDATE_TOOL'. Must match [a-z0-9_-]+"
             exit 1
           fi
+          # Platform is optional; when set it must be one of the known platforms.
+          # enrich --platform also enforces this via argparse choices, but we
+          # reject early here so a typo fails fast with a clear message.
+          if [ -n "$PLATFORM" ] && [ "$PLATFORM" != "omen" ] && [ "$PLATFORM" != "polymarket" ]; then
+            echo "::error::Invalid platform: '$PLATFORM'. Must be 'omen' or 'polymarket'"
+            exit 1
+          fi
 
           echo "tool=$TOOL" >> "$GITHUB_OUTPUT"
           echo "phase=$PHASE" >> "$GITHUB_OUTPUT"
           echo "sample=$SAMPLE" >> "$GITHUB_OUTPUT"
+          echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
           echo "seed=$SEED" >> "$GITHUB_OUTPUT"
           echo "pr=$PR" >> "$GITHUB_OUTPUT"
           echo "candidate_tool=$CANDIDATE_TOOL" >> "$GITHUB_OUTPUT"
           echo "triggered_by=$TRIGGERED_BY" >> "$GITHUB_OUTPUT"
 
-          echo "Tool: $TOOL, Phase: $PHASE, Sample: $SAMPLE, Seed: $SEED, PR: $PR, Candidate: ${CANDIDATE_TOOL:-<same as tool>}"
+          echo "Tool: $TOOL, Phase: $PHASE, Sample: $SAMPLE, Platform: ${PLATFORM:-<all>}, Seed: $SEED, PR: $PR, Candidate: ${CANDIDATE_TOOL:-<same as tool>}"
 
       # Checkout — PR head for issue_comment, current branch for workflow_dispatch
       - name: Checkout PR head
@@ -145,13 +160,32 @@ jobs:
           workflow: benchmark_flywheel.yaml
           if_no_artifact_found: fail
 
-      # Find the production log file
-      - name: Locate production log
+      # Combine the full pool of daily log shards into one file. Enrich
+      # stratified-samples before the IPFS fetch, so a large pool costs nothing
+      # extra; it just gives sparse baselines (e.g. superforcaster-polymarket-v1)
+      # enough rows to sample.
+      #
+      # The shards are NOT disjoint: the flywheel re-emits a delivery into
+      # multiple daily shards (it only dedups within a day; cross-day dedup is
+      # the consumer's job), so the raw concatenation repeats ~4% of rows
+      # (verified on flywheel run 27251720632: 204,267 rows -> 196,270 distinct
+      # row_ids). Dedup is done downstream by enrich's _load_and_filter_rows on
+      # the canonical row_id key — matching how the scorer dedups — so here we
+      # just need a deterministic union. We sort the shard list (sort -z) so the
+      # files are concatenated in chronological (filename) order: enrich keeps the
+      # first occurrence of each row_id, so oldest-shard-wins, matching the
+      # scorer's keep-oldest semantics. Stable order also keeps the hashFiles
+      # cache key and the seeded sample reproducible across runs. The glob is
+      # scoped to production_log_*.jsonl so the output can't re-include itself.
+      - name: Combine production logs
         id: log
         run: |
-          LOG_FILE=$(find benchmark/datasets/logs/ -name '*.jsonl' -type f -print0 | xargs -0 ls -t | head -1)
+          LOG_FILE=benchmark/datasets/logs/_combined.jsonl
+          find benchmark/datasets/logs/ -name 'production_log_*.jsonl' -type f -print0 \
+            | LC_ALL=C sort -z \
+            | xargs -0 cat > "$LOG_FILE"
           echo "path=$LOG_FILE" >> "$GITHUB_OUTPUT"
-          echo "Found production log: $LOG_FILE ($(wc -l < "$LOG_FILE") rows)"
+          echo "Combined pool: $LOG_FILE ($(wc -l < "$LOG_FILE") rows; deduped on row_id in enrich)"
 
       # Enrich with caching
       - name: Cache enriched dataset
@@ -159,16 +193,26 @@ jobs:
         uses: actions/cache@v4
         with:
           path: benchmark/results/ci_enriched/
-          key: benchmark-enriched-${{ steps.parse.outputs.tool }}-${{ steps.parse.outputs.sample }}-${{ steps.parse.outputs.seed }}-${{ hashFiles(steps.log.outputs.path) }}
+          key: benchmark-enriched-${{ steps.parse.outputs.tool }}-${{ steps.parse.outputs.platform }}-${{ steps.parse.outputs.sample }}-${{ steps.parse.outputs.seed }}-${{ hashFiles(steps.log.outputs.path) }}
 
       - name: Enrich dataset
         if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          PLATFORM: ${{ steps.parse.outputs.platform }}
         run: |
+          # --platform is optional; pass it only when set so the default stays
+          # all-platforms. Enrich samples to --sample-per-platform before the
+          # IPFS fetch and exits non-zero with a clear message on 0 rows.
+          PLATFORM_ARG=""
+          if [ -n "$PLATFORM" ]; then
+            PLATFORM_ARG="--platform $PLATFORM"
+          fi
           uv run python -m benchmark.prompt_replay enrich \
             --production-log "${{ steps.log.outputs.path }}" \
             --tool "${{ steps.parse.outputs.tool }}" \
             --sample-per-platform "${{ steps.parse.outputs.sample }}" \
             --seed "${{ steps.parse.outputs.seed }}" \
+            $PLATFORM_ARG \
             --output benchmark/results/ci_enriched/dataset.jsonl
 
       # Replay with PR's prompts

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -184,6 +184,12 @@ jobs:
           find benchmark/datasets/logs/ -name 'production_log_*.jsonl' -type f -print0 \
             | LC_ALL=C sort -z \
             | xargs -0 cat > "$LOG_FILE"
+          # Fail here, not downstream: an artifact with no production_log_*.jsonl
+          # shards (renamed/missing files) leaves an empty _combined.jsonl and
+          # this step would exit 0, surfacing later as enrich's "0 rows for
+          # baseline" — which misreads a data-pipeline problem as a tool mismatch.
+          # (if_no_artifact_found: fail only catches a wholly absent artifact.)
+          [ -s "$LOG_FILE" ] || { echo "::error::No production_log_*.jsonl shards found in benchmark/datasets/logs/"; exit 1; }
           echo "path=$LOG_FILE" >> "$GITHUB_OUTPUT"
           echo "Combined pool: $LOG_FILE ($(wc -l < "$LOG_FILE") rows; deduped on row_id in enrich)"
 
@@ -200,19 +206,16 @@ jobs:
         env:
           PLATFORM: ${{ steps.parse.outputs.platform }}
         run: |
-          # --platform is optional; pass it only when set so the default stays
-          # all-platforms. Enrich samples to --sample-per-platform before the
-          # IPFS fetch and exits non-zero with a clear message on 0 rows.
-          PLATFORM_ARG=""
-          if [ -n "$PLATFORM" ]; then
-            PLATFORM_ARG="--platform $PLATFORM"
-          fi
+          # --platform is optional; ${PLATFORM:+...} expands to the flag only
+          # when PLATFORM is non-empty, so the default stays all-platforms.
+          # Enrich samples to --sample-per-platform before the IPFS fetch and
+          # exits non-zero with a clear message on 0 rows.
           uv run python -m benchmark.prompt_replay enrich \
             --production-log "${{ steps.log.outputs.path }}" \
             --tool "${{ steps.parse.outputs.tool }}" \
             --sample-per-platform "${{ steps.parse.outputs.sample }}" \
             --seed "${{ steps.parse.outputs.seed }}" \
-            $PLATFORM_ARG \
+            ${PLATFORM:+--platform "$PLATFORM"} \
             --output benchmark/results/ci_enriched/dataset.jsonl
 
       # Replay with PR's prompts

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from benchmark.io import load_jsonl
+from benchmark.prompt_replay import SCOPING_BUCKETS
 
 # Status buckets emitted by parse_response. Listed in a fixed order so the PR
 # comment breakdown is diffable across runs.
@@ -276,22 +277,20 @@ def _format_reliability_block(
             f"- Pre-filter (enrich): {accepted} accepted, {total_rej} rejected, "
             f"not_valid_parse={not_valid} {pf_marker}"
         )
-        # Scoping breakdown only when any rows were rejected — otherwise four
+        # Scoping breakdown only when any rows were rejected — otherwise the
         # zeroes just add noise to the happy path. Must stay adjacent to the
         # Pre-filter bullet above: markdown nests the indented sub-bullet
-        # under the most recent top-level bullet.
+        # under the most recent top-level bullet. Iterate SCOPING_BUCKETS so the
+        # breakdown always accounts for the rejected total shown above (minus
+        # not_valid_parse, which has its own marked line).
         if total_rej > 0:
-            scoping = ", ".join(
-                [
-                    f"duplicate={r.get('duplicate', 0)}",
-                    f"wrong_tool={r.get('wrong_tool', 0)}",
-                    f"wrong_platform={r.get('wrong_platform', 0)}",
-                    f"no_deliver_id={r.get('no_deliver_id', 0)}",
-                    f"no_outcome={r.get('no_outcome', 0)}",
-                    f"older_than_cutoff={r.get('older_than_cutoff', 0)}",
-                ]
-            )
+            scoping = ", ".join(f"{k}={r.get(k, 0)}" for k in SCOPING_BUCKETS)
             lines.append(f"  - Scoping: {scoping}")
+        # no_row_id is a kept-row diagnostic (always 0 in healthy production);
+        # surface it only when nonzero so a flywheel row_id regression is loud.
+        no_row_id = filter_stats.get("no_row_id", 0)
+        if no_row_id:
+            lines.append(f"  - ⚠️ no_row_id: {no_row_id} (rows bypassed dedup)")
         # Post-filter baseline is 100% by construction (enrich drops non-valid
         # rows), so surface the *pre-filter* ratio to tell reviewers how noisy
         # production actually was — per PR #231 review. Rendered last so the

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -400,7 +400,7 @@ def format_report(
         parts.append("")
 
     # Footer
-    footer_parts = [f"{baseline['n']} markets"]
+    footer_parts = [f"{baseline['n']} deliveries"]
     if meta.get("seed"):
         footer_parts.append(f"seed {meta['seed']}")
     if meta.get("phase"):

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -283,7 +283,9 @@ def _format_reliability_block(
         if total_rej > 0:
             scoping = ", ".join(
                 [
+                    f"duplicate={r.get('duplicate', 0)}",
                     f"wrong_tool={r.get('wrong_tool', 0)}",
+                    f"wrong_platform={r.get('wrong_platform', 0)}",
                     f"no_deliver_id={r.get('no_deliver_id', 0)}",
                     f"no_outcome={r.get('no_outcome', 0)}",
                     f"older_than_cutoff={r.get('older_than_cutoff', 0)}",

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -470,12 +470,17 @@ def _load_and_filter_rows(
     production_log: Path,
     tool_filter: str,
     last_days: Optional[int],
+    platform_filter: Optional[str] = None,
 ) -> Tuple[list[dict[str, Any]], Dict[str, int]]:
     """Load production log and filter for valid rows.
+
+    Collapses cross-shard duplicates on ``row_id`` before filtering (see the
+    rejection-bucket comment below), so a multi-shard pool is safe to pass in.
 
     :param production_log: path to production_log.jsonl.
     :param tool_filter: tool name to filter for.
     :param last_days: only include rows from the last N days.
+    :param platform_filter: only include rows from this platform (default: all).
     :return: (filtered rows, rejection counts per reason).
     """
     cutoff = None
@@ -487,14 +492,24 @@ def _load_and_filter_rows(
     # it is the invariant downstream Parse-reliability reporting depends on
     # (baseline is 100% valid by construction *because* these rows are dropped
     # here). If that invariant regresses, we want this count to make it loud.
+    # The "duplicate" bucket counts cross-shard repeats: the flywheel re-emits a
+    # delivery into multiple daily shards (per-shard dedup only; cross-day dedup
+    # is the consumer's job — the scorer does it globally by row_id, scorer.py).
+    # When this function reads a multi-shard pool, ~4% of rows repeat, so we
+    # collapse on row_id (the canonical identity key, 1:1 with platform+deliver_id)
+    # keeping the first occurrence — matching the scorer's keep-oldest semantics
+    # when the combine step feeds shards in chronological order.
     rejected: Dict[str, int] = {
+        "duplicate": 0,
         "wrong_tool": 0,
+        "wrong_platform": 0,
         "no_deliver_id": 0,
         "not_valid_parse": 0,
         "no_outcome": 0,
         "older_than_cutoff": 0,
     }
 
+    seen_row_ids: set[str] = set()
     rows: list[dict[str, Any]] = []
     with open(production_log, encoding="utf-8") as f:
         for line in f:
@@ -502,8 +517,19 @@ def _load_and_filter_rows(
             if not line:
                 continue
             row = json.loads(line)
+            # Dedup first, on the canonical row_id. Rows without a row_id (e.g.
+            # hand-built fixtures) can't be keyed, so they are never collapsed.
+            row_id = row.get("row_id")
+            if row_id is not None:
+                if row_id in seen_row_ids:
+                    rejected["duplicate"] += 1
+                    continue
+                seen_row_ids.add(row_id)
             if row.get("tool_name") != tool_filter:
                 rejected["wrong_tool"] += 1
+                continue
+            if platform_filter is not None and row.get("platform") != platform_filter:
+                rejected["wrong_platform"] += 1
                 continue
             if not row.get("deliver_id"):
                 rejected["no_deliver_id"] += 1
@@ -554,6 +580,7 @@ def enrich(
     last_days: Optional[int] = None,
     sample_per_platform: Optional[int] = None,
     seed: int = 42,
+    platform_filter: Optional[str] = None,
 ) -> None:
     """Fetch IPFS prompts and extract components for replay.
 
@@ -566,17 +593,22 @@ def enrich(
     :param last_days: only include rows from the last N days.
     :param sample_per_platform: stratified sample N per platform before IPFS fetch.
     :param seed: random seed for sampling.
+    :param platform_filter: only include rows from this platform (default: all).
     """
-    rows, rejected = _load_and_filter_rows(production_log, tool_filter, last_days)
+    rows, rejected = _load_and_filter_rows(
+        production_log, tool_filter, last_days, platform_filter
+    )
     log.info(
         "Loaded %d %s rows with deliver_id + valid predictions + known outcome",
         len(rows),
         tool_filter,
     )
     log.info(
-        "Pre-filter rejections: wrong_tool=%d no_deliver_id=%d "
-        "not_valid_parse=%d no_outcome=%d older_than_cutoff=%d",
+        "Pre-filter rejections: duplicate=%d wrong_tool=%d wrong_platform=%d "
+        "no_deliver_id=%d not_valid_parse=%d no_outcome=%d older_than_cutoff=%d",
+        rejected["duplicate"],
         rejected["wrong_tool"],
+        rejected["wrong_platform"],
         rejected["no_deliver_id"],
         rejected["not_valid_parse"],
         rejected["no_outcome"],
@@ -598,8 +630,8 @@ def enrich(
     log.info("Wrote filter stats: %s", stats_path)
 
     if not rows:
-        log.warning("No rows to enrich")
-        return
+        scope = f" [platform={platform_filter}]" if platform_filter else ""
+        raise SystemExit(f"0 rows for baseline {tool_filter!r}{scope} across the pool")
 
     # Stratified sample BEFORE IPFS fetch to avoid unnecessary downloads.
     if sample_per_platform is not None:
@@ -674,8 +706,11 @@ def stratified_sample(
     """Sample rows with stratification by platform, outcome, and Brier bucket.
 
     Each platform gets ``sample_per_platform`` rows (50:50 platform split).
-    Within each platform, rows are grouped by (outcome, brier_bucket) and
-    sampled proportionally, ensuring at least 1 row per non-empty stratum.
+    When the caller pre-filtered to a single platform (``enrich --platform``),
+    only that platform group survives, so the cap is ``sample_per_platform``
+    rows total. Within each platform, rows are grouped by (outcome,
+    brier_bucket) and sampled proportionally, ensuring at least 1 row per
+    non-empty stratum.
 
     :param rows: list of row dicts with 'platform', 'final_outcome', 'p_yes'.
     :param sample_per_platform: max rows to sample per platform.
@@ -1730,6 +1765,13 @@ def main() -> None:
         default=42,
         help="Random seed for stratified sampling (default: 42)",
     )
+    enrich_parser.add_argument(
+        "--platform",
+        type=str,
+        default=None,
+        choices=["omen", "polymarket"],
+        help="Restrict to a single platform (default: all platforms)",
+    )
 
     # --- replay ---
     replay_parser = subparsers.add_parser(
@@ -1791,6 +1833,7 @@ def main() -> None:
             last_days=args.last_days,
             sample_per_platform=args.sample_per_platform,
             seed=args.seed,
+            platform_filter=args.platform,
         )
     elif args.command == "replay":
         replay(

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -1178,11 +1178,14 @@ def _log_replay_summary(
         total_rej = sum(r.values()) if r else 0
         log.info("  Pre-filter (from enrich):")
         log.info(
-            "    Accepted: %d   Rejected: %d (wrong_tool=%d, no_deliver_id=%d, "
-            "not_valid_parse=%d, no_outcome=%d, older_than_cutoff=%d)",
+            "    Accepted: %d   Rejected: %d (duplicate=%d, wrong_tool=%d, "
+            "wrong_platform=%d, no_deliver_id=%d, not_valid_parse=%d, "
+            "no_outcome=%d, older_than_cutoff=%d)",
             filter_stats.get("accepted", 0),
             total_rej,
+            r.get("duplicate", 0),
             r.get("wrong_tool", 0),
+            r.get("wrong_platform", 0),
             r.get("no_deliver_id", 0),
             r.get("not_valid_parse", 0),
             r.get("no_outcome", 0),

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -1109,7 +1109,7 @@ def _log_replay_summary(
     :param candidate_path: path to the candidate JSONL file.
     :param baseline_brier_sum: sum of baseline Brier scores.
     :param candidate_brier_sum: sum of candidate Brier scores.
-    :param total: total number of markets.
+    :param total: total number of deliveries.
     :param n_scored: number of candidate predictions scored.
     :param baseline_path: path to the baseline JSONL file.
     :param status_counts: candidate ``prediction_parse_status`` bucket counts.
@@ -1139,7 +1139,7 @@ def _log_replay_summary(
     candidate_acc = candidate_correct / n_scored if n_scored else 0
 
     log.info("=" * 60)
-    log.info("RESULTS: %d markets (%d candidate scored)", total, n_scored)
+    log.info("RESULTS: %d deliveries (%d candidate scored)", total, n_scored)
 
     # Parse reliability — baseline is always 100% (valid-only by enrich filter),
     # so this surfaces candidate drift only.

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -42,7 +42,7 @@ import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Literal, Optional, Tuple
 
 import openai
 import requests
@@ -76,6 +76,25 @@ log = logging.getLogger(__name__)
 HTTP_TIMEOUT = 60
 DEFAULT_BATCH_SIZE = 100
 DEFAULT_MODEL = "gpt-4.1-2025-04-14"
+
+# Platforms a tool can serve; also the allowed values for ``enrich --platform``.
+PLATFORMS = ("omen", "polymarket")
+
+# Reject buckets that DROP a row and are rendered in the Pre-filter "Scoping"
+# breakdown. Every renderer iterates this tuple so the breakdown always sums to
+# the rejected total — adding a bucket here updates all three sites at once.
+# ``not_valid_parse`` is also a drop but is deliberately excluded: it is the
+# load-bearing parse-reliability invariant and gets its own marked line, so it
+# is rendered separately (never fold it in here). ``no_row_id`` is NOT a drop
+# (those rows are kept) — it is a separate diagnostic, so it is not listed here.
+SCOPING_BUCKETS = (
+    "duplicate",
+    "wrong_tool",
+    "wrong_platform",
+    "no_deliver_id",
+    "no_outcome",
+    "older_than_cutoff",
+)
 
 # Regex to extract user_prompt and additional_information from the old
 # formatted PREDICTION_PROMPT.  The old format uses triple-backtick fences.
@@ -470,8 +489,8 @@ def _load_and_filter_rows(
     production_log: Path,
     tool_filter: str,
     last_days: Optional[int],
-    platform_filter: Optional[str] = None,
-) -> Tuple[list[dict[str, Any]], Dict[str, int]]:
+    platform_filter: Optional[Literal["omen", "polymarket"]] = None,
+) -> Tuple[list[dict[str, Any]], Dict[str, int], int]:
     """Load production log and filter for valid rows.
 
     Collapses cross-shard duplicates on ``row_id`` before filtering (see the
@@ -481,7 +500,8 @@ def _load_and_filter_rows(
     :param tool_filter: tool name to filter for.
     :param last_days: only include rows from the last N days.
     :param platform_filter: only include rows from this platform (default: all).
-    :return: (filtered rows, rejection counts per reason).
+    :return: (filtered rows, rejection counts per reason, no_row_id diagnostic
+        count of *kept* rows that lacked a row_id).
     """
     cutoff = None
     if last_days is not None:
@@ -496,18 +516,16 @@ def _load_and_filter_rows(
     # delivery into multiple daily shards (per-shard dedup only; cross-day dedup
     # is the consumer's job — the scorer does it globally by row_id, scorer.py).
     # When this function reads a multi-shard pool, ~4% of rows repeat, so we
-    # collapse on row_id (the canonical identity key, 1:1 with platform+deliver_id)
-    # keeping the first occurrence — matching the scorer's keep-oldest semantics
-    # when the combine step feeds shards in chronological order.
-    rejected: Dict[str, int] = {
-        "duplicate": 0,
-        "wrong_tool": 0,
-        "wrong_platform": 0,
-        "no_deliver_id": 0,
-        "not_valid_parse": 0,
-        "no_outcome": 0,
-        "older_than_cutoff": 0,
-    }
+    # collapse on row_id (the canonical identity key for production rows, derived
+    # from platform+deliver_id) keeping the FIRST occurrence. With the combine
+    # step feeding shards oldest-first, that is the oldest copy — the same order
+    # the scorer's rebuild() path uses (its incremental update() keeps whatever
+    # was scored first, which need not be the oldest).
+    rejected: Dict[str, int] = {k: 0 for k in (*SCOPING_BUCKETS, "not_valid_parse")}
+    # Diagnostic, NOT a drop: production rows always carry a row_id, so a nonzero
+    # count here means the flywheel schema regressed (and those rows silently
+    # bypassed dedup). Kept out of ``rejected`` so the rejected total stays exact.
+    no_row_id = 0
 
     seen_row_ids: set[str] = set()
     rows: list[dict[str, Any]] = []
@@ -518,12 +536,15 @@ def _load_and_filter_rows(
                 continue
             row = json.loads(line)
             # Dedup first, on the canonical row_id. Rows without a row_id (e.g.
-            # hand-built fixtures) can't be keyed, so they are never collapsed.
+            # hand-built fixtures) can't be keyed, so they are never collapsed —
+            # only counted, so a row_id regression is visible.
             row_id = row.get("row_id")
-            if row_id is not None:
-                if row_id in seen_row_ids:
-                    rejected["duplicate"] += 1
-                    continue
+            if row_id is None:
+                no_row_id += 1
+            elif row_id in seen_row_ids:
+                rejected["duplicate"] += 1
+                continue
+            else:
                 seen_row_ids.add(row_id)
             if row.get("tool_name") != tool_filter:
                 rejected["wrong_tool"] += 1
@@ -548,7 +569,7 @@ def _load_and_filter_rows(
                         rejected["older_than_cutoff"] += 1
                         continue
             rows.append(row)
-    return rows, rejected
+    return rows, rejected, no_row_id
 
 
 # ---------------------------------------------------------------------------
@@ -580,7 +601,7 @@ def enrich(
     last_days: Optional[int] = None,
     sample_per_platform: Optional[int] = None,
     seed: int = 42,
-    platform_filter: Optional[str] = None,
+    platform_filter: Optional[Literal["omen", "polymarket"]] = None,
 ) -> None:
     """Fetch IPFS prompts and extract components for replay.
 
@@ -595,7 +616,7 @@ def enrich(
     :param seed: random seed for sampling.
     :param platform_filter: only include rows from this platform (default: all).
     """
-    rows, rejected = _load_and_filter_rows(
+    rows, rejected, no_row_id = _load_and_filter_rows(
         production_log, tool_filter, last_days, platform_filter
     )
     log.info(
@@ -603,17 +624,18 @@ def enrich(
         len(rows),
         tool_filter,
     )
-    log.info(
-        "Pre-filter rejections: duplicate=%d wrong_tool=%d wrong_platform=%d "
-        "no_deliver_id=%d not_valid_parse=%d no_outcome=%d older_than_cutoff=%d",
-        rejected["duplicate"],
-        rejected["wrong_tool"],
-        rejected["wrong_platform"],
-        rejected["no_deliver_id"],
-        rejected["not_valid_parse"],
-        rejected["no_outcome"],
-        rejected["older_than_cutoff"],
+    # Render every drop bucket (Scoping set + not_valid_parse) so the line
+    # accounts for the full rejected total; no_row_id is a separate diagnostic.
+    rejections_str = " ".join(
+        f"{k}={rejected[k]}" for k in (*SCOPING_BUCKETS, "not_valid_parse")
     )
+    log.info("Pre-filter rejections: %s no_row_id=%d", rejections_str, no_row_id)
+    if no_row_id:
+        log.warning(
+            "%d kept rows lacked a row_id (expected 0 — flywheel schema "
+            "regression? these bypassed dedup)",
+            no_row_id,
+        )
 
     # Sidecar JSON carries the rejection counts into the replay + PR-comment
     # stages, where "baseline is 100% valid by construction" would otherwise be
@@ -622,7 +644,7 @@ def enrich(
     stats_path.parent.mkdir(parents=True, exist_ok=True)
     stats_path.write_text(
         json.dumps(
-            {"accepted": len(rows), "rejected": rejected},
+            {"accepted": len(rows), "rejected": rejected, "no_row_id": no_row_id},
             indent=2,
         ),
         encoding="utf-8",
@@ -705,12 +727,15 @@ def stratified_sample(
 ) -> list[dict[str, Any]]:
     """Sample rows with stratification by platform, outcome, and Brier bucket.
 
-    Each platform gets ``sample_per_platform`` rows (50:50 platform split).
-    When the caller pre-filtered to a single platform (``enrich --platform``),
-    only that platform group survives, so the cap is ``sample_per_platform``
-    rows total. Within each platform, rows are grouped by (outcome,
-    brier_bucket) and sampled proportionally, ensuring at least 1 row per
-    non-empty stratum.
+    Each platform gets up to ``sample_per_platform`` rows (50:50 platform
+    split). When the caller pre-filtered to a single platform (``enrich
+    --platform``), only that platform group survives, so the per-platform budget
+    is applied once — a ``--platform`` run draws ~``sample_per_platform`` rows,
+    not the ~2x of an all-platforms run. Within each platform, rows are grouped
+    by (outcome, brier_bucket) and sampled proportionally, ensuring at least 1
+    row per non-empty stratum — so when a platform has MORE non-empty strata
+    than the budget, the per-stratum floor wins and the count can slightly
+    exceed ``sample_per_platform`` (e.g. budget 5 over 6 strata → 6 rows).
 
     :param rows: list of row dicts with 'platform', 'final_outcome', 'p_yes'.
     :param sample_per_platform: max rows to sample per platform.
@@ -1176,20 +1201,17 @@ def _log_replay_summary(
     if filter_stats is not None:
         r = filter_stats.get("rejected", {})
         total_rej = sum(r.values()) if r else 0
+        # Scoping buckets + not_valid_parse make up the full rejected total;
+        # iterate SCOPING_BUCKETS so this can't drift out of sync.
+        breakdown = ", ".join(f"{k}={r.get(k, 0)}" for k in SCOPING_BUCKETS)
         log.info("  Pre-filter (from enrich):")
         log.info(
-            "    Accepted: %d   Rejected: %d (duplicate=%d, wrong_tool=%d, "
-            "wrong_platform=%d, no_deliver_id=%d, not_valid_parse=%d, "
-            "no_outcome=%d, older_than_cutoff=%d)",
+            "    Accepted: %d   Rejected: %d (%s, not_valid_parse=%d)  no_row_id=%d",
             filter_stats.get("accepted", 0),
             total_rej,
-            r.get("duplicate", 0),
-            r.get("wrong_tool", 0),
-            r.get("wrong_platform", 0),
-            r.get("no_deliver_id", 0),
+            breakdown,
             r.get("not_valid_parse", 0),
-            r.get("no_outcome", 0),
-            r.get("older_than_cutoff", 0),
+            filter_stats.get("no_row_id", 0),
         )
 
     log.info(
@@ -1772,7 +1794,7 @@ def main() -> None:
         "--platform",
         type=str,
         default=None,
-        choices=["omen", "polymarket"],
+        choices=list(PLATFORMS),
         help="Restrict to a single platform (default: all platforms)",
     )
 

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -73,7 +73,9 @@ def _stats(
     *,
     accepted: int = 100,
     not_valid_parse: int = 0,
+    duplicate: int = 0,
     wrong_tool: int = 0,
+    wrong_platform: int = 0,
     no_deliver_id: int = 0,
     no_outcome: int = 0,
     older_than_cutoff: int = 0,
@@ -81,7 +83,9 @@ def _stats(
     return {
         "accepted": accepted,
         "rejected": {
+            "duplicate": duplicate,
             "wrong_tool": wrong_tool,
+            "wrong_platform": wrong_platform,
             "no_deliver_id": no_deliver_id,
             "not_valid_parse": not_valid_parse,
             "no_outcome": no_outcome,
@@ -134,11 +138,22 @@ class TestReliabilityBlock:
         lines = _format_reliability_block(
             candidate,
             [],
-            _stats(accepted=5, wrong_tool=12, no_outcome=4, older_than_cutoff=7),
+            _stats(
+                accepted=5,
+                duplicate=8,
+                wrong_tool=12,
+                wrong_platform=9,
+                no_outcome=4,
+                older_than_cutoff=7,
+            ),
         )
         text = "\n".join(lines)
         assert "Scoping:" in text
         assert "wrong_tool=12" in text
+        # The full-pool/--platform buckets must surface too, else the rendered
+        # breakdown no longer sums to the rejected total shown on the line above.
+        assert "duplicate=8" in text
+        assert "wrong_platform=9" in text
         assert "no_outcome=4" in text
         assert "older_than_cutoff=7" in text
         # Scoping alone must not raise the invariant marker.

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -394,13 +394,13 @@ class TestFormatReportFooter:
         assert "@LOCKhart07" in footer
         assert "[@LOCKhart07]" not in footer
 
-    def test_footer_order_markets_seed_triggered_by(self) -> None:
-        """Footer parts stay in the existing order: markets → seed → triggered-by."""
+    def test_footer_order_deliveries_seed_triggered_by(self) -> None:
+        """Footer parts stay in the existing order: deliveries → seed → triggered-by."""
         report = self._report(
             seed="1337",
             triggered_by="LOCKhart07",
             trigger_comment_url="https://example.com/c",
         )
         footer = report.splitlines()[-1]
-        assert footer.index("markets") < footer.index("seed 1337")
+        assert footer.index("deliveries") < footer.index("seed 1337")
         assert footer.index("seed 1337") < footer.index("LOCKhart07")

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
+from unittest import mock
 
 import pytest
 from benchmark.prompt_replay import (
@@ -20,6 +21,8 @@ from benchmark.prompt_replay import (
     _prepare_output_dir,
     enrich,
     extract_prompt_components,
+    main,
+    stratified_sample,
 )
 from benchmark.tools import TOOL_REGISTRY
 
@@ -65,7 +68,7 @@ class TestLoadAndFilterRows:
         """Rows matching every filter land in rows; counters stay at zero."""
         path = tmp_path / "log.jsonl"
         _write_jsonl(path, [_row(), _row()])
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, _ = _load_and_filter_rows(path, "superforcaster", None)
         assert len(rows) == 2
         assert sum(rejected.values()) == 0
 
@@ -73,7 +76,7 @@ class TestLoadAndFilterRows:
         """Rows with a different tool_name hit the wrong_tool bucket only."""
         path = tmp_path / "log.jsonl"
         _write_jsonl(path, [_row(tool="other"), _row(tool="another")])
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, _ = _load_and_filter_rows(path, "superforcaster", None)
         assert not rows
         assert rejected["wrong_tool"] == 2
         assert rejected["not_valid_parse"] == 0
@@ -90,7 +93,7 @@ class TestLoadAndFilterRows:
                 _row(status="valid"),
             ],
         )
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, _ = _load_and_filter_rows(path, "superforcaster", None)
         assert len(rows) == 1
         assert rejected["not_valid_parse"] == 3
 
@@ -98,7 +101,7 @@ class TestLoadAndFilterRows:
         """Rows without final_outcome hit no_outcome, not not_valid_parse."""
         path = tmp_path / "log.jsonl"
         _write_jsonl(path, [_row(outcome=None)])
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, _ = _load_and_filter_rows(path, "superforcaster", None)
         assert not rows
         assert rejected["no_outcome"] == 1
         assert rejected["not_valid_parse"] == 0
@@ -107,17 +110,17 @@ class TestLoadAndFilterRows:
         """Rows without deliver_id hit no_deliver_id."""
         path = tmp_path / "log.jsonl"
         _write_jsonl(path, [_row(deliver_id="")])
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, _ = _load_and_filter_rows(path, "superforcaster", None)
         assert not rows
         assert rejected["no_deliver_id"] == 1
 
     def test_filter_order_gives_first_failing_reason(self, tmp_path: Path) -> None:
         """A row failing multiple predicates counts in the first one only.
 
-        Order: wrong_tool → wrong_platform → no_deliver_id → not_valid_parse →
-        no_outcome → cutoff. A row with wrong tool AND bad parse AND no outcome
-        increments wrong_tool only — so the total rejection count matches row
-        count exactly.
+        Order: duplicate → wrong_tool → wrong_platform → no_deliver_id →
+        not_valid_parse → no_outcome → cutoff. A row with wrong tool AND bad
+        parse AND no outcome increments wrong_tool only — so the total rejection
+        count matches row count exactly.
 
         :param tmp_path: pytest tmp_path fixture.
         """
@@ -126,7 +129,7 @@ class TestLoadAndFilterRows:
             path,
             [_row(tool="other", status="malformed", outcome=None)],
         )
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, _ = _load_and_filter_rows(path, "superforcaster", None)
         assert not rows
         assert rejected["wrong_tool"] == 1
         assert sum(rejected.values()) == 1
@@ -142,7 +145,7 @@ class TestLoadAndFilterRows:
                 _row(platform="polymarket"),
             ],
         )
-        rows, rejected = _load_and_filter_rows(
+        rows, rejected, _ = _load_and_filter_rows(
             path, "superforcaster", None, "polymarket"
         )
         assert len(rows) == 1
@@ -157,7 +160,7 @@ class TestLoadAndFilterRows:
             path,
             [_row(platform="omen"), _row(platform="polymarket")],
         )
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, _ = _load_and_filter_rows(path, "superforcaster", None)
         assert len(rows) == 2
         assert rejected["wrong_platform"] == 0
 
@@ -171,7 +174,7 @@ class TestLoadAndFilterRows:
         """
         path = tmp_path / "log.jsonl"
         _write_jsonl(path, [_row(tool="other", platform="omen")])
-        rows, rejected = _load_and_filter_rows(
+        rows, rejected, _ = _load_and_filter_rows(
             path, "superforcaster", None, "polymarket"
         )
         assert not rows
@@ -196,19 +199,26 @@ class TestLoadAndFilterRows:
                 _row(row_id="prod_y", outcome=True),
             ],
         )
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, _ = _load_and_filter_rows(path, "superforcaster", None)
         assert len(rows) == 2  # prod_x once + prod_y
         assert rejected["duplicate"] == 1
         kept = {r["row_id"]: r["final_outcome"] for r in rows}
         assert kept == {"prod_x": True, "prod_y": True}  # first prod_x wins
 
-    def test_rows_without_row_id_not_deduped(self, tmp_path: Path) -> None:
-        """Rows lacking a row_id are never collapsed (fixture/legacy contract)."""
+    def test_rows_without_row_id_not_deduped_but_counted(self, tmp_path: Path) -> None:
+        """Rows lacking a row_id are never collapsed, but counted as no_row_id.
+
+        Pins the diagnostic that surfaces a flywheel row_id-schema regression:
+        such rows bypass dedup (kept), so the count is the only signal.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
         path = tmp_path / "log.jsonl"
         _write_jsonl(path, [_row(), _row()])  # identical, no row_id
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, no_row_id = _load_and_filter_rows(path, "superforcaster", None)
         assert len(rows) == 2
         assert rejected["duplicate"] == 0
+        assert no_row_id == 2
 
     def test_duplicate_counted_before_tool_filter(self, tmp_path: Path) -> None:
         """Dedup precedes the tool check: a repeat counts as duplicate, not wrong_tool.
@@ -224,7 +234,7 @@ class TestLoadAndFilterRows:
             path,
             [_row(tool="other", row_id="prod_z"), _row(tool="other", row_id="prod_z")],
         )
-        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        rows, rejected, _ = _load_and_filter_rows(path, "superforcaster", None)
         assert not rows
         assert rejected["duplicate"] == 1
         assert rejected["wrong_tool"] == 1
@@ -240,7 +250,14 @@ class TestEnrichZeroRows:
     """
 
     def test_raises_systemexit_naming_the_tool(self, tmp_path: Path) -> None:
-        """0 qualifying rows → SystemExit mentioning the baseline tool."""
+        """0 qualifying rows → SystemExit mentioning the baseline tool.
+
+        The filter_stats sidecar must still be written (enrich writes it before
+        the guard) so the zero-row run stays diagnosable — pin that here so a
+        future refactor moving the write below the guard can't silently drop it.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
         log_path = tmp_path / "log.jsonl"
         _write_jsonl(log_path, [_row(tool="other"), _row(tool="another")])
         output = tmp_path / "out" / "dataset.jsonl"
@@ -248,6 +265,7 @@ class TestEnrichZeroRows:
             enrich(log_path, "superforcaster", output)
         assert "superforcaster" in str(exc.value)
         assert not output.exists()
+        assert (tmp_path / "out" / "dataset.jsonl.filter_stats.json").exists()
 
     def test_message_includes_platform_scope(self, tmp_path: Path) -> None:
         """When a platform filter empties the pool, the scope is in the message."""
@@ -258,6 +276,93 @@ class TestEnrichZeroRows:
             enrich(log_path, "superforcaster", output, platform_filter="polymarket")
         assert "platform=polymarket" in str(exc.value)
         assert not output.exists()
+        assert (tmp_path / "out" / "dataset.jsonl.filter_stats.json").exists()
+
+
+class TestStratifiedSampleSinglePlatform:
+    """`stratified_sample` applies the per-platform budget once for one platform."""
+
+    @staticmethod
+    def _pm(p_yes: float, outcome: bool, i: int) -> dict:
+        r = _row(platform="polymarket", outcome=outcome, row_id=f"r{i}")
+        r["p_yes"] = p_yes
+        return r
+
+    def test_budget_applied_once_not_doubled(self) -> None:
+        """One platform, single stratum → exactly sample_per_platform (not ~2x).
+
+        Pins the --platform semantics: the budget is applied once. A single
+        stratum avoids the per-stratum floor and proportional-rounding overshoot
+        (both of which can push the count above the budget — see the sibling
+        test), isolating the cap so a future two-platform floor (e.g.
+        ``sample_per_platform * 2``) that drew 10 here would trip it.
+        """
+        # One stratum only: all (outcome=yes, brier=good) via p_yes 0.9.
+        rows = [self._pm(0.9, True, i) for i in range(20)]
+        sampled = stratified_sample(rows, 5, seed=42)
+        assert len(sampled) == 5
+        assert {r["platform"] for r in sampled} == {"polymarket"}
+
+    def test_per_stratum_floor_can_exceed_budget(self) -> None:
+        """Documented edge: more non-empty strata than budget → floor wins.
+
+        With 6 strata (2 outcomes x 3 brier buckets) and budget 3, the ">=1 per
+        stratum" floor yields 6 rows — pinning the behaviour the docstring calls
+        out (so the count slightly exceeding sample_per_platform is intentional,
+        not a regression).
+        """
+        rows = []
+        i = 0
+        for outcome, ys in ((True, (0.95, 0.5, 0.1)), (False, (0.05, 0.5, 0.9))):
+            for p_yes in ys:  # good, moderate, poor for each outcome
+                rows += [self._pm(p_yes, outcome, i), self._pm(p_yes, outcome, i + 1)]
+                i += 2
+        sampled = stratified_sample(rows, 3, seed=42)
+        assert len(sampled) == 6  # 6 strata x floor 1, budget 3 overridden
+
+
+class TestEnrichCli:
+    """The ``main()`` argparse seam: --platform wires to enrich + is validated."""
+
+    def test_platform_arg_wires_to_enrich(self, monkeypatch: Any) -> None:
+        """`--platform polymarket` reaches enrich() as platform_filter.
+
+        All other tests call enrich() directly, so this is the only thing
+        pinning the args.platform → platform_filter kwarg in the dispatch.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        argv = [
+            "prompt_replay",
+            "enrich",
+            "--production-log",
+            "x.jsonl",
+            "--tool",
+            "superforcaster",
+            "--platform",
+            "polymarket",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        with mock.patch("benchmark.prompt_replay.enrich") as enrich_mock:
+            main()
+        assert enrich_mock.call_args.kwargs["platform_filter"] == "polymarket"
+        assert enrich_mock.call_args.kwargs["tool_filter"] == "superforcaster"
+
+    def test_invalid_platform_rejected_by_choices(self, monkeypatch: Any) -> None:
+        """An unknown --platform value is rejected by argparse choices (exit 2)."""
+        argv = [
+            "prompt_replay",
+            "enrich",
+            "--production-log",
+            "x.jsonl",
+            "--platform",
+            "ethereum",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        with mock.patch("benchmark.prompt_replay.enrich") as enrich_mock:
+            with pytest.raises(SystemExit):
+                main()
+        enrich_mock.assert_not_called()
 
 
 class TestLogReplaySummaryFilterStats:

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -18,6 +18,7 @@ from benchmark.prompt_replay import (
     _load_and_filter_rows,
     _log_replay_summary,
     _prepare_output_dir,
+    enrich,
     extract_prompt_components,
 )
 from benchmark.tools import TOOL_REGISTRY
@@ -32,6 +33,8 @@ def _row(
     status: str = "valid",
     outcome: Any = True,
     predicted_at: str | None = None,
+    platform: str | None = None,
+    row_id: str | None = None,
 ) -> dict:
     r: dict = {
         "tool_name": tool,
@@ -41,6 +44,10 @@ def _row(
     }
     if predicted_at is not None:
         r["predicted_at"] = predicted_at
+    if platform is not None:
+        r["platform"] = platform
+    if row_id is not None:
+        r["row_id"] = row_id
     return r
 
 
@@ -107,9 +114,10 @@ class TestLoadAndFilterRows:
     def test_filter_order_gives_first_failing_reason(self, tmp_path: Path) -> None:
         """A row failing multiple predicates counts in the first one only.
 
-        Order: wrong_tool → no_deliver_id → not_valid_parse → no_outcome → cutoff.
-        A row with wrong tool AND bad parse AND no outcome increments wrong_tool
-        only — so the total rejection count matches row count exactly.
+        Order: wrong_tool → wrong_platform → no_deliver_id → not_valid_parse →
+        no_outcome → cutoff. A row with wrong tool AND bad parse AND no outcome
+        increments wrong_tool only — so the total rejection count matches row
+        count exactly.
 
         :param tmp_path: pytest tmp_path fixture.
         """
@@ -122,6 +130,134 @@ class TestLoadAndFilterRows:
         assert not rows
         assert rejected["wrong_tool"] == 1
         assert sum(rejected.values()) == 1
+
+    def test_wrong_platform_counted(self, tmp_path: Path) -> None:
+        """With a platform filter, off-platform rows hit wrong_platform only."""
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _row(platform="omen"),
+                _row(platform="omen"),
+                _row(platform="polymarket"),
+            ],
+        )
+        rows, rejected = _load_and_filter_rows(
+            path, "superforcaster", None, "polymarket"
+        )
+        assert len(rows) == 1
+        assert rows[0]["platform"] == "polymarket"
+        assert rejected["wrong_platform"] == 2
+        assert rejected["wrong_tool"] == 0
+
+    def test_platform_filter_none_keeps_all_platforms(self, tmp_path: Path) -> None:
+        """Default (no platform filter) keeps every platform — additive contract."""
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(
+            path,
+            [_row(platform="omen"), _row(platform="polymarket")],
+        )
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert len(rows) == 2
+        assert rejected["wrong_platform"] == 0
+
+    def test_wrong_platform_ordered_after_wrong_tool(self, tmp_path: Path) -> None:
+        """A row failing both tool and platform counts as wrong_tool only.
+
+        Pins wrong_platform's position in the filter order (right after
+        wrong_tool): a foreign-tool row never reaches the platform check.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(path, [_row(tool="other", platform="omen")])
+        rows, rejected = _load_and_filter_rows(
+            path, "superforcaster", None, "polymarket"
+        )
+        assert not rows
+        assert rejected["wrong_tool"] == 1
+        assert rejected["wrong_platform"] == 0
+
+    def test_duplicate_row_ids_collapsed_keeping_first(self, tmp_path: Path) -> None:
+        """Cross-shard repeats (same row_id) collapse to the first occurrence.
+
+        Mirrors the flywheel emitting one delivery into multiple daily shards,
+        sometimes with a flipped outcome in the later shard. With shards fed
+        oldest-first, keep-first wins, matching the scorer's keep-oldest dedup.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(
+            path,
+            [
+                _row(row_id="prod_x", outcome=True),
+                _row(row_id="prod_x", outcome=False),  # later shard, flipped
+                _row(row_id="prod_y", outcome=True),
+            ],
+        )
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert len(rows) == 2  # prod_x once + prod_y
+        assert rejected["duplicate"] == 1
+        kept = {r["row_id"]: r["final_outcome"] for r in rows}
+        assert kept == {"prod_x": True, "prod_y": True}  # first prod_x wins
+
+    def test_rows_without_row_id_not_deduped(self, tmp_path: Path) -> None:
+        """Rows lacking a row_id are never collapsed (fixture/legacy contract)."""
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(path, [_row(), _row()])  # identical, no row_id
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert len(rows) == 2
+        assert rejected["duplicate"] == 0
+
+    def test_duplicate_counted_before_tool_filter(self, tmp_path: Path) -> None:
+        """Dedup precedes the tool check: a repeat counts as duplicate, not wrong_tool.
+
+        Two rows share a row_id but carry a foreign tool. The first is rejected
+        as wrong_tool (and its row_id remembered); the second is caught by the
+        dedup pass first, so it lands in ``duplicate`` rather than wrong_tool.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        path = tmp_path / "log.jsonl"
+        _write_jsonl(
+            path,
+            [_row(tool="other", row_id="prod_z"), _row(tool="other", row_id="prod_z")],
+        )
+        rows, rejected = _load_and_filter_rows(path, "superforcaster", None)
+        assert not rows
+        assert rejected["duplicate"] == 1
+        assert rejected["wrong_tool"] == 1
+
+
+class TestEnrichZeroRows:
+    """`enrich` fails loudly when the filtered pool is empty.
+
+    The guard fires after filtering but before the IPFS fetch, so these tests
+    need no network — a baseline with no qualifying rows must abort with a
+    clear message rather than silently skipping the dataset write and letting
+    the downstream replay step die on a FileNotFoundError.
+    """
+
+    def test_raises_systemexit_naming_the_tool(self, tmp_path: Path) -> None:
+        """0 qualifying rows → SystemExit mentioning the baseline tool."""
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row(tool="other"), _row(tool="another")])
+        output = tmp_path / "out" / "dataset.jsonl"
+        with pytest.raises(SystemExit) as exc:
+            enrich(log_path, "superforcaster", output)
+        assert "superforcaster" in str(exc.value)
+        assert not output.exists()
+
+    def test_message_includes_platform_scope(self, tmp_path: Path) -> None:
+        """When a platform filter empties the pool, the scope is in the message."""
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row(platform="omen"), _row(platform="omen")])
+        output = tmp_path / "out" / "dataset.jsonl"
+        with pytest.raises(SystemExit) as exc:
+            enrich(log_path, "superforcaster", output, platform_filter="polymarket")
+        assert "platform=polymarket" in str(exc.value)
+        assert not output.exists()
 
 
 class TestLogReplaySummaryFilterStats:

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -285,7 +285,9 @@ class TestLogReplaySummaryFilterStats:
         stats = {
             "accepted": 2,
             "rejected": {
+                "duplicate": 5,
                 "wrong_tool": 4,
+                "wrong_platform": 3,
                 "no_deliver_id": 0,
                 "not_valid_parse": 1,
                 "no_outcome": 2,
@@ -312,6 +314,10 @@ class TestLogReplaySummaryFilterStats:
         text = caplog.text
         assert "Pre-filter" in text
         assert "not_valid_parse=1" in text
+        # New full-pool/--platform buckets must render, else the breakdown no
+        # longer accounts for the rejected total.
+        assert "duplicate=5" in text
+        assert "wrong_platform=3" in text
 
     def test_block_omitted_when_stats_none(self, tmp_path: Path, caplog: Any) -> None:
         """When no sidecar is provided the summary logs exactly as before."""


### PR DESCRIPTION
## Summary

Two related fixes in the `/benchmark` replay pipeline, shipped together (same two files):

- **Closes #336** (bug): enrich read only the newest daily shard (`ls -t | head -1`), so a sparse baseline (e.g. `superforcaster-polymarket-v1`) could have 0 rows on a given day → no `dataset.jsonl` → replay died with an opaque `FileNotFoundError`.
- **Closes #337** (enhancement): no way to restrict a both-platform tool (e.g. `superforcaster`) to a single platform's population, so a Polymarket-targeted change couldn't be measured in isolation.

```
/benchmark superforcaster --candidate-tool superforcaster-polymarket-v2 --platform polymarket --sample 300
```

## #336 — full pool + dedup + fail-loud

- **Combine the full pool** of daily shards (`find … -print0 | sort -z | xargs -0 cat`) instead of picking the newest one.
- **Dedup on `row_id`** in `_load_and_filter_rows` (new `duplicate` reject bucket). The shards are **not** disjoint — the flywheel re-emits a delivery into multiple daily shards *by design* (`fetch_production.load_existing_row_ids` dedups only within a day; cross-day dedup is the consumer's job, which the scorer already does globally on `row_id`). `prompt_replay` never needed it before because it read a single shard; the full-pool union is what introduces the need. Keep-first + chronological combine order = oldest-shard-wins, matching the scorer.
- **Fail loud on 0 rows** (`raise SystemExit` with the tool + platform scope) instead of silently skipping the dataset write.

> ⚠️ This **corrects #336's stated assumption** that the shards are disjoint. Verified on flywheel run [27251720632](https://github.com/valory-xyz/mech-predict/actions/runs/27251720632): raw pool = **204,267 rows but only 196,270 distinct `row_id`s** (~4% cross-shard repeats). A byte-level `sort -u` was considered and rejected — on the real pool it leaves 3 rows doubled (non-key field drift, incl. one `final_outcome` flip as a market resolved), i.e. it silently under-collapses. `row_id` is the canonical key, present on every row, and matches the scorer's dedup.

## #337 — `--platform` filter

- Add `--platform {omen,polymarket}` to enrich (new `platform_filter` + `wrong_platform` reject counter).
- Plumb `--platform` through the workflow `/benchmark` parser (whitelist-validated, injection-safe `grep -oP`) and the enrich step.
- Add `platform` to the cache key — prevents same-tool/sample/seed runs on different platforms from colliding on a cached `dataset.jsonl`.

No `--last-days` in CI: enrich stratified-samples **before** the IPFS fetch, so the full pool costs nothing extra (≤`--sample` IPFS calls) and gives sparse baselines enough rows to sample from.

## Reporting fixes (caught while validating)

- **Surface the new reject buckets.** `_log_replay_summary` and the ci_replay PR comment printed a hardcoded subset of reject reasons, so once `duplicate` + `wrong_platform` existed the rendered breakdown no longer summed to the rejected total (a real n=10 run showed `186,842 rejected` but only ~94k itemised). Both renderers now include every bucket; tests assert it.
- **Relabel `markets` → `deliveries`.** The replay summary and footer called the row count "markets", but each row is one delivery keyed on `row_id` — a single market can be predicted multiple times (an n=10 sample held 9 distinct `market_id`s), so "markets" overstated the count.

## Validation (real data, run 27251720632 — full pipeline, real LLM)

- #336 reproduced: newest shard → **0** `superforcaster-polymarket-v1` rows; full pool → **877**.
- Dedup collapses all **7,997** cross-shard repeats → `superforcaster` **101,918** rows (`duplicate=7997` in `filter_stats`).
- #337: `--platform polymarket` isolates **17,425** on-platform `superforcaster` rows, then stratified-samples before the fetch.
- Ran the **full enrich → replay → ci_replay pipeline** end-to-end (real IPFS + real LLM) at n=10: dataset written, baseline-vs-candidate Brier computed, PR comment renders with the corrected breakdown that sums to the rejected total.
- `tomte tox -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint` → all OK; **102** unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)