### PR TITLE
Fix release build: bump typing_extensions to 4.15.0 for anthropic 0.109.1

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -7,7 +7,7 @@
         "custom/napthaai/prediction_url_cot_v1/0.1.0": "bafybeife4x6syyji4jtfbg2jmxec7b2bv3z6d4lkvj6a7da5nhelrunyja",
         "custom/napthaai/resolve_market_reasoning/0.1.0": "bafybeidji6or6kpmawho64tc7qetinykhrklvv2gmnqfcd6ejmg43j3i7q",
         "custom/nickcom007/prediction_request_sme/0.1.0": "bafybeifsk4og24t22agcrj7mm6fz3wxwfbdg554yjhc6odpxal5ofg22ti",
-        "custom/valory/prediction_langchain/0.1.0": "bafybeidtixb6gkctowphterybnlxwvb6rrzj2z2wwbcfyalgfb2at3r63q",
+        "custom/valory/prediction_langchain/0.1.0": "bafybeieirig3irwmfubxjoxcujiwxxb7knl3c3amhqhjy7bxvo2tdvybpm",
         "custom/valory/prediction_request_v1/0.1.0": "bafybeifgxisrmslzwcmk4dhn5vkyygfeyhdrktxjzkmex5eyl2oiibw5ce",
         "custom/valory/prepare_tx/0.1.0": "bafybeidpvkwtn5m5yjp5mr2tn6f52btmlki32syahvkkuvlw3oq5eee3di",
         "custom/valory/resolve_market/0.1.0": "bafybeiaozazbggoglwrnfyn5v2qebyn4y4jpaxxbdodi3bd5eyieo4a55i",
@@ -24,8 +24,8 @@
         "custom/valory/superforcaster_polymarket_v2/0.1.0": "bafybeigopot226az3ida2rwlamlr2isi4i2m3nk36dtzug3w3jvnk673uy",
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
-        "agent/valory/mech_predict/0.1.0": "bafybeiekyvwdsuo5dmfd5avmahop44qt5sfn36krxwq5nvtdivaskqirdu",
-        "service/valory/mech_predict/0.1.0": "bafybeidqbdrxz5rl637ulhmbuimfftzopgo4c2vqn4az2ijbz7kz356ta4"
+        "agent/valory/mech_predict/0.1.0": "bafybeib6vgyz52zcvjce6sydak6nydqjwdvlswqhdr6c4fcqopljsfrx7q",
+        "service/valory/mech_predict/0.1.0": "bafybeigjv5fjei73hfj5uf4veaajsl2mfjl3c6gmbtiafh4kyohbm5w5nm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -58,7 +58,7 @@ customs:
 - napthaai/prediction_request_reasoning_v1:0.1.0:bafybeigpzvqh2gbcqurqaefoopqpgmqu3dpy6p36l42pvfyx2iyy2ebvka
 - valory/prepare_tx:0.1.0:bafybeidpvkwtn5m5yjp5mr2tn6f52btmlki32syahvkkuvlw3oq5eee3di
 - napthaai/prediction_url_cot_v1:0.1.0:bafybeife4x6syyji4jtfbg2jmxec7b2bv3z6d4lkvj6a7da5nhelrunyja
-- valory/prediction_langchain:0.1.0:bafybeidtixb6gkctowphterybnlxwvb6rrzj2z2wwbcfyalgfb2at3r63q
+- valory/prediction_langchain:0.1.0:bafybeieirig3irwmfubxjoxcujiwxxb7knl3c3amhqhjy7bxvo2tdvybpm
 - victorpolisetty/gemini_request:0.1.0:bafybeiamjk5mfycjqkstkzymggako2jt7yjros2zx4l54zyuei2xkj4gqu
 - victorpolisetty/dalle_request:0.1.0:bafybeiadatvfc6opcsmhpxxzmsqpwgbckblciqypx2iwe5uwove6nmki3e
 - valory/superforcaster:0.1.0:bafybeidkraklf5c6rkv6g7y7lqj2woy4j5u5dmupjez6mtjhdek3lzbmki
@@ -165,7 +165,7 @@ dependencies:
   tqdm:
     version: ==4.67.1
   typing_extensions:
-    version: ==4.12.2
+    version: ==4.15.0
 default_connection: null
 ---
 public_id: valory/websocket_client:0.1.0:bafybeiexove4oqyhoae5xmk2hilskthosov5imdp65olpgj3cfrepbouyy

--- a/packages/valory/customs/prediction_langchain/component.yaml
+++ b/packages/valory/customs/prediction_langchain/component.yaml
@@ -31,4 +31,4 @@ dependencies:
   google-api-python-client:
     version: ==2.95.0
   typing_extensions:
-    version: ==4.12.2
+    version: ==4.15.0

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeiekyvwdsuo5dmfd5avmahop44qt5sfn36krxwq5nvtdivaskqirdu
+agent: valory/mech_predict:0.1.0:bafybeib6vgyz52zcvjce6sydak6nydqjwdvlswqhdr6c4fcqopljsfrx7q
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
The [v0.21.5 Release Flow](https://github.com/valory-xyz/mech-predict/actions/runs/27541964127) failed at **Publish Docker Images → Build Images** with a pip `ResolutionImpossible`:

```
ERROR: Cannot install anthropic==0.109.1, openai==1.93.0 and typing_extensions==4.12.2
       because these package versions have conflicting dependencies.
```

## Root cause

PR #356 bumped `anthropic` to `0.109.1` (and `openai` to `1.93.0`) but left `typing_extensions==4.12.2` pinned in the two places that pin it (the agent config and the `prediction_langchain` custom). `anthropic 0.109.1` requires `typing-extensions>=4.14`, so the aggregated agent `pip install` is unsatisfiable and the Docker build exits non-zero (login/push and both deploy jobs are skipped). The `v0.21.5` tag landed on the later #362 merge, which only carried the bug forward.

## Fix

Bump the floor to `typing_extensions==4.15.0` in both pins. `4.15.0` is the only value that satisfies every constraint at once:

| Source | Constraint |
| --- | --- |
| anthropic 0.109.1 | `>=4.14,<5` (floor) |
| openai 1.93.0 | `>=4.11,<5` |
| open-autonomy 0.21.18 / 0.21.23 | `<=4.15.0,>=3.10.0.2` (ceiling) |

The `>=4.14` floor and `<=4.15.0` ceiling collapse to exactly `4.15.0` — which is also what the dev env already resolves to in `uv.lock`, so it is known-good. This is an output-preserving dependency fix (typing backport only); no tool behaviour or `p_yes` change, so `tool_lineage.json` / `tournament_tools.json` / `TOOL_REGISTRY` are untouched.

## Changed files

- `aea-config.yaml` + `prediction_langchain/component.yaml` — the two `typing_extensions` pin bumps
- `packages.json` + `service.yaml` — cascading CID bumps (`prediction_langchain` custom → agent → service) from `autonomy packages lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)