### PR TITLE
fix: bump task_execution for claude-fable-5 / claude-sonnet-4-6 TOKEN_PRICES

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -23,8 +23,8 @@
         "custom/valory/factual_research_v1/0.1.0": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeih2ciwkf7edrmwlb5knk4nw5dedh7cz2lo6d6ecyehxlt6q7i7i3a",
-        "agent/valory/mech_predict/0.1.0": "bafybeigkwuflnmxza4g2hwvjreohqh5r5zfrbscq4qhe5jyyvn623c6wpq",
-        "service/valory/mech_predict/0.1.0": "bafybeielumgxe6ls36ot4ybgnrlv3bpuy6cxvuymgyvnqfe3fddpbx3ko4"
+        "agent/valory/mech_predict/0.1.0": "bafybeifxnqtt3uxksg4lctepvujjxfpnkj5m7bxdalj3fsotjxcqxz6jmq",
+        "service/valory/mech_predict/0.1.0": "bafybeigjydpn6c6vcwkmc3renrk2p5eya2wac43xbbspzervskjgx7dfn4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -63,8 +63,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki",
         "skill/valory/termination_abci/0.1.0": "bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeicmu7ljnomrdrarvm2ep3325rdvajwdk5eqyoukjbcsmy5uyjs6wi",
-        "skill/valory/task_execution/0.1.0": "bafybeigy6h6po63cshmsjl57nioupmu3jppiivfdqm4jbnrkaszlwilubu",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeifehpnj7k5pawmzdpvnybpukinhe7n6ymgcnunooyzfyykeocig3q"
+        "skill/valory/mech_abci/0.1.0": "bafybeicaxrvsspr5pablbah57yhwfcms3nengun67eozbhemzn34cqzqde",
+        "skill/valory/task_execution/0.1.0": "bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja"
     }
 }

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeicmu7ljnomrdrarvm2ep3325rdvajwdk5eqyoukjbcsmy5uyjs6wi
+- valory/mech_abci:0.1.0:bafybeicaxrvsspr5pablbah57yhwfcms3nengun67eozbhemzn34cqzqde
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeigy6h6po63cshmsjl57nioupmu3jppiivfdqm4jbnrkaszlwilubu
-- valory/task_submission_abci:0.1.0:bafybeifehpnj7k5pawmzdpvnybpukinhe7n6ymgcnunooyzfyykeocig3q
+- valory/task_execution:0.1.0:bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4
+- valory/task_submission_abci:0.1.0:bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeigkwuflnmxza4g2hwvjreohqh5r5zfrbscq4qhe5jyyvn623c6wpq
+agent: valory/mech_predict:0.1.0:bafybeifxnqtt3uxksg4lctepvujjxfpnkj5m7bxdalj3fsotjxcqxz6jmq
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ pytest_targets_extra = ["benchmark/tests"]
 # Third-party skills/contracts on disk are synced from mech upstream;
 # tomte auto-prepends valory-xyz/open-autonomy@... and open-aea@...
 # from pyproject pins, so only the non-PyPI mech upstream needs listing.
-upstream_pins = ["valory-xyz/mech@v0.33.1"]
+upstream_pins = ["valory-xyz/mech@v0.33.2"]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
## DO NOT MERGE until valory-xyz/mech#453 is merged AND released

CI here will stay red on IPFS resolution until `autonomy push-all` (mech's release flow) publishes the new skill CIDs.

## What

Consumes [mech#453](https://github.com/valory-xyz/mech/pull/453) — `TokenCounterCallback.TOKEN_PRICES` was missing `claude-fable-5` (and `claude-sonnet-4-6`), so every delivery for the v3 fable tools failed with `Model claude-fable-5 not supported.` even though the LLM call succeeded. Polygon services 21/25/44 had the fable tools reverted as a stop-gap; this is the roll-forward.

Pin bump only (3 skills, lock cascade into agent + service):

| Skill | Old | New |
|---|---|---|
| `task_execution` | `bafybeigy6h6po…` | `bafybeibgegj5o…` |
| `mech_abci` | `bafybeicmu7ljn…` | `bafybeicaxrvss…` |
| `task_submission_abci` | `bafybeifehpnj7…` | `bafybeifimk7xd…` |

Verified with the repo toolchain (open-autonomy 0.21.23): replacing the vendored dirs with mech#453 content and running `autonomy packages lock` reproduces these CIDs byte-identically — no phantom-CID risk.

## After merge

Release (push-all) -> agent-deployments re-applies the fable-tool envs with the new `PROPEL_SERVICE_HASH_ID` -> Propel redeploy 21/25/44 -> live smoke call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)