### PR TITLE
ci: raise tournament-run and replay job timeouts to 6h max

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -402,11 +402,8 @@ jobs:
     needs: [tournament-fetch, check-secrets]
     if: needs.check-secrets.outputs.has_keys == 'true'
     runs-on: ubuntu-22.04
-    # Bumped from 90 → 150 to accommodate the growing tournament_tools.json
-    # set (now 4 tools, two of which scrape top organic pages so per-eval
-    # latency is higher than the snippet-only path) plus the possibility of
-    # workflow_dispatch bumping max_markets above the 30/platform default.
-    timeout-minutes: 150
+    # GitHub-hosted runner max (6h).
+    timeout-minutes: 360
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -46,7 +46,8 @@ jobs:
         && contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)
       )
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    # GitHub-hosted runner max (6h).
+    timeout-minutes: 360
 
     steps:
       # Acknowledge the trigger (issue_comment only)


### PR DESCRIPTION
## What

Raise `timeout-minutes` to **360** — the GitHub-hosted runner hard maximum (6h) — for two jobs:

| Job | File | Before | After |
| --- | --- | --- | --- |
| `tournament-run` (scheduled) | `benchmark_flywheel.yaml` | 150 | 360 |
| replay (`/benchmark`) | `benchmark_replay.yaml` | 45 | 360 |

## Why

**`tournament-run`:** run [27322395772](https://github.com/valory-xyz/mech-predict/actions/runs/27322395772) was killed by the 150m cap having reached only **380/420** tasks (`The job has exceeded the maximum execution time of 2h30m0s`). The downstream `benchmark` job then couldn't find the `tournament-predictions` artifact. The `tournament_tools.json` set has grown to 7 tools (4 of them slow `factual_research` variants), so per-run latency keeps climbing.

**replay:** the `/benchmark` replay job replays a tool's prompts against a sample of production markets. Larger `--sample` sizes per platform mean longer runs, so the old 45m cap is restrictive for big-sample replays.

360m is the ceiling GitHub enforces per job; beyond this, sharding the work across a matrix is the only remaining lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)