### PR TITLE
feat(superforcaster-polymarket-v4): gpt-5.4 model swap of v2

### DIFF
--- a/benchmark/tools.py
+++ b/benchmark/tools.py
@@ -100,6 +100,16 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         ),
         family="superforcaster",
     ),
+    # valory/superforcaster_polymarket_v4 — one-axis model swap of v2:
+    # v2's criterion-specificity prompt + pipeline, with the gpt-4.1 backend
+    # swapped for the gpt-5.4 reasoning model (reasoning_effort medium).
+    "superforcaster-polymarket-v4": ToolSpec(
+        module=(
+            "packages.valory.customs.superforcaster_polymarket_v4"
+            ".superforcaster_polymarket_v4"
+        ),
+        family="superforcaster",
+    ),
     # napthaai/prediction_request_reasoning
     "prediction-request-reasoning": ToolSpec(
         module="packages.napthaai.customs.prediction_request_reasoning.prediction_request_reasoning",

--- a/benchmark/tournament_tools.json
+++ b/benchmark/tournament_tools.json
@@ -3,5 +3,6 @@
   "superforcaster_full_search": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
   "superforcaster_calibrated_full_search": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
   "superforcaster-polymarket-v2": "bafybeigopot226az3ida2rwlamlr2isi4i2m3nk36dtzug3w3jvnk673uy",
-  "superforcaster-polymarket-v3": "bafybeifstfsg3h6x24wclzc3f2ci35i5sd5kpfkhk3ekcr653u5iiz4h2m"
+  "superforcaster-polymarket-v3": "bafybeifstfsg3h6x24wclzc3f2ci35i5sd5kpfkhk3ekcr653u5iiz4h2m",
+  "superforcaster-polymarket-v4": "bafybeig5tirlyz5iekcziqxb3fio54pjdivnzzr3i53fnqk27wmylumpvm"
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -22,6 +22,7 @@
         "custom/valory/superforcaster_polymarket_v3/0.1.0": "bafybeigwcghcfq4d7zbjixg3d4mqvyo6ci4wp4jfstuyhm5357bhz2aeoy",
         "custom/valory/factual_research_v1/0.1.0": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
         "custom/valory/superforcaster_polymarket_v2/0.1.0": "bafybeigopot226az3ida2rwlamlr2isi4i2m3nk36dtzug3w3jvnk673uy",
+        "custom/valory/superforcaster_polymarket_v4/0.1.0": "bafybeig5tirlyz5iekcziqxb3fio54pjdivnzzr3i53fnqk27wmylumpvm",
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeih2ciwkf7edrmwlb5knk4nw5dedh7cz2lo6d6ecyehxlt6q7i7i3a",
         "agent/valory/mech_predict/0.1.0": "bafybeifxnqtt3uxksg4lctepvujjxfpnkj5m7bxdalj3fsotjxcqxz6jmq",

--- a/packages/valory/customs/superforcaster_polymarket_v4/__init__.py
+++ b/packages/valory/customs/superforcaster_polymarket_v4/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the Superforcaster tool."""

--- a/packages/valory/customs/superforcaster_polymarket_v4/component.yaml
+++ b/packages/valory/customs/superforcaster_polymarket_v4/component.yaml
@@ -1,0 +1,32 @@
+name: superforcaster_polymarket_v4
+author: valory
+version: 0.1.0
+type: custom
+description: A tool for making binary predictions on markets using the Serper API
+  and LLMs. Returns the standard mech prediction output (p_yes, p_no, confidence,
+  info_utility). One-axis model swap of superforcaster-polymarket-v2 that changes
+  the default LLM from OpenAI gpt-4.1 to the gpt-5.4 reasoning model (reasoning_effort
+  medium) while keeping v2's resolution-criterion specificity prompt, Serper pipeline,
+  output format and retry logic byte-identical. Sends max_completion_tokens instead
+  of max_tokens and omits temperature, as gpt-5.4 requires.
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  __init__.py: bafybeidr6ok7hgnywgtlggdajgklohlpaxnxmvpo2wn5fayq7fhzrr2sli
+  superforcaster_polymarket_v4.py: bafybeidoponn56qfr5ahjtlpoe5cjs7hdvowl66mh2i7sbhdzvx6bdso4y
+  tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
+  tests/test_superforcaster.py: bafybeibsyodvk6lqmky6vtm3ohdzefxj4dbsnozqrhi4edxpzuole4r5my
+fingerprint_ignore_patterns: []
+entry_point: superforcaster_polymarket_v4.py
+callable: run
+params:
+  default_model: gpt-5.4
+dependencies:
+  openai:
+    version: ==1.93.0
+  httpx:
+    version: ==0.25.2
+  tiktoken:
+    version: ==0.12.0
+  requests:
+    version: ==2.32.5

--- a/packages/valory/customs/superforcaster_polymarket_v4/superforcaster_polymarket_v4.py
+++ b/packages/valory/customs/superforcaster_polymarket_v4/superforcaster_polymarket_v4.py
@@ -1,0 +1,570 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+r"""Contains the job definitions.
+
+What v4 changes vs superforcaster-polymarket-v2
+-----------------------------------------------
+v4 is a one-axis model swap of v2:
+
+  superforcaster-polymarket-v2  (gpt-4.1-2025-04-14)
+      \-- superforcaster-polymarket-v4  (gpt-5.4)
+
+v2's criterion-specificity prompt, Serper pipeline, output format, retry
+behaviour and key-rotation decorator are kept byte-for-byte. The ONLY axis
+that changes is the LLM backend: ``gpt-4.1-2025-04-14`` -> ``gpt-5.4``.
+
+gpt-5.4 is a GPT-5-family *reasoning* model, which forces three mechanical
+adaptations to v2's OpenAI call site (the API rejects v2's params otherwise;
+see the OpenAI reasoning-models guide):
+
+* ``temperature`` / ``top_p`` / ``max_tokens`` are NOT sent — reasoning
+  models return HTTP 400 ("Unsupported parameter") for all three. v2 sent
+  ``temperature=0`` + ``max_tokens=500``; v4 sends neither.
+* ``max_completion_tokens`` replaces ``max_tokens`` and the cap is raised
+  to 16000. Reasoning tokens share this budget with the visible JSON, so
+  v2's 500 cap would be consumed by reasoning and return empty/partial
+  output. A ``finish_reason == "length"`` truncation guard raises so the
+  caller's retry loop engages instead of shipping truncated JSON on-chain.
+* ``reasoning_effort`` is set to ``"medium"`` (the model default is
+  ``"none"``, which would barely reason — defeating the superforcaster
+  prompt). Overridable via the ``reasoning_effort`` kwarg.
+
+Also: ``count_tokens`` gains a tiktoken fallback. tiktoken 0.12.0 has no
+model-name mapping for ``gpt-5.4`` (raises ``KeyError``); gpt-5.x uses the
+same ``o200k_base`` tokenizer as gpt-5 / gpt-4o, so we fall back to it.
+
+The pinned ``openai==1.93.0`` SDK already accepts ``max_completion_tokens``
+and ``reasoning_effort`` as ``chat.completions.create`` kwargs, and the
+model id is resolved server-side — so no ``pyproject.toml`` bump is needed.
+"""
+
+import functools
+import json
+import re
+import time
+from datetime import date
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import openai
+import requests
+from tiktoken import encoding_for_model, get_encoding
+
+MechResponseWithKeys = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]], Any
+]
+MechResponse = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]]
+]
+MaxCostResponse = float
+
+N_MODEL_CALLS = 1
+DEFAULT_DELIVERY_RATE = 100
+
+
+def with_key_rotation(func: Callable) -> Callable:
+    """
+    Decorator that retries a function with API key rotation on failure.
+
+    :param func: The function to be decorated.
+    :type func: Callable
+    :returns: Callable -- the wrapped function that handles retries with key rotation.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> MechResponseWithKeys:
+        # this is expected to be a KeyChain object,
+        # although it is not explicitly typed as such
+        api_keys = kwargs["api_keys"]
+        retries_left: Dict[str, int] = api_keys.max_retries()
+
+        def execute() -> MechResponseWithKeys:
+            """Retry the function with a new key."""
+            try:
+                result: MechResponse = func(*args, **kwargs)
+                return result + (api_keys,)
+            except openai.RateLimitError as e:
+                # try with a new key again
+                if retries_left["openai"] <= 0 and retries_left["openrouter"] <= 0:
+                    raise e
+                retries_left["openai"] -= 1
+                retries_left["openrouter"] -= 1
+                api_keys.rotate("openai")
+                api_keys.rotate("openrouter")
+                return execute()
+            except Exception as e:
+                return str(e), "", None, None, None, api_keys
+
+        mech_response = execute()
+        return mech_response
+
+    return wrapper
+
+
+class OpenAIClientManager:
+    """Client context manager for OpenAI."""
+
+    def __init__(self, api_key: str):
+        """Initializes with API keys"""
+        self.api_key = api_key
+        self._client: Optional["OpenAIClient"] = None
+
+    def __enter__(self) -> "OpenAIClient":
+        """Initializes and returns LLM client."""
+        self._client = OpenAIClient(api_key=self.api_key)
+        return self._client
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Closes the LLM client"""
+        if self._client is not None:
+            self._client.client.close()
+            self._client = None
+
+
+class Usage:
+    """Usage class."""
+
+    def __init__(
+        self,
+        prompt_tokens: Optional[Any] = None,
+        completion_tokens: Optional[Any] = None,
+    ):
+        """Initializes with prompt tokens and completion tokens."""
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+
+class OpenAIResponse:
+    """Response class."""
+
+    def __init__(self, content: Optional[str] = None, usage: Optional[Usage] = None):
+        """Initializes with content and usage class."""
+        self.content = content
+        self.usage = Usage()
+
+
+class OpenAIClient:
+    """OpenAI Client"""
+
+    def __init__(self, api_key: str):
+        """Initializes with API keys and client."""
+        self.api_key = api_key
+        self.client = openai.OpenAI(api_key=self.api_key)
+
+    def completions(
+        self,
+        model: str,
+        messages: List = [],  # noqa: B006
+        timeout: Optional[Union[float, int]] = None,
+        reasoning_effort: str = "medium",
+        n: Optional[int] = None,
+        stop: Any = None,
+        max_completion_tokens: Optional[int] = None,
+    ) -> Optional[OpenAIResponse]:
+        """Generate a completion from gpt-5.4 via the Chat Completions API.
+
+        gpt-5.4 is a reasoning model: ``temperature`` / ``top_p`` /
+        ``max_tokens`` are NOT passed (the API rejects them with HTTP 400).
+        Token output is bounded by ``max_completion_tokens`` (which the
+        reasoning tokens share with the visible JSON) and reasoning depth is
+        controlled by ``reasoning_effort``.
+
+        :param model: the gpt-5.4 model id.
+        :param messages: ordered ``{"role", "content"}`` dicts.
+        :param timeout: kept for signature parity; the call hard-codes 150s.
+        :param reasoning_effort: ``none`` | ``low`` | ``medium`` | ``high``
+            | ``xhigh``; deeper effort spends more (billed) reasoning tokens.
+        :param n: kept for signature parity; pinned to 1.
+        :param stop: kept for signature parity; not forwarded.
+        :param max_completion_tokens: ceiling on reasoning + visible tokens.
+        :raises ValueError: when the response is truncated
+            (``finish_reason == "length"``) — reasoning consumed the whole
+            budget, leaving empty/partial visible content that would
+            otherwise propagate silently and bypass the caller's retry loop.
+        :return: ``OpenAIResponse`` carrying ``.content`` and ``.usage``.
+        """
+        response_provider = self.client.chat.completions.create(
+            model=model,
+            messages=messages,
+            max_completion_tokens=max_completion_tokens,
+            reasoning_effort=reasoning_effort,
+            n=1,
+            timeout=150,
+        )
+        choice = response_provider.choices[0]
+        # Truncation guard: reasoning tokens share max_completion_tokens with
+        # the visible JSON. If the budget is exhausted the API returns
+        # finish_reason == "length" with empty/partial content; raise so the
+        # caller's retry loop engages instead of shipping truncated JSON.
+        if choice.finish_reason == "length":
+            raise ValueError(
+                f"Response truncated (finish_reason='length', "
+                f"max_completion_tokens={max_completion_tokens}); "
+                f"raise max_completion_tokens for this call site"
+            )
+        response = OpenAIResponse()
+        response.content = choice.message.content
+        response.usage.prompt_tokens = response_provider.usage.prompt_tokens
+        response.usage.completion_tokens = response_provider.usage.completion_tokens
+        return response
+
+
+def count_tokens(text: str, model: str) -> int:
+    """Count the number of tokens in a text.
+
+    Falls back to the ``o200k_base`` encoding when tiktoken has no
+    model-name mapping (tiktoken 0.12.0 raises ``KeyError`` for ``gpt-5.4``;
+    gpt-5.x shares the ``o200k_base`` tokenizer with gpt-5 / gpt-4o).
+
+    :param text: the text to tokenize.
+    :param model: the model id used to pick the tokenizer.
+    :return: the number of tokens in ``text``.
+    """
+    try:
+        enc = encoding_for_model(model)
+    except KeyError:
+        enc = get_encoding("o200k_base")
+    return len(enc.encode(text))
+
+
+DEFAULT_OPENAI_SETTINGS = {
+    "max_completion_tokens": 16000,
+    "reasoning_effort": "medium",
+}
+DEFAULT_OPENAI_MODEL = "gpt-5.4"
+ALLOWED_TOOLS = ["superforcaster-polymarket-v4"]
+ALLOWED_MODELS = [DEFAULT_OPENAI_MODEL]
+ALLOWED_REASONING_EFFORTS = ["none", "low", "medium", "high", "xhigh"]
+MAX_SOURCES = 5
+COMPLETION_RETRIES = 3
+COMPLETION_DELAY = 2
+
+
+PREDICTION_PROMPT = """
+You are an advanced AI system which has been finetuned to provide calibrated probabilistic
+forecasts under uncertainty, with your performance evaluated according to the Brier score. When
+forecasting, do not treat 0.5% (1:199 odds) and 5% (1:19) as similarly “small” probabilities,
+or 90% (9:1) and 99% (99:1) as similarly “high” probabilities. As the odds show, they are
+markedly different, so output your probabilities accordingly.
+
+Question:
+{question}
+
+Today's date: {today}
+Your pretraining knowledge cutoff: October 2023
+
+We have retrieved the following information for this question:
+<background>{sources}</background>
+
+Recall the question you are forecasting:
+{question}
+
+Instructions:
+1. Compress key factual information from the sources, as well as useful background information
+which may not be in the sources, into a list of core factual points to reference. Aim for
+information which is specific, relevant, and covers the core considerations you'll use to make
+your forecast. For this step, do not draw any conclusions about how a fact will influence your
+answer or forecast. Place this section of your response in <facts></facts> tags.
+
+2. Provide a few reasons why the answer might be no. Rate the strength of each reason on a
+scale of 1-10. Use <no></no> tags.
+
+3. Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
+scale of 1-10. Use <yes></yes> tags.
+
+4. Aggregate your considerations. Do not summarize or repeat previous points; instead,
+investigate how the competing factors and mechanisms interact and weigh against each other.
+Factorize your thinking across (exhaustive, mutually exclusive) cases if and only if it would be
+beneficial to your reasoning. We have detected that you overestimate world conflict, drama,
+violence, and crises due to news' negativity bias, which doesn't necessarily represent overall
+trends or base rates. Similarly, we also have detected you overestimate dramatic, shocking,
+or emotionally charged news due to news' sensationalism bias. Therefore adjust for news'
+negativity bias and sensationalism bias by considering reasons to why your provided sources
+might be biased or exaggerated. Think like a superforecaster. Use <thinking></thinking> tags
+for this section of your response.
+
+5. Output an initial probability (prediction) as a single number between 0 and 1 given steps 1-4.
+Use <tentative></tentative> tags.
+
+6. Reflect on your answer, performing sanity checks and mentioning any additional knowledge
+or background information which may be relevant. Check for over/underconfidence, improper
+treatment of conjunctive or disjunctive conditions (only if applicable), and other forecasting
+biases when reviewing your reasoning. Consider priors/base rates, and the extent to which
+case-specific information justifies the deviation between your tentative forecast and the prior.
+Critically: identify the exact resolution criterion -- the specific condition that must literally
+be true for this market to resolve YES. For each piece of evidence, ask: does this evidence
+bear on whether the criterion itself will be satisfied, or does it only establish that the topic
+is relevant? Topical relevance is not criterion evidence. Derive p_yes by reasoning explicitly
+about the probability that the criterion is satisfied: consider the base rate for this type of
+condition, any case-specific factors that raise or lower that probability, and whether any
+evidence directly confirms or denies criterion satisfaction. Ground your estimate in that
+reasoning chain -- do not substitute topical signal strength for a criterion probability.
+Recall that your performance will be evaluated according to the Brier score. Be precise with tail
+probabilities. Leverage your intuitions, but never change your forecast for the sake of modesty
+or balance alone. Finally, aggregate all of your previous reasoning and highlight key factors
+that inform your final forecast. Use <thinking></thinking> tags for this portion of your response.
+
+7. Output your final prediction (a number between 0 and 1 with an asterisk at the beginning and
+end of the decimal) in <answer></answer> tags.
+
+
+OUTPUT_FORMAT
+* Your output response must be only a single JSON object to be parsed by Python's "json.loads()".
+* The JSON must contain four fields: "p_yes", "p_no", "confidence", and "info_utility".
+* Each item in the JSON must have a value between 0 and 1.
+   - "p_yes": Estimated probability that the event in the "Question" occurs.
+   - "p_no": Estimated probability that the event in the "Question" does not occur.
+   - "confidence": A value between 0 and 1 indicating the confidence in the prediction. 0 indicates lowest
+     confidence value; 1 maximum confidence value.
+   - "info_utility": Utility of the information provided in "sources" to help you make the prediction.
+     0 indicates lowest utility; 1 maximum utility.
+* The sum of "p_yes" and "p_no" must equal 1.
+* Output only the JSON object. Do not include any other contents in your response.
+* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
+* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
+* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
+"""
+
+
+def generate_prediction_with_retry(
+    client: "OpenAIClient",
+    model: str,
+    messages: List[Dict[str, str]],
+    reasoning_effort: str,
+    max_completion_tokens: int,
+    retries: int = COMPLETION_RETRIES,
+    delay: int = COMPLETION_DELAY,
+    counter_callback: Optional[Callable] = None,
+) -> Tuple[Any, Optional[Callable]]:
+    """Attempt to generate a prediction with retries on failure."""
+    attempt = 0
+    while attempt < retries:
+        try:
+            response = client.completions(
+                model=model,
+                messages=messages,
+                reasoning_effort=reasoning_effort,
+                max_completion_tokens=max_completion_tokens,
+                n=1,
+                timeout=90,
+                stop=None,
+            )
+
+            if (
+                response
+                and response.content is not None
+                and counter_callback is not None
+            ):
+                counter_callback(
+                    input_tokens=response.usage.prompt_tokens,
+                    output_tokens=response.usage.completion_tokens,
+                    model=model,
+                    token_counter=count_tokens,
+                )
+
+            content = response.content if response else None
+            # A reasoning model can return empty visible content (e.g. all
+            # budget spent on reasoning). Engage the retry loop rather than
+            # returning None as the prediction.
+            if content is None:
+                raise ValueError("LLM returned empty content")
+            return content, counter_callback
+        except Exception as e:
+            print(f"Attempt {attempt + 1} failed with error: {e}")
+            time.sleep(delay)
+            attempt += 1
+    raise Exception("Failed to generate prediction after retries")
+
+
+def fetch_additional_sources(question: Any, serper_api_key: Any) -> requests.Response:
+    """Fetches additional sources for the given question using the Serper API."""
+    url = "https://google.serper.dev/search"
+    payload = json.dumps({"q": question})
+    headers = {
+        "X-API-KEY": serper_api_key,
+        "Content-Type": "application/json",
+    }
+
+    response = requests.request("POST", url, headers=headers, data=payload)
+
+    return response
+
+
+def format_sources_data(organic_data: Any, misc_data: Any) -> str:
+    """Formats organic search results and "People Also Ask" data into a human-readable string."""
+    sources = ""
+
+    if len(organic_data) > 0:
+        print("Adding organic data...")
+
+        sources = """
+        Organic Results:
+        """
+
+        for item in organic_data:
+            sources += f"""{item.get('position', 'N/A')}. **Title:** {item.get("title", 'N/A')}
+            - **Link:** [{item.get("link", '#')}]({item.get("link", '#')})
+            - **Snippet:** {item.get("snippet", 'N/A')}
+            """
+
+    if len(misc_data) > 0:
+        print("Adding misc data...")
+
+        sources += "People Also Ask:\n"
+
+        counter = 1
+        for item in misc_data:
+            sources += f"""{counter}. **Question:** {item.get("question", 'N/A')}
+            - **Link:** [{item.get("link", '#')}]({item.get("link", '#')})
+            - **Snippet:** {item.get("snippet", 'N/A')}
+            """
+            counter += 1
+
+    return sources
+
+
+def extract_question(prompt: str) -> str:
+    """Uses regexp to extract question from the prompt"""
+    # Match from 'question "' to '" and the `yes`' to handle nested quotes
+    pattern = r'question\s+"(.+?)"\s+and\s+the\s+`yes`'
+    try:
+        question = re.findall(pattern, prompt, re.DOTALL)[0]
+    except Exception as e:
+        print(f"Error extracting question: {e}")
+        question = prompt
+    return question
+
+
+@with_key_rotation
+def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
+    """Run the task"""
+    tool = kwargs["tool"]
+    if tool not in ALLOWED_TOOLS:
+        raise ValueError(f"Tool {tool} is not supported.")
+
+    model = kwargs.get("model")
+    if model is None:
+        raise ValueError("Model not supplied.")
+    if model not in ALLOWED_MODELS:
+        # v4 sends reasoning-model-only params (max_completion_tokens,
+        # reasoning_effort) and omits temperature/max_tokens. A non-reasoning
+        # model routed here would reject those, failing deep in the SDK with
+        # an opaque error — enforce the allow-list so the wire-name error is
+        # unambiguous.
+        raise ValueError(
+            f"Model {model!r} is not in ALLOWED_MODELS={ALLOWED_MODELS!r}."
+        )
+
+    delivery_rate = int(kwargs.get("delivery_rate", DEFAULT_DELIVERY_RATE))
+    counter_callback: Optional[Callable[..., Any]] = kwargs.get(
+        "counter_callback", None
+    )
+    if delivery_rate == 0:
+        if not counter_callback:
+            raise ValueError(
+                "A delivery rate of `0` was passed, but no counter callback was given to calculate the max cost with."
+            )
+
+        max_cost = counter_callback(
+            max_cost=True,
+            models_calls=(model,) * N_MODEL_CALLS,
+        )
+        return max_cost
+
+    openai_api_key = kwargs["api_keys"]["openai"]
+    source_content = kwargs.get("source_content", None)
+    return_source_content = (
+        kwargs["api_keys"].get("return_source_content", "false") == "true"
+    )
+    source_content_mode = kwargs["api_keys"].get("source_content_mode", "cleaned")
+    if source_content_mode not in ("cleaned", "raw"):
+        raise ValueError(
+            f"Invalid source_content_mode: {source_content_mode!r}. Must be 'cleaned' or 'raw'."
+        )
+    with OpenAIClientManager(openai_api_key) as llm_client:
+        max_completion_tokens = kwargs.get(
+            "max_completion_tokens", DEFAULT_OPENAI_SETTINGS["max_completion_tokens"]
+        )
+        reasoning_effort = kwargs.get(
+            "reasoning_effort", DEFAULT_OPENAI_SETTINGS["reasoning_effort"]
+        )
+        if reasoning_effort not in ALLOWED_REASONING_EFFORTS:
+            raise ValueError(
+                f"Invalid reasoning_effort: {reasoning_effort!r}. "
+                f"Must be one of {ALLOWED_REASONING_EFFORTS!r}."
+            )
+        prompt = kwargs["prompt"]
+
+        today = date.today()
+        d = today.strftime("%d/%m/%Y")
+
+        question = extract_question(prompt)
+
+        if source_content is not None:
+            print("Using provided source content (cached replay)...")
+            captured_source_content = source_content
+            serper_data = source_content.get("serper_response", source_content)
+            organic_data = serper_data.get("organic", [])[:MAX_SOURCES]
+            misc_data = serper_data.get("peopleAlsoAsk", [])
+            sources = format_sources_data(organic_data, misc_data)
+        else:
+            serper_api_key = kwargs["api_keys"]["serperapi"]
+            print("Fetching additional sources...")
+            serper_response = fetch_additional_sources(question, serper_api_key)
+            sources_data = serper_response.json()
+            # mode tag included for consistency across tools; content is identical
+            # regardless of mode since Serper returns structured JSON, not HTML
+            captured_source_content = {
+                "mode": source_content_mode,
+                "serper_response": sources_data,
+            }
+            print(f"Additional sources fetched: {sources_data}")
+            organic_data = sources_data.get("organic", [])[:MAX_SOURCES]
+            misc_data = sources_data.get("peopleAlsoAsk", [])
+            print("Formating sources...")
+            sources = format_sources_data(organic_data, misc_data)
+
+        print("Updating prompt...")
+        prediction_prompt = PREDICTION_PROMPT.format(
+            question=question, today=d, sources=sources
+        )
+        print(f"\n{prediction_prompt=}\n")
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": prediction_prompt},
+        ]
+        print("Getting prompt response...")
+        extracted_block, counter_callback = generate_prediction_with_retry(
+            client=llm_client,
+            model=model,
+            messages=messages,
+            reasoning_effort=reasoning_effort,
+            max_completion_tokens=max_completion_tokens,
+            retries=COMPLETION_RETRIES,
+            delay=COMPLETION_DELAY,
+            counter_callback=counter_callback,
+        )
+
+        used_params = {
+            "model": model,
+            "reasoning_effort": reasoning_effort,
+            "max_completion_tokens": max_completion_tokens,
+        }
+        if return_source_content:
+            used_params["source_content"] = captured_source_content
+        return extracted_block, prediction_prompt, None, counter_callback, used_params

--- a/packages/valory/customs/superforcaster_polymarket_v4/tests/__init__.py
+++ b/packages/valory/customs/superforcaster_polymarket_v4/tests/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for superforcaster custom package."""

--- a/packages/valory/customs/superforcaster_polymarket_v4/tests/test_superforcaster.py
+++ b/packages/valory/customs/superforcaster_polymarket_v4/tests/test_superforcaster.py
@@ -1,0 +1,503 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Unit tests for superforcaster_polymarket v4.
+
+v4 is a one-axis model swap of v2 (gpt-4.1 -> gpt-5.4). The first half of
+this file re-validates v2's shared surface (client manager, source_content
+capture/replay) against v4's own module. The classes after the
+``# v4-specific tests`` divider pin the reasoning-model adaptations that v4
+introduces: max_completion_tokens + reasoning_effort wiring, the
+finish_reason truncation guard, the empty-content guard, the tiktoken
+fallback for gpt-5.4, and the ALLOWED_MODELS enforcement.
+"""
+
+import inspect
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import packages.valory.customs.superforcaster_polymarket_v4.superforcaster_polymarket_v4 as module
+from packages.valory.customs.superforcaster_polymarket_v4.superforcaster_polymarket_v4 import (
+    ALLOWED_MODELS,
+    ALLOWED_REASONING_EFFORTS,
+    ALLOWED_TOOLS,
+    DEFAULT_OPENAI_MODEL,
+    OpenAIClient,
+    OpenAIClientManager,
+    OpenAIResponse,
+    count_tokens,
+    generate_prediction_with_retry,
+    run,
+)
+
+SF_MODULE = (
+    "packages.valory.customs.superforcaster_polymarket_v4.superforcaster_polymarket_v4"
+)
+
+
+class TestOpenAIClientManager:
+    """Verify OpenAIClientManager creates per-context clients without globals."""
+
+    def test_context_manager_returns_client_instance(self) -> None:
+        """__enter__ returns a fresh OpenAIClient, __exit__ closes it."""
+        mgr = OpenAIClientManager(api_key="sk-test")
+        with patch(f"{SF_MODULE}.OpenAIClient") as MockClient:
+            mock_instance = MagicMock()
+            MockClient.return_value = mock_instance
+
+            with mgr as client:
+                assert client is mock_instance
+                MockClient.assert_called_once_with(api_key="sk-test")
+
+            mock_instance.client.close.assert_called_once()
+
+    def test_no_global_client_variable(self) -> None:
+        """The module must not define a module-level 'client' variable."""
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        for i, line in enumerate(source.split("\n"), 1):
+            stripped = line.lstrip()
+            if stripped.startswith("client:") or stripped.startswith("client ="):
+                if not line.startswith(" ") and not line.startswith("\t"):
+                    pytest.fail(
+                        f"Module-level 'client' variable found at line {i}: {line}"
+                    )
+
+    def test_generate_prediction_requires_client_param(self) -> None:
+        """generate_prediction_with_retry requires client as first param."""
+        params = list(inspect.signature(generate_prediction_with_retry).parameters)
+        assert params[0] == "client"
+
+
+FAKE_SERPER_RESPONSE = {
+    "searchParameters": {"q": "test query", "type": "search"},
+    "organic": [
+        {
+            "title": "Test Result",
+            "link": "http://example.com/result",
+            "snippet": "Test snippet content",
+            "position": 1,
+        },
+    ],
+    "peopleAlsoAsk": [
+        {"question": "What is test?", "snippet": "A test answer."},
+    ],
+}
+
+PREDICTION_JSON = json.dumps(
+    {"p_yes": 0.5, "p_no": 0.5, "confidence": 0.5, "info_utility": 0.5}
+)
+
+PREDICTION_PROMPT = (
+    'With the given question "Will X happen?" '
+    "and the `yes` option represented by `Yes` and the `no` option represented by `No`, "
+    "what are the respective probabilities of `p_yes` and `p_no` occurring?"
+)
+
+
+def _make_mock_api_keys(return_source_content: str = "false") -> MagicMock:
+    """Create a mock KeyChain-like api_keys object."""
+    services = {
+        "openai": ["sk-test"],
+        "serperapi": ["serper-test"],
+        "return_source_content": [return_source_content],
+    }
+    mock = MagicMock()
+    mock.__getitem__ = lambda self, key: services[key][0]
+    mock.get = lambda key, default="": services.get(key, [default])[0]
+    return mock
+
+
+def _install_mock_client(mock_client_mgr: MagicMock) -> MagicMock:
+    """Wire OpenAIClientManager to return a client whose completions() yields PREDICTION_JSON.
+
+    The wrapper's call path is `OpenAIClient.completions(...)`, so the response
+    must be configured on `mock_client.completions.return_value` — not on
+    `mock_client.chat.completions.create` (which is the raw OpenAI SDK path the
+    wrapper hides).
+
+    :param mock_client_mgr: the patched OpenAIClientManager mock.
+    :return: the inner mock_client wired into the manager's __enter__.
+    """
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = PREDICTION_JSON
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 5
+    mock_client.completions.return_value = mock_response
+    mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+    mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_client
+
+
+class TestSuperforcasterSourceContent:
+    """Verify superforcaster captures and replays source_content correctly."""
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_live_capture_wraps_serper_json(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """Live run wraps Serper response in {'serper_response': ...}."""
+        mock_serper = MagicMock()
+        mock_serper.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_serper
+        _install_mock_client(mock_client_mgr)
+
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-5.4",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("true"),
+            counter_callback=None,
+        )
+
+        assert result[0] == PREDICTION_JSON
+        used_params = result[4]
+        assert "source_content" in used_params
+        assert "mode" in used_params["source_content"]
+        assert "serper_response" in used_params["source_content"]
+        assert used_params["source_content"]["serper_response"] == FAKE_SERPER_RESPONSE
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    def test_replay_with_serper_response_format(
+        self, mock_client_mgr: MagicMock
+    ) -> None:
+        """Replay with {'serper_response': ...} uses organic and peopleAlsoAsk."""
+        _install_mock_client(mock_client_mgr)
+
+        source_content = {"serper_response": FAKE_SERPER_RESPONSE}
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-5.4",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("true"),
+            counter_callback=None,
+            source_content=source_content,
+        )
+
+        assert result[0] == PREDICTION_JSON
+        prediction_prompt = result[1]
+        assert "Test Result" in prediction_prompt
+        assert "Test snippet content" in prediction_prompt
+        assert "What is test?" in prediction_prompt
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_flag_off_no_source_content(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """When return_source_content is false, source_content is not in used_params."""
+        mock_serper = MagicMock()
+        mock_serper.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_serper
+        _install_mock_client(mock_client_mgr)
+
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-5.4",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("false"),
+            counter_callback=None,
+        )
+
+        assert result[0] == PREDICTION_JSON
+        used_params = result[4]
+        assert "source_content" not in used_params
+
+
+# ---------------------------------------------------------------------------
+# v4-specific tests — verify the gpt-5.4 reasoning-model adaptations.
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_chat_response(
+    content: Any,
+    *,
+    finish_reason: str = "stop",
+    prompt_tokens: int = 7,
+    completion_tokens: int = 13,
+) -> MagicMock:
+    """Build a mock ``chat.completions.create`` response.
+
+    Shapes it like the real ``ChatCompletion``: ``choices[0].message.content``,
+    ``choices[0].finish_reason`` and a ``usage`` block.
+
+    :param content: the visible message content (``None`` for an empty
+        reasoning-only response).
+    :param finish_reason: ``"stop"`` (normal) or ``"length"`` (truncated).
+    :param prompt_tokens: prompt token count for the usage block.
+    :param completion_tokens: completion token count for the usage block.
+    :return: a MagicMock shaped like ``openai.types.ChatCompletion``.
+    """
+    choice = MagicMock()
+    choice.message.content = content
+    choice.finish_reason = finish_reason
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = MagicMock(
+        prompt_tokens=prompt_tokens, completion_tokens=completion_tokens
+    )
+    return resp
+
+
+def _client_with_chat_response(resp: Any) -> OpenAIClient:
+    """Build a v4 OpenAIClient with a mocked openai.OpenAI backing."""
+    with patch(f"{SF_MODULE}.openai.OpenAI") as MockOpenAI:
+        mock_instance = MagicMock()
+        mock_instance.chat.completions.create.return_value = resp
+        MockOpenAI.return_value = mock_instance
+        client = OpenAIClient(api_key="sk-test")
+    return client
+
+
+class TestV4Constants:
+    """Pin v4's wire-name, model allow-list and reasoning-effort menu."""
+
+    def test_default_model_is_gpt_5_4(self) -> None:
+        """The new default for v4 is gpt-5.4 and it's the only allowed model."""
+        assert DEFAULT_OPENAI_MODEL == "gpt-5.4"
+        assert ALLOWED_MODELS == ["gpt-5.4"]
+
+    def test_allowed_tools_targets_v4(self) -> None:
+        """The wire-name for this variant is superforcaster-polymarket-v4."""
+        assert ALLOWED_TOOLS == ["superforcaster-polymarket-v4"]
+
+    def test_reasoning_effort_menu(self) -> None:
+        """ALLOWED_REASONING_EFFORTS matches the gpt-5.4 effort levels."""
+        assert ALLOWED_REASONING_EFFORTS == [
+            "none",
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+        ]
+
+
+class TestV4CountTokensFallback:
+    """tiktoken 0.12.0 has no gpt-5.4 mapping; count_tokens must not crash."""
+
+    def test_count_tokens_falls_back_for_gpt_5_4(self) -> None:
+        """``count_tokens(text, "gpt-5.4")`` falls back to o200k_base, not KeyError."""
+        # Sanity: tiktoken genuinely lacks the gpt-5.4 mapping (otherwise this
+        # test would pass without exercising the fallback branch).
+        import tiktoken
+
+        with pytest.raises(KeyError):
+            tiktoken.encoding_for_model("gpt-5.4")
+
+        n = count_tokens("hello world", "gpt-5.4")
+        assert n == len(tiktoken.get_encoding("o200k_base").encode("hello world"))
+        assert n > 0
+
+    def test_count_tokens_uses_native_mapping_when_present(self) -> None:
+        """A model tiktoken knows still uses its native encoding."""
+        import tiktoken
+
+        n = count_tokens("hello world", "gpt-4o")
+        assert n == len(tiktoken.encoding_for_model("gpt-4o").encode("hello world"))
+
+
+class TestV4OpenAICompletions:
+    """Pin the gpt-5.4 reasoning-model call contract in OpenAIClient.completions."""
+
+    def test_sends_reasoning_params_not_legacy_params(self) -> None:
+        """completions() sends max_completion_tokens + reasoning_effort, NOT temperature/max_tokens/top_p."""
+        client = _client_with_chat_response(_make_openai_chat_response(PREDICTION_JSON))
+        client.completions(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "U1"}],
+            reasoning_effort="medium",
+            max_completion_tokens=16000,
+        )
+        kwargs = client.client.chat.completions.create.call_args.kwargs
+        assert kwargs["max_completion_tokens"] == 16000
+        assert kwargs["reasoning_effort"] == "medium"
+        assert kwargs["model"] == "gpt-5.4"
+        # Reasoning models reject these — they must never be forwarded.
+        assert "temperature" not in kwargs
+        assert "top_p" not in kwargs
+        assert "max_tokens" not in kwargs
+
+    def test_truncation_raises(self) -> None:
+        """finish_reason == 'length' raises so the retry loop engages."""
+        client = _client_with_chat_response(
+            _make_openai_chat_response('{"p_yes": 0.5', finish_reason="length")
+        )
+        with pytest.raises(ValueError, match="Response truncated"):
+            client.completions(
+                model="gpt-5.4",
+                messages=[{"role": "user", "content": "U1"}],
+                max_completion_tokens=10,
+            )
+
+    def test_returns_content_and_usage_on_success(self) -> None:
+        """A normal response carries content + usage through unchanged."""
+        client = _client_with_chat_response(
+            _make_openai_chat_response(
+                PREDICTION_JSON, prompt_tokens=111, completion_tokens=222
+            )
+        )
+        result = client.completions(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "U1"}],
+        )
+        assert isinstance(result, OpenAIResponse)
+        assert result.content == PREDICTION_JSON
+        assert result.usage.prompt_tokens == 111
+        assert result.usage.completion_tokens == 222
+
+
+class TestV4GeneratePredictionWithRetry:
+    """The empty-content guard added for reasoning models."""
+
+    def test_empty_content_engages_retry_then_fails(self) -> None:
+        """``content is None`` raises inside the loop; exhausting retries raises a clean error."""
+        mock_client = MagicMock()
+        # client.completions() returns an OpenAIResponse-shaped object whose
+        # .content is None (the reasoning-only / empty-output case).
+        empty = MagicMock()
+        empty.content = None
+        mock_client.completions.return_value = empty
+
+        with patch(f"{SF_MODULE}.time.sleep"):
+            with pytest.raises(Exception, match="Failed to generate prediction"):
+                generate_prediction_with_retry(
+                    client=mock_client,
+                    model="gpt-5.4",
+                    messages=[{"role": "user", "content": "U1"}],
+                    reasoning_effort="medium",
+                    max_completion_tokens=16000,
+                    retries=2,
+                    delay=0,
+                    counter_callback=None,
+                )
+        # Both attempts ran (the None content didn't short-circuit as success).
+        assert mock_client.completions.call_count == 2
+
+    def test_threads_reasoning_params_into_completions(self) -> None:
+        """reasoning_effort + max_completion_tokens reach the client unchanged."""
+        mock_client = MagicMock()
+        ok = MagicMock()
+        ok.content = PREDICTION_JSON
+        ok.usage.prompt_tokens = 10
+        ok.usage.completion_tokens = 5
+        mock_client.completions.return_value = ok
+        content, _ = generate_prediction_with_retry(
+            client=mock_client,
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "U1"}],
+            reasoning_effort="high",
+            max_completion_tokens=12345,
+            retries=1,
+            delay=0,
+            counter_callback=None,
+        )
+        assert content == PREDICTION_JSON
+        kwargs = mock_client.completions.call_args.kwargs
+        assert kwargs["reasoning_effort"] == "high"
+        assert kwargs["max_completion_tokens"] == 12345
+
+
+class TestV4RunEndToEnd:
+    """End-to-end ``run()`` smoke tests on v4 with gpt-5.4."""
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_run_records_reasoning_params_and_default_effort(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """run() defaults to reasoning_effort='medium' and records the reasoning params."""
+        mock_serper = MagicMock()
+        mock_serper.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_serper
+        mock_client = _install_mock_client(mock_client_mgr)
+
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-5.4",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("false"),
+            counter_callback=None,
+        )
+
+        assert result[0] == PREDICTION_JSON
+        used_params = result[4]
+        assert used_params["model"] == "gpt-5.4"
+        assert used_params["reasoning_effort"] == "medium"
+        assert used_params["max_completion_tokens"] == 16000
+        # The default effort + budget were forwarded to the client.
+        call_kwargs = mock_client.completions.call_args.kwargs
+        assert call_kwargs["reasoning_effort"] == "medium"
+        assert call_kwargs["max_completion_tokens"] == 16000
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_run_honors_reasoning_effort_override(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """A caller-supplied reasoning_effort overrides the default."""
+        mock_serper = MagicMock()
+        mock_serper.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_serper
+        mock_client = _install_mock_client(mock_client_mgr)
+
+        run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-5.4",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("false"),
+            counter_callback=None,
+            reasoning_effort="high",
+        )
+
+        assert mock_client.completions.call_args.kwargs["reasoning_effort"] == "high"
+
+    def test_run_with_unknown_model_returns_allowed_models_error(self) -> None:
+        """A model outside ALLOWED_MODELS produces a clean error tuple, not an SDK error.
+
+        ``@with_key_rotation`` catches the inner ``ValueError`` and wraps it
+        into the standard mech response tuple, so we assert on the first
+        element rather than ``pytest.raises``.
+        """
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-4.1-2025-04-14",
+            prompt="P",
+            api_keys=_make_mock_api_keys("false"),
+            delivery_rate=10000,
+        )
+        assert "ALLOWED_MODELS" in result[0]
+        assert "gpt-4.1-2025-04-14" in result[0]
+
+    def test_run_with_invalid_reasoning_effort_returns_error(self) -> None:
+        """An out-of-menu reasoning_effort is rejected with a clean error tuple."""
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-5.4",
+            prompt="P",
+            api_keys=_make_mock_api_keys("false"),
+            delivery_rate=10000,
+            reasoning_effort="ultra",
+        )
+        assert "reasoning_effort" in result[0]
+        assert "ultra" in result[0]

--- a/tool_lineage.json
+++ b/tool_lineage.json
@@ -141,6 +141,10 @@
     "superforcaster-polymarket-v3": {
       "parent": "superforcaster-polymarket-v1",
       "reason": "Swap the default LLM model from OpenAI gpt-4.1-2025-04-14 to Anthropic claude-fable-5. Same prompt, pipeline, output format and retry logic as v1 \u2014 one-axis change to measure the model's contribution to v1's baseline. Sibling of v2 (which is a prompt-only resolution-criterion specificity variant), both depart from v1."
+    },
+    "superforcaster-polymarket-v4": {
+      "parent": "superforcaster-polymarket-v2",
+      "reason": "Swap the default LLM model from OpenAI gpt-4.1-2025-04-14 to the gpt-5.4 reasoning model (reasoning_effort medium). Keeps v2's resolution-criterion specificity prompt, Serper pipeline, output format and retry logic byte-identical; sends max_completion_tokens instead of max_tokens and omits temperature as gpt-5.4 requires. One-axis change to measure gpt-5.4's contribution to v2's baseline."
     }
   }
 }


### PR DESCRIPTION
## What

Adds **`superforcaster-polymarket-v4`** — a one-axis model swap of `superforcaster-polymarket-v2`. v2's resolution-criterion specificity prompt, Serper pipeline, output format and retry logic are kept **byte-identical**; the only axis that changes is the LLM backend: OpenAI `gpt-4.1-2025-04-14` → the **`gpt-5.4`** reasoning model (`reasoning_effort=medium`).

Based on (and targeting) the v2 branch so the diff is scoped to just the v4 additions.

## Hypothesis

v2 isolated a prompt improvement (criterion-specificity) on the gpt-4.1 baseline. v4 isolates the **model** axis on top of that same prompt: does gpt-5.4's reasoning improve calibrated Brier on Polymarket markets enough to justify ~3–5× the per-call cost? Sibling-style to v3 (which swapped v1→claude-fable-5), but built on v2's improved prompt and staying on OpenAI.

## Why the swap isn't a one-liner

`gpt-5.4` is a GPT-5-family **reasoning** model. Verified against the OpenAI model/reasoning docs and the installed SDK before coding:

- Rejects `temperature` / `top_p` / `max_tokens` (HTTP 400). → v4 sends **`max_completion_tokens`** (default 16000) and omits the rest, with a `finish_reason=="length"` **truncation guard** (reasoning tokens share the budget with the visible JSON; exhaustion would otherwise ship empty/partial JSON on-chain) and an empty-content guard so both engage the retry loop.
- Model default `reasoning.effort` is **`none`** (barely reasons). → v4 sends **`reasoning_effort="medium"`** explicitly; overridable via kwarg and validated against the effort menu.
- `tiktoken==0.12.0` has **no `gpt-5.4` mapping** (`KeyError`). → `count_tokens` falls back to `o200k_base` (the gpt-5.x / gpt-4o tokenizer).
- The pinned **`openai==1.93.0`** already accepts `max_completion_tokens` + `reasoning_effort` as kwargs, and the model id resolves server-side — **no `pyproject.toml` bump**.

## Cost

~**$0.03–0.05/call (~3–5× v2)** at `reasoning_effort=medium` (gpt-5.4 $2.50/M in, $15/M out; reasoning tokens billed as output). `high` would be ~7–12×.

## Housekeeping

- New: `packages/valory/customs/superforcaster_polymarket_v4/` (module, `__init__.py`, `component.yaml`, tests).
- `benchmark/tools.py` + `benchmark/tournament_tools.json`: register `superforcaster-polymarket-v4`.
- `packages/packages.json`: CID `bafybeig5tirlyz5iekcziqxb3fio54pjdivnzzr3i53fnqk27wmylumpvm`.
- `tool_lineage.json`: one entry, parent `superforcaster-polymarket-v2`.
- Did **not** `push-all` to IPFS or touch `agent-deployments` (human pre-merge steps).

## Checks

- 20/20 v4 unit tests pass.
- black / isort / flake8 / mypy / pylint / darglint all green.
- `autonomy packages lock --check` → verification successful.
- Trader `is_prediction_tool` predicate on v4 description + binary-predictor schema → `(True, 'schema_prediction_shape')`, same as v2.

## Note

The prompt's `Your pretraining knowledge cutoff: October 2023` line is kept byte-identical to v2, though gpt-5.4's actual cutoff is Aug 2025 — left unchanged to preserve the one-axis comparison; can revisit separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)