### PR TITLE
chore: trim tournament tools

### DIFF
--- a/benchmark/tournament_tools.json
+++ b/benchmark/tournament_tools.json
@@ -1,7 +1,5 @@
 {
   "factual_research-v2": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
   "superforcaster_full_search": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
-  "superforcaster_calibrated_full_search": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
-  "superforcaster-polymarket-v2": "bafybeigopot226az3ida2rwlamlr2isi4i2m3nk36dtzug3w3jvnk673uy",
-  "superforcaster-polymarket-v3": "bafybeifstfsg3h6x24wclzc3f2ci35i5sd5kpfkhk3ekcr653u5iiz4h2m"
+  "superforcaster_calibrated_full_search": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe"
 }


### PR DESCRIPTION
removed `superforcaster-polymarket-v2` as it now runs in prod
removed `superforcaster-polymarket-v3` as fable was discontinued