### PR TITLE
fix: declare factual_research-v3 + superforcaster-polymarket-v3 in mech_predict agent

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,8 +23,8 @@
         "custom/valory/factual_research_v1/0.1.0": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeih2ciwkf7edrmwlb5knk4nw5dedh7cz2lo6d6ecyehxlt6q7i7i3a",
-        "agent/valory/mech_predict/0.1.0": "bafybeibhwh3ym52554qlnw3f7y3swng5y664hn6kimvtaow6mjktrozfpu",
-        "service/valory/mech_predict/0.1.0": "bafybeiev33iia6jb6czalbaw7jboodyos3gdwlhixb5rl6den2qsr56tcq"
+        "agent/valory/mech_predict/0.1.0": "bafybeicelvefobkfghslz3gfwgxkjtuz3tw6cahcwba66lknnoowgk7ufu",
+        "service/valory/mech_predict/0.1.0": "bafybeigrzemas22vmswfbnpgypwx36b4funn3v7qg2mcmlye3pepi247ou"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -63,10 +63,12 @@ customs:
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
 - valory/superforcaster:0.1.0:bafybeidkraklf5c6rkv6g7y7lqj2woy4j5u5dmupjez6mtjhdek3lzbmki
 - valory/superforcaster_polymarket_v1:0.1.0:bafybeiawfhy3w5aclmxm5zxebwd5l7paseqlgmihwbqfyhcdpn2kccgtrq
+- valory/superforcaster_polymarket_v3:0.1.0:bafybeifstfsg3h6x24wclzc3f2ci35i5sd5kpfkhk3ekcr653u5iiz4h2m
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeifssc6ed7itkvqot6qunlpd3prghwsf5dh26kin3xduci3sohulqq
 - valory/factual_research:0.1.0:bafybeidcxmqemvzm7cz2ydyjsmu53zflsqpcj2gpco5kwn3ldvf22rqx4i
+- valory/factual_research_v3:0.1.0:bafybeih2ciwkf7edrmwlb5knk4nw5dedh7cz2lo6d6ecyehxlt6q7i7i3a
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeibhwh3ym52554qlnw3f7y3swng5y664hn6kimvtaow6mjktrozfpu
+agent: valory/mech_predict:0.1.0:bafybeicelvefobkfghslz3gfwgxkjtuz3tw6cahcwba66lknnoowgk7ufu
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

Both v3 customs were merged via #339 and #340 but never added to the agent's `aea-config.yaml`. Without those entries the agent image doesn't ship the components, and downstream `agent-deployments` PRs that reference the v3 CIDs in `TOOLS_TO_PACKAGE_HASH` fail `verify_tool_hashes` ("IPFS unreachable" / "some deployment files have mismatches").

This patch adds the two missing entries and re-locks the agent + service fingerprints.

## Changes

`packages/valory/agents/mech_predict/aea-config.yaml`:

```diff
+ valory/superforcaster_polymarket_v3:0.1.0:bafybeifstfsg3h6x24wclzc3f2ci35i5sd5kpfkhk3ekcr653u5iiz4h2m
+ valory/factual_research_v3:0.1.0:bafybeih2ciwkf7edrmwlb5knk4nw5dedh7cz2lo6d6ecyehxlt6q7i7i3a
```

Cascaded fingerprint updates (from `autonomy packages lock`):
- agent `mech_predict/0.1.0`: `bafybeibhwh3y…` → `bafybeicelvef…`
- service `mech_predict/0.1.0`: `bafybeiev33ii…` → `bafybeigrzema…`

## Why

PRs #339 and #340 added the components under `packages/valory/customs/` but the agent declaration step was missed. That's actually the same omission for `factual_research_v1`, `factual_research_v2`, `superforcaster_full_search`, and `superforcaster_calibrated_full_search` — all live in `customs/` but not listed in the agent. **Flagging as follow-up; not in scope here** because no current env declares them. They should be added together in a follow-up cleanup PR.

## Unblocks

valory-xyz/agent-deployments#285 — the polymarket-mechs deployment is currently blocked at `verify_tool_hashes` ("IPFS unreachable" for the v3 CIDs) because the agent's customs list doesn't include them. Once this PR merges and a release goes out, that PR will pass and we can deploy v3 to the 3 polygon mechs.