### PR TITLE
feat(superforcaster-polymarket-v4): anchor forecast on market-implied prior

### DIFF
--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -131,6 +131,166 @@ def compute_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
     return overall
 
 
+def compute_market_diagnostics(
+    baseline_rows: list[dict[str, Any]],
+    candidate_rows: list[dict[str, Any]],
+) -> Optional[dict[str, Any]]:
+    """Market-anchor diagnostics: blend benchmark and surrendered-edge counts.
+
+    Headline Brier hides two things a market-anchored candidate can do. A
+    candidate that merely shrinks the baseline
+    toward a well-calibrated market price almost always improves average Brier,
+    so the question is whether it beats the mechanical 50/50 blend of baseline
+    and market — and whether the Brier gain is bought by giving up the rows
+    where the baseline *disagreed* with the market and was *right* (the edge a
+    trader actually monetises).
+
+    Rows are paired by position: ``prompt_replay.replay`` writes one baseline
+    and one candidate row per sampled delivery, in lockstep, so index *i* is the
+    same market on both sides. A row contributes only when it carries a
+    ``market_prob`` and the relevant ``p_yes`` values — runs without recorded
+    market prices (e.g. Omen) yield None and the report omits the block.
+
+    :param baseline_rows: baseline.jsonl rows (production v1 predictions).
+    :param candidate_rows: candidate.jsonl rows (PR predictions).
+    :return: diagnostics dict, or None when no row carries a market price.
+    """
+    n = min(len(baseline_rows), len(candidate_rows))
+
+    # Blend arm: baseline, candidate, and 0.5*baseline+0.5*market Briers over
+    # the rows where all three are defined (candidate must have parsed).
+    blend_base_sum = blend_cand_sum = blend_sum = 0.0
+    n_blend = 0
+
+    # Edge arm: rows where the baseline's directional call disagreed with the
+    # market's and the baseline was right.
+    n_disagree_right = 0  # size of the edge subset (baseline always valid)
+    n_edge_scored = 0  # subset rows where the candidate also parsed
+    n_edge_lost = 0  # ...of those, candidate no longer directionally correct
+    edge_base_sum = edge_cand_sum = 0.0
+
+    saw_market = False
+    for i in range(n):
+        b, c = baseline_rows[i], candidate_rows[i]
+        market = b.get("market_prob")
+        if market is None:
+            market = c.get("market_prob")
+        if market is None:
+            continue
+        saw_market = True
+
+        base_p = b.get("p_yes")
+        outcome = b.get("final_outcome")
+        if base_p is None or outcome is None:
+            continue
+        outcome_val = 1.0 if outcome else 0.0
+        cand_p = c.get("p_yes")
+
+        if cand_p is not None:
+            blend_p = 0.5 * base_p + 0.5 * market
+            blend_base_sum += (base_p - outcome_val) ** 2
+            blend_cand_sum += (cand_p - outcome_val) ** 2
+            blend_sum += (blend_p - outcome_val) ** 2
+            n_blend += 1
+
+        # Directional disagreement; ties at exactly 0.5 carry no direction.
+        if base_p == 0.5 or market == 0.5:
+            continue
+        base_yes = base_p > 0.5
+        market_yes = market > 0.5
+        if base_yes != market_yes and base_yes == bool(outcome):
+            n_disagree_right += 1
+            edge_base_sum += (base_p - outcome_val) ** 2
+            if cand_p is not None:
+                n_edge_scored += 1
+                edge_cand_sum += (cand_p - outcome_val) ** 2
+                # "Gave up the edge" = candidate is no longer on the winning
+                # side (flipped to the market's losing call, or went neutral).
+                if not (cand_p != 0.5 and (cand_p > 0.5) == bool(outcome)):
+                    n_edge_lost += 1
+
+    if not saw_market:
+        return None
+
+    return {
+        "blend": {
+            "n": n_blend,
+            "baseline_brier": (blend_base_sum / n_blend) if n_blend else None,
+            "blend_brier": (blend_sum / n_blend) if n_blend else None,
+            "candidate_brier": (blend_cand_sum / n_blend) if n_blend else None,
+        },
+        "edge": {
+            "n_disagree_right": n_disagree_right,
+            "n_scored": n_edge_scored,
+            "n_lost": n_edge_lost,
+            "lost_rate": (n_edge_lost / n_edge_scored) if n_edge_scored else None,
+            "baseline_brier": (
+                (edge_base_sum / n_disagree_right) if n_disagree_right else None
+            ),
+            "candidate_brier": (
+                (edge_cand_sum / n_edge_scored) if n_edge_scored else None
+            ),
+        },
+    }
+
+
+def _format_market_diagnostics_block(diag: dict[str, Any]) -> list[str]:
+    """Render the market-anchor diagnostics as markdown lines.
+
+    :param diag: dict from :func:`compute_market_diagnostics`.
+    :return: markdown lines (empty when there is nothing to report).
+    """
+    blend = diag["blend"]
+    edge = diag["edge"]
+    lines: list[str] = ["**Market-anchor diagnostics**", ""]
+
+    # Diagnostic 1 — beat-vs-blend.
+    if blend["n"]:
+        b = blend["baseline_brier"]
+        mix = blend["blend_brier"]
+        cand = blend["candidate_brier"]
+        # Beats the blend only if strictly lower Brier than the mechanical mix.
+        verdict = (
+            "✅ candidate beats the blend"
+            if cand < mix
+            else "⚠️ candidate does **not** beat the blend (gain is ~mechanical)"
+        )
+        lines += [
+            f"- Beat-vs-blend (n={blend['n']}): "
+            f"baseline {b:.4f} · 50/50 blend {mix:.4f} · candidate {cand:.4f} "
+            f"→ {verdict}",
+            "  - Blend = 0.5·baseline + 0.5·market. If the candidate can't beat "
+            "it, the Brier gain is just ensembling toward a calibrated market.",
+        ]
+    else:
+        lines.append("- Beat-vs-blend: no rows with market price + candidate.")
+
+    # Diagnostic 2 — edge given up.
+    if edge["n_disagree_right"]:
+        nlost = edge["n_lost"]
+        nsc = edge["n_scored"]
+        rate = edge["lost_rate"]
+        eb = edge["baseline_brier"]
+        ec = edge["candidate_brier"]
+        rate_str = f"{rate * 100:.0f}%" if rate is not None else "N/A"
+        ec_str = f"{ec:.4f}" if ec is not None else "N/A"
+        lines += [
+            f"- Edge given up (n={edge['n_disagree_right']}): on rows where "
+            f"baseline disagreed with the market and was **right**, the "
+            f"candidate surrendered {nlost}/{nsc} ({rate_str}).",
+            f"  - Brier on that subset: baseline {eb:.4f} → candidate {ec_str} "
+            "(higher = edge traded away for the headline gain).",
+        ]
+    else:
+        lines.append(
+            "- Edge given up: no rows where baseline correctly disagreed with "
+            "the market (nothing to surrender)."
+        )
+
+    lines.append("")
+    return lines
+
+
 def _fmt_delta(
     baseline_val: float | None,
     candidate_val: float | None,
@@ -321,6 +481,7 @@ def format_report(
     meta: dict[str, str],
     failure_rows: list[dict[str, Any]] | None = None,
     filter_stats: Optional[dict[str, Any]] = None,
+    market_diagnostics: Optional[dict[str, Any]] = None,
 ) -> str:
     """Format the full benchmark report as markdown.
 
@@ -333,6 +494,9 @@ def format_report(
     :param filter_stats: optional ``{accepted, rejected}`` dict from
         filter_stats.json sidecar. When present, a Production parse rate line
         is rendered showing how many in-scope production deliveries parsed.
+    :param market_diagnostics: optional dict from compute_market_diagnostics.
+        When present (runs whose rows carry a market price), the beat-vs-blend
+        and edge-given-up block is rendered.
     :return: markdown string.
     """
     tool = meta.get("tool", "unknown")
@@ -355,6 +519,9 @@ def format_report(
         "",
     ]
     parts.extend(_format_reliability_block(candidate, failure_rows or [], filter_stats))
+
+    if market_diagnostics is not None:
+        parts.extend(_format_market_diagnostics_block(market_diagnostics))
 
     if len(all_platforms) > 1:
         detail_lines = ["<details><summary>Per-platform breakdown</summary>", ""]
@@ -505,6 +672,7 @@ def main() -> None:
 
     baseline_metrics = compute_metrics(baseline_rows)
     candidate_metrics = compute_metrics(candidate_rows)
+    market_diagnostics = compute_market_diagnostics(baseline_rows, candidate_rows)
 
     # Infer tool from data
     tool = baseline_rows[0].get("tool_name", "unknown")
@@ -522,6 +690,7 @@ def main() -> None:
         meta,
         failure_rows=failure_rows,
         filter_stats=filter_stats,
+        market_diagnostics=market_diagnostics,
     )
 
     # Always print to stdout

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -1594,10 +1594,25 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
                         ADDITIONAL_INFORMATION=row["extracted_additional_information"],
                     )
                 elif is_superforcaster:
+                    # Variants that anchor on the market price (e.g.
+                    # superforcaster-polymarket-v4) expose format_market_prior
+                    # and carry a {market_prior} placeholder; render the block
+                    # from the row's recorded price. Variants without the
+                    # placeholder (v1/v2/v3) ignore the extra kwarg, so this is
+                    # a no-op for them.
+                    format_prior = getattr(
+                        candidate_module, "format_market_prior", None
+                    )
+                    market_prior = (
+                        format_prior(row.get("market_prob_at_prediction"))
+                        if callable(format_prior)
+                        else ""
+                    )
                     formatted_prompt = PREDICTION_PROMPT.format(
                         question=row["extracted_user_prompt"],
                         today=row.get("extracted_today", ""),
                         sources=row["extracted_additional_information"],
+                        market_prior=market_prior,
                     )
                 elif is_factual_research:
                     formatted_prompt = PREDICTION_PROMPT.format(

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -1556,6 +1556,10 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
                 "p_no": row["p_no"],
                 "prediction_parse_status": "valid",
                 "confidence": row.get("confidence"),
+                # Carry the recorded market price through so ci_replay can run
+                # the market-anchor diagnostics (blend / edge-given-up). None on
+                # rows that never had one (e.g. Omen); diagnostics skip those.
+                "market_prob": row.get("market_prob_at_prediction"),
                 "final_outcome": outcome,
                 "predicted_at": row.get("predicted_at", now),
                 "resolved_at": row.get("resolved_at"),
@@ -1664,6 +1668,9 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
                 "p_no": parsed["p_no"],
                 "prediction_parse_status": parsed["prediction_parse_status"],
                 "confidence": parsed.get("confidence"),
+                # Same recorded market price as the paired baseline row; lets
+                # ci_replay pair by index and run the market-anchor diagnostics.
+                "market_prob": row.get("market_prob_at_prediction"),
                 "final_outcome": outcome,
                 "predicted_at": now,
                 "resolved_at": row.get("resolved_at"),

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -9,8 +9,10 @@ from pathlib import Path
 from benchmark.ci_replay import (
     PARSE_STATUS_BUCKETS,
     _compute_parse_reliability,
+    _format_market_diagnostics_block,
     _format_reliability_block,
     _load_filter_stats,
+    compute_market_diagnostics,
     compute_metrics,
     format_report,
 )
@@ -436,3 +438,164 @@ class TestFormatReportFooter:
         footer = report.splitlines()[-1]
         assert footer.index("deliveries") < footer.index("seed 1337")
         assert footer.index("seed 1337") < footer.index("LOCKhart07")
+
+
+def _pair(
+    base_p: float | None,
+    cand_p: float | None,
+    market: float | None,
+    outcome: bool,
+) -> tuple[dict, dict]:
+    """Build a paired (baseline_row, candidate_row) for diagnostics tests."""
+    base = {
+        "platform": "polymarket",
+        "tool_name": "superforcaster-polymarket-v1",
+        "p_yes": base_p,
+        "p_no": None if base_p is None else 1 - base_p,
+        "prediction_parse_status": "valid",
+        "market_prob": market,
+        "final_outcome": outcome,
+    }
+    cand = {
+        "platform": "polymarket",
+        "tool_name": "superforcaster-polymarket-v1",
+        "p_yes": cand_p,
+        "p_no": None if cand_p is None else 1 - cand_p,
+        "prediction_parse_status": "valid" if cand_p is not None else "malformed",
+        "market_prob": market,
+        "final_outcome": outcome,
+    }
+    return base, cand
+
+
+def _diag(b_rows: list[dict], c_rows: list[dict]) -> dict:
+    """compute_market_diagnostics with a non-None assertion (mypy narrowing)."""
+    result = compute_market_diagnostics(b_rows, c_rows)
+    assert result is not None
+    return result
+
+
+class TestMarketDiagnostics:
+    """`compute_market_diagnostics` — blend arm and edge-given-up arm."""
+
+    def test_none_when_no_market_price(self) -> None:
+        """Rows without any market_prob yield None (block is omitted)."""
+        b, c = _pair(0.6, 0.5, None, True)
+        assert compute_market_diagnostics([b], [c]) is None
+
+    def test_blend_briers_hand_computed(self) -> None:
+        """Baseline/blend/candidate Briers match a hand calculation."""
+        # base=0.2, market=0.6 -> blend=0.4; outcome=YES(1).
+        b, c = _pair(0.2, 0.5, 0.6, True)
+        diag = compute_market_diagnostics([b], [c])
+        assert diag is not None
+        blend = diag["blend"]
+        assert blend["n"] == 1
+        assert abs(blend["baseline_brier"] - 0.64) < 1e-9  # (0.2-1)^2
+        assert abs(blend["blend_brier"] - 0.36) < 1e-9  # (0.4-1)^2
+        assert abs(blend["candidate_brier"] - 0.25) < 1e-9  # (0.5-1)^2
+
+    def test_candidate_parse_fail_excluded_from_blend(self) -> None:
+        """A candidate with p_yes=None contributes nothing to the blend arm."""
+        b, c = _pair(0.2, None, 0.6, True)
+        diag = compute_market_diagnostics([b], [c])
+        assert diag is not None
+        assert diag["blend"]["n"] == 0
+        assert diag["blend"]["candidate_brier"] is None
+
+    def test_edge_subset_lost(self) -> None:
+        """Baseline right vs market, candidate flips to wrong -> edge lost."""
+        # base=0.7 (YES, right), market=0.3 (NO), outcome=YES; cand=0.4 (NO).
+        b, c = _pair(0.7, 0.4, 0.3, True)
+        edge = _diag([b], [c])["edge"]
+        assert edge["n_disagree_right"] == 1
+        assert edge["n_scored"] == 1
+        assert edge["n_lost"] == 1
+        assert edge["lost_rate"] == 1.0
+        assert abs(edge["baseline_brier"] - 0.09) < 1e-9  # (0.7-1)^2
+        assert abs(edge["candidate_brier"] - 0.36) < 1e-9  # (0.4-1)^2
+
+    def test_edge_subset_kept(self) -> None:
+        """Candidate that stays on the winning side does not lose the edge."""
+        # base=0.7 right vs market 0.3; cand=0.8 still YES -> kept.
+        b, c = _pair(0.7, 0.8, 0.3, True)
+        edge = _diag([b], [c])["edge"]
+        assert edge["n_disagree_right"] == 1
+        assert edge["n_lost"] == 0
+        assert edge["lost_rate"] == 0.0
+
+    def test_baseline_wrong_disagreement_not_in_edge_subset(self) -> None:
+        """Disagreement where the baseline was wrong is not edge to give up."""
+        # base=0.7 (YES) vs market 0.3 (NO), but outcome=NO -> baseline wrong.
+        b, c = _pair(0.7, 0.4, 0.3, False)
+        edge = _diag([b], [c])["edge"]
+        assert edge["n_disagree_right"] == 0
+
+    def test_agreement_not_in_edge_subset(self) -> None:
+        """When baseline agrees with the market, there is no edge to give up."""
+        # base=0.7 and market=0.6 both YES -> agreement.
+        b, c = _pair(0.7, 0.4, 0.6, True)
+        edge = _diag([b], [c])["edge"]
+        assert edge["n_disagree_right"] == 0
+
+    def test_tie_excluded_from_edge_subset(self) -> None:
+        """A baseline or market at exactly 0.5 carries no direction."""
+        b, c = _pair(0.5, 0.4, 0.3, True)
+        assert _diag([b], [c])["edge"]["n_disagree_right"] == 0
+        b2, c2 = _pair(0.7, 0.4, 0.5, True)
+        assert _diag([b2], [c2])["edge"]["n_disagree_right"] == 0
+
+    def test_rows_paired_by_index(self) -> None:
+        """Index i on both sides is the same market; mixed rows aggregate."""
+        rows = [
+            _pair(0.2, 0.5, 0.6, True),  # blend row
+            _pair(0.7, 0.4, 0.3, True),  # edge-lost row
+        ]
+        b_rows = [b for b, _ in rows]
+        c_rows = [c for _, c in rows]
+        diag = _diag(b_rows, c_rows)
+        assert diag["blend"]["n"] == 2
+        assert diag["edge"]["n_disagree_right"] == 1
+        assert diag["edge"]["n_lost"] == 1
+
+
+class TestMarketDiagnosticsRendering:
+    """`_format_market_diagnostics_block` verdict text reflects the numbers."""
+
+    def test_beats_blend_marked(self) -> None:
+        """Candidate Brier below the blend renders the ✅ beats verdict."""
+        b, c = _pair(0.2, 0.5, 0.6, True)  # candidate 0.25 < blend 0.36
+        block = "\n".join(_format_market_diagnostics_block(_diag([b], [c])))
+        assert "✅" in block and "beats the blend" in block
+
+    def test_does_not_beat_blend_marked(self) -> None:
+        """Candidate Brier above the blend renders the ⚠️ warning."""
+        # base=0.2, market=0.6 -> blend 0.36; cand=0.1 -> (0.1-1)^2=0.81 > blend.
+        b, c = _pair(0.2, 0.1, 0.6, True)
+        block = "\n".join(_format_market_diagnostics_block(_diag([b], [c])))
+        assert "⚠️" in block and "does **not** beat" in block
+
+    def test_edge_lost_count_rendered(self) -> None:
+        """The edge-given-up line shows the surrendered count."""
+        b, c = _pair(0.7, 0.4, 0.3, True)
+        block = "\n".join(_format_market_diagnostics_block(_diag([b], [c])))
+        assert "Edge given up" in block and "1/1" in block
+
+    def test_no_edge_rows_message(self) -> None:
+        """With no correct-disagreement rows, the 'nothing to surrender' note shows."""
+        b, c = _pair(0.7, 0.4, 0.6, True)  # agreement, so empty edge subset
+        block = "\n".join(_format_market_diagnostics_block(_diag([b], [c])))
+        assert "nothing to surrender" in block
+
+    def test_block_present_in_full_report(self) -> None:
+        """format_report includes the block only when diagnostics are passed."""
+        b, c = _pair(0.2, 0.5, 0.6, True)
+        diag = compute_market_diagnostics([b], [c])
+        base_m = compute_metrics([b])
+        cand_m = compute_metrics([c])
+        with_block = format_report(
+            base_m, cand_m, {"tool": "t"}, market_diagnostics=diag
+        )
+        without = format_report(base_m, cand_m, {"tool": "t"})
+        assert "Market-anchor diagnostics" in with_block
+        assert "Market-anchor diagnostics" not in without

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -809,7 +809,15 @@ _FAMILY_TEMPLATES = {
     ],
     "rag": [("PREDICTION_PROMPT", {"USER_PROMPT": "q", "ADDITIONAL_INFORMATION": "a"})],
     "superforcaster": [
-        ("PREDICTION_PROMPT", {"question": "q", "today": "t", "sources": "s"}),
+        # ``market_prior`` is required by superforcaster-polymarket-v4 (the
+        # market-price anchor block, filled by the replay path via the module's
+        # format_market_prior) and tolerated as an unused placeholder by v1/v2/v3,
+        # so one fixture covers all four — mirroring how the replay path passes
+        # market_prior= to every superforcaster tool.
+        (
+            "PREDICTION_PROMPT",
+            {"question": "q", "today": "t", "sources": "s", "market_prior": "m"},
+        ),
     ],
     "factual_research": [
         # ``resolution_rules`` is required by factual_research-v2 (Polymarket

--- a/benchmark/tools.py
+++ b/benchmark/tools.py
@@ -100,6 +100,18 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         ),
         family="superforcaster",
     ),
+    # valory/superforcaster_polymarket_v4 — variant of v1 that anchors the
+    # forecast on the market-implied probability as an explicit prior. Same
+    # superforcaster PREDICTION_PROMPT schema/family as its parent; the replay
+    # path fills the {market_prior} placeholder via the module's
+    # format_market_prior helper.
+    "superforcaster-polymarket-v4": ToolSpec(
+        module=(
+            "packages.valory.customs.superforcaster_polymarket_v4"
+            ".superforcaster_polymarket_v4"
+        ),
+        family="superforcaster",
+    ),
     # napthaai/prediction_request_reasoning_v1
     "prediction-request-reasoning-v1": ToolSpec(
         module="packages.napthaai.customs.prediction_request_reasoning_v1.prediction_request_reasoning_v1",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -22,6 +22,7 @@
         "custom/valory/superforcaster_polymarket_v3/0.1.0": "bafybeiblm5te562opborjns6jngeqzgldklzegsm7csfgpzdps7y4mfpnu",
         "custom/valory/factual_research_v1/0.1.0": "bafybeicg52wve2ytam3eisks7gumvrswm2v6bkuafburdlmh6d553nrvee",
         "custom/valory/superforcaster_polymarket_v2/0.1.0": "bafybeigopot226az3ida2rwlamlr2isi4i2m3nk36dtzug3w3jvnk673uy",
+        "custom/valory/superforcaster_polymarket_v4/0.1.0": "bafybeifhfwxqisgduutyyiuxdlicm3tuil3yb2pkzabnhehprx32qbl2lq",
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
         "agent/valory/mech_predict/0.1.0": "bafybeib6vgyz52zcvjce6sydak6nydqjwdvlswqhdr6c4fcqopljsfrx7q",

--- a/packages/valory/customs/superforcaster_polymarket_v4/__init__.py
+++ b/packages/valory/customs/superforcaster_polymarket_v4/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the Superforcaster tool."""

--- a/packages/valory/customs/superforcaster_polymarket_v4/component.yaml
+++ b/packages/valory/customs/superforcaster_polymarket_v4/component.yaml
@@ -1,0 +1,28 @@
+name: superforcaster_polymarket_v4
+author: valory
+version: 0.1.0
+type: custom
+description: A tool for making binary predictions on markets. Variant of superforcaster-polymarket-v1
+  that anchors the forecast on the market-implied probability (passed alongside the
+  request) as an explicit base rate / prior, using the Serper API and LLMs.
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  __init__.py: bafybeidr6ok7hgnywgtlggdajgklohlpaxnxmvpo2wn5fayq7fhzrr2sli
+  superforcaster_polymarket_v4.py: bafybeid5qxwggjl4d5egeqm3qjlmku5ws4amzogzkybwkopl67kn77zy7q
+  tests/__init__.py: bafybeidegv7yfxpdytmvepvcqquzawanqjczrqdp2cesxxdx5vvdfmdgue
+  tests/test_superforcaster.py: bafybeifdeiw6f54nldkkt3hgdyda4sth3kpukpfxlsmdy4xjtyjgxz3bti
+fingerprint_ignore_patterns: []
+entry_point: superforcaster_polymarket_v4.py
+callable: run
+params:
+  default_model: gpt-4.1-2025-04-14
+dependencies:
+  openai:
+    version: ==1.93.0
+  httpx:
+    version: ==0.25.2
+  tiktoken:
+    version: ==0.12.0
+  requests:
+    version: ==2.32.5

--- a/packages/valory/customs/superforcaster_polymarket_v4/superforcaster_polymarket_v4.py
+++ b/packages/valory/customs/superforcaster_polymarket_v4/superforcaster_polymarket_v4.py
@@ -1,0 +1,523 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Contains the job definitions"""
+
+import functools
+import json
+import re
+import time
+from datetime import date
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import openai
+import requests
+from tiktoken import encoding_for_model
+
+MechResponseWithKeys = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]], Any
+]
+MechResponse = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]]
+]
+MaxCostResponse = float
+
+N_MODEL_CALLS = 1
+DEFAULT_DELIVERY_RATE = 100
+
+
+def with_key_rotation(func: Callable) -> Callable:
+    """
+    Decorator that retries a function with API key rotation on failure.
+
+    :param func: The function to be decorated.
+    :type func: Callable
+    :returns: Callable -- the wrapped function that handles retries with key rotation.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> MechResponseWithKeys:
+        # this is expected to be a KeyChain object,
+        # although it is not explicitly typed as such
+        api_keys = kwargs["api_keys"]
+        retries_left: Dict[str, int] = api_keys.max_retries()
+
+        def execute() -> MechResponseWithKeys:
+            """Retry the function with a new key."""
+            try:
+                result: MechResponse = func(*args, **kwargs)
+                return result + (api_keys,)
+            except openai.RateLimitError as e:
+                # try with a new key again
+                if retries_left["openai"] <= 0 and retries_left["openrouter"] <= 0:
+                    raise e
+                retries_left["openai"] -= 1
+                retries_left["openrouter"] -= 1
+                api_keys.rotate("openai")
+                api_keys.rotate("openrouter")
+                return execute()
+            except Exception as e:
+                return str(e), "", None, None, None, api_keys
+
+        mech_response = execute()
+        return mech_response
+
+    return wrapper
+
+
+class OpenAIClientManager:
+    """Client context manager for OpenAI."""
+
+    def __init__(self, api_key: str):
+        """Initializes with API keys"""
+        self.api_key = api_key
+        self._client: Optional["OpenAIClient"] = None
+
+    def __enter__(self) -> "OpenAIClient":
+        """Initializes and returns LLM client."""
+        self._client = OpenAIClient(api_key=self.api_key)
+        return self._client
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Closes the LLM client"""
+        if self._client is not None:
+            self._client.client.close()
+            self._client = None
+
+
+class Usage:
+    """Usage class."""
+
+    def __init__(
+        self,
+        prompt_tokens: Optional[Any] = None,
+        completion_tokens: Optional[Any] = None,
+    ):
+        """Initializes with prompt tokens and completion tokens."""
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+
+class OpenAIResponse:
+    """Response class."""
+
+    def __init__(self, content: Optional[str] = None, usage: Optional[Usage] = None):
+        """Initializes with content and usage class."""
+        self.content = content
+        self.usage = Usage()
+
+
+class OpenAIClient:
+    """OpenAI Client"""
+
+    def __init__(self, api_key: str):
+        """Initializes with API keys and client."""
+        self.api_key = api_key
+        self.client = openai.OpenAI(api_key=self.api_key)
+
+    def completions(
+        self,
+        model: str,
+        messages: List = [],  # noqa: B006
+        timeout: Optional[Union[float, int]] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        n: Optional[int] = None,
+        stop: Any = None,
+        max_tokens: Optional[float] = None,
+    ) -> Optional[OpenAIResponse]:
+        """Generate a completion from the specified LLM provider using the given model and messages."""
+        response_provider = self.client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            n=1,
+            timeout=150,
+            stop=None,
+        )
+        response = OpenAIResponse()
+        response.content = response_provider.choices[0].message.content
+        response.usage.prompt_tokens = response_provider.usage.prompt_tokens
+        response.usage.completion_tokens = response_provider.usage.completion_tokens
+        return response
+
+
+def count_tokens(text: str, model: str) -> int:
+    """Count the number of tokens in a text."""
+    enc = encoding_for_model(model)
+    return len(enc.encode(text))
+
+
+DEFAULT_OPENAI_SETTINGS = {
+    "max_tokens": 500,
+    "limit_max_tokens": 4096,
+    "temperature": 0,
+}
+DEFAULT_OPENAI_MODEL = "gpt-4.1-2025-04-14"
+ALLOWED_TOOLS = ["superforcaster-polymarket-v4"]
+ALLOWED_MODELS = [DEFAULT_OPENAI_MODEL]
+MAX_SOURCES = 5
+COMPLETION_RETRIES = 3
+COMPLETION_DELAY = 2
+
+# Keys under which the market-implied probability may arrive, checked both at the
+# top level of kwargs and inside a request_context dict. The trader does not pass
+# this today (prediction tools deliberately never see odds) — this variant is an
+# experiment that anchors on it when supplied, and degrades to v1 behaviour when
+# it is absent.
+MARKET_PROB_KEYS = ("market_prob", "market_prob_at_prediction", "current_prob")
+
+# Soft-anchor instruction injected into the prompt when a market price is known.
+# `{market_prob}` is filled with the decimal YES probability (e.g. 0.62).
+MARKET_PRIOR_INSTRUCTION = (
+    "The current market-implied probability that the answer is YES is "
+    "{market_prob}. This price aggregates the views of other informed "
+    "participants — treat it as your base rate / prior. Anchor on it, and "
+    "deviate only to the extent your case-specific evidence justifies, "
+    "explaining the deviation."
+)
+
+
+def _extract_market_prob(kwargs: Dict[str, Any]) -> Optional[Any]:
+    """Pull the market-implied YES probability from kwargs, if present.
+
+    Looks at the top-level kwargs and inside a ``request_context`` dict, under
+    any of :data:`MARKET_PROB_KEYS`. Returns the first non-None hit, or None.
+
+    :param kwargs: the run() keyword arguments.
+    :return: the raw market probability value, or None when not supplied.
+    """
+    candidate_sources: List[Dict[str, Any]] = [kwargs]
+    request_context = kwargs.get("request_context")
+    if isinstance(request_context, dict):
+        candidate_sources.append(request_context)
+    for source in candidate_sources:
+        for key in MARKET_PROB_KEYS:
+            value = source.get(key)
+            if value is not None:
+                return value
+    return None
+
+
+def format_market_prior(market_prob: Optional[Any]) -> str:
+    """Render the market-prior anchor block, or "" when there is no valid price.
+
+    A valid price is a number in [0, 1]. The returned block carries its own
+    trailing blank line so it slots into the prompt template cleanly; an absent
+    or out-of-range price yields "", collapsing the variant to v1's prompt.
+
+    Also called by the benchmark replay path (``benchmark/prompt_replay.py``) so
+    the injected text has a single source of truth.
+
+    :param market_prob: the market-implied YES probability (any numeric-ish).
+    :return: the formatted anchor block, or an empty string.
+    """
+    try:
+        prob = float(market_prob)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return ""
+    if not 0.0 <= prob <= 1.0:
+        return ""
+    return MARKET_PRIOR_INSTRUCTION.format(market_prob=str(round(prob, 4))) + "\n\n"
+
+
+PREDICTION_PROMPT = """
+You are an advanced AI system which has been finetuned to provide calibrated probabilistic
+forecasts under uncertainty, with your performance evaluated according to the Brier score. When
+forecasting, do not treat 0.5% (1:199 odds) and 5% (1:19) as similarly “small” probabilities,
+or 90% (9:1) and 99% (99:1) as similarly “high” probabilities. As the odds show, they are
+markedly different, so output your probabilities accordingly.
+
+Question:
+{question}
+
+Today's date: {today}
+Your pretraining knowledge cutoff: October 2023
+
+{market_prior}We have retrieved the following information for this question:
+<background>{sources}</background>
+
+Recall the question you are forecasting:
+{question}
+
+Instructions:
+1. Compress key factual information from the sources, as well as useful background information
+which may not be in the sources, into a list of core factual points to reference. Aim for
+information which is specific, relevant, and covers the core considerations you'll use to make
+your forecast. For this step, do not draw any conclusions about how a fact will influence your
+answer or forecast. Place this section of your response in <facts></facts> tags.
+
+2. Provide a few reasons why the answer might be no. Rate the strength of each reason on a
+scale of 1-10. Use <no></no> tags.
+
+3. Provide a few reasons why the answer might be yes. Rate the strength of each reason on a
+scale of 1-10. Use <yes></yes> tags.
+
+4. Aggregate your considerations. Do not summarize or repeat previous points; instead,
+investigate how the competing factors and mechanisms interact and weigh against each other.
+Factorize your thinking across (exhaustive, mutually exclusive) cases if and only if it would be
+beneficial to your reasoning. We have detected that you overestimate world conflict, drama,
+violence, and crises due to news' negativity bias, which doesn't necessarily represent overall
+trends or base rates. Similarly, we also have detected you overestimate dramatic, shocking,
+or emotionally charged news due to news' sensationalism bias. Therefore adjust for news'
+negativity bias and sensationalism bias by considering reasons to why your provided sources
+might be biased or exaggerated. Think like a superforecaster. Use <thinking></thinking> tags
+for this section of your response.
+
+5. Output an initial probability (prediction) as a single number between 0 and 1 given steps 1-4.
+Use <tentative></tentative> tags.
+
+6. Reflect on your answer, performing sanity checks and mentioning any additional knowledge
+or background information which may be relevant. Check for over/underconfidence, improper
+treatment of conjunctive or disjunctive conditions (only if applicable), and other forecasting
+biases when reviewing your reasoning. Consider priors/base rates (including the market-implied
+prior provided above, when available), and the extent to which case-specific information
+justifies the deviation between your tentative forecast and that prior.
+Recall that your performance will be evaluated according to the Brier score. Be precise with tail
+probabilities. Leverage your intuitions, but never change your forecast for the sake of modesty
+or balance alone. Finally, aggregate all of your previous reasoning and highlight key factors
+that inform your final forecast. Use <thinking></thinking> tags for this portion of your response.
+
+7. Output your final prediction (a number between 0 and 1 with an asterisk at the beginning and
+end of the decimal) in <answer></answer> tags.
+
+
+OUTPUT_FORMAT
+* Your output response must be only a single JSON object to be parsed by Python's "json.loads()".
+* The JSON must contain four fields: "p_yes", "p_no", "confidence", and "info_utility".
+* Each item in the JSON must have a value between 0 and 1.
+   - "p_yes": Estimated probability that the event in the "Question" occurs.
+   - "p_no": Estimated probability that the event in the "Question" does not occur.
+   - "confidence": A value between 0 and 1 indicating the confidence in the prediction. 0 indicates lowest
+     confidence value; 1 maximum confidence value.
+   - "info_utility": Utility of the information provided in "sources" to help you make the prediction.
+     0 indicates lowest utility; 1 maximum utility.
+* The sum of "p_yes" and "p_no" must equal 1.
+* Output only the JSON object. Do not include any other contents in your response.
+* This is incorrect:"```json{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}```"
+* This is incorrect:```json"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"```
+* This is correct:"{{\n  \"p_yes\": 0.2,\n  \"p_no\": 0.8,\n  \"confidence\": 0.7,\n  \"info_utility\": 0.5\n}}"
+"""
+
+
+def generate_prediction_with_retry(
+    client: "OpenAIClient",
+    model: str,
+    messages: List[Dict[str, str]],
+    temperature: float,
+    max_tokens: int,
+    retries: int = COMPLETION_RETRIES,
+    delay: int = COMPLETION_DELAY,
+    counter_callback: Optional[Callable] = None,
+) -> Tuple[Any, Optional[Callable]]:
+    """Attempt to generate a prediction with retries on failure."""
+    attempt = 0
+    while attempt < retries:
+        try:
+            response = client.completions(
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                n=1,
+                timeout=90,
+                stop=None,
+            )
+
+            if (
+                response
+                and response.content is not None
+                and counter_callback is not None
+            ):
+                counter_callback(
+                    input_tokens=response.usage.prompt_tokens,
+                    output_tokens=response.usage.completion_tokens,
+                    model=model,
+                    token_counter=count_tokens,
+                )
+
+            content = response.content if response else None
+            return content, counter_callback
+        except Exception as e:
+            print(f"Attempt {attempt + 1} failed with error: {e}")
+            time.sleep(delay)
+            attempt += 1
+    raise Exception("Failed to generate prediction after retries")
+
+
+def fetch_additional_sources(question: Any, serper_api_key: Any) -> requests.Response:
+    """Fetches additional sources for the given question using the Serper API."""
+    url = "https://google.serper.dev/search"
+    payload = json.dumps({"q": question})
+    headers = {
+        "X-API-KEY": serper_api_key,
+        "Content-Type": "application/json",
+    }
+
+    response = requests.request("POST", url, headers=headers, data=payload)
+
+    return response
+
+
+def format_sources_data(organic_data: Any, misc_data: Any) -> str:
+    """Formats organic search results and "People Also Ask" data into a human-readable string."""
+    sources = ""
+
+    if len(organic_data) > 0:
+        print("Adding organic data...")
+
+        sources = """
+        Organic Results:
+        """
+
+        for item in organic_data:
+            sources += f"""{item.get('position', 'N/A')}. **Title:** {item.get("title", 'N/A')}
+            - **Link:** [{item.get("link", '#')}]({item.get("link", '#')})
+            - **Snippet:** {item.get("snippet", 'N/A')}
+            """
+
+    if len(misc_data) > 0:
+        print("Adding misc data...")
+
+        sources += "People Also Ask:\n"
+
+        counter = 1
+        for item in misc_data:
+            sources += f"""{counter}. **Question:** {item.get("question", 'N/A')}
+            - **Link:** [{item.get("link", '#')}]({item.get("link", '#')})
+            - **Snippet:** {item.get("snippet", 'N/A')}
+            """
+            counter += 1
+
+    return sources
+
+
+def extract_question(prompt: str) -> str:
+    """Uses regexp to extract question from the prompt"""
+    # Match from 'question "' to '" and the `yes`' to handle nested quotes
+    pattern = r'question\s+"(.+?)"\s+and\s+the\s+`yes`'
+    try:
+        question = re.findall(pattern, prompt, re.DOTALL)[0]
+    except Exception as e:
+        print(f"Error extracting question: {e}")
+        question = prompt
+    return question
+
+
+@with_key_rotation
+def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
+    """Run the task"""
+    tool = kwargs["tool"]
+    if tool not in ALLOWED_TOOLS:
+        raise ValueError(f"Tool {tool} is not supported.")
+
+    model = kwargs.get("model")
+    if model is None:
+        raise ValueError("Model not supplied.")
+
+    delivery_rate = int(kwargs.get("delivery_rate", DEFAULT_DELIVERY_RATE))
+    counter_callback: Optional[Callable[..., Any]] = kwargs.get(
+        "counter_callback", None
+    )
+    if delivery_rate == 0:
+        if not counter_callback:
+            raise ValueError(
+                "A delivery rate of `0` was passed, but no counter callback was given to calculate the max cost with."
+            )
+
+        max_cost = counter_callback(
+            max_cost=True,
+            models_calls=(model,) * N_MODEL_CALLS,
+        )
+        return max_cost
+
+    openai_api_key = kwargs["api_keys"]["openai"]
+    source_content = kwargs.get("source_content", None)
+    return_source_content = (
+        kwargs["api_keys"].get("return_source_content", "false") == "true"
+    )
+    source_content_mode = kwargs["api_keys"].get("source_content_mode", "cleaned")
+    if source_content_mode not in ("cleaned", "raw"):
+        raise ValueError(
+            f"Invalid source_content_mode: {source_content_mode!r}. Must be 'cleaned' or 'raw'."
+        )
+    with OpenAIClientManager(openai_api_key) as llm_client:
+        max_tokens = kwargs.get("max_tokens", DEFAULT_OPENAI_SETTINGS["max_tokens"])
+        temperature = kwargs.get("temperature", DEFAULT_OPENAI_SETTINGS["temperature"])
+        prompt = kwargs["prompt"]
+
+        today = date.today()
+        d = today.strftime("%d/%m/%Y")
+
+        question = extract_question(prompt)
+        market_prior = format_market_prior(_extract_market_prob(kwargs))
+
+        if source_content is not None:
+            print("Using provided source content (cached replay)...")
+            captured_source_content = source_content
+            serper_data = source_content.get("serper_response", source_content)
+            organic_data = serper_data.get("organic", [])[:MAX_SOURCES]
+            misc_data = serper_data.get("peopleAlsoAsk", [])
+            sources = format_sources_data(organic_data, misc_data)
+        else:
+            serper_api_key = kwargs["api_keys"]["serperapi"]
+            print("Fetching additional sources...")
+            serper_response = fetch_additional_sources(question, serper_api_key)
+            sources_data = serper_response.json()
+            # mode tag included for consistency across tools; content is identical
+            # regardless of mode since Serper returns structured JSON, not HTML
+            captured_source_content = {
+                "mode": source_content_mode,
+                "serper_response": sources_data,
+            }
+            print(f"Additional sources fetched: {sources_data}")
+            organic_data = sources_data.get("organic", [])[:MAX_SOURCES]
+            misc_data = sources_data.get("peopleAlsoAsk", [])
+            print("Formating sources...")
+            sources = format_sources_data(organic_data, misc_data)
+
+        print("Updating prompt...")
+        prediction_prompt = PREDICTION_PROMPT.format(
+            question=question, today=d, sources=sources, market_prior=market_prior
+        )
+        print(f"\n{prediction_prompt=}\n")
+        messages = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": prediction_prompt},
+        ]
+        print("Getting prompt response...")
+        extracted_block, counter_callback = generate_prediction_with_retry(
+            client=llm_client,
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            retries=COMPLETION_RETRIES,
+            delay=COMPLETION_DELAY,
+            counter_callback=counter_callback,
+        )
+
+        used_params = {
+            "model": model,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        if return_source_content:
+            used_params["source_content"] = captured_source_content
+        return extracted_block, prediction_prompt, None, counter_callback, used_params

--- a/packages/valory/customs/superforcaster_polymarket_v4/tests/__init__.py
+++ b/packages/valory/customs/superforcaster_polymarket_v4/tests/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for superforcaster custom package."""

--- a/packages/valory/customs/superforcaster_polymarket_v4/tests/test_superforcaster.py
+++ b/packages/valory/customs/superforcaster_polymarket_v4/tests/test_superforcaster.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Unit tests for superforcaster: thread-safe client, offline tiktoken, source_content, market prior."""
+
+import inspect
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import packages.valory.customs.superforcaster_polymarket_v4.superforcaster_polymarket_v4 as module
+from packages.valory.customs.superforcaster_polymarket_v4.superforcaster_polymarket_v4 import (
+    OpenAIClientManager,
+    _extract_market_prob,
+    format_market_prior,
+    generate_prediction_with_retry,
+    run,
+)
+
+
+class TestOpenAIClientManager:
+    """Verify OpenAIClientManager creates per-context clients without globals."""
+
+    def test_context_manager_returns_client_instance(self) -> None:
+        """__enter__ returns a fresh OpenAIClient, __exit__ closes it."""
+        mgr = OpenAIClientManager(api_key="sk-test")
+        with patch(
+            "packages.valory.customs.superforcaster_polymarket_v4.superforcaster_polymarket_v4.OpenAIClient"
+        ) as MockClient:
+            mock_instance = MagicMock()
+            MockClient.return_value = mock_instance
+
+            with mgr as client:
+                assert client is mock_instance
+                MockClient.assert_called_once_with(api_key="sk-test")
+
+            mock_instance.client.close.assert_called_once()
+
+    def test_no_global_client_variable(self) -> None:
+        """The module must not define a module-level 'client' variable."""
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        for i, line in enumerate(source.split("\n"), 1):
+            stripped = line.lstrip()
+            if stripped.startswith("client:") or stripped.startswith("client ="):
+                if not line.startswith(" ") and not line.startswith("\t"):
+                    pytest.fail(
+                        f"Module-level 'client' variable found at line {i}: {line}"
+                    )
+
+    def test_generate_prediction_requires_client_param(self) -> None:
+        """generate_prediction_with_retry requires client as first param."""
+        params = list(inspect.signature(generate_prediction_with_retry).parameters)
+        assert params[0] == "client"
+
+
+SF_MODULE = (
+    "packages.valory.customs.superforcaster_polymarket_v4.superforcaster_polymarket_v4"
+)
+
+FAKE_SERPER_RESPONSE = {
+    "searchParameters": {"q": "test query", "type": "search"},
+    "organic": [
+        {
+            "title": "Test Result",
+            "link": "http://example.com/result",
+            "snippet": "Test snippet content",
+            "position": 1,
+        },
+    ],
+    "peopleAlsoAsk": [
+        {"question": "What is test?", "snippet": "A test answer."},
+    ],
+}
+
+PREDICTION_JSON = json.dumps(
+    {"p_yes": 0.5, "p_no": 0.5, "confidence": 0.5, "info_utility": 0.5}
+)
+
+PREDICTION_PROMPT = (
+    'With the given question "Will X happen?" '
+    "and the `yes` option represented by `Yes` and the `no` option represented by `No`, "
+    "what are the respective probabilities of `p_yes` and `p_no` occurring?"
+)
+
+
+def _make_mock_api_keys(return_source_content: str = "false") -> MagicMock:
+    """Create a mock KeyChain-like api_keys object."""
+    services = {
+        "openai": ["sk-test"],
+        "serperapi": ["serper-test"],
+        "return_source_content": [return_source_content],
+    }
+    mock = MagicMock()
+    mock.__getitem__ = lambda self, key: services[key][0]
+    mock.get = lambda key, default="": services.get(key, [default])[0]
+    return mock
+
+
+def _install_mock_client(mock_client_mgr: MagicMock) -> MagicMock:
+    """Wire OpenAIClientManager to return a client whose completions() yields PREDICTION_JSON.
+
+    The wrapper's call path is `OpenAIClient.completions(...)`, so the response
+    must be configured on `mock_client.completions.return_value` — not on
+    `mock_client.chat.completions.create` (which is the raw OpenAI SDK path the
+    wrapper hides).
+
+    :param mock_client_mgr: the patched OpenAIClientManager mock.
+    :return: the inner mock_client wired into the manager's __enter__.
+    """
+    mock_client = MagicMock()
+    mock_response = MagicMock()
+    mock_response.content = PREDICTION_JSON
+    mock_response.usage.prompt_tokens = 10
+    mock_response.usage.completion_tokens = 5
+    mock_client.completions.return_value = mock_response
+    mock_client_mgr.return_value.__enter__ = MagicMock(return_value=mock_client)
+    mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_client
+
+
+class TestSuperforcasterSourceContent:
+    """Verify superforcaster captures and replays source_content correctly."""
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_live_capture_wraps_serper_json(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """Live run wraps Serper response in {'serper_response': ...}."""
+        mock_serper = MagicMock()
+        mock_serper.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_serper
+        _install_mock_client(mock_client_mgr)
+
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-4o",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("true"),
+            counter_callback=None,
+        )
+
+        assert result[0] == PREDICTION_JSON
+        used_params = result[4]
+        assert "source_content" in used_params
+        assert "mode" in used_params["source_content"]
+        assert "serper_response" in used_params["source_content"]
+        assert used_params["source_content"]["serper_response"] == FAKE_SERPER_RESPONSE
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    def test_replay_with_serper_response_format(
+        self, mock_client_mgr: MagicMock
+    ) -> None:
+        """Replay with {'serper_response': ...} uses organic and peopleAlsoAsk."""
+        _install_mock_client(mock_client_mgr)
+
+        source_content = {"serper_response": FAKE_SERPER_RESPONSE}
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-4o",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("true"),
+            counter_callback=None,
+            source_content=source_content,
+        )
+
+        assert result[0] == PREDICTION_JSON
+        prediction_prompt = result[1]
+        assert "Test Result" in prediction_prompt
+        assert "Test snippet content" in prediction_prompt
+        assert "What is test?" in prediction_prompt
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    @patch(f"{SF_MODULE}.fetch_additional_sources")
+    def test_flag_off_no_source_content(
+        self, mock_fetch: MagicMock, mock_client_mgr: MagicMock
+    ) -> None:
+        """When return_source_content is false, source_content is not in used_params."""
+        mock_serper = MagicMock()
+        mock_serper.json.return_value = FAKE_SERPER_RESPONSE
+        mock_fetch.return_value = mock_serper
+        _install_mock_client(mock_client_mgr)
+
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-4o",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("false"),
+            counter_callback=None,
+        )
+
+        assert result[0] == PREDICTION_JSON
+        used_params = result[4]
+        assert "source_content" not in used_params
+
+
+class TestFormatMarketPrior:
+    """Verify the market-prior anchor block rendering and validation."""
+
+    def test_valid_decimal_renders_anchor_with_number(self) -> None:
+        """A valid price yields the anchor instruction containing that decimal."""
+        block = format_market_prior(0.62)
+        assert "0.62" in block
+        assert "market-implied probability" in block
+        # carries its own trailing blank line so it slots into the template
+        assert block.endswith("\n\n")
+
+    def test_string_numeric_is_accepted(self) -> None:
+        """A numeric string (as it may arrive over the wire) is parsed."""
+        assert "0.3" in format_market_prior("0.3")
+
+    @pytest.mark.parametrize("bad", [None, "", "n/a", -0.1, 1.5])
+    def test_absent_or_out_of_range_yields_empty(self, bad: object) -> None:
+        """Missing, non-numeric, or out-of-[0,1] prices collapse to no anchor."""
+        assert format_market_prior(bad) == ""
+
+    def test_rounds_to_four_decimals(self) -> None:
+        """Long decimals are rounded so the prompt stays clean."""
+        assert "0.6667" in format_market_prior(0.6666666)
+
+
+class TestExtractMarketProb:
+    """Verify market-prob extraction from kwargs and request_context."""
+
+    def test_top_level_key(self) -> None:
+        """A top-level market_prob is found."""
+        assert _extract_market_prob({"market_prob": 0.42}) == 0.42
+
+    def test_request_context_key(self) -> None:
+        """A price nested in request_context is found."""
+        assert _extract_market_prob({"request_context": {"current_prob": 0.7}}) == 0.7
+
+    def test_top_level_takes_precedence(self) -> None:
+        """Top-level kwargs win over request_context for the same concept."""
+        kwargs = {
+            "market_prob": 0.1,
+            "request_context": {"market_prob_at_prediction": 0.9},
+        }
+        assert _extract_market_prob(kwargs) == 0.1
+
+    def test_absent_returns_none(self) -> None:
+        """No recognised key anywhere returns None."""
+        assert _extract_market_prob({"foo": "bar"}) is None
+
+
+class TestMarketPriorInPrompt:
+    """End-to-end: the rendered anchor block reaches the formatted prompt."""
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    def test_price_present_injects_anchor(self, mock_client_mgr: MagicMock) -> None:
+        """A supplied market_prob places the anchor sentence into the prompt."""
+        _install_mock_client(mock_client_mgr)
+
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-4o",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("false"),
+            counter_callback=None,
+            source_content={"serper_response": FAKE_SERPER_RESPONSE},
+            market_prob=0.62,
+        )
+
+        prediction_prompt = result[1]
+        assert (
+            "market-implied probability that the answer is YES is 0.62"
+            in prediction_prompt
+        )
+
+    @patch(f"{SF_MODULE}.OpenAIClientManager")
+    def test_price_absent_no_anchor(self, mock_client_mgr: MagicMock) -> None:
+        """Without a price the prompt has no anchor block (degrades to v1)."""
+        _install_mock_client(mock_client_mgr)
+
+        result = run(
+            tool="superforcaster-polymarket-v4",
+            model="gpt-4o",
+            prompt=PREDICTION_PROMPT,
+            api_keys=_make_mock_api_keys("false"),
+            counter_callback=None,
+            source_content={"serper_response": FAKE_SERPER_RESPONSE},
+        )
+
+        prediction_prompt = result[1]
+        assert "market-implied probability" not in prediction_prompt

--- a/tool_lineage.json
+++ b/tool_lineage.json
@@ -181,6 +181,10 @@
     "superforcaster-polymarket-v3": {
       "parent": "superforcaster-polymarket-v1",
       "reason": "Swap the default LLM model from OpenAI gpt-4.1-2025-04-14 to Anthropic claude-fable-5. Same prompt, pipeline, output format and retry logic as v1 \u2014 one-axis change to measure the model's contribution to v1's baseline. Sibling of v2 (which is a prompt-only resolution-criterion specificity variant), both depart from v1."
+    },
+    "superforcaster-polymarket-v4": {
+      "parent": "superforcaster-polymarket-v1",
+      "reason": "Prompt-only variant of v1 that injects the market-implied probability (passed alongside the request) as an explicit soft-anchor base rate / prior. One-axis change to test whether seeing the market price improves calibrated Brier vs v1."
     }
   }
 }


### PR DESCRIPTION
## What

Adds **`superforcaster-polymarket-v4`** — a prompt-only variant of `superforcaster-polymarket-v1` that injects the **market-implied YES probability** into the prompt as an explicit soft-anchor *base rate / prior*. Serper pipeline, model (`gpt-4.1`), output format and retry logic are kept **byte-identical** to v1; the only axis that changes is the addition of the market-price anchor.

## Hypothesis

v1 only *qualitatively* instructs the model to "consider priors/base rates" — it has no actual prior to anchor on. v4 supplies the real number: the market price the prediction is made against. Since prediction markets are well-calibrated, a model that anchors on the price and deviates only when its evidence justifies should produce a lower (better) Brier than v1.

## Mechanism (soft anchor)

When a price is supplied, this block is injected right after the date line:

> The current market-implied probability that the answer is YES is `{p}`. This price aggregates the views of other informed participants — treat it as your base rate / prior. Anchor on it, and deviate only to the extent your case-specific evidence justifies, explaining the deviation.

Step 6's existing prior-reasoning line is widened to reference "the market-implied prior provided above, when available". The price is rendered as a **decimal** (e.g. `0.62`).

- Read from `kwargs` (top-level or `request_context`) under `market_prob` / `market_prob_at_prediction` / `current_prob` via a new `format_market_prior` helper.
- When the price is **absent or out of `[0, 1]`**, the block collapses to `""` and the prompt is exactly v1's — graceful degradation.

## Replay wiring

The benchmark replay (`benchmark/prompt_replay.py`) renders the same block from each row's recorded `market_prob_at_prediction` by calling the module's `format_market_prior`, so the injected text has a **single source of truth**. The shared superforcaster branch passes `market_prior=` to `.format()`; v1/v2/v3 have no `{market_prior}` placeholder and ignore the extra kwarg, so it's a no-op for them. (96% of Polymarket rows in the production logs carry `market_prob_at_prediction`.)

## ⚠️ Design note

The benchmark/trader deliberately withhold odds from prediction tools (`runner.py:241` — *"those tools must never see odds"*) because the trader uses the tool's **independent** estimate to find *edge* vs. the market. This variant intentionally breaks that principle as an experiment. Two things to watch when reading results, beyond headline Brier:
- Did Brier drop by **more** than a naive 50/50 LLM↔market blend would predict? (Else the LLM adds nothing beyond ensembling toward the price.)
- On the subset where v1 **disagreed with the market and was right** — does v4 give up those wins? That's the trading edge traded away for the Brier gain.

Deploying it would also require a trader-side change to start passing the price on the request — out of scope here.

## Housekeeping

- New: `packages/valory/customs/superforcaster_polymarket_v4/` (module, `__init__.py`, `component.yaml`, tests).
- `benchmark/tools.py`: register `superforcaster-polymarket-v4` (family `superforcaster`).
- `tool_lineage.json`: one entry, parent `superforcaster-polymarket-v1`.
- `packages/packages.json`: CID `bafybeifhfwxqisgduutyyiuxdlicm3tuil3yb2pkzabnhehprx32qbl2lq`.
- **Not** added to `tournament_tools.json` — benchmark-only experiment.
- Did **not** `push-all` to IPFS or touch `agent-deployments` (human pre-merge steps).

## Checks

- 20/20 v4 unit tests pass.
- black / isort / flake8 / mypy / pylint / darglint all green.
- `autonomy packages lock` → done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)