### PR TITLE
chore(benchmark): name platform in report header, simplify reliability block

### DIFF
--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -29,7 +29,6 @@ from pathlib import Path
 from typing import Any, Optional
 
 from benchmark.io import load_jsonl
-from benchmark.prompt_replay import SCOPING_BUCKETS
 
 # Status buckets emitted by parse_response. Listed in a fixed order so the PR
 # comment breakdown is diffable across runs.
@@ -231,16 +230,15 @@ def _format_reliability_block(
     failure_rows: list[dict[str, Any]],
     filter_stats: Optional[dict[str, Any]] = None,
 ) -> list[str]:
-    """Render the Reliability section: candidate parse rate + pre-filter stats.
+    """Render the Reliability section: candidate parse rate + production parse rate.
 
-    Baseline parse rate is 100% by construction (the enrich step drops
-    non-valid rows), so it is not reported as part of a baseline-vs-candidate
-    comparison. The two observations here are one-sided:
+    The two observations here are one-sided:
 
     - candidate parse rate: did the PR's code produce parseable responses?
-    - pre-filter: did the upstream enrich filter's "drop non-valid" invariant
-      hold? (non-zero ``not_valid_parse`` rejects = silent regression of the
-      invariant that made baseline 100% trustworthy in the first place)
+    - production parse rate: of the in-scope production deliveries, how many
+      parsed before enrich dropped the rest. Tells reviewers how noisy
+      production was. The scored baseline is 100% valid by construction (enrich
+      drops the non-parseable rows), so only that pre-drop ratio is informative.
 
     :param candidate: metrics dict including ``parse_reliability``.
     :param failure_rows: rows from ``candidate_failures.jsonl`` (may be empty).
@@ -270,37 +268,24 @@ def _format_reliability_block(
     if filter_stats is not None:
         r = filter_stats.get("rejected", {}) or {}
         accepted = filter_stats.get("accepted", 0)
-        total_rej = sum(r.values())
         not_valid = r.get("not_valid_parse", 0)
-        pf_marker = "✅" if not_valid == 0 else "⚠️"
-        lines.append(
-            f"- Pre-filter (enrich): {accepted} accepted, {total_rej} rejected, "
-            f"not_valid_parse={not_valid} {pf_marker}"
-        )
-        # Scoping breakdown only when any rows were rejected — otherwise the
-        # zeroes just add noise to the happy path. Must stay adjacent to the
-        # Pre-filter bullet above: markdown nests the indented sub-bullet
-        # under the most recent top-level bullet. Iterate SCOPING_BUCKETS so the
-        # breakdown always accounts for the rejected total shown above (minus
-        # not_valid_parse, which has its own marked line).
-        if total_rej > 0:
-            scoping = ", ".join(f"{k}={r.get(k, 0)}" for k in SCOPING_BUCKETS)
-            lines.append(f"  - Scoping: {scoping}")
+        # Production parse rate: of the in-scope production deliveries, how many
+        # parsed. enrich drops the non-parseable ones (that is what keeps the
+        # scored baseline 100% valid), so they are the only rejections that
+        # belong in this ratio. The scoping rejections (wrong_tool,
+        # wrong_platform, ...) are just rows for other tools/platforms and carry
+        # no reliability signal, so they are not reported.
+        denom = accepted + not_valid
+        if denom > 0:
+            lines.append(
+                f"- Production parse rate: {accepted}/{denom} "
+                f"({accepted / denom * 100:.1f}%)"
+            )
         # no_row_id is a kept-row diagnostic (always 0 in healthy production);
         # surface it only when nonzero so a flywheel row_id regression is loud.
         no_row_id = filter_stats.get("no_row_id", 0)
         if no_row_id:
-            lines.append(f"  - ⚠️ no_row_id: {no_row_id} (rows bypassed dedup)")
-        # Post-filter baseline is 100% by construction (enrich drops non-valid
-        # rows), so surface the *pre-filter* ratio to tell reviewers how noisy
-        # production actually was — per PR #231 review. Rendered last so the
-        # Scoping sub-bullet above stays nested under Pre-filter, not here.
-        denom = accepted + not_valid
-        if denom > 0:
-            lines.append(
-                f"- Baseline pre-filter parse rate: {accepted}/{denom} "
-                f"({accepted / denom * 100:.1f}%)"
-            )
+            lines.append(f"- ⚠️ no_row_id: {no_row_id} (rows bypassed dedup)")
 
     lines.append("")
 
@@ -351,19 +336,25 @@ def format_report(
     :return: markdown string.
     """
     tool = meta.get("tool", "unknown")
+
+    # Platforms present in the scored data. A run scoped to one platform
+    # (`--platform polymarket`) suppresses the per-platform breakdown below, so
+    # naming the platform in the header is the only place the scope is visible.
+    b_platforms = baseline.get("by_platform", {})
+    c_platforms = candidate.get("by_platform", {})
+    all_platforms = sorted(set(b_platforms) | set(c_platforms))
+    platform_label = (
+        all_platforms[0].title() if len(all_platforms) == 1 else "All platforms"
+    )
+
     parts: list[str] = [
         f"<!-- benchmark-result:{tool} -->",
-        f"## Benchmark: {tool}",
+        f"## Benchmark: {tool} — {platform_label}",
         "",
         _metrics_table(baseline, candidate),
         "",
     ]
     parts.extend(_format_reliability_block(candidate, failure_rows or [], filter_stats))
-
-    # Per-platform breakdown
-    b_platforms = baseline.get("by_platform", {})
-    c_platforms = candidate.get("by_platform", {})
-    all_platforms = sorted(set(b_platforms) | set(c_platforms))
 
     if len(all_platforms) > 1:
         detail_lines = ["<details><summary>Per-platform breakdown</summary>", ""]

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -331,8 +331,8 @@ def format_report(
         candidate_failures.jsonl. When non-empty, bodies are inlined in a
         collapsed <details> block.
     :param filter_stats: optional ``{accepted, rejected}`` dict from
-        filter_stats.json sidecar. When present, a Pre-filter block is
-        rendered so an upstream filter regression would be visible.
+        filter_stats.json sidecar. When present, a Production parse rate line
+        is rendered showing how many in-scope production deliveries parsed.
     :return: markdown string.
     """
     tool = meta.get("tool", "unknown")

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -101,18 +101,17 @@ class TestReliabilityBlock:
         return compute_metrics(rows)
 
     def test_green_happy_path_is_two_lines(self) -> None:
-        """All-valid candidate + clean pre-filter → two bullets, no breakdown noise."""
+        """All-valid candidate + clean pre-filter → two bullets, no scoping noise."""
         candidate = self._metrics([_row("valid")] * 5)
         lines = _format_reliability_block(candidate, [], _stats(accepted=5))
         text = "\n".join(lines)
         assert "Candidate parse rate: 5/5 (100.0%) ✅" in text
-        assert (
-            "Pre-filter (enrich): 5 accepted, 0 rejected, not_valid_parse=0 ✅" in text
-        )
+        assert "Production parse rate: 5/5 (100.0%)" in text
         # Breakdown is hidden when candidate is at 100%.
         assert "Breakdown:" not in text
-        # Scoping is hidden when there are no rejections.
+        # Scoping rejections are expected noise and never reported.
         assert "Scoping:" not in text
+        assert "wrong_tool" not in text
         assert "⚠️" not in text
 
     def test_candidate_drift_flags_and_shows_breakdown(self) -> None:
@@ -123,17 +122,25 @@ class TestReliabilityBlock:
         assert "Candidate parse rate: 7/10 (70.0%) ⚠️" in text
         assert "malformed=3" in text
 
-    def test_prefilter_not_valid_parse_flagged(self) -> None:
-        """not_valid_parse > 0 is the load-bearing invariant — must surface ⚠️."""
+    def test_not_valid_parse_is_not_a_warning(self) -> None:
+        """Production deliveries enrich dropped for not parsing are normal noise.
+
+        They land in the *rejected* bucket because the filter correctly
+        excluded them — that is what keeps the scored baseline 100% valid — so
+        a non-zero count must not raise a warning. It only lowers the reported
+        production parse rate.
+        """
         candidate = self._metrics([_row("valid")] * 5)
         lines = _format_reliability_block(
             candidate, [], _stats(accepted=5, not_valid_parse=2)
         )
         text = "\n".join(lines)
-        assert "not_valid_parse=2 ⚠️" in text
+        assert "⚠️" not in text
+        # 5 / (5 + 2) = 71.4%
+        assert "Production parse rate: 5/7 (71.4%)" in text
 
-    def test_scoping_rejections_shown_but_not_flagged(self) -> None:
-        """Scoping buckets (wrong_tool etc.) are informational, not warnings."""
+    def test_scoping_rejections_are_not_reported(self) -> None:
+        """Scoping buckets (wrong_tool etc.) are rows for other tools — pure noise."""
         candidate = self._metrics([_row("valid")] * 5)
         lines = _format_reliability_block(
             candidate,
@@ -148,38 +155,36 @@ class TestReliabilityBlock:
             ),
         )
         text = "\n".join(lines)
-        assert "Scoping:" in text
-        assert "wrong_tool=12" in text
-        # The full-pool/--platform buckets must surface too, else the rendered
-        # breakdown no longer sums to the rejected total shown on the line above.
-        assert "duplicate=8" in text
-        assert "wrong_platform=9" in text
-        assert "no_outcome=4" in text
-        assert "older_than_cutoff=7" in text
-        # Scoping alone must not raise the invariant marker.
+        # None of the scoping buckets leak into the report.
+        for bucket in (
+            "duplicate",
+            "wrong_tool",
+            "wrong_platform",
+            "older_than_cutoff",
+        ):
+            assert bucket not in text
         assert "⚠️" not in text
+        # Scoping rejections do not affect the production parse rate either.
+        assert "Production parse rate: 5/5 (100.0%)" in text
 
-    def test_baseline_prefilter_parse_rate_rendered_with_rejections(self) -> None:
-        """Rejections > 0: render ``accepted/(accepted+not_valid_parse)`` as a percentage.
+    def test_production_parse_rate_rendered_with_rejections(self) -> None:
+        """Render ``accepted/(accepted+not_valid_parse)`` as a percentage.
 
-        Direct response to PR #231 review — post-filter baseline=100% is a
-        tautology because enrich drops non-valid rows. The ratio before the
-        filter is what tells reviewers how noisy production actually was.
+        The scored baseline is 100% valid by construction (enrich drops the
+        non-parseable rows). The pre-drop ratio is what tells reviewers how
+        noisy production actually was.
         """
         candidate = self._metrics([_row("valid")] * 100)
         lines = _format_reliability_block(
             candidate, [], _stats(accepted=100, not_valid_parse=35)
         )
         text = "\n".join(lines)
-        assert "Baseline pre-filter parse rate: 100/135 (74.1%)" in text
+        assert "Production parse rate: 100/135 (74.1%)" in text
 
-    def test_baseline_prefilter_parse_rate_at_100_when_no_parse_rejections(
-        self,
-    ) -> None:
+    def test_production_parse_rate_at_100_when_no_parse_rejections(self) -> None:
         """Zero not_valid_parse rejections: rate is 100%, but still rendered.
 
-        Keeping it rendered on the happy path surfaces the *fact* that this
-        is now a reported metric, so a later regression (non-zero
+        Keeping it on the happy path means a later regression (non-zero
         ``not_valid_parse``) isn't a surprise line appearing out of nowhere.
         """
         candidate = self._metrics([_row("valid")] * 50)
@@ -189,36 +194,19 @@ class TestReliabilityBlock:
             _stats(accepted=50, wrong_tool=3, no_outcome=1),
         )
         text = "\n".join(lines)
-        assert "Baseline pre-filter parse rate: 50/50 (100.0%)" in text
+        assert "Production parse rate: 50/50 (100.0%)" in text
 
-    def test_baseline_prefilter_parse_rate_omitted_when_no_sidecar(self) -> None:
-        """Older pipelines (no filter_stats) don't render the baseline rate line."""
+    def test_production_parse_rate_omitted_when_no_sidecar(self) -> None:
+        """Older pipelines (no filter_stats) don't render the production rate line."""
         candidate = self._metrics([_row("valid")] * 5)
         text = "\n".join(_format_reliability_block(candidate, [], None))
-        assert "Baseline pre-filter parse rate" not in text
-
-    def test_scoping_stays_nested_under_prefilter_not_parse_rate(self) -> None:
-        """Scoping (breakdown of rejections) must remain adjacent to Pre-filter.
-
-        Scoping renders as an indented sub-bullet; markdown nests it under
-        the preceding top-level bullet. If Baseline pre-filter parse rate is
-        inserted between Pre-filter and Scoping, the sub-bullet visually
-        becomes a child of the wrong parent.
-        """
-        candidate = self._metrics([_row("valid")] * 50)
-        lines = _format_reliability_block(
-            candidate,
-            [],
-            _stats(accepted=50, wrong_tool=3, no_outcome=1),
-        )
-        text = "\n".join(lines)
-        assert text.index("Scoping:") < text.index("Baseline pre-filter parse rate:")
+        assert "Production parse rate" not in text
 
     def test_prefilter_omitted_when_stats_none(self) -> None:
-        """Older pipelines (no sidecar) render without the Pre-filter line."""
+        """Older pipelines (no sidecar) render without the production parse line."""
         candidate = self._metrics([_row("valid")] * 3)
         text = "\n".join(_format_reliability_block(candidate, [], None))
-        assert "Pre-filter" not in text
+        assert "Production parse rate" not in text
         assert "Candidate parse rate" in text
 
     def test_failure_bodies_rendered_in_collapsed_details(self) -> None:
@@ -319,8 +307,8 @@ class TestFormatReportEndToEnd:
         assert "Boom." in report
         assert "⚠️" in report
 
-    def test_report_renders_prefilter_when_stats_provided(self) -> None:
-        """A filter_stats dict adds the Pre-filter line to the reliability block."""
+    def test_report_renders_production_parse_rate_when_stats_provided(self) -> None:
+        """A filter_stats dict adds the Production parse rate to the reliability block."""
         baseline = compute_metrics([_row("valid")] * 3)
         candidate = compute_metrics([_row("valid")] * 3)
         report = format_report(
@@ -329,21 +317,65 @@ class TestFormatReportEndToEnd:
             {"tool": "superforcaster"},
             filter_stats=_stats(accepted=3, wrong_tool=10, no_outcome=2),
         )
-        assert "Pre-filter (enrich): 3 accepted, 12 rejected" in report
-        assert "⚠️" not in report  # scoping only, invariant held
+        # Scoping rejections don't enter the ratio or raise a warning.
+        assert "Production parse rate: 3/3 (100.0%)" in report
+        assert "⚠️" not in report
 
-    def test_filter_regression_surfaces_warning_in_full_report(self) -> None:
-        """not_valid_parse > 0 propagates the ⚠️ marker into the final report."""
+    def test_not_valid_parse_lowers_rate_without_warning_in_full_report(self) -> None:
+        """not_valid_parse rows lower the production rate but never raise ⚠️."""
         baseline = compute_metrics([_row("valid")] * 3)
         candidate = compute_metrics([_row("valid")] * 3)
         report = format_report(
             baseline,
             candidate,
             {"tool": "superforcaster"},
-            filter_stats=_stats(accepted=3, not_valid_parse=2),
+            filter_stats=_stats(accepted=3, not_valid_parse=1),
         )
-        assert "⚠️" in report
-        assert "not_valid_parse=2 ⚠️" in report
+        assert "Production parse rate: 3/4 (75.0%)" in report
+        assert "⚠️" not in report
+
+
+class TestFormatReportHeader:
+    """Header must name the platform so a scoped run's scope is visible.
+
+    A run scoped to one platform (``--benchmark ... --platform polymarket``)
+    suppresses the per-platform breakdown, so the header is the only place the
+    scope appears.
+    """
+
+    @staticmethod
+    def _prow(platform: str) -> dict:
+        return {**_row("valid"), "platform": platform}
+
+    def test_single_platform_named_in_header(self) -> None:
+        """A run scoped to one platform names it in the header."""
+        rows = [self._prow("polymarket")] * 3
+        report = format_report(
+            compute_metrics(rows), compute_metrics(rows), {"tool": "superforcaster"}
+        )
+        assert "## Benchmark: superforcaster — Polymarket" in report
+
+    def test_multiple_platforms_render_all_platforms(self) -> None:
+        """An unscoped run spanning platforms reads 'All platforms'."""
+        rows = [self._prow("omen"), self._prow("polymarket")]
+        report = format_report(
+            compute_metrics(rows), compute_metrics(rows), {"tool": "superforcaster"}
+        )
+        assert "## Benchmark: superforcaster — All platforms" in report
+
+    def test_header_platform_set_unions_baseline_and_candidate(self) -> None:
+        """The platform set is the union of baseline and candidate platforms.
+
+        A platform present on only one side still counts, so a baseline/
+        candidate platform mismatch reads 'All platforms', not a single name.
+        """
+        cand = [self._prow("polymarket")] * 3
+        report = format_report(
+            compute_metrics([_row("valid")] * 3),  # omen baseline
+            compute_metrics(cand),
+            {"tool": "superforcaster"},
+        )
+        assert "## Benchmark: superforcaster — All platforms" in report
 
 
 class TestFormatReportFooter:


### PR DESCRIPTION
## What

Addresses two pieces of review feedback on the `/benchmark` PR comment output ([PR #333 thread](https://github.com/valory-xyz/mech-predict/pull/333#issuecomment-4681064685)):

1. **The output should be clear about the platform.** A run scoped with `--platform polymarket` suppresses the per-platform breakdown, so the platform was invisible in the report.
2. **Simplify the reliability reporting**, and remove a confusing warning.

## Changes

- **Header now names the platform** — `## Benchmark: <tool> — Polymarket` (or `— All platforms` for an unscoped run), derived from the platforms present in the scored rows.
- **Reliability block trimmed** to the two lines that carry signal: candidate parse rate and production parse rate. Dropped the `Pre-filter (enrich): N accepted, M rejected` total and the whole `Scoping:` breakdown — those rejections are dominated by `wrong_tool`/`wrong_platform`, i.e. rows for *other* tools/platforms in the shared production log, expected by design and carrying no reliability signal.
- **Removed the spurious ⚠️ on `not_valid_parse`.** Those are production deliveries `enrich` correctly dropped for not parsing (which is what keeps the scored baseline 100% valid), so a non-zero count is the normal state, not a regression. It now only lowers the reported production parse rate.

## How the output looks now

**Before** (n=500 Polymarket run — platform unnamed, verbose, always-on warning):

```
## Benchmark: superforcaster

| Metric | Baseline (prod) | Candidate (PR) | Delta |
|--------|-----------------|----------------|-------|
| Brier score | 0.2815 | 0.2646 | -6.0% |
| Directional Accuracy | 61.8% | 62.8% | +1.6% |
| Overconf-wrong | 109 | 85 | -22.0% |
| Overconf-wrong rate | 0.2180 | 0.1700 | -22.0% |

**Reliability**

- Candidate parse rate: 500/500 (100.0%) ✅
- Pre-filter (enrich): 17425 accepted, 186842 rejected, not_valid_parse=160 ⚠️
  - Scoping: duplicate=7997, wrong_tool=94110, wrong_platform=84575, no_deliver_id=0, no_outcome=0, older_than_cutoff=0
- Baseline pre-filter parse rate: 17425/17585 (99.1%)

*500 deliveries | seed 42 | triggered by @LOCKhart07*
```

**After** (platform in the header, two clean reliability lines, no spurious warning):

```
## Benchmark: superforcaster — Polymarket

| Metric | Baseline (prod) | Candidate (PR) | Delta |
|--------|-----------------|----------------|-------|
| Brier score | 0.2815 | 0.2646 | -6.0% |
| Directional Accuracy | 61.8% | 62.8% | +1.6% |
| Overconf-wrong | 109 | 85 | -22.0% |
| Overconf-wrong rate | 0.2180 | 0.1700 | -22.0% |

**Reliability**

- Candidate parse rate: 500/500 (100.0%) ✅
- Production parse rate: 17425/17585 (99.1%)

*500 deliveries | seed 42 | triggered by @LOCKhart07*
```

For an unscoped (all-platforms) run the header reads `## Benchmark: <tool> — All platforms` and the existing per-platform `<details>` breakdown still renders.

## Notes

- Genuine signals are preserved: the candidate parse-status breakdown still appears on candidate drift, and the `no_row_id` diagnostic still surfaces (loud, only when non-zero).
- Tests in `benchmark/tests/test_ci_replay.py` updated to cover the platform header and the simplified block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## LOC breakdown

Added lines by category (`git diff main...` → `+124 / −101`, net **+23**):

| Category | `ci_replay.py` | tests | Total |
|---|---:|---:|---:|
| Production code | 11 | — | **11** |
| Test code | — | 52 | **52** |
| Docstrings | 6 | 31 | **37** |
| Comments | 11 | 5 | **16** |
| Blank | 2 | 6 | **8** |
| IPFS / package hashes | 0 | 0 | **0** |
| **Total added** | **30** | **94** | **124** |

The actual production-logic change is small (11 added lines) and net-negative — `ci_replay.py` removes 39 lines (mostly the verbose Pre-filter/Scoping rendering) for 30 added. The bulk of the diff is test coverage and the docstring/comment rewrites explaining the new reporting. No IPFS or package hashes are touched.