### PR TITLE
fix(superforcaster-polymarket-v3): prepend canonical predictor sentence to description so the trader classifier accepts it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -314,6 +314,18 @@ If you are adding a tool that has no predecessor (a brand-new tool, not a varian
 - Do NOT modify `agent-deployments`. Routing a CID to live traffic is a separate human PR.
 - Do NOT delete old variants. The previous version keeps running until a human explicitly retires it.
 
+#### Prediction tools: description must satisfy the trader's `is_prediction_tool` predicate
+
+Applies to **prediction tools only** (binary-predictor `output.schema`). Resolver / image / market-creator / other tools have separate contracts and are unaffected.
+
+The trader's `is_prediction_tool` predicate (in `valory-xyz/trader` at `decision_maker_abci/utils/tool_suitability.py`) runs every `ToolSelectionRound`. A tool that fails is silently dropped from the candidate set; the policy never learns it. Treat the predicate as an **abstract contract**, not its current regex: a binary-predictor schema must be corroborated by a plain-prose sentence in the description. The regex implementing this has already been widened twice and may change again.
+
+- **Pattern that works**: lead the description with one short sentence stating what the tool predicts. e.g. `"A tool for making binary predictions on markets."`, `"Estimates the probability of a binary event."`. Variant-specific detail follows; the lead sentence makes the rest safe.
+- **Anti-pattern**: predictor stems only inside identifiers (`prediction_request`, `prediction_url_cot`). Whether the regex treats those as standalone depends on Python's `\b`/`\w` semantics — don't rely on that.
+- **Anti-pattern**: pure-metadata descriptions (`"Variant of X that swaps the LLM..."`) — describes the delta, not the function.
+
+Verify before publishing: run `explain_prediction_tool(tool_metadata_dict)` from a `valory-xyz/trader` clone — verdict must be `(True, ...)`. Precedent: `mech-predict#284` fixed the same class of bug for `superforcaster` + the SME variants.
+
 ### API Key Management
 
 The `KeyChain` class (in `packages/valory/skills/task_execution/utils/apis.py`) handles:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -19,12 +19,12 @@
         "custom/valory/superforcaster_full_search/0.1.0": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
         "custom/valory/superforcaster_calibrated_full_search/0.1.0": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
         "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafybeiawfhy3w5aclmxm5zxebwd5l7paseqlgmihwbqfyhcdpn2kccgtrq",
-        "custom/valory/superforcaster_polymarket_v3/0.1.0": "bafybeifstfsg3h6x24wclzc3f2ci35i5sd5kpfkhk3ekcr653u5iiz4h2m",
+        "custom/valory/superforcaster_polymarket_v3/0.1.0": "bafybeigwcghcfq4d7zbjixg3d4mqvyo6ci4wp4jfstuyhm5357bhz2aeoy",
         "custom/valory/factual_research_v1/0.1.0": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeih2ciwkf7edrmwlb5knk4nw5dedh7cz2lo6d6ecyehxlt6q7i7i3a",
-        "agent/valory/mech_predict/0.1.0": "bafybeicelvefobkfghslz3gfwgxkjtuz3tw6cahcwba66lknnoowgk7ufu",
-        "service/valory/mech_predict/0.1.0": "bafybeigrzemas22vmswfbnpgypwx36b4funn3v7qg2mcmlye3pepi247ou"
+        "agent/valory/mech_predict/0.1.0": "bafybeigkwuflnmxza4g2hwvjreohqh5r5zfrbscq4qhe5jyyvn623c6wpq",
+        "service/valory/mech_predict/0.1.0": "bafybeielumgxe6ls36ot4ybgnrlv3bpuy6cxvuymgyvnqfe3fddpbx3ko4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -63,7 +63,7 @@ customs:
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
 - valory/superforcaster:0.1.0:bafybeidkraklf5c6rkv6g7y7lqj2woy4j5u5dmupjez6mtjhdek3lzbmki
 - valory/superforcaster_polymarket_v1:0.1.0:bafybeiawfhy3w5aclmxm5zxebwd5l7paseqlgmihwbqfyhcdpn2kccgtrq
-- valory/superforcaster_polymarket_v3:0.1.0:bafybeifstfsg3h6x24wclzc3f2ci35i5sd5kpfkhk3ekcr653u5iiz4h2m
+- valory/superforcaster_polymarket_v3:0.1.0:bafybeigwcghcfq4d7zbjixg3d4mqvyo6ci4wp4jfstuyhm5357bhz2aeoy
 - dvilela/corcel_request:0.1.0:bafybeic74xc32orfiffumv3cxe7o4vktzobk6gszjecuhto4or7k5ppi5y
 - dvilela/gemini_prediction:0.1.0:bafybeifpoil2wjh6hr7sqoomlilhsyt3ktpy6tjzmisrlopxcjbkr3hhfq
 - nickcom007/prediction_request_sme:0.1.0:bafybeifssc6ed7itkvqot6qunlpd3prghwsf5dh26kin3xduci3sohulqq

--- a/packages/valory/customs/superforcaster_polymarket_v3/component.yaml
+++ b/packages/valory/customs/superforcaster_polymarket_v3/component.yaml
@@ -2,13 +2,15 @@ name: superforcaster_polymarket_v3
 author: valory
 version: 0.1.0
 type: custom
-description: Variant of superforcaster-polymarket-v1 that swaps the default LLM model
-  from OpenAI gpt-4.1 to Anthropic claude-fable-5 while keeping v1's prompt, output
-  format and retry logic byte-identical. The OpenAI fallback path is preserved so
-  the tool can still serve the older model when requested. Sibling of v2 (which is
-  a prompt-only resolution-criterion specificity variant); both depart from v1. Follows
-  the dual-SDK convention every other claude-using tool in this repo uses (prediction_request,
-  prediction_request_rag, prediction_request_reasoning, prediction_url_cot).
+description: A tool for making binary predictions on markets. Returns the standard
+  mech prediction output (p_yes, p_no, confidence, info_utility). Variant of superforcaster-polymarket-v1
+  that swaps the default LLM model from OpenAI gpt-4.1 to Anthropic claude-fable-5
+  while keeping v1's prompt, output format and retry logic byte-identical. The OpenAI
+  fallback path is preserved so the tool can still serve the older model when requested.
+  Sibling of v2 (which is a prompt-only resolution-criterion specificity variant);
+  both depart from v1. Follows the dual-SDK convention every other claude-using tool
+  in this repo uses (prediction_request, prediction_request_rag, prediction_request_reasoning,
+  prediction_url_cot).
 license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeicelvefobkfghslz3gfwgxkjtuz3tw6cahcwba66lknnoowgk7ufu
+agent: valory/mech_predict:0.1.0:bafybeigkwuflnmxza4g2hwvjreohqh5r5zfrbscq4qhe5jyyvn623c6wpq
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

The trader's `is_prediction_tool` predicate (in `valory-xyz/trader` at `decision_maker_abci/utils/tool_suitability.py`) requires every tool whose `output.schema` claims a binary-predictor shape to corroborate that claim in natural language in its description. `superforcaster-polymarket-v3`'s description contains the word "prediction" four times but only as part of identifiers (`prediction_request`, `prediction_url_cot`, …). Python's `\b` regex anchor treats `_` as a word character so none of those match the predicate's standalone-word check — and the live trader silently drops the tool from the candidate set.

Same class of failure hit `superforcaster`, `prediction-offline-sme`, `prediction-online-sme` two weeks ago — fixed via `mech-predict#284` + `agent-deployments#272`. This PR applies the same playbook.

## Diff

1. **`component.yaml`** — prepend one canonical-form sentence to the description; the rest is byte-identical:

   ```diff
   description: |
   + A tool for making binary predictions on markets.
     Variant of superforcaster-polymarket-v1 that swaps the default LLM model
     from OpenAI gpt-4.1 to Anthropic claude-fable-5 ...
   ```

   The lede shape mirrors `factual_research-v3`'s description, which already passes the classifier.

2. **`CLAUDE.md`** — new section *"Tool description must satisfy the trader's `is_prediction_tool` predicate"* under the existing tool-improvement housekeeping rules. Framed against the predicate's contract (corroborate a binary-predictor schema in natural language), **not** the current regex implementation — which has already been widened twice (trader `#977` rounds) and may be widened or replaced again. Covers the corroboration pattern, anti-patterns, the test-before-publish recipe, and the precedent incidents.

3. **Lock cascade** — re-fingerprints `superforcaster_polymarket_v3` → agent → service via `autonomy packages lock`.

## Downstream cascade (NOT in this PR)

After this merges and the next release runs `autonomy push-all`, the in-flight `agent-deployments#285` deployment needs:

1. Bump `PROPEL_SERVICE_HASH_ID` in the 3 polygon env files to the new service CID.
2. Regenerate + publish the polymarket `metadata.json` (with the corrected description) and bump `METADATA_HASH`.
3. Bump the `superforcaster-polymarket-v3` entry in `TOOLS_TO_PACKAGE_HASH` to the new per-tool component CID.

## Acceptance

Verify post-merge against the new manifest:

```python
from packages.valory.skills.decision_maker_abci.utils.tool_suitability import explain_prediction_tool
# expected:
#   superforcaster-polymarket-v3      -> (True,  'schema_prediction_shape')
#   factual_research-v3               -> (True,  'schema_prediction_shape')
#   superforcaster-polymarket-v1      -> (True,  'schema_prediction_shape')
#   resolve-market-reasoning-gpt-4.1  -> (False, 'schema_resolver_shape')
```

## Out of scope

- The trader's regex itself. The contract is what tools should rely on; the regex internals are the trader team's to evolve.
- A sixth check in the classifier. The lede shape `factual_research-v3` uses is the convention; aligning v3 with v3 keeps the classifier mechanical.
- Hand-editing `metadata.json`. The source of truth is `component.yaml`; the metadata republish is a separate `agent-deployments` step.

## Refs

- `trader#977` — the widened `_PROSE_PREDICT_PREDICATE`.
- `mech-predict#284` + `agent-deployments#272` — precedent fix for the SME variants two weeks ago.
- `agent-deployments#285` — the in-flight deployment that will inherit this fix's cascade.
- Plan: `.claude/plans/superforcaster_polymarket_v3_description_fix.md`.