### PR TITLE
ci(benchmark-replay): allow valory-coding-agent bot to trigger via /benchmark comment

### DIFF
--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -38,12 +38,23 @@ jobs:
   replay:
     # For issue_comment: only run on PR comments starting with /benchmark, from authorized users
     # For workflow_dispatch: always run
+    #
+    # Authorized = a human MEMBER/OWNER/COLLABORATOR, OR the valory-coding-agent
+    # GitHub App bot. The bot is matched by its immutable numeric user id
+    # (272559038 = valory-coding-agent[bot]), NOT its login string: a login is
+    # only globally unique while the App lives, so if the App were ever deleted
+    # its slug — and thus the "valory-coding-agent[bot]" login — could be
+    # re-registered by someone else. The numeric id is never reused, so it
+    # can't be spoofed by a same-named app created later.
     if: >-
       github.event_name == 'workflow_dispatch'
       || (
         github.event.issue.pull_request
         && startsWith(github.event.comment.body, '/benchmark ')
-        && contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)
+        && (
+          contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.comment.author_association)
+          || github.event.comment.user.id == 272559038
+        )
       )
     runs-on: ubuntu-22.04
     # GitHub-hosted runner max (6h).


### PR DESCRIPTION
## Problem

The `benchmark-replay` workflow gates `issue_comment` triggers on the commenter's `author_association` being one of `MEMBER`/`OWNER`/`COLLABORATOR`. GitHub App bots have `author_association: NONE`, so a `/benchmark ...` comment from `valory-coding-agent[bot]` creates a workflow run that is **immediately skipped** by the job's `if:` guard.

Observed on PR #367: comment at `05:19:08Z` → run `27667564518` (event `issue_comment`) → conclusion `skipped`. Every recent bot-comment-triggered run shows the same `skipped` outcome.

## Fix

Add the `valory-coding-agent` bot to the authorized set, matched by its **immutable numeric user id (`272559038`)** rather than its login string.

Why the numeric id and not `user.login == 'valory-coding-agent[bot]'`:
- A GitHub App slug (and therefore its `<slug>[bot]` login) is globally unique only **while the App exists**. If the App were ever deleted, the slug could be re-registered by anyone, who would then inherit the same login.
- The numeric user id is **never reused**, so a same-named app created later cannot match.
- A bot also still needs to be installed on the repo to comment at all, so this does not widen the attack surface.

The human allowlist (`MEMBER`/`OWNER`/`COLLABORATOR`) is unchanged. The existing downstream injection defenses (env-passed comment body, whitelist regex on tool/candidate/platform names) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
