### PR TITLE
chore: trim tournament tool set to fix run timeout

### DIFF
--- a/benchmark/tournament_tools.json
+++ b/benchmark/tournament_tools.json
@@ -1,9 +1,5 @@
 {
-  "factual_research": "bafybeib7askinfzv5yolxxqojbqnmpygrg3lbxnwc77grr3nzuopha5era",
-  "factual_research-v1": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
   "factual_research-v2": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
-  "factual_research-v3": "bafybeih2ciwkf7edrmwlb5knk4nw5dedh7cz2lo6d6ecyehxlt6q7i7i3a",
-  "superforcaster": "bafybeic2ziubkeyjq6syiqcs2bq7o5og3n62q6c2fnvv2oysczpnjdl56m",
   "superforcaster_full_search": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
   "superforcaster_calibrated_full_search": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
   "superforcaster-polymarket-v3": "bafybeifstfsg3h6x24wclzc3f2ci35i5sd5kpfkhk3ekcr653u5iiz4h2m"


### PR DESCRIPTION
## Why

Today's tournament run failed by hitting its **2.5h timeout**.

This is the second half of a two-part fix:

- #353 (merged) raised the job timeout ceiling to 6h, buying headroom.
- **This PR** attacks the root cause — too many tools enrolled in tournament mode — by trimming the set, so we don't lean on an ever-growing timeout. This was the agreed approach in the team thread.

## What

Remove four tools from `benchmark/tournament_tools.json` (8 → 4):

| Removed | Reason |
| --- | --- |
| `factual_research` | Not in prod; known bad prod performance |
| `factual_research-v1` | Improvements subsumed by v2 |
| `factual_research-v3` | Slated to run in prod |
| `superforcaster` | Already runs in prod |

Kept in tournament mode:

- `factual_research-v2`
- `superforcaster_full_search`
- `superforcaster_calibrated_full_search`
- `superforcaster-polymarket-v3`

## Effect

Halving the tool count should bring the run comfortably back under budget. With #353's headroom on top, this gives margin for future tools without another timeout bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)