### PR TITLE
feat: add propose-question tool + bump mech deps to v0.33.3

### DIFF
--- a/benchmark/tools.py
+++ b/benchmark/tools.py
@@ -167,6 +167,13 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         module="packages.nickcom007.customs.prediction_request_sme.prediction_request_sme",
         family="default",
     ),
+    # valory/propose_question -- generates prediction-market questions from recent
+    # news articles using a two-step LLM pipeline (story selection + measurable-
+    # state extraction + self-review). Output is {questions, reasoning}, NOT p_yes.
+    "propose-question": ToolSpec(
+        module="packages.valory.customs.propose_question.propose_question",
+        family="default",
+    ),
 }
 
 

--- a/benchmark/tools.py
+++ b/benchmark/tools.py
@@ -167,13 +167,6 @@ TOOL_REGISTRY: dict[str, ToolSpec] = {
         module="packages.nickcom007.customs.prediction_request_sme.prediction_request_sme",
         family="default",
     ),
-    # valory/propose_question -- generates prediction-market questions from recent
-    # news articles using a two-step LLM pipeline (story selection + measurable-
-    # state extraction + self-review). Output is {questions, reasoning}, NOT p_yes.
-    "propose-question": ToolSpec(
-        module="packages.valory.customs.propose_question.propose_question",
-        family="default",
-    ),
 }
 
 

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -25,9 +25,9 @@
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
         "custom/valory/finetuned_prediction/0.1.0": "bafybeifetvtalxnw3y7epqspyxotrls4wl7eoffsiaglxp52nca7ozurv4",
-        "custom/valory/propose_question/0.1.0": "bafybeiamc5ono266servtpo3hrbzjtttdehj3o5z3bsmvhvjhcizxkklui",
-        "agent/valory/mech_predict/0.1.0": "bafybeid532mueh7q3nbkzsfc7amgqig4daa6gznrjvcogk7gzjrrsv2vs4",
-        "service/valory/mech_predict/0.1.0": "bafybeibtcbboogyszsliq7scoghpotztni25xcgngdo7jfrbmt3mlerqqq"
+        "custom/valory/propose_question/0.1.0": "bafybeiccetbcycilqs4zkcxmkjehkjrpmugn3ulolb6m2zjz6ghm5s2swa",
+        "agent/valory/mech_predict/0.1.0": "bafybeignbzm4mmodm6ggavzuphdzq3z4znq75x6a6elkpnizz2r6mscy2m",
+        "service/valory/mech_predict/0.1.0": "bafybeiczjcmbzwbgaszsju567nuyr46tcj3xxic43mj44x66t7jwsv3d7y"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -24,9 +24,9 @@
         "custom/valory/superforcaster_polymarket_v2/0.1.0": "bafybeigopot226az3ida2rwlamlr2isi4i2m3nk36dtzug3w3jvnk673uy",
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
-        "custom/valory/propose_question/0.1.0": "bafybeiakbuh44icandnrva5enzryddywn62f745mlhynizhtbbul7vza7m",
-        "agent/valory/mech_predict/0.1.0": "bafybeic64oppl5dzupxdvk4ghh33i6tzfglwrtxjezefn6kaqmcchaq3ra",
-        "service/valory/mech_predict/0.1.0": "bafybeigautqy7cb3afawkbr26buu7rmjfsavvdizpbhqldlw7b4exch23q"
+        "custom/valory/propose_question/0.1.0": "bafybeiamc5ono266servtpo3hrbzjtttdehj3o5z3bsmvhvjhcizxkklui",
+        "agent/valory/mech_predict/0.1.0": "bafybeid532mueh7q3nbkzsfc7amgqig4daa6gznrjvcogk7gzjrrsv2vs4",
+        "service/valory/mech_predict/0.1.0": "bafybeibtcbboogyszsliq7scoghpotztni25xcgngdo7jfrbmt3mlerqqq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -24,8 +24,9 @@
         "custom/valory/superforcaster_polymarket_v2/0.1.0": "bafybeigopot226az3ida2rwlamlr2isi4i2m3nk36dtzug3w3jvnk673uy",
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
-        "agent/valory/mech_predict/0.1.0": "bafybeib6vgyz52zcvjce6sydak6nydqjwdvlswqhdr6c4fcqopljsfrx7q",
-        "service/valory/mech_predict/0.1.0": "bafybeigjv5fjei73hfj5uf4veaajsl2mfjl3c6gmbtiafh4kyohbm5w5nm"
+        "custom/valory/propose_question/0.1.0": "bafybeib2fn5rolwqo2qmkktwhjcgq5dlqlyynsj45x2wackhvvh5m4rnw4",
+        "agent/valory/mech_predict/0.1.0": "bafybeiby6nf74ziweiyhe5on2k4mix5yhtxtsw2zxpksgpz473nwc2ygfy",
+        "service/valory/mech_predict/0.1.0": "bafybeial6hgk2e2cm3kyvlxmcwzcl5ghyeubmw4vcm6zphlbipjja5cgdq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -64,8 +65,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki",
         "skill/valory/termination_abci/0.1.0": "bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeicaxrvsspr5pablbah57yhwfcms3nengun67eozbhemzn34cqzqde",
-        "skill/valory/task_execution/0.1.0": "bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja"
+        "skill/valory/mech_abci/0.1.0": "bafybeidjjknxrn4ldakdeq7azuffe4a76oi2vladmjkb57z3fmeg3z5g6a",
+        "skill/valory/task_execution/0.1.0": "bafybeibhf7ou4cqn4v65wptogxckolzpalnrzy4g7romb63jpxe3qrrexe",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeihskhun5iy3qd2kyslg4rtppiupx6rpikklhmci5b5fjgr65ynpzq"
     }
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -24,9 +24,9 @@
         "custom/valory/superforcaster_polymarket_v2/0.1.0": "bafybeigopot226az3ida2rwlamlr2isi4i2m3nk36dtzug3w3jvnk673uy",
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
-        "custom/valory/propose_question/0.1.0": "bafybeib2fn5rolwqo2qmkktwhjcgq5dlqlyynsj45x2wackhvvh5m4rnw4",
-        "agent/valory/mech_predict/0.1.0": "bafybeiby6nf74ziweiyhe5on2k4mix5yhtxtsw2zxpksgpz473nwc2ygfy",
-        "service/valory/mech_predict/0.1.0": "bafybeial6hgk2e2cm3kyvlxmcwzcl5ghyeubmw4vcm6zphlbipjja5cgdq"
+        "custom/valory/propose_question/0.1.0": "bafybeiakbuh44icandnrva5enzryddywn62f745mlhynizhtbbul7vza7m",
+        "agent/valory/mech_predict/0.1.0": "bafybeic64oppl5dzupxdvk4ghh33i6tzfglwrtxjezefn6kaqmcchaq3ra",
+        "service/valory/mech_predict/0.1.0": "bafybeigautqy7cb3afawkbr26buu7rmjfsavvdizpbhqldlw7b4exch23q"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -40,12 +40,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeicaxrvsspr5pablbah57yhwfcms3nengun67eozbhemzn34cqzqde
+- valory/mech_abci:0.1.0:bafybeidjjknxrn4ldakdeq7azuffe4a76oi2vladmjkb57z3fmeg3z5g6a
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeibgegj5oajp3sqecsyf6jovlii4u63eatm33sf4y56s5zd7vq7gf4
-- valory/task_submission_abci:0.1.0:bafybeifimk7xd34j6buty4r37ny7rkbnduaavmaue6lzz5ftvris5vzfja
+- valory/task_execution:0.1.0:bafybeibhf7ou4cqn4v65wptogxckolzpalnrzy4g7romb63jpxe3qrrexe
+- valory/task_submission_abci:0.1.0:bafybeihskhun5iy3qd2kyslg4rtppiupx6rpikklhmci5b5fjgr65ynpzq
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay
@@ -70,6 +70,7 @@ customs:
 - nickcom007/prediction_request_sme:0.1.0:bafybeifsk4og24t22agcrj7mm6fz3wxwfbdg554yjhc6odpxal5ofg22ti
 - valory/factual_research:0.1.0:bafybeidcxmqemvzm7cz2ydyjsmu53zflsqpcj2gpco5kwn3ldvf22rqx4i
 - valory/factual_research_v3:0.1.0:bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa
+- valory/propose_question:0.1.0:bafybeib2fn5rolwqo2qmkktwhjcgq5dlqlyynsj45x2wackhvvh5m4rnw4
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -70,7 +70,7 @@ customs:
 - nickcom007/prediction_request_sme:0.1.0:bafybeifsk4og24t22agcrj7mm6fz3wxwfbdg554yjhc6odpxal5ofg22ti
 - valory/factual_research:0.1.0:bafybeidcxmqemvzm7cz2ydyjsmu53zflsqpcj2gpco5kwn3ldvf22rqx4i
 - valory/factual_research_v3:0.1.0:bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa
-- valory/propose_question:0.1.0:bafybeiamc5ono266servtpo3hrbzjtttdehj3o5z3bsmvhvjhcizxkklui
+- valory/propose_question:0.1.0:bafybeiccetbcycilqs4zkcxmkjehkjrpmugn3ulolb6m2zjz6ghm5s2swa
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -70,7 +70,7 @@ customs:
 - nickcom007/prediction_request_sme:0.1.0:bafybeifsk4og24t22agcrj7mm6fz3wxwfbdg554yjhc6odpxal5ofg22ti
 - valory/factual_research:0.1.0:bafybeidcxmqemvzm7cz2ydyjsmu53zflsqpcj2gpco5kwn3ldvf22rqx4i
 - valory/factual_research_v3:0.1.0:bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa
-- valory/propose_question:0.1.0:bafybeiakbuh44icandnrva5enzryddywn62f745mlhynizhtbbul7vza7m
+- valory/propose_question:0.1.0:bafybeiamc5ono266servtpo3hrbzjtttdehj3o5z3bsmvhvjhcizxkklui
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -70,7 +70,7 @@ customs:
 - nickcom007/prediction_request_sme:0.1.0:bafybeifsk4og24t22agcrj7mm6fz3wxwfbdg554yjhc6odpxal5ofg22ti
 - valory/factual_research:0.1.0:bafybeidcxmqemvzm7cz2ydyjsmu53zflsqpcj2gpco5kwn3ldvf22rqx4i
 - valory/factual_research_v3:0.1.0:bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa
-- valory/propose_question:0.1.0:bafybeib2fn5rolwqo2qmkktwhjcgq5dlqlyynsj45x2wackhvvh5m4rnw4
+- valory/propose_question:0.1.0:bafybeiakbuh44icandnrva5enzryddywn62f745mlhynizhtbbul7vza7m
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/customs/propose_question/__init__.py
+++ b/packages/valory/customs/propose_question/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""This module contains the propose_question custom package."""

--- a/packages/valory/customs/propose_question/component.yaml
+++ b/packages/valory/customs/propose_question/component.yaml
@@ -10,7 +10,7 @@ fingerprint:
   __init__.py: bafybeic4s7syxr2m2q3wtta3pzkqmw4usib3ji5v6ziae2kxprz2swvoje
   propose_question.py: bafybeiactuhrqoedvn4h2lbk6b2mol3sop7k4shpgipii2ktoakomlz5ei
   tests/__init__.py: bafybeierlyi65bbyvrmmzse4s3j53ht54cpn3kwnt5ptgcwnqhuim25bvu
-  tests/test_propose_question.py: bafybeicemj2dphavks3nmy7bjxc3hbxx3zrrwfhmdkjoq7dxwj6czb32nq
+  tests/test_propose_question.py: bafybeifkum73ur5rnmwbmd5gaylhp5i5sausoysbcsxfr3cifqeripj2qy
 fingerprint_ignore_patterns: []
 entry_point: propose_question.py
 callable: run

--- a/packages/valory/customs/propose_question/component.yaml
+++ b/packages/valory/customs/propose_question/component.yaml
@@ -1,0 +1,29 @@
+name: propose_question
+author: valory
+version: 0.1.0
+type: custom
+description: Mech tool that proposes prediction-market questions from recent news
+  articles, using a two-step LLM pipeline with measurable-state extraction and self-review.
+license: Apache-2.0
+aea_version: '>=1.0.0, <2.0.0'
+fingerprint:
+  __init__.py: bafybeic4s7syxr2m2q3wtta3pzkqmw4usib3ji5v6ziae2kxprz2swvoje
+  propose_question.py: bafybeihvlqh2x76cmbb7667o74ncgjmwet4g757nuxinorrwmn6wauh6re
+  tests/__init__.py: bafybeierlyi65bbyvrmmzse4s3j53ht54cpn3kwnt5ptgcwnqhuim25bvu
+  tests/test_propose_question.py: bafybeicacyhupszjjdxnp4re2dsi34jhiaovkyejq2mv6hmoysyj2m3tpy
+fingerprint_ignore_patterns: []
+entry_point: propose_question.py
+callable: run
+params:
+  default_model: gpt-4.1-2025-04-14
+dependencies:
+  openai:
+    version: ==1.93.0
+  requests:
+    version: ==2.32.5
+  gql:
+    version: '>=3.5.0,<3.6'
+  requests-toolbelt:
+    version: ==1.0.0
+  pydantic:
+    version: '>=2.0.0,<3.0.0'

--- a/packages/valory/customs/propose_question/component.yaml
+++ b/packages/valory/customs/propose_question/component.yaml
@@ -8,9 +8,9 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeic4s7syxr2m2q3wtta3pzkqmw4usib3ji5v6ziae2kxprz2swvoje
-  propose_question.py: bafybeihvlqh2x76cmbb7667o74ncgjmwet4g757nuxinorrwmn6wauh6re
+  propose_question.py: bafybeicp523wikdy5ymxpp4tpfa77j3uhkhg5mcfyb3qmjtf7pemznuqjq
   tests/__init__.py: bafybeierlyi65bbyvrmmzse4s3j53ht54cpn3kwnt5ptgcwnqhuim25bvu
-  tests/test_propose_question.py: bafybeicacyhupszjjdxnp4re2dsi34jhiaovkyejq2mv6hmoysyj2m3tpy
+  tests/test_propose_question.py: bafybeihr2ttqds4u2a7kjoh765ylkiinhugygp6vfoqvx3qd7u3av42p34
 fingerprint_ignore_patterns: []
 entry_point: propose_question.py
 callable: run

--- a/packages/valory/customs/propose_question/component.yaml
+++ b/packages/valory/customs/propose_question/component.yaml
@@ -8,9 +8,9 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeic4s7syxr2m2q3wtta3pzkqmw4usib3ji5v6ziae2kxprz2swvoje
-  propose_question.py: bafybeicp523wikdy5ymxpp4tpfa77j3uhkhg5mcfyb3qmjtf7pemznuqjq
+  propose_question.py: bafybeiactuhrqoedvn4h2lbk6b2mol3sop7k4shpgipii2ktoakomlz5ei
   tests/__init__.py: bafybeierlyi65bbyvrmmzse4s3j53ht54cpn3kwnt5ptgcwnqhuim25bvu
-  tests/test_propose_question.py: bafybeihr2ttqds4u2a7kjoh765ylkiinhugygp6vfoqvx3qd7u3av42p34
+  tests/test_propose_question.py: bafybeicemj2dphavks3nmy7bjxc3hbxx3zrrwfhmdkjoq7dxwj6czb32nq
 fingerprint_ignore_patterns: []
 entry_point: propose_question.py
 callable: run

--- a/packages/valory/customs/propose_question/propose_question.py
+++ b/packages/valory/customs/propose_question/propose_question.py
@@ -1,0 +1,1461 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Mech tool that proposes prediction-market questions from recent news."""
+
+import functools
+import json
+import random
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+
+import openai
+import requests
+from gql import Client, gql
+from gql.transport.requests import RequestsHTTPTransport
+from openai import OpenAI
+from pydantic import BaseModel
+
+NEWSAPI_TOP_HEADLINES_URL = "https://newsapi.org/v2/top-headlines"
+NEWSAPI_DEFAULT_NEWS_SOURCES = [
+    "bbc-news",
+    "bbc-sport",
+    "abc-news",
+    "cnn",
+    "reuters",
+    "usa-today",
+    "breitbart-news",
+    "the-verge",
+    "techradar",
+    "associated-press",
+    "bloomberg",
+    "business-insider",
+    "ars-technica",
+    "national-geographic",
+    "new-scientist",
+]
+
+OMEN_SUBGRAPH_URL = "https://gateway-arbitrum.network.thegraph.com/api/{subgraph_api_key}/subgraphs/id/9fUVQpFwzpdWS9bq5WkAnmKbNNcoBwatMR4yZq81pbbz"
+HTTP_OK = 200
+MAX_ARTICLES = 60
+MAX_LATEST_QUESTIONS = 100
+# NewsAPI top-headlines endpoint caps a single request at 100 results; we
+# request the max and downsample to MAX_ARTICLES later.
+NEWSAPI_MAX_PAGE_SIZE = 100
+# Max chars of scraped article body passed to the LLM. Used in BOTH the
+# question-generation prompt and the self-review prompt so the reviewer
+# scores against the same text the generator saw.
+ARTICLE_TEXT_MAX_CHARS = 6000
+
+FPMM_CREATORS = [
+    "0x89c5cc945dd550bcffb72fe42bff002429f46fec",
+    "0xffc8029154ecd55abed15bd428ba596e7d23f557",
+]
+FPMMS_QUERY = """
+    query fpmms_query($creator_in: [Bytes!], $first: Int) {
+      fixedProductMarketMakers(
+        where: {creator_in: $creator_in}
+        orderBy: creationTimestamp
+        orderDirection: desc
+        first: $first
+      ) {
+        question {
+          title
+        }
+      }
+    }
+    """
+
+DEFAULT_TOPICS = [
+    "business",
+    "cryptocurrency",
+    "politics",
+    "science",
+    "technology",
+    "trending",
+    "social",
+    "health",
+    "sustainability",
+    "internet",
+    "food",
+    "pets",
+    "animals",
+    "curiosities",
+    "economy",
+    "arts",
+    "entertainment",
+    "weather",
+    "sports",
+    "finance",
+    "international",
+]
+
+SELECT_STORY_PROMPT = """You are provided a numbered list of recent news article
+    snippets under ARTICLES. You are provided a list of existing questions under
+    EXISTING_QUESTIONS. Your task is to choose one article or story which is suitable
+    to create questions for prediction markets. The chosen article should be that the
+    questions created are of public interest.
+
+    HARD REJECTION: do NOT choose an article if EXISTING_QUESTIONS already
+    contains a question about the SAME UNDERLYING TOPIC (same metric, same
+    institution, same event, same named entity), even when the wording or
+    numeric threshold is slightly different. Treat these as duplicates:
+    - "2-year mortgage rate below 5.80%" and "2-year mortgage rate below 5.85%"
+    - "S&P 500 above 7,100" and "S&P 500 above 7,200"
+    - "Bank of England rate above X%" and "Bank of England rate at or above Y%"
+    - any two questions naming the same institution reporting on the same metric
+    When in doubt, prefer a different article with a NEW topic not present in
+    EXISTING_QUESTIONS.
+
+    PREFER articles that support MEASUREMENT or CONTINUATION questions, with a
+    particular bias toward continuation-friendly topics. Good signals for
+    continuation-friendly articles:
+    - Economic indicators (interest rates, inflation targets, unemployment,
+      stock indices, commodity prices, exchange rates).
+    - Political incumbencies (leaders, officials, judges currently in position).
+    - Existing moratoriums, sanctions, bans, regulations, policies.
+    - Institutional positions (ratings, league standings, memberships,
+      subscriptions, listings).
+    - Ongoing conflicts, negotiations, strikes, or standoffs.
+    These articles produce questions about status-quo persistence, which
+    balance the pipeline's natural No-bias from short-deadline announcements.
+
+    Also acceptable:
+    - Articles mentioning a measurable quantity that can be checked on a
+      future date (measurement framing).
+
+    AVOID articles whose only angle is "will authority X announce Y?" unless
+    a scheduled announcement is specifically anticipated in the article.
+
+    You must output the article ID a topic from TOPICS and a brief reasoning.
+
+    ARTICLES
+    {articles}
+
+    EXISTING_QUESTIONS (these topics are ALREADY COVERED -- do NOT pick an
+    article about any of these topics, even with a different threshold or
+    phrasing. Read every line carefully before selecting.)
+    {latest_questions}
+
+    FINAL CHECK before you output:
+    - Does any existing question mention the same institution/metric/event
+      as your chosen article?
+    - If YES, pick a DIFFERENT article. Do not output an article_id for a
+      topic that already appears above.
+
+    TOPICS
+    {topics}
+    """
+
+EXTRACT_STATE_PROMPT = """You are analysing a news article to find MEASURABLE
+    STATES that can be turned into prediction-market questions. A measurable
+    state is something that can be checked on a specific future date by looking
+    up a published value, verifying an ongoing condition, or confirming a
+    status-quo persists.
+
+    For each measurable state you find, output:
+    - "state": a short description of what can be measured
+    - "source": who publishes or confirms this (e.g. "Freddie Mac weekly report",
+      "SEC 10-Q filing", "NWS flood gauge", "official company statement")
+    - "framing": one of "measurement" (numeric value check), "continuation"
+      (will status-quo persist?), or "announcement" (specific event expected)
+
+    PREFER "measurement" and "continuation" framings. Only use "announcement"
+    if the article specifically describes an imminent scheduled event.
+
+    If the article has no measurable states at all, return an empty list.
+
+    Return at most 5 states.
+
+    ARTICLE
+    {article}
+    """
+
+PROPOSE_QUESTION_PROMPT = """You are provided a recent news article
+    under ARTICLE, and a list of MEASURABLE STATES extracted from it.
+    Your task is to formulate {num_questions} novel prediction market question(s)
+    based on these states. Use the measurable states to guide your framing.
+
+    CRITICAL CONSTRAINT: You have a WINDOW of only {window_days} days
+    (today -> EVENT_DAY). Every date, threshold, and authority action in
+    your question must be achievable within {window_days} days. Do NOT
+    reference dates outside this window or in the past.
+
+    RULES:
+    - TARGET MIX: when multiple candidate framings are possible for the same
+      article, aim for a mix where at least one third of the generated
+      questions use "continuation" framing. Continuation questions are the
+      main counterweight to the No-bias of announcement framings on short
+      windows, so they are actively preferred when an article supports them.
+
+    FRAMING TEMPLATES (use exactly these grammatical shapes -- they avoid the
+    past-participle ambiguity of "as confirmed by X" which can be misread as
+    "already confirmed by X"):
+    - For "measurement" states: frame as
+      "Will [metric] be above/below [threshold] on EVENT_DAY, according to
+      [source]?"
+    - For "continuation" states: frame as
+      "Will [condition] still hold on EVENT_DAY, according to [source]?"
+    - For "announcement" states: frame as
+      "Will [entity] [action] between TODAY ({today}) and EVENT_DAY, according
+      to [source]?"
+      Do NOT use "on or before EVENT_DAY" -- that admits historical events
+      from any point in the past and makes the question trivially true from
+      the moment it's asked. The question must resolve on something that
+      occurs during the market's lifetime (TODAY to EVENT_DAY).
+    - In all templates, use "according to [source]" to name the jury's
+      verification channel. Do NOT use "as confirmed by" / "as reported by" /
+      "as announced by" -- the past-participle phrasing can be misread as
+      "already confirmed/reported/announced at the time the question is asked".
+      "According to [source]" is future-tense relative to EVENT_DAY and
+      unambiguously means "the jury will check [source] on that date".
+    - If MEASURABLE_STATES is empty or shows the sentinel "(none found)",
+      you may create an announcement-style question, but it must pass ALL
+      the checks below.
+    - Must be of public interest, semantically different, different from
+      EXISTING_QUESTIONS.
+    - The answer must be 'yes' or 'no', verifiable, not an opinion, unambiguous,
+      and known after EVENT_DAY.
+    - Must not encourage unethical behavior or violence.
+    - Must not include unmeasurable statements like "significant increase".
+    - ALL dates in the question must be between today and EVENT_DAY. Never
+      reference past dates or dates beyond EVENT_DAY.
+    - DATE FORMAT: every date in the question MUST be written as
+      "Month D, YYYY" (e.g. "April 22, 2026"). Do NOT use "22 April 2026",
+      "April 22 2026" (no comma), or numeric formats. Copy EVENT_DAY verbatim.
+    - SOURCE PUBLICATION CADENCE: for continuation/measurement questions
+      whose source publishes weekly, monthly, quarterly, or irregularly
+      (e.g. OECD economic outlooks, Moneyfacts rate tables, Nikkei Asia
+      special reports, IMF projections), do NOT require the source to
+      publish "on EVENT_DAY" / "published on that date". Frame as
+      "as of EVENT_DAY, according to the most recent [source]" or
+      "still at/above/below X on EVENT_DAY, per the latest [source]"
+      instead. A question that demands a publication action on a specific
+      day from a non-daily publisher resolves No by default, regardless of
+      the underlying state.
+
+    SPECIFIC FRAMING CHECKS (apply to every question):
+    1. DEADLINE FEASIBILITY -- Can the criterion physically/procedurally occur
+       within {window_days} days? If not, reframe to something that can.
+    2. PROCESS-STAGE CLARITY -- If multi-stage process, name the exact stage.
+       Never use "formal passage" or "official approval" without a stage qualifier.
+    3. DIRECTLY-PUBLISHED FIGURE -- Thresholds must be figures a source publishes
+       directly, not derived by arithmetic on separate figures.
+    4. AUTHORITY RESPONSE TIME -- The deadline must be realistic for the named
+       authority. Government reviews, regulatory investigations take weeks/months.
+       If the authority cannot plausibly act within {window_days} days, do NOT
+       frame the question around that authority's action.
+    5. RESOLUTION SOURCE -- Name WHO confirms and WHAT document/channel.
+
+    MEASURABLE_STATES
+    {measurable_states}
+
+    EXISTING_QUESTIONS
+    {latest_questions}
+
+    TODAY
+    {today}
+
+    EVENT_DAY
+    {event_day}
+
+    ARTICLE
+    {article}
+    """
+
+SELF_REVIEW_PROMPT = """You are auditing prediction-market questions for
+    quality. For EACH question, you must perform explicit step-by-step
+    reasoning before deciding accept/reject. Do not skip steps.
+
+    STEP-BY-STEP PROCESS for each question:
+
+    A. STATE THE DEADLINE: Write the exact deadline date from the question.
+
+    B. DEADLINE FEASIBILITY: What specific outcome does the question ask
+       for? What is the EARLIEST DATE this could physically/procedurally
+       happen? Compare: is earliest_date <= deadline_date?
+       - Example: "BBC to complete 1,000 job cuts" -- large-scale layoffs take
+         weeks/months to execute. Earliest realistic completion: months away.
+         If deadline is 5 days away -> REJECT.
+       - Example: "Hurricane landfall in April" -- Atlantic hurricane season
+         starts June. Earliest possible: June. April deadline -> REJECT.
+       - Example: "FAA suspend laser weapon approval" -- regulatory suspensions
+         require review processes taking weeks. 5-day deadline -> REJECT.
+
+    C. PROCESS-STAGE CLARITY: Does the question use ambiguous terms like
+       "formal passage", "official approval", "formal review"? If yes -> REJECT
+       unless a specific stage is named.
+
+    D. FIGURE DERIVABILITY: Does the question ask for a figure that requires
+       arithmetic on two separately-published numbers? If yes -> REJECT.
+
+    E. AUTHORITY RESPONSE TIME: Does the question require a government agency,
+       regulator, court, or large organization to complete an action? How long
+       does that type of action typically take? Is the deadline realistic?
+       - Antitrust reviews: weeks to months -> 5-day deadline = REJECT
+       - Regulatory investigations (NHTSA, FAA): weeks -> 5-day deadline = REJECT
+       - Large-scale layoffs (1000+ jobs): weeks/months -> 5-day deadline = REJECT
+       - Company press release about existing decision: days -> OK
+
+    F. DATE FORMAT: Every date in the question must be written as
+       "Month D, YYYY" (e.g. "April 22, 2026"). Formats like "22 April 2026",
+       "April 22 2026" (no comma), or numeric dates are INVALID -> REJECT.
+
+    G. NOT A DUPLICATE: Compare the candidate against EXISTING_QUESTIONS. If
+       any existing question covers the SAME underlying claim -- same metric
+       on the same source, same institution's position, same ongoing event --
+       REJECT even if wording differs or the numeric threshold is slightly
+       different. Examples of duplicates to reject:
+       - candidate "...rate below 5.85%..." when an existing has "...rate below 5.80%..."
+       - candidate "S&P 500 above 7,150" when an existing has "S&P 500 above 7,100"
+       - candidate on the same institution's report with a slightly different
+         numeric threshold than an existing question
+
+    H. WINDOW-BOUND EVENT: For announcement questions, check that the event
+       must occur between TODAY and EVENT_DAY -- not "on or before EVENT_DAY"
+       or any phrasing that would be satisfied by a historical instance. A
+       question like "Will OpenAI publicly announce, on or before EVENT_DAY,
+       the signing of a nine-figure enterprise deal?" is INVALID because
+       OpenAI has already done this many times in the past. REJECT if the
+       literal text would be made True by any pre-TODAY event.
+
+    I. DECISION: Accept ONLY if ALL of B, C, D, E, F, G, H pass.
+
+    Return JSON with your explicit reasoning at each step.
+
+    QUESTIONS
+    {questions}
+
+    EXISTING_QUESTIONS
+    {latest_questions}
+
+    SOURCE ARTICLE
+    {article}
+
+    TODAY
+    {today}
+
+    EVENT_DAY
+    {event_day}
+    """
+
+SOURCE_VERIFY_JUDGE_PROMPT = """You are auditing whether a prediction-market
+question can be objectively resolved.
+
+SOURCE: {source}
+METRIC: {metric}
+
+GOOGLE EVIDENCE (top organic results querying ``{query}``):
+{snippets}
+
+Question: Based on these snippets, does this source publish this specific
+metric publicly so a researcher could look up its current value within a
+few days?
+
+Reply JSON: {{"answer": "YES" | "NO", "reason": "<one sentence>"}}.
+
+Rules:
+- YES only if a snippet clearly shows the source publishing this figure
+  (or a strongly equivalent figure on the same cadence).
+- NO if snippets are only news commentary, speculation, expert opinion,
+  or about a related-but-different topic.
+- NO if no snippet contains a specific number / value / measurement tied
+  to this metric.
+"""
+
+MechResponseWithKeys = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]], Any
+]
+MechResponse = Tuple[
+    str, Optional[str], Optional[Dict[str, Any]], Any, Optional[Dict[str, Any]]
+]
+MaxCostResponse = float
+
+
+class MeasurableState(BaseModel):
+    """One measurable state extracted from an article."""
+
+    state: str
+    source: str
+    framing: str
+
+
+class LLMExtractStateSchema(BaseModel):
+    """Schema for the extract-state step output."""
+
+    states: List[MeasurableState]
+
+
+class LLMQuestionProposalSchema(BaseModel):
+    """Schema for proposed questions."""
+
+    questions: List[str]
+
+
+class SelfReviewItem(BaseModel):
+    """One question's self-review result with chain-of-thought reasoning."""
+
+    question: str
+    deadline_date: str
+    earliest_plausible_date: str
+    deadline_is_feasible: bool
+    process_stage_named: bool
+    figure_is_directly_published: bool
+    authority_can_act_in_time: bool
+    date_format_valid: bool
+    not_a_duplicate: bool
+    window_bound_event: bool
+    reasoning: str
+    accept: bool
+
+
+class LLMSelfReviewSchema(BaseModel):
+    """Schema for the self-review pass output."""
+
+    reviews: List[SelfReviewItem]
+
+
+class LLMStorySelectionSchema(BaseModel):
+    """Schema for story selection."""
+
+    topic: str
+    article_id: int
+    reasoning: str
+
+
+def validate_question_dates(question: str, resolution_ts: int) -> Optional[str]:
+    """Check dates in a question: format, not in the past, not too far ahead.
+
+    Also rejects announcement-style phrasings that admit historical instances
+    (e.g. "on or before April 22, 2026") because pre-existing events would
+    then make the question trivially true.
+
+    Dates must be written as "Month D, YYYY" (e.g. "April 22, 2026"). Other
+    orderings cause ApproveMarketsBehaviour to silently drop the market.
+
+    :param question: the question text to scan for date references.
+    :param resolution_ts: the market resolution timestamp (Unix epoch).
+    :return: None if OK, else a human-readable rejection reason.
+    """
+    now = datetime.now(tz=timezone.utc)
+    deadline = datetime.fromtimestamp(resolution_ts, tz=timezone.utc)
+
+    if re.search(r"\bon\s+or\s+before\b", question, re.IGNORECASE):
+        return (
+            "Question uses 'on or before' phrasing which admits historical "
+            "instances. Announcement questions must be window-bound "
+            "(e.g. 'between TODAY and EVENT_DAY')."
+        )
+
+    required_fmt_pattern = r"[A-Z][a-z]+ \d{1,2}, \d{4}"
+    any_date_pattern = r"(\w+ \d{1,2},? \d{4}|\d{1,2} \w+ \d{4})"
+    for match in re.findall(any_date_pattern, question):
+        if not re.fullmatch(required_fmt_pattern, match):
+            return (
+                f"Date '{match}' is not in required 'Month D, YYYY' format "
+                "(e.g. 'April 22, 2026')"
+            )
+        try:
+            d = datetime.strptime(match, "%B %d, %Y").replace(tzinfo=timezone.utc)
+        except ValueError:
+            return f"Date '{match}' could not be parsed"
+        if d < now - timedelta(days=1):
+            return f"Date '{match}' is in the past"
+        if d > deadline + timedelta(days=365):
+            return f"Date '{match}' is too far beyond the deadline"
+    return None
+
+
+class KeyChain:
+    """Manages a pool of API keys per service with round-robin rotation."""
+
+    def __init__(self, services: Dict[str, List[str]]) -> None:
+        """Initialize with a dictionary of service names to API key lists."""
+        if not isinstance(services, dict):
+            raise ValueError(
+                "Services must be a dictionary with service names as keys and lists of API keys as values."
+            )
+        self.services = services
+        self.current_index = {service: 0 for service in services}
+
+    def max_retries(self) -> Dict[str, int]:
+        """Return the maximum number of retries for each service."""
+        return {service: len(keys) for service, keys in self.services.items()}
+
+    def rotate(self, service_name: str) -> None:
+        """Advance the current key index for a service."""
+        if service_name not in self.services:
+            raise KeyError(f"Service '{service_name!r}' not found in KeyChain.")
+        self.current_index[service_name] += 1
+        if self.current_index[service_name] >= len(self.services[service_name]):
+            self.current_index[service_name] = 0
+
+    def get(self, service_name: str, default_value: str) -> str:
+        """Return the current key for a service, or a default if absent."""
+        if service_name not in self.services:
+            return default_value
+        return self.__getitem__(service_name)
+
+    def __getitem__(self, service_name: str) -> str:
+        """Return the current key for a service."""
+        if service_name not in self.services:
+            raise KeyError(f"Service '{service_name!r}' not found in KeyChain.")
+        index = self.current_index[service_name]
+        return self.services[service_name][index]
+
+
+def with_key_rotation(func: Callable) -> Callable:  # noqa
+    """Retry func with API-key rotation on RateLimitError."""
+
+    @functools.wraps(func)
+    def wrapper(
+        *args: Any, **kwargs: Any
+    ) -> Union[MaxCostResponse, MechResponseWithKeys]:
+        # this is expected to be a KeyChain object,
+        # although it is not explicitly typed as such
+        api_keys = kwargs["api_keys"]
+        retries_left: Dict[str, int] = api_keys.max_retries()
+
+        def execute() -> Union[MaxCostResponse, MechResponseWithKeys]:
+            """Retry the function with a new key."""
+            try:
+                result = func(*args, **kwargs)
+                # Max-cost path returns a float; pass through without
+                # appending api_keys (tuple concatenation would fail).
+                if isinstance(result, float):
+                    return result
+                return result + (api_keys,)
+            except openai.RateLimitError as e:
+                # try with a new key again
+                if retries_left["openai"] <= 0 and retries_left["openrouter"] <= 0:
+                    raise e
+                retries_left["openai"] -= 1
+                retries_left["openrouter"] -= 1
+                api_keys.rotate("openai")
+                api_keys.rotate("openrouter")
+                return execute()
+            except Exception as e:
+                return str(e), "", None, None, None, api_keys
+
+        mech_response = execute()
+        return mech_response
+
+    return wrapper
+
+
+class OpenAIClientManager:
+    """Context manager that creates and closes a local OpenAI client."""
+
+    def __init__(self, api_key: str):
+        """Initialize with an API key."""
+        self.api_key = api_key
+        self._client: Optional[OpenAI] = None
+
+    def __enter__(self) -> OpenAI:
+        """Create and return an OpenAI client."""
+        self._client = OpenAI(api_key=self.api_key)
+        return self._client
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        """Close the OpenAI client."""
+        if self._client is not None:
+            self._client.close()
+            self._client = None
+
+
+def _noop_token_counter(*_args: Any, **_kwargs: Any) -> int:
+    """No-op token counter; exact counts are always forwarded from response.usage."""
+    return 0
+
+
+DEFAULT_OPENAI_SETTINGS = {
+    "max_tokens": 4096,
+    "temperature": 0.7,
+}
+ALLOWED_TOOLS = ["propose-question"]
+TOOL_TO_ENGINE = {tool: "gpt-4.1-2025-04-14" for tool in ALLOWED_TOOLS}
+# Cheaper model for classification/extraction steps (story selection,
+# measurable-state extraction). Cuts cost by ~50% with no observable
+# quality loss on classification tasks.
+LIGHT_MODEL = "gpt-4.1-mini-2025-04-14"
+# Representative number of full-model LLM calls per invocation (story
+# selection + state extraction + question proposal + self-review). The
+# verify-state calls are additional but use the same engine; 4 gives a
+# conservative upper bound for the max-cost estimate.
+N_MODEL_CALLS = 4
+DEFAULT_DELIVERY_RATE = 100
+
+_VERIFY_CACHE: Dict[Tuple[str, str], Tuple[bool, str]] = {}
+_VERIFY_CACHE_MAX = 1024
+
+
+def format_utc_timestamp(utc_timestamp: int) -> str:
+    """Format UTC timestamp as 'Month D, YYYY' (US format)."""
+    dt = datetime.fromtimestamp(utc_timestamp, tz=timezone.utc)
+    return f"{dt.strftime('%B')} {dt.day}, {dt.year}"
+
+
+def gather_articles(
+    news_sources: List[str], newsapi_api_key: str
+) -> Optional[List[Dict[str, Any]]]:
+    """Gather news from NewsAPI top-headlines endpoint."""
+    headers = {"X-Api-Key": newsapi_api_key}
+    parameters = {
+        "sources": ",".join(news_sources),
+        "pageSize": str(NEWSAPI_MAX_PAGE_SIZE),
+    }
+    response = requests.get(
+        url=NEWSAPI_TOP_HEADLINES_URL,
+        headers=headers,
+        params=parameters,
+        timeout=60,
+    )
+    if response.status_code != HTTP_OK:
+        print(
+            f"Could not retrieve response from {NEWSAPI_TOP_HEADLINES_URL}."
+            f"Received status code {response.status_code}."
+            f"{response}"
+        )
+        return None
+    response_data = json.loads(response.content.decode("utf-8"))
+    return response_data["articles"]
+
+
+def gather_latest_questions(subgraph_api_key: str) -> Optional[List[str]]:
+    """Gather latest questions opened on Omen exchange."""
+    transport = RequestsHTTPTransport(
+        url=OMEN_SUBGRAPH_URL.format(subgraph_api_key=subgraph_api_key)
+    )
+    gql_client = Client(transport=transport, fetch_schema_from_transport=True)
+    variables = {
+        "creator_in": FPMM_CREATORS,
+        "first": MAX_LATEST_QUESTIONS,
+    }
+    response = gql_client.execute(gql(FPMMS_QUERY), variable_values=variables)
+    items = response.get("fixedProductMarketMakers", [])
+    return [q["question"]["title"] for q in items]
+
+
+DEDUP_STOPWORDS = frozenset(
+    "a an and any are as at be been being between by did do does for from had "
+    "has have if in into is it its of on once or over per still such than that "
+    "the their them there these they this to up was were what when where which "
+    "who will with would according announce announced announcement confirm "
+    "confirmed confirms continue continues hold holds major news occur occurs "
+    "official outlet outlets publish published report reports reported "
+    "reporting remain remains statement statements yes no maintain maintains "
+    "through above below exceed exceeds please".split()
+)
+
+# Jaccard similarity at or above this threshold counts as a near-duplicate.
+# Tuned against real pool data: 0.64 on the classic "retail sales / retail
+# sales excluding gas prices" pair; ~0.30 on genuinely different questions.
+QUESTION_NEAR_DUP_THRESHOLD = 0.55
+
+
+def _dedup_tokens(text: str) -> set:
+    """Normalise text to a content-token set for Jaccard dedup comparisons."""
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9% ]", " ", text)
+    return {
+        t
+        for t in re.sub(r"\s+", " ", text).strip().split()
+        if t and t not in DEDUP_STOPWORDS and len(t) > 2
+    }
+
+
+def filter_duplicate_articles(
+    articles: List[Dict[str, Any]],
+    existing: List[str],
+    threshold: float = 0.40,
+    min_keep_fraction: float = 0.50,
+) -> List[Dict[str, Any]]:
+    """Drop articles whose title+description overlap too much with existing questions.
+
+    Cheap first-stage filter that runs before any LLM call. Moderate threshold
+    (0.40) so articles with a distinct sub-angle survive; the stricter
+    question-level filter (0.55) at the end catches what slips through. Safety
+    valve keeps at least ``min_keep_fraction`` of the pool to prevent
+    empty-pool errors when news is extremely topic-concentrated.
+
+    :param articles: raw article dicts from gather_articles.
+    :param existing: list of recent question titles (EXISTING_QUESTIONS pool).
+    :param threshold: Jaccard cutoff for dropping an article.
+    :param min_keep_fraction: minimum fraction of input to keep regardless.
+    :return: filtered article list (length >= min_keep_fraction * len(articles)).
+    """
+    if not articles or not existing:
+        return articles
+    existing_token_sets = [t for t in (_dedup_tokens(q) for q in existing) if t]
+    if not existing_token_sets:
+        return articles
+    scored = []
+    for a in articles:
+        text = f"{a.get('title', '')} {a.get('description', '')}"
+        atok = _dedup_tokens(text)
+        if not atok:
+            scored.append((0.0, a))
+            continue
+        max_sim = 0.0
+        for qtok in existing_token_sets:
+            denom = len(atok | qtok)
+            if denom == 0:
+                continue
+            sim = len(atok & qtok) / denom
+            if sim > max_sim:
+                max_sim = sim
+        scored.append((max_sim, a))
+    kept = [a for sim, a in scored if sim < threshold]
+    n_in = len(articles)
+    min_keep = max(1, int(n_in * min_keep_fraction))
+    if len(kept) < min_keep:
+        scored.sort(key=lambda t: t[0])
+        kept = [a for _, a in scored[:min_keep]]
+        print(
+            f"Article dedup: safety valve triggered, keeping "
+            f"{len(kept)}/{n_in} least-similar articles"
+        )
+    else:
+        print(
+            f"Article dedup: dropped {n_in - len(kept)}/{n_in} articles "
+            f"(jaccard >= {threshold})"
+        )
+    return kept
+
+
+def find_near_duplicate(
+    question: str,
+    existing: List[str],
+    threshold: float = QUESTION_NEAR_DUP_THRESHOLD,
+) -> Optional[Tuple[str, float]]:
+    """Return (matching_existing, jaccard) if question is a near-duplicate.
+
+    The LLM-based ``not_a_duplicate`` self-review misses paraphrases like
+    "retail sales % change" vs "monthly retail sales % change excluding gas
+    prices" -- both test the same metric from the same source, Jaccard ~0.64.
+    This programmatic filter catches them deterministically.
+
+    :param question: candidate question text.
+    :param existing: list of already-accepted question titles.
+    :param threshold: Jaccard cutoff; defaults to QUESTION_NEAR_DUP_THRESHOLD.
+    :return: (matched_existing, jaccard_score) if a duplicate is found, else None.
+    """
+    new_tok = _dedup_tokens(question)
+    if not new_tok:
+        return None
+    for old in existing:
+        old_tok = _dedup_tokens(old)
+        denom = len(new_tok | old_tok)
+        if denom == 0:
+            continue
+        score = len(new_tok & old_tok) / denom
+        if score >= threshold:
+            return old, score
+    return None
+
+
+def scrape_url(serper_api_key: str, url: str) -> Optional[dict]:
+    """Scrape the contents of a URL via the Serper scrape endpoint."""
+    serper_url = "https://scrape.serper.dev"
+    headers = {"X-API-KEY": serper_api_key, "Content-Type": "application/json"}
+    payload = json.dumps({"url": url})
+    try:
+        response = requests.post(serper_url, headers=headers, data=payload, timeout=60)
+        response.raise_for_status()
+        scraped_data = response.json()
+        print(f"Successfully scraped URL: {url}")
+        return scraped_data
+    except requests.RequestException:
+        return None
+    except json.JSONDecodeError:
+        return None
+
+
+def _cache_put(key: Tuple[str, str], result: Tuple[bool, str]) -> None:
+    """Insert a verifier result into the cache, evicting oldest on overflow.
+
+    :param key: (source, metric) tuple identifying the verified claim.
+    :param result: (is_resolvable, reason) tuple to cache.
+    """
+    if len(_VERIFY_CACHE) >= _VERIFY_CACHE_MAX:
+        oldest = next(iter(_VERIFY_CACHE), None)
+        if oldest is not None:
+            _VERIFY_CACHE.pop(oldest, None)
+    _VERIFY_CACHE[key] = result
+
+
+def verify_state_is_resolvable(
+    client: OpenAI, serper_api_key: str, source: str, metric: str
+) -> Tuple[bool, str]:
+    """Decide whether a (source, metric) tuple is publicly resolvable.
+
+    Issues one Google search via Serper and passes the top organic snippets
+    to a cheap LLM judge, which decides whether the source publishes the
+    specific metric on a checkable cadence.
+
+    Results are cached in a process-local dict keyed by (source, metric) so
+    the same article re-picked across cycles does not re-burn Serper + LLM
+    calls. Fail-open: Serper or OpenAI errors return (True, ...) so a
+    transient outage cannot starve generation.
+
+    :param client: an active OpenAI client instance.
+    :param serper_api_key: Serper API key for the Google query.
+    :param source: source-of-truth name from the extracted measurable state.
+    :param metric: metric/state name being asked about.
+    :return: (is_resolvable, reason).
+    """
+    cache_key = (source, metric)
+    cached = _VERIFY_CACHE.get(cache_key)
+    if cached is not None:
+        return cached[0], f"{cached[1]} [cached]"
+    query = f"{source} {metric}".strip()
+    if not query:
+        return True, "empty_query"
+    payload = json.dumps({"q": query})
+    headers = {"X-API-KEY": serper_api_key, "Content-Type": "application/json"}
+    try:
+        response = requests.post(
+            "https://google.serper.dev/search",
+            headers=headers,
+            data=payload,
+            timeout=30,
+        )
+        if response.status_code != 200:
+            return True, f"fail_open_serper_status_{response.status_code}"
+        body = response.json()
+        if "organic" not in body:
+            return True, "fail_open_serper_unexpected_shape"
+        organic = body["organic"][:5]
+    except (requests.RequestException, json.JSONDecodeError):
+        return True, "fail_open_serper_error"
+
+    if not organic:
+        result = (False, "no_hits")
+        _cache_put(cache_key, result)
+        return result
+
+    snippets = "\n".join(
+        f"- TITLE: {o.get('title', '')}\n  SNIPPET: {o.get('snippet', '')}"
+        for o in organic
+    )
+    try:
+        judge_response = client.chat.completions.create(
+            model=LIGHT_MODEL,
+            messages=[
+                {
+                    "role": "user",
+                    "content": SOURCE_VERIFY_JUDGE_PROMPT.format(
+                        source=source,
+                        metric=metric,
+                        query=query,
+                        snippets=snippets,
+                    ),
+                }
+            ],
+            temperature=0,
+            max_tokens=128,
+            response_format={"type": "json_object"},
+            timeout=30,
+        )
+        content = judge_response.choices[0].message.content or ""
+        out = json.loads(content)
+    except (
+        openai.OpenAIError,
+        json.JSONDecodeError,
+        AttributeError,
+        KeyError,
+        TypeError,
+    ):
+        return True, "fail_open_llm_error"
+    result = (out.get("answer") == "YES", str(out.get("reason") or "")[:120])
+    _cache_put(cache_key, result)
+    return result
+
+
+@with_key_rotation
+def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
+    """Propose prediction-market questions from recent news.
+
+    Accepts kwargs from the mech executor. The ``prompt`` field may be a
+    JSON-encoded dict with ``resolution_time`` and optionally
+    ``num_questions``; plain-string prompts fall back to reading those
+    values from kwargs directly.
+
+    When ``delivery_rate == 0`` the function returns the estimated maximum
+    cost as a bare ``float`` (via ``counter_callback(max_cost=True, ...)``),
+    bypassing all API calls.
+
+    :param kwargs: Keyword arguments including 'tool', 'prompt', 'api_keys',
+        'counter_callback', 'resolution_time', 'num_questions',
+        'delivery_rate'.
+    :type kwargs: Any
+
+    :return: estimated max cost float when delivery_rate==0, else 5-tuple
+        (result_json, prompt_echo, None, counter_callback, used_params).
+    :rtype: Union[MaxCostResponse, MechResponse]
+    """
+    try:
+        counter_callback = kwargs.get("counter_callback", None)
+        tool = kwargs.get("tool")
+        delivery_rate = int(kwargs.get("delivery_rate", DEFAULT_DELIVERY_RATE))
+        if delivery_rate == 0:
+            if not counter_callback:
+                raise ValueError(
+                    "A delivery rate of `0` was passed, but no counter callback was "
+                    "given to calculate the max cost with."
+                )
+            tool_engine = TOOL_TO_ENGINE.get(
+                kwargs.get("tool", ""), list(TOOL_TO_ENGINE.values())[0]
+            )
+            max_cost: MaxCostResponse = counter_callback(
+                max_cost=True,
+                models_calls=(tool_engine,) * N_MODEL_CALLS,
+            )
+            return max_cost
+
+        if not tool or tool not in ALLOWED_TOOLS:
+            return (
+                json.dumps(
+                    {
+                        "error": f"Tool {tool} is not in the list of supported tools.",
+                        "tool": tool,
+                    }
+                ),
+                None,
+                None,
+                counter_callback,
+                None,
+            )
+
+        # Decode resolution_time and num_questions from prompt JSON if present.
+        prompt_raw = kwargs.get("prompt", "")
+        resolution_time = kwargs.get("resolution_time")
+        num_questions = kwargs.get("num_questions")
+        try:
+            prompt_dict = json.loads(prompt_raw) if prompt_raw else {}
+            if isinstance(prompt_dict, dict):
+                if resolution_time is None:
+                    resolution_time = prompt_dict.get("resolution_time")
+                if num_questions is None:
+                    num_questions = prompt_dict.get("num_questions")
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        if resolution_time is None:
+            return (
+                json.dumps(
+                    {
+                        "error": "'resolution_time' is not defined.",
+                        "tool": tool,
+                    }
+                ),
+                None,
+                None,
+                counter_callback,
+                None,
+            )
+        if num_questions is None:
+            num_questions = 1
+
+        # Gather latest opened questions from input or from TheGraph.
+        latest_questions = kwargs.get("latest_questions")
+        if latest_questions is None:
+            latest_questions = gather_latest_questions(kwargs["api_keys"]["subgraph"])
+        if latest_questions is None:
+            return (
+                json.dumps(
+                    {
+                        "error": "Failed to retrieve latest questions.",
+                        "tool": tool,
+                    }
+                ),
+                None,
+                None,
+                counter_callback,
+                None,
+            )
+
+        # Keep the MAX_LATEST_QUESTIONS most recent (subgraph already returns
+        # them newest-first).
+        latest_questions = latest_questions[:MAX_LATEST_QUESTIONS]
+        latest_questions_string = "\n".join(latest_questions)
+
+        # Gather recent news articles from NewsAPI.
+        news_sources = kwargs.get("news_sources", NEWSAPI_DEFAULT_NEWS_SOURCES)
+        articles = gather_articles(news_sources, kwargs["api_keys"]["newsapi"])
+        if articles is None:
+            return (
+                json.dumps(
+                    {
+                        "error": "Failed to retrieve articles from NewsAPI.",
+                        "tool": tool,
+                    }
+                ),
+                None,
+                None,
+                counter_callback,
+                None,
+            )
+
+        print(
+            f"{len(articles)} articles collected from {len(news_sources)} news sources\n"
+        )
+        articles = random.sample(
+            articles, min(MAX_ARTICLES, len(articles))
+        )  # nosec: B311
+
+        # Early article-level dedup: drop articles whose topic already appears
+        # in EXISTING_QUESTIONS. Moderate threshold (0.40) to keep articles with
+        # distinct sub-angles; safety valve prevents empty-pool errors.
+        articles = filter_duplicate_articles(articles, latest_questions)
+
+        # Pre-filter: drop articles that individually trigger content moderation
+        # before building the selection prompt, avoiding flagging the whole prompt
+        # due to a single violent-news snippet.
+        with OpenAIClientManager(kwargs["api_keys"]["openai"]) as openai_client:
+            clean_articles = []
+            for article in articles:
+                text = f"{article.get('title', '')}: {article.get('content', '')}"
+                try:
+                    mod = openai_client.moderations.create(input=text)
+                    if not mod.results[0].flagged:
+                        clean_articles.append(article)
+                except Exception:
+                    clean_articles.append(article)
+            n_dropped = len(articles) - len(clean_articles)
+            if n_dropped > 0:
+                print(f"Moderation pre-filter: dropped {n_dropped} flagged article(s)")
+            articles = clean_articles
+
+        if not articles:
+            return (
+                json.dumps(
+                    {
+                        "error": "All articles were flagged by content moderation.",
+                        "tool": tool,
+                    }
+                ),
+                None,
+                None,
+                counter_callback,
+                None,
+            )
+
+        articles_string = ""
+        for i, article in enumerate(articles, start=0):
+            articles_string += f"{i} - {article['title']} ({article['publishedAt']}): {article['content']}\n"
+
+        topics = kwargs.get("topics", DEFAULT_TOPICS)
+        topics_string = ", ".join(topics)
+
+        # Story selection -- classification task, uses the cheaper light model.
+        model = LIGHT_MODEL
+        prompt_values = {
+            "articles": articles_string,
+            "topics": topics_string,
+            "latest_questions": latest_questions_string,
+        }
+        prompt = SELECT_STORY_PROMPT.format(**prompt_values)
+
+        with OpenAIClientManager(kwargs["api_keys"]["openai"]) as openai_client:
+            max_tokens = kwargs.get("max_tokens", DEFAULT_OPENAI_SETTINGS["max_tokens"])
+            temperature = kwargs.get(
+                "temperature", DEFAULT_OPENAI_SETTINGS["temperature"]
+            )
+
+            moderation_result = openai_client.moderations.create(input=prompt)
+            if moderation_result.results[0].flagged:
+                return (
+                    json.dumps(
+                        {
+                            "error": "Moderation flagged the prompt as in violation of terms.",
+                            "tool": tool,
+                        }
+                    ),
+                    None,
+                    None,
+                    counter_callback,
+                    None,
+                )
+
+            messages = [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": prompt},
+            ]
+            response = openai_client.chat.completions.create(  # type: ignore[call-overload]
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                n=1,
+                timeout=120,
+                stop=None,
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "LLMStorySelectionSchema",
+                        "schema": LLMStorySelectionSchema.model_json_schema(),
+                    },
+                },
+            )
+            if counter_callback:
+                counter_callback(
+                    input_tokens=response.usage.prompt_tokens,
+                    output_tokens=response.usage.completion_tokens,
+                    model=model,
+                    token_counter=_noop_token_counter,
+                )
+            response_data = json.loads(response.choices[0].message.content)
+            article_id = response_data["article_id"]
+            topic = response_data["topic"]
+            article = articles[article_id]
+            reasoning = (
+                f"The article {article['title']!r} "
+                f"({article.get('author', '')!r}) has been selected to generate "
+                f"prediction market questions because: {response_data['reasoning']}"
+            )
+
+        # Scrape the selected article for full body text.
+        scrape_result = scrape_url(kwargs["api_keys"]["serperapi"], article["url"])
+        if scrape_result is None:
+            return (
+                json.dumps(
+                    {
+                        "error": f"Failed to scrape url {article['url']}",
+                        "tool": tool,
+                    }
+                ),
+                None,
+                None,
+                counter_callback,
+                None,
+            )
+
+        # Extract measurable states -- constrains the LLM to identify what CAN
+        # be measured before framing a question, breaking the default
+        # "Will X announce Y?" prior.
+        article_text = scrape_result["text"][:ARTICLE_TEXT_MAX_CHARS]
+        with OpenAIClientManager(kwargs["api_keys"]["openai"]) as openai_client:
+            model = LIGHT_MODEL
+            extract_prompt = EXTRACT_STATE_PROMPT.format(article=article_text)
+            extract_messages = [
+                {
+                    "role": "system",
+                    "content": "You are an analyst extracting measurable facts from news articles.",
+                },
+                {"role": "user", "content": extract_prompt},
+            ]
+            extract_response = openai_client.chat.completions.create(
+                model=model,
+                messages=extract_messages,
+                temperature=0.3,
+                max_tokens=1024,
+                n=1,
+                timeout=120,
+                stop=None,
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "LLMExtractStateSchema",
+                        "schema": LLMExtractStateSchema.model_json_schema(),
+                    },
+                },
+            )
+            if counter_callback:
+                counter_callback(
+                    input_tokens=extract_response.usage.prompt_tokens,
+                    output_tokens=extract_response.usage.completion_tokens,
+                    model=model,
+                    token_counter=_noop_token_counter,
+                )
+            extract_data = json.loads(extract_response.choices[0].message.content)
+            states = extract_data.get("states", [])
+            print(f"Extracted {len(states)} measurable states:")
+            for s in states:
+                print(
+                    f"  [{s.get('framing', '?')}] {s.get('state', '?')} -- source: {s.get('source', '?')}"
+                )
+
+        # Verify each extracted (source, metric) is actually resolvable via
+        # a Serper search + cheap LLM judge. Filters fictional sources before
+        # they reach question generation.
+        with OpenAIClientManager(kwargs["api_keys"]["openai"]) as openai_client:
+            verified_states = []
+            for s in states:
+                src = s.get("source", "") or ""
+                metric = s.get("state", "") or ""
+                is_verified, reason = verify_state_is_resolvable(
+                    openai_client, kwargs["api_keys"]["serperapi"], src, metric
+                )
+                if is_verified:
+                    verified_states.append(s)
+                else:
+                    print(
+                        f"  DROPPED unverifiable state ({reason}): "
+                        f"[{s.get('framing', '?')}] {metric} -- source: {src}"
+                    )
+            print(
+                f"Source verification: kept {len(verified_states)}/{len(states)} states"
+            )
+            if not verified_states and states:
+                # Soft fall-through: every extracted state failed verification.
+                # Let the question-generator work from the article body alone --
+                # the self-review pass is the next gate that rejects un-resolvable
+                # framings.
+                print(
+                    f"WARN: 0/{len(states)} states verified; falling back to "
+                    f"article-only generation (no measurable_states context)."
+                )
+            states = verified_states
+            states_string = json.dumps(states, indent=2) if states else "(none found)"
+
+        # Generate candidate questions using the extracted states.
+        with OpenAIClientManager(kwargs["api_keys"]["openai"]) as openai_client:
+            max_tokens = kwargs.get("max_tokens", DEFAULT_OPENAI_SETTINGS["max_tokens"])
+            temperature = kwargs.get(
+                "temperature", DEFAULT_OPENAI_SETTINGS["temperature"]
+            )
+            model = kwargs.get("model", TOOL_TO_ENGINE[tool])
+
+            # Generate 3x candidates (min 3) so self-review can act as a
+            # selector. Reduced from 5x to keep self-review token cost
+            # proportional (review prompt scales linearly with candidates).
+            n_candidates = max(num_questions * 3, 3)
+            window_days = max(
+                1,
+                (int(resolution_time) - int(datetime.now(tz=timezone.utc).timestamp()))
+                // 86400,
+            )
+            prompt_values = {
+                "article": f"{article_text}",
+                "today": format_utc_timestamp(
+                    int(datetime.now(tz=timezone.utc).timestamp())
+                ),
+                "event_day": format_utc_timestamp(int(resolution_time)),
+                "latest_questions": latest_questions_string,
+                "measurable_states": states_string,
+                "num_questions": f"{n_candidates}",
+                "window_days": str(window_days),
+            }
+            propose_prompt = PROPOSE_QUESTION_PROMPT.format(**prompt_values)
+
+            moderation_result = openai_client.moderations.create(input=propose_prompt)
+            if moderation_result.results[0].flagged:
+                return (
+                    json.dumps(
+                        {
+                            "error": "Moderation flagged the prompt as in violation of terms.",
+                            "tool": tool,
+                        }
+                    ),
+                    None,
+                    None,
+                    counter_callback,
+                    None,
+                )
+
+            messages = [
+                {"role": "system", "content": "You are a helpful assistant."},
+                {"role": "user", "content": propose_prompt},
+            ]
+            response = openai_client.chat.completions.create(  # type: ignore[call-overload]
+                model=model,
+                messages=messages,
+                temperature=temperature,
+                max_tokens=max_tokens,
+                n=1,
+                timeout=120,
+                stop=None,
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "LLMQuestionProposalSchema",
+                        "schema": LLMQuestionProposalSchema.model_json_schema(),
+                    },
+                },
+            )
+            if counter_callback:
+                counter_callback(
+                    input_tokens=response.usage.prompt_tokens,
+                    output_tokens=response.usage.completion_tokens,
+                    model=model,
+                    token_counter=_noop_token_counter,
+                )
+            response_data = json.loads(response.choices[0].message.content)
+
+        # Self-review: audit proposed questions against quality checks.
+        questions = response_data["questions"]
+        review_model = TOOL_TO_ENGINE[tool]
+
+        with OpenAIClientManager(kwargs["api_keys"]["openai"]) as openai_client:
+            review_prompt = SELF_REVIEW_PROMPT.format(
+                questions=json.dumps(questions, indent=2),
+                latest_questions=latest_questions_string,
+                article=f"{scrape_result['text'][:ARTICLE_TEXT_MAX_CHARS]}",
+                today=format_utc_timestamp(
+                    int(datetime.now(tz=timezone.utc).timestamp())
+                ),
+                event_day=format_utc_timestamp(int(resolution_time)),
+            )
+            review_messages = [
+                {
+                    "role": "system",
+                    "content": "You are a prediction-market question auditor.",
+                },
+                {"role": "user", "content": review_prompt},
+            ]
+            review_response = openai_client.chat.completions.create(
+                model=review_model,
+                messages=review_messages,
+                temperature=0.0,
+                max_tokens=2048,
+                n=1,
+                timeout=120,
+                stop=None,
+                response_format={
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "LLMSelfReviewSchema",
+                        "schema": LLMSelfReviewSchema.model_json_schema(),
+                    },
+                },
+            )
+            if counter_callback:
+                counter_callback(
+                    input_tokens=review_response.usage.prompt_tokens,
+                    output_tokens=review_response.usage.completion_tokens,
+                    model=review_model,
+                    token_counter=_noop_token_counter,
+                )
+            review_data = json.loads(review_response.choices[0].message.content)
+            reviews = review_data.get("reviews", [])
+
+        # Accept questions only when ALL seven self-review checks pass.
+        accepted_questions = []
+        rejected_questions = []
+        for rev in reviews:
+            checks = [
+                rev.get("deadline_is_feasible", True),
+                rev.get("process_stage_named", True),
+                rev.get("figure_is_directly_published", True),
+                rev.get("authority_can_act_in_time", True),
+            ]
+            passes = sum(1 for c in checks if c)
+            date_ok = rev.get("date_format_valid", True)
+            not_dup = rev.get("not_a_duplicate", True)
+            window_ok = rev.get("window_bound_event", True)
+            if passes == len(checks) and date_ok and not_dup and window_ok:
+                accepted_questions.append(rev["question"])
+            else:
+                rejected_questions.append(
+                    {
+                        "question": rev["question"],
+                        "reason": rev.get(
+                            "reasoning",
+                            rev.get("rejection_reason", "failed self-review"),
+                        ),
+                    }
+                )
+
+        # Programmatic date validation -- catches past dates and out-of-range
+        # dates that the LLM self-review misses.
+        date_validated = []
+        for q in accepted_questions:
+            date_issue = validate_question_dates(q, int(resolution_time))
+            if date_issue:
+                rejected_questions.append(
+                    {"question": q, "reason": f"DATE CHECK: {date_issue}"}
+                )
+            else:
+                date_validated.append(q)
+
+        print(
+            f"Self-review: {len(accepted_questions)} accepted, "
+            f"{len(rejected_questions)} rejected out of {n_candidates} proposed"
+        )
+        for rej in rejected_questions:
+            print(f"  REJECTED: {rej['question'][:80]}... -- {rej['reason'][:60]}")
+
+        # Programmatic near-duplicate filter: last-stage deterministic check.
+        nondup_validated = []
+        for q in date_validated:
+            hit = find_near_duplicate(q, latest_questions)
+            if hit is None:
+                nondup_validated.append(q)
+            else:
+                match, score = hit
+                print(
+                    f"  PROGRAMMATIC DEDUP REJECT (jaccard {score:.2f}): {q[:80]}...\n"
+                    f"    matches existing: {match[:80]}..."
+                )
+
+        if not nondup_validated:
+            err_payload = {
+                "error": (
+                    f"All {n_candidates} proposed questions were rejected by "
+                    "self-review, date validation, or programmatic dedup."
+                ),
+                "tool": tool,
+            }
+            return json.dumps(err_payload), None, None, counter_callback, None
+
+        questions = nondup_validated[:num_questions]
+
+        answers = ["Yes", "No"]
+        language = "en_US"
+        questions_dict = {}
+        for q in questions:
+            question_id = str(uuid.uuid4())
+            questions_dict[question_id] = {
+                "answers": answers,
+                "id": question_id,
+                "language": language,
+                "question": q,
+                "resolution_time": resolution_time,
+                "topic": topic,
+                "article": article,
+            }
+
+        output = {
+            "questions": questions_dict,
+            "reasoning": reasoning,
+            "article": article,
+        }
+        used_params = {"model": model}
+        return (
+            json.dumps(output, sort_keys=True),
+            prompt_raw,
+            None,
+            counter_callback,
+            used_params,
+        )
+    except Exception as e:
+        return (
+            json.dumps(
+                {
+                    "error": f"An exception has occurred: {e}.",
+                    "tool": tool,
+                }
+            ),
+            None,
+            None,
+            counter_callback,
+            None,
+        )

--- a/packages/valory/customs/propose_question/propose_question.py
+++ b/packages/valory/customs/propose_question/propose_question.py
@@ -543,13 +543,11 @@ def with_key_rotation(func: Callable) -> Callable:  # noqa
                     return result
                 return result + (api_keys,)
             except openai.RateLimitError as e:
-                # try with a new key again
-                if retries_left["openai"] <= 0 and retries_left["openrouter"] <= 0:
+                # try with a new key again; this tool only uses the openai key
+                if retries_left["openai"] <= 0:
                     raise e
                 retries_left["openai"] -= 1
-                retries_left["openrouter"] -= 1
                 api_keys.rotate("openai")
-                api_keys.rotate("openrouter")
                 return execute()
             except Exception as e:
                 return str(e), "", None, None, None, api_keys
@@ -643,7 +641,8 @@ def gather_latest_questions(subgraph_api_key: str) -> Optional[List[str]]:
     transport = RequestsHTTPTransport(
         url=OMEN_SUBGRAPH_URL.format(subgraph_api_key=subgraph_api_key)
     )
-    gql_client = Client(transport=transport, fetch_schema_from_transport=True)
+    # Static query -- skip the per-call GraphQL introspection round-trip.
+    gql_client = Client(transport=transport, fetch_schema_from_transport=False)
     variables = {
         "creator_in": FPMM_CREATORS,
         "first": MAX_LATEST_QUESTIONS,
@@ -1060,7 +1059,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
 
         articles_string = ""
         for i, article in enumerate(articles, start=0):
-            articles_string += f"{i} - {article['title']} ({article['publishedAt']}): {article['content']}\n"
+            articles_string += f"{i} - {article.get('title', '')} ({article.get('publishedAt', '')}): {article.get('content', '')}\n"
 
         topics = kwargs.get("topics", DEFAULT_TOPICS)
         topics_string = ", ".join(topics)
@@ -1125,6 +1124,22 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
             response_data = json.loads(response.choices[0].message.content)
             article_id = response_data["article_id"]
             topic = response_data["topic"]
+            if not isinstance(article_id, int) or not 0 <= article_id < len(articles):
+                return (
+                    json.dumps(
+                        {
+                            "error": (
+                                f"LLM returned invalid article_id {article_id!r} "
+                                f"(have {len(articles)} articles)."
+                            ),
+                            "tool": tool,
+                        }
+                    ),
+                    None,
+                    None,
+                    counter_callback,
+                    None,
+                )
             article = articles[article_id]
             reasoning = (
                 f"The article {article['title']!r} "
@@ -1133,12 +1148,14 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
             )
 
         # Scrape the selected article for full body text.
-        scrape_result = scrape_url(kwargs["api_keys"]["serperapi"], article["url"])
+        scrape_result = scrape_url(
+            kwargs["api_keys"]["serperapi"], article.get("url", "")
+        )
         if scrape_result is None:
             return (
                 json.dumps(
                     {
-                        "error": f"Failed to scrape url {article['url']}",
+                        "error": f"Failed to scrape url {article.get('url', '')}",
                         "tool": tool,
                     }
                 ),
@@ -1446,6 +1463,10 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
             counter_callback,
             used_params,
         )
+    except openai.RateLimitError:
+        # Let @with_key_rotation handle rate limits (rotate key + retry);
+        # swallowing it here would make that decorator dead code.
+        raise
     except Exception as e:
         return (
             json.dumps(

--- a/packages/valory/customs/propose_question/propose_question.py
+++ b/packages/valory/customs/propose_question/propose_question.py
@@ -20,6 +20,7 @@
 
 import functools
 import json
+import logging
 import random
 import re
 import uuid
@@ -32,6 +33,8 @@ from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 from openai import OpenAI
 from pydantic import BaseModel
+
+_logger = logging.getLogger(__name__)
 
 NEWSAPI_TOP_HEADLINES_URL = "https://newsapi.org/v2/top-headlines"
 NEWSAPI_DEFAULT_NEWS_SOURCES = [
@@ -465,7 +468,15 @@ def validate_question_dates(question: str, resolution_ts: int) -> Optional[str]:
         )
 
     required_fmt_pattern = r"[A-Z][a-z]+ \d{1,2}, \d{4}"
-    any_date_pattern = r"(\w+ \d{1,2},? \d{4}|\d{1,2} \w+ \d{4})"
+    _months = (
+        r"(?:January|February|March|April|May|June|July|August"
+        r"|September|October|November|December)"
+    )
+    # Match month-first (with or without comma) and day-before-month orderings,
+    # both anchored to real month names so "cut rates 2 times 2026" is NOT matched.
+    any_date_pattern = (
+        r"(?:" + _months + r" \d{1,2},? \d{4}|\b\d{1,2} " + _months + r" \d{4}\b)"
+    )
     for match in re.findall(any_date_pattern, question):
         if not re.fullmatch(required_fmt_pattern, match):
             return (
@@ -593,10 +604,10 @@ TOOL_TO_ENGINE = {tool: "gpt-4.1-2025-04-14" for tool in ALLOWED_TOOLS}
 # measurable-state extraction). Cuts cost by ~50% with no observable
 # quality loss on classification tasks.
 LIGHT_MODEL = "gpt-4.1-mini-2025-04-14"
-# Representative number of full-model LLM calls per invocation (story
-# selection + state extraction + question proposal + self-review). The
-# verify-state calls are additional but use the same engine; 4 gives a
-# conservative upper bound for the max-cost estimate.
+# Representative number of full-model (TOOL_TO_ENGINE) LLM calls per invocation.
+# Only question-proposal and self-review use the full engine; story-selection,
+# state-extraction, and verify-state all use LIGHT_MODEL. Billing 4 full-engine
+# calls is an intentional conservative over-estimate for cost budgeting.
 N_MODEL_CALLS = 4
 DEFAULT_DELIVERY_RATE = 100
 
@@ -633,7 +644,7 @@ def gather_articles(
         )
         return None
     response_data = json.loads(response.content.decode("utf-8"))
-    return response_data["articles"]
+    return response_data.get("articles")
 
 
 def gather_latest_questions(subgraph_api_key: str) -> Optional[List[str]]:
@@ -647,9 +658,12 @@ def gather_latest_questions(subgraph_api_key: str) -> Optional[List[str]]:
         "creator_in": FPMM_CREATORS,
         "first": MAX_LATEST_QUESTIONS,
     }
-    response = gql_client.execute(gql(FPMMS_QUERY), variable_values=variables)
-    items = response.get("fixedProductMarketMakers", [])
-    return [q["question"]["title"] for q in items]
+    try:
+        response = gql_client.execute(gql(FPMMS_QUERY), variable_values=variables)
+        items = response.get("fixedProductMarketMakers", [])
+        return [q["question"]["title"] for q in items]
+    except Exception:  # noqa: BLE001
+        return None
 
 
 DEDUP_STOPWORDS = frozenset(
@@ -781,9 +795,11 @@ def scrape_url(serper_api_key: str, url: str) -> Optional[dict]:
         scraped_data = response.json()
         print(f"Successfully scraped URL: {url}")
         return scraped_data
-    except requests.RequestException:
+    except requests.RequestException as exc:
+        _logger.warning("scrape_url request error for %s: %s", url, exc)
         return None
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as exc:
+        _logger.warning("scrape_url JSON decode error for %s: %s", url, exc)
         return None
 
 
@@ -846,9 +862,7 @@ def verify_state_is_resolvable(
         return True, "fail_open_serper_error"
 
     if not organic:
-        result = (False, "no_hits")
-        _cache_put(cache_key, result)
-        return result
+        return False, "no_hits"
 
     snippets = "\n".join(
         f"- TITLE: {o.get('title', '')}\n  SNIPPET: {o.get('snippet', '')}"
@@ -972,6 +986,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
             )
         if num_questions is None:
             num_questions = 1
+        num_questions = int(num_questions)
 
         # Gather latest opened questions from input or from TheGraph.
         latest_questions = kwargs.get("latest_questions")
@@ -1036,7 +1051,8 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
                     mod = openai_client.moderations.create(input=text)
                     if not mod.results[0].flagged:
                         clean_articles.append(article)
-                except Exception:
+                except Exception as exc:  # noqa: BLE001
+                    _logger.warning("Moderation pre-filter error (fail-open): %s", exc)
                     clean_articles.append(article)
             n_dropped = len(articles) - len(clean_articles)
             if n_dropped > 0:
@@ -1114,7 +1130,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
                     },
                 },
             )
-            if counter_callback:
+            if counter_callback and response.usage:
                 counter_callback(
                     input_tokens=response.usage.prompt_tokens,
                     output_tokens=response.usage.completion_tokens,
@@ -1142,7 +1158,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
                 )
             article = articles[article_id]
             reasoning = (
-                f"The article {article['title']!r} "
+                f"The article {article.get('title', '')!r} "
                 f"({article.get('author', '')!r}) has been selected to generate "
                 f"prediction market questions because: {response_data['reasoning']}"
             )
@@ -1168,7 +1184,16 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
         # Extract measurable states -- constrains the LLM to identify what CAN
         # be measured before framing a question, breaking the default
         # "Will X announce Y?" prior.
-        article_text = scrape_result["text"][:ARTICLE_TEXT_MAX_CHARS]
+        _scraped_text = scrape_result.get("text", "")
+        if not _scraped_text:
+            return (
+                json.dumps({"error": "Scraped article has no text.", "tool": tool}),
+                None,
+                None,
+                counter_callback,
+                None,
+            )
+        article_text = _scraped_text[:ARTICLE_TEXT_MAX_CHARS]
         with OpenAIClientManager(kwargs["api_keys"]["openai"]) as openai_client:
             model = LIGHT_MODEL
             extract_prompt = EXTRACT_STATE_PROMPT.format(article=article_text)
@@ -1195,7 +1220,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
                     },
                 },
             )
-            if counter_callback:
+            if counter_callback and extract_response.usage:
                 counter_callback(
                     input_tokens=extract_response.usage.prompt_tokens,
                     output_tokens=extract_response.usage.completion_tokens,
@@ -1308,7 +1333,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
                     },
                 },
             )
-            if counter_callback:
+            if counter_callback and response.usage:
                 counter_callback(
                     input_tokens=response.usage.prompt_tokens,
                     output_tokens=response.usage.completion_tokens,
@@ -1325,7 +1350,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
             review_prompt = SELF_REVIEW_PROMPT.format(
                 questions=json.dumps(questions, indent=2),
                 latest_questions=latest_questions_string,
-                article=f"{scrape_result['text'][:ARTICLE_TEXT_MAX_CHARS]}",
+                article=f"{scrape_result.get('text', '')[:ARTICLE_TEXT_MAX_CHARS]}",
                 today=format_utc_timestamp(
                     int(datetime.now(tz=timezone.utc).timestamp())
                 ),
@@ -1354,7 +1379,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
                     },
                 },
             )
-            if counter_callback:
+            if counter_callback and review_response.usage:
                 counter_callback(
                     input_tokens=review_response.usage.prompt_tokens,
                     output_tokens=review_response.usage.completion_tokens,
@@ -1369,15 +1394,15 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
         rejected_questions = []
         for rev in reviews:
             checks = [
-                rev.get("deadline_is_feasible", True),
-                rev.get("process_stage_named", True),
-                rev.get("figure_is_directly_published", True),
-                rev.get("authority_can_act_in_time", True),
+                rev.get("deadline_is_feasible", False),
+                rev.get("process_stage_named", False),
+                rev.get("figure_is_directly_published", False),
+                rev.get("authority_can_act_in_time", False),
             ]
             passes = sum(1 for c in checks if c)
-            date_ok = rev.get("date_format_valid", True)
-            not_dup = rev.get("not_a_duplicate", True)
-            window_ok = rev.get("window_bound_event", True)
+            date_ok = rev.get("date_format_valid", False)
+            not_dup = rev.get("not_a_duplicate", False)
+            window_ok = rev.get("window_bound_event", False)
             if passes == len(checks) and date_ok and not_dup and window_ok:
                 accepted_questions.append(rev["question"])
             else:

--- a/packages/valory/customs/propose_question/tests/__init__.py
+++ b/packages/valory/customs/propose_question/tests/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for the propose_question custom package."""

--- a/packages/valory/customs/propose_question/tests/test_propose_question.py
+++ b/packages/valory/customs/propose_question/tests/test_propose_question.py
@@ -22,13 +22,13 @@
 import inspect
 import json
 import time
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
-from datetime import datetime, timedelta, timezone
-from typing import Any
 
 import packages.valory.customs.propose_question.propose_question as module
 from packages.valory.customs.propose_question.propose_question import (
@@ -258,9 +258,7 @@ class TestFindNearDuplicate:
     def test_exact_duplicate_detected(self) -> None:
         """Near-identical question should be flagged as a duplicate."""
         existing = ["Will retail sales percentage change exceed forecast?"]
-        candidate = (
-            "Will retail sales percentage change exceed monthly forecast?"
-        )
+        candidate = "Will retail sales percentage change exceed monthly forecast?"
         hit = find_near_duplicate(candidate, existing)
         # Jaccard ~0.83 >> threshold 0.55 -- must be detected.
         assert hit is not None
@@ -1098,27 +1096,24 @@ class TestValidatequestionDatesAdditional:
         """A date more than 365 days beyond the deadline is rejected."""
         resolution_ts = int(time.time()) + 86400 * 30
         # Construct a date 366 days after the deadline.
-        far_future = datetime.fromtimestamp(
-            resolution_ts, tz=timezone.utc
-        ) + timedelta(days=366)
-        far_str = format_utc_timestamp(int(far_future.timestamp()))
-        question = (
-            f"Will something happen on {far_str}, according to Reuters?"
+        far_future = datetime.fromtimestamp(resolution_ts, tz=timezone.utc) + timedelta(
+            days=366
         )
+        far_str = format_utc_timestamp(int(far_future.timestamp()))
+        question = f"Will something happen on {far_str}, according to Reuters?"
         result = validate_question_dates(question, resolution_ts)
         assert result is not None
         assert "too far" in result
 
     def test_unparseable_date_rejected(self) -> None:
-        """A date string that passes the format regex but fails strptime is rejected.
+        r"""A date string that passes the format regex but fails strptime is rejected.
 
         'February 30, 2026' passes [A-Z][a-z]+ \\d{1,2}, \\d{4} but is
         not a real calendar date, so strptime raises ValueError.
         """
         resolution_ts = int(time.time()) + 86400 * 365
         question = (
-            "Will something happen on February 30, 2026, "
-            "according to Reuters?"
+            "Will something happen on February 30, 2026, " "according to Reuters?"
         )
         result = validate_question_dates(question, resolution_ts)
         assert result is not None
@@ -1127,9 +1122,7 @@ class TestValidatequestionDatesAdditional:
     def test_non_date_number_word_year_not_flagged(self) -> None:
         """'cut rates 2 times 2026' must NOT be mistakenly matched as a date."""
         resolution_ts = int(time.time()) + 86400 * 30
-        question = (
-            "Will the Fed cut rates 2 times 2026, according to Reuters?"
-        )
+        question = "Will the Fed cut rates 2 times 2026, according to Reuters?"
         result = validate_question_dates(question, resolution_ts)
         assert result is None
 
@@ -1150,7 +1143,7 @@ class TestWithKeyRotation:
         return keys
 
     def test_rate_limit_rotates_and_retries(self) -> None:
-        """RateLimitError causes key rotation; second call succeeds."""
+        """A rate-limit error triggers key rotation; the retried call succeeds."""
         import openai as _openai
 
         from packages.valory.customs.propose_question.propose_question import (
@@ -1231,9 +1224,7 @@ def _base_run_patches(
         "organic": [{"title": "hit", "snippet": "data"}]
     }
     openai_client = MagicMock()
-    mock_client_mgr.return_value.__enter__ = MagicMock(
-        return_value=openai_client
-    )
+    mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
     mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
     openai_client.moderations.create.return_value = _make_moderation_clean()
     openai_client.chat.completions.create.side_effect = extra_completions
@@ -1339,14 +1330,12 @@ class TestRunAdditionalBranches:
         mock_articles.return_value = [SAMPLE_ARTICLE]
         mock_filter.return_value = [SAMPLE_ARTICLE]
         openai_client = MagicMock()
-        mock_client_mgr.return_value.__enter__ = MagicMock(
-            return_value=openai_client
-        )
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
         # First moderation call (article pre-filter) passes; second flags prompt.
         openai_client.moderations.create.side_effect = [
-            _make_moderation_clean(),   # article pre-filter
-            _make_moderation_flagged(), # story-selection prompt
+            _make_moderation_clean(),  # article pre-filter
+            _make_moderation_flagged(),  # story-selection prompt
         ]
         result = run(
             tool="propose-question",
@@ -1383,9 +1372,7 @@ class TestRunAdditionalBranches:
             "organic": [{"title": "h", "snippet": "s"}]
         }
         openai_client = MagicMock()
-        mock_client_mgr.return_value.__enter__ = MagicMock(
-            return_value=openai_client
-        )
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
         judge_resp = _make_openai_completion(
             json.dumps({"answer": "YES", "reason": "ok"})
@@ -1393,9 +1380,9 @@ class TestRunAdditionalBranches:
         # Moderations: article pre-filter clean, story prompt clean,
         # propose prompt flagged.
         openai_client.moderations.create.side_effect = [
-            _make_moderation_clean(),   # article pre-filter
-            _make_moderation_clean(),   # story-selection prompt
-            _make_moderation_flagged(), # question-proposal prompt
+            _make_moderation_clean(),  # article pre-filter
+            _make_moderation_clean(),  # story-selection prompt
+            _make_moderation_flagged(),  # question-proposal prompt
         ]
         openai_client.chat.completions.create.side_effect = [
             _make_openai_completion(STORY_SELECTION_RESPONSE),
@@ -1464,13 +1451,9 @@ class TestRunAdditionalBranches:
             json.dumps({"answer": "YES", "reason": "ok"})
         )
         openai_client = MagicMock()
-        mock_client_mgr.return_value.__enter__ = MagicMock(
-            return_value=openai_client
-        )
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
-        openai_client.moderations.create.return_value = (
-            _make_moderation_clean()
-        )
+        openai_client.moderations.create.return_value = _make_moderation_clean()
         openai_client.chat.completions.create.side_effect = [
             _make_openai_completion(STORY_SELECTION_RESPONSE),
             _make_openai_completion(EXTRACT_STATE_RESPONSE),
@@ -1528,9 +1511,7 @@ class TestRunAdditionalBranches:
                     {
                         "question": dup_question,
                         "deadline_date": format_utc_timestamp(FUTURE_TS),
-                        "earliest_plausible_date": format_utc_timestamp(
-                            FUTURE_TS
-                        ),
+                        "earliest_plausible_date": format_utc_timestamp(FUTURE_TS),
                         "deadline_is_feasible": True,
                         "process_stage_named": True,
                         "figure_is_directly_published": True,
@@ -1548,13 +1529,9 @@ class TestRunAdditionalBranches:
             json.dumps({"answer": "YES", "reason": "ok"})
         )
         openai_client = MagicMock()
-        mock_client_mgr.return_value.__enter__ = MagicMock(
-            return_value=openai_client
-        )
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
         mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
-        openai_client.moderations.create.return_value = (
-            _make_moderation_clean()
-        )
+        openai_client.moderations.create.return_value = _make_moderation_clean()
         openai_client.chat.completions.create.side_effect = [
             _make_openai_completion(STORY_SELECTION_RESPONSE),
             _make_openai_completion(EXTRACT_STATE_RESPONSE),

--- a/packages/valory/customs/propose_question/tests/test_propose_question.py
+++ b/packages/valory/customs/propose_question/tests/test_propose_question.py
@@ -555,7 +555,6 @@ def _make_mock_api_keys() -> MagicMock:
         "newsapi": ["newsapi-test"],
         "serperapi": ["serper-test"],
         "subgraph": ["sg-test"],
-        "openrouter": ["or-test"],
     }
     mock = MagicMock()
     mock.__getitem__ = lambda self, key: services[key][0]
@@ -600,7 +599,10 @@ SAMPLE_ARTICLE = {
     "description": "Test description",
 }
 
-SAMPLE_QUESTION = "Will something happen on June 17, 2026, according to Reuters?"
+SAMPLE_QUESTION = (
+    f"Will something happen on {format_utc_timestamp(FUTURE_TS)}, "
+    "according to Reuters?"
+)
 
 SAMPLE_STATE = {
     "state": "mortgage rate",
@@ -618,7 +620,7 @@ SELF_REVIEW_ACCEPT = json.dumps(
         "reviews": [
             {
                 "question": SAMPLE_QUESTION,
-                "deadline_date": "June 17, 2026",
+                "deadline_date": format_utc_timestamp(FUTURE_TS),
                 "earliest_plausible_date": "June 1, 2026",
                 "deadline_is_feasible": True,
                 "process_stage_named": True,
@@ -914,7 +916,7 @@ class TestRunErrors:
                 "reviews": [
                     {
                         "question": SAMPLE_QUESTION,
-                        "deadline_date": "June 17, 2026",
+                        "deadline_date": format_utc_timestamp(FUTURE_TS),
                         "earliest_plausible_date": "never",
                         "deadline_is_feasible": False,
                         "process_stage_named": True,
@@ -953,7 +955,7 @@ class TestRunErrors:
         """Unhandled exception in run() returns error JSON, does not crash."""
         bad_keys = MagicMock()
         bad_keys.__getitem__.side_effect = RuntimeError("boom")
-        bad_keys.max_retries.return_value = {"openai": 1, "openrouter": 1}
+        bad_keys.max_retries.return_value = {"openai": 1}
         result = run(
             tool="propose-question",
             prompt=json.dumps({"resolution_time": FUTURE_TS}),

--- a/packages/valory/customs/propose_question/tests/test_propose_question.py
+++ b/packages/valory/customs/propose_question/tests/test_propose_question.py
@@ -27,6 +27,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import requests
+from datetime import datetime, timedelta, timezone
+from typing import Any
 
 import packages.valory.customs.propose_question.propose_question as module
 from packages.valory.customs.propose_question.propose_question import (
@@ -211,18 +213,26 @@ class TestFilterDuplicateArticles:
         assert result == articles
 
     def test_highly_similar_article_dropped(self) -> None:
-        """Article with high Jaccard overlap with existing should be dropped."""
+        """Article with high Jaccard overlap with existing should be dropped.
+
+        Uses two articles so the safety valve does not force-keep the similar
+        one (min_keep_fraction * 2 = 1, so dropping one still satisfies it).
+        """
         existing = ["Will inflation rate exceed five percent in the economy?"]
         articles = [
             {
                 "title": "inflation rate economy percent",
                 "description": "economy inflation five percent threshold",
-            }
+            },
+            {
+                "title": "SpaceX launches rocket to Moon",
+                "description": "space mission launch",
+            },
         ]
         result = filter_duplicate_articles(articles, existing, threshold=0.40)
-        # May or may not drop depending on Jaccard; safety valve ensures at
-        # least min_keep_fraction are kept
-        assert isinstance(result, list)
+        titles = [a["title"] for a in result]
+        assert "SpaceX launches rocket to Moon" in titles
+        assert "inflation rate economy percent" not in titles
 
     def test_safety_valve_keeps_minimum(self) -> None:
         """Safety valve keeps at least min_keep_fraction articles."""
@@ -246,12 +256,17 @@ class TestFindNearDuplicate:
     """Tests for find_near_duplicate."""
 
     def test_exact_duplicate_detected(self) -> None:
-        """Near-identical question should be flagged."""
+        """Near-identical question should be flagged as a duplicate."""
         existing = ["Will retail sales percentage change exceed forecast?"]
-        candidate = "Will retail sales percentage change exceed monthly forecast?"
+        candidate = (
+            "Will retail sales percentage change exceed monthly forecast?"
+        )
         hit = find_near_duplicate(candidate, existing)
-        # May or may not hit depending on Jaccard threshold
-        assert hit is None or isinstance(hit, tuple)
+        # Jaccard ~0.83 >> threshold 0.55 -- must be detected.
+        assert hit is not None
+        matched, score = hit
+        assert matched == existing[0]
+        assert score >= 0.55
 
     def test_no_duplicate_for_different_question(self) -> None:
         """Clearly different question should not be flagged."""
@@ -1069,3 +1084,490 @@ class TestMaxCostBranch:
         """N_MODEL_CALLS must be a positive integer."""
         assert isinstance(N_MODEL_CALLS, int)
         assert N_MODEL_CALLS > 0
+
+
+# ---------------------------------------------------------------------------
+# validate_question_dates -- additional branches
+# ---------------------------------------------------------------------------
+
+
+class TestValidatequestionDatesAdditional:
+    """Additional branches for validate_question_dates."""
+
+    def test_too_far_future_rejected(self) -> None:
+        """A date more than 365 days beyond the deadline is rejected."""
+        resolution_ts = int(time.time()) + 86400 * 30
+        # Construct a date 366 days after the deadline.
+        far_future = datetime.fromtimestamp(
+            resolution_ts, tz=timezone.utc
+        ) + timedelta(days=366)
+        far_str = format_utc_timestamp(int(far_future.timestamp()))
+        question = (
+            f"Will something happen on {far_str}, according to Reuters?"
+        )
+        result = validate_question_dates(question, resolution_ts)
+        assert result is not None
+        assert "too far" in result
+
+    def test_unparseable_date_rejected(self) -> None:
+        """A date string that passes the format regex but fails strptime is rejected.
+
+        'February 30, 2026' passes [A-Z][a-z]+ \\d{1,2}, \\d{4} but is
+        not a real calendar date, so strptime raises ValueError.
+        """
+        resolution_ts = int(time.time()) + 86400 * 365
+        question = (
+            "Will something happen on February 30, 2026, "
+            "according to Reuters?"
+        )
+        result = validate_question_dates(question, resolution_ts)
+        assert result is not None
+        assert "could not be parsed" in result
+
+    def test_non_date_number_word_year_not_flagged(self) -> None:
+        """'cut rates 2 times 2026' must NOT be mistakenly matched as a date."""
+        resolution_ts = int(time.time()) + 86400 * 30
+        question = (
+            "Will the Fed cut rates 2 times 2026, according to Reuters?"
+        )
+        result = validate_question_dates(question, resolution_ts)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# with_key_rotation -- key rotation behavior
+# ---------------------------------------------------------------------------
+
+
+class TestWithKeyRotation:
+    """Tests for the with_key_rotation decorator."""
+
+    def _make_keys(self, n_openai: int = 2) -> MagicMock:
+        """Build a minimal KeyChain-like mock."""
+        keys = MagicMock()
+        keys.max_retries.return_value = {"openai": n_openai}
+        keys.__add__ = lambda self, other: other  # for tuple concat in decorator
+        return keys
+
+    def test_rate_limit_rotates_and_retries(self) -> None:
+        """RateLimitError causes key rotation; second call succeeds."""
+        import openai as _openai
+
+        from packages.valory.customs.propose_question.propose_question import (
+            with_key_rotation,
+        )
+
+        call_count = [0]
+
+        @with_key_rotation
+        def fake_tool(**kwargs: Any) -> tuple:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise _openai.RateLimitError(
+                    "rate limit",
+                    response=MagicMock(
+                        status_code=429,
+                        headers={},
+                        json=lambda: {},
+                    ),
+                    body={},
+                )
+            return ("ok", None, None, None, None)
+
+        keys = self._make_keys(n_openai=2)
+        result = fake_tool(api_keys=keys)
+        assert result[0] == "ok"
+        keys.rotate.assert_called_once_with("openai")
+        assert call_count[0] == 2
+
+    def test_retries_exhausted_reraises(self) -> None:
+        """When all keys exhausted, RateLimitError propagates."""
+        import openai as _openai
+
+        from packages.valory.customs.propose_question.propose_question import (
+            with_key_rotation,
+        )
+
+        @with_key_rotation
+        def always_rate_limit(**kwargs: Any) -> tuple:
+            raise _openai.RateLimitError(
+                "rate limit",
+                response=MagicMock(
+                    status_code=429,
+                    headers={},
+                    json=lambda: {},
+                ),
+                body={},
+            )
+
+        keys = self._make_keys(n_openai=1)
+        keys.max_retries.return_value = {"openai": 1}
+        with pytest.raises(_openai.RateLimitError):
+            always_rate_limit(api_keys=keys)
+
+
+# ---------------------------------------------------------------------------
+# run() -- additional branches (invalid article_id, moderation flags,
+#           in-pipeline date rejection, in-pipeline dedup rejection)
+# ---------------------------------------------------------------------------
+
+
+def _base_run_patches(
+    mock_serper: MagicMock,
+    mock_client_mgr: MagicMock,
+    mock_scrape: MagicMock,
+    mock_filter: MagicMock,
+    mock_q: MagicMock,
+    mock_articles: MagicMock,
+    extra_completions: list,
+) -> MagicMock:
+    """Wire standard mocks for a run() invocation up to the first LLM call."""
+    mock_q.return_value = ["Will X happen?"]
+    mock_articles.return_value = [SAMPLE_ARTICLE]
+    mock_filter.return_value = [SAMPLE_ARTICLE]
+    mock_scrape.return_value = {"text": "full article body here"}
+    mock_serper.return_value.status_code = 200
+    mock_serper.return_value.json.return_value = {
+        "organic": [{"title": "hit", "snippet": "data"}]
+    }
+    openai_client = MagicMock()
+    mock_client_mgr.return_value.__enter__ = MagicMock(
+        return_value=openai_client
+    )
+    mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+    openai_client.moderations.create.return_value = _make_moderation_clean()
+    openai_client.chat.completions.create.side_effect = extra_completions
+    return openai_client
+
+
+class TestRunAdditionalBranches:
+    """Additional run() branches not covered by existing tests."""
+
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_invalid_article_id_out_of_range(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_scrape: MagicMock,
+        mock_filter: MagicMock,
+        mock_articles: MagicMock,
+        mock_q: MagicMock,
+    ) -> None:
+        """LLM returning out-of-range article_id produces an error tuple."""
+        bad_selection = json.dumps(
+            {"topic": "finance", "article_id": 999, "reasoning": "x"}
+        )
+        _base_run_patches(
+            mock_serper,
+            mock_client_mgr,
+            mock_scrape,
+            mock_filter,
+            mock_q,
+            mock_articles,
+            extra_completions=[
+                _make_openai_completion(bad_selection),
+            ],
+        )
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "article_id" in data["error"]
+
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_invalid_article_id_non_int(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_scrape: MagicMock,
+        mock_filter: MagicMock,
+        mock_articles: MagicMock,
+        mock_q: MagicMock,
+    ) -> None:
+        """LLM returning non-int article_id produces an error tuple."""
+        bad_selection = json.dumps(
+            {"topic": "finance", "article_id": "abc", "reasoning": "x"}
+        )
+        _base_run_patches(
+            mock_serper,
+            mock_client_mgr,
+            mock_scrape,
+            mock_filter,
+            mock_q,
+            mock_articles,
+            extra_completions=[
+                _make_openai_completion(bad_selection),
+            ],
+        )
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "article_id" in data["error"]
+
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    def test_story_selection_prompt_moderation_flagged(
+        self,
+        mock_client_mgr: MagicMock,
+        mock_filter: MagicMock,
+        mock_articles: MagicMock,
+        mock_q: MagicMock,
+    ) -> None:
+        """Story-selection prompt flagged by moderation returns error."""
+        mock_q.return_value = ["Will X happen?"]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(
+            return_value=openai_client
+        )
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        # First moderation call (article pre-filter) passes; second flags prompt.
+        openai_client.moderations.create.side_effect = [
+            _make_moderation_clean(),   # article pre-filter
+            _make_moderation_flagged(), # story-selection prompt
+        ]
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "moderation" in data["error"].lower()
+
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_propose_prompt_moderation_flagged(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_scrape: MagicMock,
+        mock_filter: MagicMock,
+        mock_articles: MagicMock,
+        mock_q: MagicMock,
+    ) -> None:
+        """Question-proposal prompt flagged by moderation returns error."""
+        mock_q.return_value = ["Will X happen?"]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        mock_scrape.return_value = {"text": "article body text"}
+        mock_serper.return_value.status_code = 200
+        mock_serper.return_value.json.return_value = {
+            "organic": [{"title": "h", "snippet": "s"}]
+        }
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(
+            return_value=openai_client
+        )
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        judge_resp = _make_openai_completion(
+            json.dumps({"answer": "YES", "reason": "ok"})
+        )
+        # Moderations: article pre-filter clean, story prompt clean,
+        # propose prompt flagged.
+        openai_client.moderations.create.side_effect = [
+            _make_moderation_clean(),   # article pre-filter
+            _make_moderation_clean(),   # story-selection prompt
+            _make_moderation_flagged(), # question-proposal prompt
+        ]
+        openai_client.chat.completions.create.side_effect = [
+            _make_openai_completion(STORY_SELECTION_RESPONSE),
+            _make_openai_completion(EXTRACT_STATE_RESPONSE),
+            judge_resp,
+        ]
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "moderation" in data["error"].lower()
+
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_in_pipeline_date_rejection(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_scrape: MagicMock,
+        mock_filter: MagicMock,
+        mock_articles: MagicMock,
+        mock_q: MagicMock,
+    ) -> None:
+        """Question with a past date is rejected by the programmatic date check."""
+        mock_q.return_value = ["Will X happen?"]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        mock_scrape.return_value = {"text": "article body"}
+        mock_serper.return_value.status_code = 200
+        mock_serper.return_value.json.return_value = {
+            "organic": [{"title": "h", "snippet": "s"}]
+        }
+        past_date_question = (
+            "Will something happen on January 1, 2020, according to Reuters?"
+        )
+        past_date_review = json.dumps(
+            {
+                "reviews": [
+                    {
+                        "question": past_date_question,
+                        "deadline_date": "January 1, 2020",
+                        "earliest_plausible_date": "January 1, 2020",
+                        "deadline_is_feasible": True,
+                        "process_stage_named": True,
+                        "figure_is_directly_published": True,
+                        "authority_can_act_in_time": True,
+                        "date_format_valid": True,
+                        "not_a_duplicate": True,
+                        "window_bound_event": True,
+                        "reasoning": "Passes all checks.",
+                        "accept": True,
+                    }
+                ]
+            }
+        )
+        past_proposal = json.dumps({"questions": [past_date_question]})
+        judge_resp = _make_openai_completion(
+            json.dumps({"answer": "YES", "reason": "ok"})
+        )
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(
+            return_value=openai_client
+        )
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        openai_client.moderations.create.return_value = (
+            _make_moderation_clean()
+        )
+        openai_client.chat.completions.create.side_effect = [
+            _make_openai_completion(STORY_SELECTION_RESPONSE),
+            _make_openai_completion(EXTRACT_STATE_RESPONSE),
+            judge_resp,
+            _make_openai_completion(past_proposal),
+            _make_openai_completion(past_date_review),
+        ]
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "rejected" in data["error"].lower()
+
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_in_pipeline_programmatic_dedup_rejection(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_scrape: MagicMock,
+        mock_filter: MagicMock,
+        mock_articles: MagicMock,
+        mock_q: MagicMock,
+    ) -> None:
+        """Question identical to an existing one is caught by programmatic dedup."""
+        existing_q = (
+            "Will retail sales percentage change exceed monthly forecast "
+            f"on {format_utc_timestamp(FUTURE_TS)}, according to Reuters?"
+        )
+        mock_q.return_value = [existing_q]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        mock_scrape.return_value = {"text": "article body"}
+        mock_serper.return_value.status_code = 200
+        mock_serper.return_value.json.return_value = {
+            "organic": [{"title": "h", "snippet": "s"}]
+        }
+        # Propose a question token-identical to the existing one.
+        dup_question = (
+            "Will retail sales percentage change exceed monthly forecast "
+            f"on {format_utc_timestamp(FUTURE_TS)}, according to Reuters?"
+        )
+        dup_proposal = json.dumps({"questions": [dup_question]})
+        dup_review = json.dumps(
+            {
+                "reviews": [
+                    {
+                        "question": dup_question,
+                        "deadline_date": format_utc_timestamp(FUTURE_TS),
+                        "earliest_plausible_date": format_utc_timestamp(
+                            FUTURE_TS
+                        ),
+                        "deadline_is_feasible": True,
+                        "process_stage_named": True,
+                        "figure_is_directly_published": True,
+                        "authority_can_act_in_time": True,
+                        "date_format_valid": True,
+                        "not_a_duplicate": True,
+                        "window_bound_event": True,
+                        "reasoning": "Passes all checks.",
+                        "accept": True,
+                    }
+                ]
+            }
+        )
+        judge_resp = _make_openai_completion(
+            json.dumps({"answer": "YES", "reason": "ok"})
+        )
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(
+            return_value=openai_client
+        )
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        openai_client.moderations.create.return_value = (
+            _make_moderation_clean()
+        )
+        openai_client.chat.completions.create.side_effect = [
+            _make_openai_completion(STORY_SELECTION_RESPONSE),
+            _make_openai_completion(EXTRACT_STATE_RESPONSE),
+            judge_resp,
+            _make_openai_completion(dup_proposal),
+            _make_openai_completion(dup_review),
+        ]
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "rejected" in data["error"].lower()

--- a/packages/valory/customs/propose_question/tests/test_propose_question.py
+++ b/packages/valory/customs/propose_question/tests/test_propose_question.py
@@ -1,0 +1,1069 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2023-2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+
+"""Tests for the propose_question mech tool."""
+
+import inspect
+import json
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+import packages.valory.customs.propose_question.propose_question as module
+from packages.valory.customs.propose_question.propose_question import (
+    DEFAULT_DELIVERY_RATE,
+    N_MODEL_CALLS,
+    OpenAIClientManager,
+    _VERIFY_CACHE,
+    _cache_put,
+    _dedup_tokens,
+    filter_duplicate_articles,
+    find_near_duplicate,
+    format_utc_timestamp,
+    gather_articles,
+    gather_latest_questions,
+    run,
+    scrape_url,
+    validate_question_dates,
+    verify_state_is_resolvable,
+)
+
+_MODULE = "packages.valory.customs.propose_question.propose_question"
+
+FUTURE_TS = int(time.time()) + 86400 * 30
+
+
+@pytest.fixture(autouse=True)
+def clear_verify_cache() -> None:
+    """Clear the verify cache before each test to avoid cross-test pollution."""
+    _VERIFY_CACHE.clear()
+
+
+# ---------------------------------------------------------------------------
+# Module-level invariant: no global client variable
+# ---------------------------------------------------------------------------
+
+
+class TestNoGlobalClientVariable:
+    """The module must not define a module-level 'client' variable."""
+
+    def test_no_global_client_variable(self) -> None:
+        """Module must not have a module-level 'client' variable."""
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        for i, line in enumerate(source.split("\n"), 1):
+            stripped = line.lstrip()
+            if stripped.startswith("client:") or stripped.startswith("client ="):
+                if not line.startswith(" ") and not line.startswith("\t"):
+                    pytest.fail(
+                        f"Module-level 'client' variable found at line {i}: {line}"
+                    )
+
+
+# ---------------------------------------------------------------------------
+# OpenAIClientManager
+# ---------------------------------------------------------------------------
+
+
+class TestOpenAIClientManager:
+    """Verify OpenAIClientManager creates per-context clients without globals."""
+
+    def test_context_manager_creates_and_closes_client(self) -> None:
+        """__enter__ returns a fresh client; __exit__ closes it."""
+        mgr = OpenAIClientManager(api_key="sk-test")
+        with patch(f"{_MODULE}.OpenAI") as MockOpenAI:
+            mock_instance = MagicMock()
+            MockOpenAI.return_value = mock_instance
+            with mgr as client:
+                assert client is mock_instance
+                MockOpenAI.assert_called_once_with(api_key="sk-test")
+            mock_instance.close.assert_called_once()
+
+    def test_verify_state_is_resolvable_requires_client_param(self) -> None:
+        """verify_state_is_resolvable requires client as first param."""
+        params = list(inspect.signature(verify_state_is_resolvable).parameters)
+        assert params[0] == "client"
+
+
+# ---------------------------------------------------------------------------
+# validate_question_dates
+# ---------------------------------------------------------------------------
+
+
+class TestValidatequestionDates:
+    """Tests for validate_question_dates."""
+
+    def test_future_valid_date_accepted(self) -> None:
+        """A question with a valid future date is accepted."""
+        future = time.time() + 86400 * 60
+        dt_str = format_utc_timestamp(int(future))
+        question = f"Will something happen on {dt_str}, according to Reuters?"
+        result = validate_question_dates(question, int(future))
+        assert result is None
+
+    def test_on_or_before_rejected(self) -> None:
+        """Questions using 'on or before' phrasing are rejected."""
+        future = time.time() + 86400 * 60
+        dt_str = format_utc_timestamp(int(future))
+        question = f"Will OpenAI announce a deal on or before {dt_str}?"
+        result = validate_question_dates(question, int(future))
+        assert result is not None
+        assert "on or before" in result
+
+    def test_past_date_rejected(self) -> None:
+        """A question referencing a past date is rejected."""
+        resolution_ts = int(time.time()) + 86400 * 60
+        question = "Will something happen on January 1, 2020, according to Reuters?"
+        result = validate_question_dates(question, resolution_ts)
+        assert result is not None
+        assert "past" in result
+
+    def test_wrong_date_format_rejected(self) -> None:
+        """A date in wrong format is rejected."""
+        future = int(time.time()) + 86400 * 60
+        question = "Will something happen on 22 April 2026, according to Reuters?"
+        result = validate_question_dates(question, future)
+        assert result is not None
+        assert "required" in result.lower() or "not in required" in result
+
+
+# ---------------------------------------------------------------------------
+# format_utc_timestamp
+# ---------------------------------------------------------------------------
+
+
+class TestFormatUtcTimestamp:
+    """Tests for format_utc_timestamp."""
+
+    def test_format_known_timestamp(self) -> None:
+        """A known timestamp should produce the expected date string."""
+        ts = 1745280000  # April 22, 2025
+        result = format_utc_timestamp(ts)
+        assert "April" in result
+        assert "2025" in result
+        # Should contain a day number followed by comma
+        assert "," in result
+
+
+# ---------------------------------------------------------------------------
+# _dedup_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestDedupTokens:
+    """Tests for _dedup_tokens."""
+
+    def test_stopwords_removed(self) -> None:
+        """Stop words should be removed."""
+        tokens = _dedup_tokens("Will the economy recover")
+        assert "will" not in tokens
+        assert "the" not in tokens
+
+    def test_short_tokens_removed(self) -> None:
+        """Tokens with 2 or fewer characters should be removed."""
+        tokens = _dedup_tokens("AI is big")
+        assert "is" not in tokens
+        assert "ai" not in tokens  # 2 chars, removed
+
+    def test_content_tokens_retained(self) -> None:
+        """Meaningful content tokens should be retained."""
+        tokens = _dedup_tokens("inflation rate federal reserve")
+        assert "inflation" in tokens
+        assert "federal" in tokens
+        assert "reserve" in tokens
+
+
+# ---------------------------------------------------------------------------
+# filter_duplicate_articles
+# ---------------------------------------------------------------------------
+
+
+class TestFilterDuplicateArticles:
+    """Tests for filter_duplicate_articles."""
+
+    def test_empty_articles_returns_empty(self) -> None:
+        """Empty articles list returns empty list."""
+        result = filter_duplicate_articles([], ["existing question"])
+        assert result == []
+
+    def test_empty_existing_returns_all(self) -> None:
+        """Empty existing list returns all articles unchanged."""
+        articles = [{"title": "tech news", "description": "something"}]
+        result = filter_duplicate_articles(articles, [])
+        assert result == articles
+
+    def test_highly_similar_article_dropped(self) -> None:
+        """Article with high Jaccard overlap with existing should be dropped."""
+        existing = ["Will inflation rate exceed five percent in the economy?"]
+        articles = [
+            {
+                "title": "inflation rate economy percent",
+                "description": "economy inflation five percent threshold",
+            }
+        ]
+        result = filter_duplicate_articles(articles, existing, threshold=0.40)
+        # May or may not drop depending on Jaccard; safety valve ensures at
+        # least min_keep_fraction are kept
+        assert isinstance(result, list)
+
+    def test_safety_valve_keeps_minimum(self) -> None:
+        """Safety valve keeps at least min_keep_fraction articles."""
+        existing = ["inflation rate economy"]
+        articles = [
+            {"title": "inflation economy rate", "description": "economy inflation"},
+            {"title": "inflation economy rate", "description": "economy inflation"},
+        ]
+        result = filter_duplicate_articles(
+            articles, existing, threshold=0.01, min_keep_fraction=0.50
+        )
+        assert len(result) >= 1
+
+
+# ---------------------------------------------------------------------------
+# find_near_duplicate
+# ---------------------------------------------------------------------------
+
+
+class TestFindNearDuplicate:
+    """Tests for find_near_duplicate."""
+
+    def test_exact_duplicate_detected(self) -> None:
+        """Near-identical question should be flagged."""
+        existing = ["Will retail sales percentage change exceed forecast?"]
+        candidate = "Will retail sales percentage change exceed monthly forecast?"
+        hit = find_near_duplicate(candidate, existing)
+        # May or may not hit depending on Jaccard threshold
+        assert hit is None or isinstance(hit, tuple)
+
+    def test_no_duplicate_for_different_question(self) -> None:
+        """Clearly different question should not be flagged."""
+        existing = ["Will the Federal Reserve raise rates?"]
+        candidate = "Will SpaceX launch a rocket to Mars?"
+        hit = find_near_duplicate(candidate, existing)
+        assert hit is None
+
+    def test_empty_question_returns_none(self) -> None:
+        """Empty candidate question should return None."""
+        hit = find_near_duplicate("", ["some existing question"])
+        assert hit is None
+
+
+# ---------------------------------------------------------------------------
+# gather_articles
+# ---------------------------------------------------------------------------
+
+
+class TestGatherArticles:
+    """Tests for gather_articles."""
+
+    @patch(f"{_MODULE}.requests.get")
+    def test_success_returns_articles(self, mock_get: MagicMock) -> None:
+        """Successful NewsAPI response returns article list."""
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.content = json.dumps(
+            {"articles": [{"title": "Test", "content": "Content"}]}
+        ).encode("utf-8")
+        result = gather_articles(["bbc-news"], "newsapi-key")
+        assert result == [{"title": "Test", "content": "Content"}]
+
+    @patch(f"{_MODULE}.requests.get")
+    def test_non_200_returns_none(self, mock_get: MagicMock) -> None:
+        """Non-200 status code returns None."""
+        mock_get.return_value.status_code = 401
+        result = gather_articles(["bbc-news"], "bad-key")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# gather_latest_questions
+# ---------------------------------------------------------------------------
+
+
+class TestGatherLatestQuestions:
+    """Tests for gather_latest_questions."""
+
+    @patch(f"{_MODULE}.Client")
+    @patch(f"{_MODULE}.RequestsHTTPTransport")
+    def test_success_returns_titles(
+        self, mock_transport: MagicMock, mock_client: MagicMock
+    ) -> None:
+        """Successful subgraph response returns question title list."""
+        mock_gql_client = MagicMock()
+        mock_client.return_value = mock_gql_client
+        mock_gql_client.execute.return_value = {
+            "fixedProductMarketMakers": [
+                {"question": {"title": "Will X happen?"}},
+                {"question": {"title": "Will Y happen?"}},
+            ]
+        }
+        result = gather_latest_questions("sg-key")
+        assert result == ["Will X happen?", "Will Y happen?"]
+
+
+# ---------------------------------------------------------------------------
+# scrape_url
+# ---------------------------------------------------------------------------
+
+
+class TestScrapeUrl:
+    """Tests for scrape_url."""
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_success_returns_data(self, mock_post: MagicMock) -> None:
+        """Successful scrape returns parsed JSON."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"text": "article body"}
+        mock_post.return_value.raise_for_status = MagicMock()
+        result = scrape_url("serper-key", "https://example.com/article")
+        assert result == {"text": "article body"}
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_request_exception_returns_none(self, mock_post: MagicMock) -> None:
+        """A requests.RequestException should return None."""
+        mock_post.side_effect = requests.RequestException("timeout")
+        result = scrape_url("serper-key", "https://example.com/article")
+        assert result is None
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_json_decode_error_returns_none(self, mock_post: MagicMock) -> None:
+        """A json.JSONDecodeError should return None."""
+        mock_post.return_value.raise_for_status = MagicMock()
+        mock_post.return_value.json.side_effect = json.JSONDecodeError("err", "", 0)
+        result = scrape_url("serper-key", "https://example.com/article")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# verify_state_is_resolvable (adapted for new signature: client is first arg)
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyStateIsResolvable:
+    """Tests for verify_state_is_resolvable (client passed explicitly)."""
+
+    def _make_client(self) -> MagicMock:
+        """Build a mock OpenAI client."""
+        return MagicMock()
+
+    def test_empty_query_keeps(self) -> None:
+        """Empty source+metric should fail open."""
+        client = self._make_client()
+        ok, reason = verify_state_is_resolvable(client, "key", "", "")
+        assert ok is True
+        assert reason == "empty_query"
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_serper_non_200_fails_open(self, mock_post: MagicMock) -> None:
+        """Non-200 Serper response should fail open."""
+        mock_post.return_value.status_code = 500
+        client = self._make_client()
+        ok, reason = verify_state_is_resolvable(client, "key", "CDC", "volunteers")
+        assert ok is True
+        assert "fail_open_serper_status_500" in reason
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_serper_request_exception_fails_open(self, mock_post: MagicMock) -> None:
+        """Serper network error should fail open."""
+        mock_post.side_effect = requests.RequestException("timeout")
+        client = self._make_client()
+        ok, reason = verify_state_is_resolvable(client, "key", "CDC", "volunteers")
+        assert ok is True
+        assert reason == "fail_open_serper_error"
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_serper_no_organic_key_fails_open(self, mock_post: MagicMock) -> None:
+        """Serper 200 with no organic key should fail open."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"searchParameters": {}}
+        client = self._make_client()
+        ok, reason = verify_state_is_resolvable(client, "key", "Freddie Mac", "rate")
+        assert ok is True
+        assert reason == "fail_open_serper_unexpected_shape"
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_serper_empty_organic_drops(self, mock_post: MagicMock) -> None:
+        """Serper 200 with empty organic list should drop."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"organic": []}
+        client = self._make_client()
+        ok, reason = verify_state_is_resolvable(
+            client, "key", "fictional corp", "metric"
+        )
+        assert ok is False
+        assert reason == "no_hits"
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_judge_says_yes_keeps(self, mock_post: MagicMock) -> None:
+        """Judge returning YES should keep the state."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "organic": [{"title": "PMMS", "snippet": "6.5%"}]
+        }
+        body = {"answer": "YES", "reason": "publishes weekly"}
+        choice = MagicMock()
+        choice.message.content = json.dumps(body)
+        client = self._make_client()
+        client.chat.completions.create.return_value.choices = [choice]
+        ok, reason = verify_state_is_resolvable(
+            client, "key", "Freddie Mac", "mortgage rate"
+        )
+        assert ok is True
+        assert "publishes weekly" in reason
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_judge_says_no_drops(self, mock_post: MagicMock) -> None:
+        """Judge returning NO should drop the state."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "organic": [{"title": "tangential", "snippet": "x"}]
+        }
+        body = {"answer": "NO", "reason": "not published"}
+        choice = MagicMock()
+        choice.message.content = json.dumps(body)
+        client = self._make_client()
+        client.chat.completions.create.return_value.choices = [choice]
+        ok, reason = verify_state_is_resolvable(
+            client, "key", "Tesla", "repair records"
+        )
+        assert ok is False
+        assert "not published" in reason
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_judge_null_reason_no_crash(self, mock_post: MagicMock) -> None:
+        """Judge null reason should not crash."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "organic": [{"title": "hit", "snippet": "d"}]
+        }
+        body = {"answer": "YES", "reason": None}
+        choice = MagicMock()
+        choice.message.content = json.dumps(body)
+        client = self._make_client()
+        client.chat.completions.create.return_value.choices = [choice]
+        ok, reason = verify_state_is_resolvable(client, "key", "Freddie Mac", "rate")
+        assert ok is True
+        assert isinstance(reason, str)
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_judge_llm_error_fails_open(self, mock_post: MagicMock) -> None:
+        """Judge LLM error should fail open."""
+        import openai as _openai
+
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "organic": [{"title": "hit", "snippet": "d"}]
+        }
+        client = self._make_client()
+        client.chat.completions.create.side_effect = _openai.OpenAIError("API down")
+        ok, reason = verify_state_is_resolvable(client, "key", "Freddie Mac", "rate")
+        assert ok is True
+        assert reason == "fail_open_llm_error"
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_cache_hit_skips_serper_and_llm(self, mock_post: MagicMock) -> None:
+        """Second call with same (source, metric) should hit cache."""
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {
+            "organic": [{"title": "PMMS", "snippet": "6.5%"}]
+        }
+        body = {"answer": "YES", "reason": "publishes weekly"}
+        choice = MagicMock()
+        choice.message.content = json.dumps(body)
+        client = self._make_client()
+        client.chat.completions.create.return_value.choices = [choice]
+        ok1, reason1 = verify_state_is_resolvable(
+            client, "k", "Freddie Mac", "mortgage rate"
+        )
+        ok2, reason2 = verify_state_is_resolvable(
+            client, "k", "Freddie Mac", "mortgage rate"
+        )
+        assert ok1 is True and ok2 is True
+        assert "[cached]" not in reason1
+        assert "[cached]" in reason2
+        assert mock_post.call_count == 1
+        assert client.chat.completions.create.call_count == 1
+
+    @patch(f"{_MODULE}.requests.post")
+    def test_fail_open_not_cached(self, mock_post: MagicMock) -> None:
+        """Fail-open paths (transient errors) must NOT be cached.
+
+        :param mock_post: patched requests.post raising RequestException.
+        """
+        mock_post.side_effect = requests.RequestException("timeout")
+        client = self._make_client()
+        ok1, reason1 = verify_state_is_resolvable(client, "k", "Freddie Mac", "rate")
+        ok2, reason2 = verify_state_is_resolvable(client, "k", "Freddie Mac", "rate")
+        assert ok1 is True and ok2 is True
+        assert reason1 == "fail_open_serper_error"
+        assert reason2 == "fail_open_serper_error"
+        assert "[cached]" not in reason2
+        assert mock_post.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _cache_put
+# ---------------------------------------------------------------------------
+
+
+class TestCachePut:
+    """Tests for _cache_put overflow eviction."""
+
+    def test_overflow_evicts_oldest(self) -> None:
+        """Cache evicts oldest entry when full."""
+        from packages.valory.customs.propose_question.propose_question import (
+            _VERIFY_CACHE_MAX,
+        )
+
+        _VERIFY_CACHE.clear()
+        for i in range(_VERIFY_CACHE_MAX):
+            _cache_put((f"src{i}", f"metric{i}"), (True, "ok"))
+        assert len(_VERIFY_CACHE) == _VERIFY_CACHE_MAX
+        # Adding one more should evict the oldest
+        _cache_put(("new_src", "new_metric"), (False, "no_hits"))
+        assert len(_VERIFY_CACHE) == _VERIFY_CACHE_MAX
+        assert ("src0", "metric0") not in _VERIFY_CACHE
+        assert ("new_src", "new_metric") in _VERIFY_CACHE
+
+
+# ---------------------------------------------------------------------------
+# run() -- end-to-end with all external boundaries mocked
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_api_keys() -> MagicMock:
+    """Build a mock KeyChain-like api_keys object."""
+    services = {
+        "openai": ["sk-test"],
+        "newsapi": ["newsapi-test"],
+        "serperapi": ["serper-test"],
+        "subgraph": ["sg-test"],
+        "openrouter": ["or-test"],
+    }
+    mock = MagicMock()
+    mock.__getitem__ = lambda self, key: services[key][0]
+    mock.get = lambda key, default="": services.get(key, [default])[0]
+    mock.max_retries.return_value = {k: len(v) for k, v in services.items()}
+    return mock
+
+
+def _make_openai_completion(content: str) -> MagicMock:
+    """Build a mock chat completion response."""
+    choice = MagicMock()
+    choice.message.content = content
+    usage = MagicMock()
+    usage.prompt_tokens = 10
+    usage.completion_tokens = 5
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = usage
+    return resp
+
+
+def _make_moderation_clean() -> MagicMock:
+    """Build a mock moderation response that does not flag content."""
+    mod = MagicMock()
+    mod.results = [MagicMock(flagged=False)]
+    return mod
+
+
+def _make_moderation_flagged() -> MagicMock:
+    """Build a mock moderation response that flags content."""
+    mod = MagicMock()
+    mod.results = [MagicMock(flagged=True)]
+    return mod
+
+
+SAMPLE_ARTICLE = {
+    "title": "Test Article",
+    "publishedAt": "2026-01-01",
+    "content": "Some content here",
+    "author": "Author",
+    "url": "https://example.com/test",
+    "description": "Test description",
+}
+
+SAMPLE_QUESTION = "Will something happen on June 17, 2026, according to Reuters?"
+
+SAMPLE_STATE = {
+    "state": "mortgage rate",
+    "source": "Freddie Mac",
+    "framing": "measurement",
+}
+
+STORY_SELECTION_RESPONSE = json.dumps(
+    {"topic": "finance", "article_id": 0, "reasoning": "Good article."}
+)
+EXTRACT_STATE_RESPONSE = json.dumps({"states": [SAMPLE_STATE]})
+QUESTION_PROPOSAL_RESPONSE = json.dumps({"questions": [SAMPLE_QUESTION]})
+SELF_REVIEW_ACCEPT = json.dumps(
+    {
+        "reviews": [
+            {
+                "question": SAMPLE_QUESTION,
+                "deadline_date": "June 17, 2026",
+                "earliest_plausible_date": "June 1, 2026",
+                "deadline_is_feasible": True,
+                "process_stage_named": True,
+                "figure_is_directly_published": True,
+                "authority_can_act_in_time": True,
+                "date_format_valid": True,
+                "not_a_duplicate": True,
+                "window_bound_event": True,
+                "reasoning": "Passes all checks.",
+                "accept": True,
+            }
+        ]
+    }
+)
+
+
+class TestRunSuccess:
+    """Test run() successful paths."""
+
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_run_success_returns_questions(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_filter: MagicMock,
+        mock_scrape: MagicMock,
+        mock_articles: MagicMock,
+        mock_questions: MagicMock,
+    ) -> None:
+        """run() with all mocks returns a tuple with questions JSON."""
+        mock_questions.return_value = ["Will X happen?"]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        mock_scrape.return_value = {"text": "full article body here"}
+
+        # Serper verify call returns YES
+        mock_serper.return_value.status_code = 200
+        mock_serper.return_value.json.return_value = {
+            "organic": [{"title": "hit", "snippet": "data"}]
+        }
+
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+
+        # Each moderation call returns clean
+        openai_client.moderations.create.return_value = _make_moderation_clean()
+
+        # Wire up the four chat completion calls in order:
+        # 1. story selection, 2. extract states, 3. verify judge, 4. propose, 5. self-review
+        judge_resp = _make_openai_completion(
+            json.dumps({"answer": "YES", "reason": "ok"})
+        )
+        openai_client.chat.completions.create.side_effect = [
+            _make_openai_completion(STORY_SELECTION_RESPONSE),
+            _make_openai_completion(EXTRACT_STATE_RESPONSE),
+            judge_resp,
+            _make_openai_completion(QUESTION_PROPOSAL_RESPONSE),
+            _make_openai_completion(SELF_REVIEW_ACCEPT),
+        ]
+
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS, "num_questions": 1}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+
+        # Result is a 6-tuple (the decorator appends api_keys)
+        assert isinstance(result, tuple)
+        assert len(result) >= 5
+        result_json = json.loads(result[0])
+        assert "questions" in result_json
+        assert "reasoning" in result_json
+
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_run_prompt_json_resolution_time(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_filter: MagicMock,
+        mock_scrape: MagicMock,
+        mock_articles: MagicMock,
+        mock_questions: MagicMock,
+    ) -> None:
+        """run() reads resolution_time from prompt JSON."""
+        mock_questions.return_value = ["Will X happen?"]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        mock_scrape.return_value = {"text": "full article body here"}
+        mock_serper.return_value.status_code = 200
+        mock_serper.return_value.json.return_value = {
+            "organic": [{"title": "hit", "snippet": "data"}]
+        }
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        openai_client.moderations.create.return_value = _make_moderation_clean()
+        judge_resp = _make_openai_completion(
+            json.dumps({"answer": "YES", "reason": "ok"})
+        )
+        openai_client.chat.completions.create.side_effect = [
+            _make_openai_completion(STORY_SELECTION_RESPONSE),
+            _make_openai_completion(EXTRACT_STATE_RESPONSE),
+            judge_resp,
+            _make_openai_completion(QUESTION_PROPOSAL_RESPONSE),
+            _make_openai_completion(SELF_REVIEW_ACCEPT),
+        ]
+        # Pass resolution_time in prompt JSON only (not as kwarg)
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        result_json = json.loads(result[0])
+        assert "questions" in result_json
+
+
+class TestRunErrors:
+    """Test run() error paths."""
+
+    def test_invalid_tool_returns_error(self) -> None:
+        """Unknown tool name returns an error JSON."""
+        result = run(
+            tool="unknown-tool",
+            prompt="",
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        assert isinstance(result, tuple)
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "unknown-tool" in data["error"]
+
+    def test_missing_resolution_time_returns_error(self) -> None:
+        """Missing resolution_time returns an error JSON."""
+        result = run(
+            tool="propose-question",
+            prompt="plain text prompt with no json",
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        assert isinstance(result, tuple)
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "resolution_time" in data["error"]
+
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.gather_latest_questions")
+    def test_failed_articles_returns_error(
+        self, mock_q: MagicMock, mock_articles: MagicMock
+    ) -> None:
+        """None from gather_articles returns error JSON."""
+        mock_q.return_value = ["existing question"]
+        mock_articles.return_value = None
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "articles" in data["error"].lower()
+
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.gather_latest_questions")
+    def test_failed_latest_questions_returns_error(
+        self, mock_q: MagicMock, mock_articles: MagicMock
+    ) -> None:
+        """None from gather_latest_questions returns error JSON."""
+        mock_q.return_value = None
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "latest questions" in data["error"].lower()
+
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    def test_all_articles_flagged_returns_error(
+        self,
+        mock_client_mgr: MagicMock,
+        mock_filter: MagicMock,
+        mock_q: MagicMock,
+        mock_articles: MagicMock,
+    ) -> None:
+        """All articles flagged by moderation returns error JSON."""
+        mock_q.return_value = ["existing question"]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        # All articles flagged
+        openai_client.moderations.create.return_value = _make_moderation_flagged()
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "flagged" in data["error"].lower()
+
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_failed_scrape_returns_error(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_scrape: MagicMock,
+        mock_filter: MagicMock,
+        mock_q: MagicMock,
+        mock_articles: MagicMock,
+    ) -> None:
+        """Failed scrape returns error JSON."""
+        mock_q.return_value = ["existing question"]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        mock_scrape.return_value = None
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        openai_client.moderations.create.return_value = _make_moderation_clean()
+        openai_client.chat.completions.create.return_value = _make_openai_completion(
+            STORY_SELECTION_RESPONSE
+        )
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "scrape" in data["error"].lower()
+
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_all_questions_rejected_returns_error(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_scrape: MagicMock,
+        mock_filter: MagicMock,
+        mock_q: MagicMock,
+        mock_articles: MagicMock,
+    ) -> None:
+        """All questions rejected by self-review returns error JSON."""
+        mock_q.return_value = ["existing question"]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        mock_scrape.return_value = {"text": "full article body here"}
+        mock_serper.return_value.status_code = 200
+        mock_serper.return_value.json.return_value = {
+            "organic": [{"title": "hit", "snippet": "data"}]
+        }
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        openai_client.moderations.create.return_value = _make_moderation_clean()
+
+        reject_review = json.dumps(
+            {
+                "reviews": [
+                    {
+                        "question": SAMPLE_QUESTION,
+                        "deadline_date": "June 17, 2026",
+                        "earliest_plausible_date": "never",
+                        "deadline_is_feasible": False,
+                        "process_stage_named": True,
+                        "figure_is_directly_published": True,
+                        "authority_can_act_in_time": False,
+                        "date_format_valid": True,
+                        "not_a_duplicate": True,
+                        "window_bound_event": True,
+                        "reasoning": "Fails feasibility.",
+                        "accept": False,
+                    }
+                ]
+            }
+        )
+        judge_resp = _make_openai_completion(
+            json.dumps({"answer": "YES", "reason": "ok"})
+        )
+        openai_client.chat.completions.create.side_effect = [
+            _make_openai_completion(STORY_SELECTION_RESPONSE),
+            _make_openai_completion(EXTRACT_STATE_RESPONSE),
+            judge_resp,
+            _make_openai_completion(QUESTION_PROPOSAL_RESPONSE),
+            _make_openai_completion(reject_review),
+        ]
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "rejected" in data["error"].lower()
+
+    def test_unexpected_exception_returns_error(self) -> None:
+        """Unhandled exception in run() returns error JSON, does not crash."""
+        bad_keys = MagicMock()
+        bad_keys.__getitem__.side_effect = RuntimeError("boom")
+        bad_keys.max_retries.return_value = {"openai": 1, "openrouter": 1}
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=bad_keys,
+            counter_callback=None,
+        )
+        assert isinstance(result, tuple)
+        data = json.loads(result[0])
+        assert "error" in data
+        assert "exception" in data["error"].lower()
+
+
+class TestRunNoneOutputPath:
+    """Verify run() returns an error (not None) when LLM produces no output."""
+
+    @patch(f"{_MODULE}.gather_articles")
+    @patch(f"{_MODULE}.gather_latest_questions")
+    @patch(f"{_MODULE}.filter_duplicate_articles")
+    @patch(f"{_MODULE}.scrape_url")
+    @patch(f"{_MODULE}.OpenAIClientManager")
+    @patch(f"{_MODULE}.requests.post")
+    def test_none_output_from_question_generation(
+        self,
+        mock_serper: MagicMock,
+        mock_client_mgr: MagicMock,
+        mock_scrape: MagicMock,
+        mock_filter: MagicMock,
+        mock_q: MagicMock,
+        mock_articles: MagicMock,
+    ) -> None:
+        """Empty questions list from LLM produces an error return."""
+        mock_q.return_value = ["existing question"]
+        mock_articles.return_value = [SAMPLE_ARTICLE]
+        mock_filter.return_value = [SAMPLE_ARTICLE]
+        mock_scrape.return_value = {"text": "full article body here"}
+        mock_serper.return_value.status_code = 200
+        mock_serper.return_value.json.return_value = {
+            "organic": [{"title": "hit", "snippet": "data"}]
+        }
+        openai_client = MagicMock()
+        mock_client_mgr.return_value.__enter__ = MagicMock(return_value=openai_client)
+        mock_client_mgr.return_value.__exit__ = MagicMock(return_value=False)
+        openai_client.moderations.create.return_value = _make_moderation_clean()
+
+        # LLM returns zero questions
+        empty_proposal = json.dumps({"questions": []})
+        empty_review = json.dumps({"reviews": []})
+        judge_resp = _make_openai_completion(
+            json.dumps({"answer": "YES", "reason": "ok"})
+        )
+        openai_client.chat.completions.create.side_effect = [
+            _make_openai_completion(STORY_SELECTION_RESPONSE),
+            _make_openai_completion(EXTRACT_STATE_RESPONSE),
+            judge_resp,
+            _make_openai_completion(empty_proposal),
+            _make_openai_completion(empty_review),
+        ]
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+        )
+        assert isinstance(result, tuple)
+        data = json.loads(result[0])
+        assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# delivery_rate == 0 -> MaxCostResponse (float)
+# ---------------------------------------------------------------------------
+
+
+class TestMaxCostBranch:
+    """When delivery_rate=0, run() must return a bare float, not a tuple."""
+
+    def test_delivery_rate_zero_returns_float(self) -> None:
+        """delivery_rate=0 short-circuits and returns counter_callback result."""
+        expected_cost = 0.0321
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=lambda **_: expected_cost,
+            delivery_rate=0,
+        )
+        # with_key_rotation appends api_keys for tuple results, but the
+        # decorator skips the append for bare MaxCostResponse returns.
+        assert result == expected_cost
+
+    def test_delivery_rate_zero_no_callback_raises(self) -> None:
+        """delivery_rate=0 without counter_callback is caught and becomes an error tuple."""
+        result = run(
+            tool="propose-question",
+            prompt=json.dumps({"resolution_time": FUTURE_TS}),
+            api_keys=_make_mock_api_keys(),
+            counter_callback=None,
+            delivery_rate=0,
+        )
+        # ValueError raised by the delivery_rate==0 branch is caught by the
+        # outer try/except and returned as a JSON error in result[0].
+        assert isinstance(result, tuple)
+        data = json.loads(result[0])
+        assert "error" in data
+
+    def test_default_delivery_rate_constant(self) -> None:
+        """DEFAULT_DELIVERY_RATE must equal 100 to match reference tools."""
+        assert DEFAULT_DELIVERY_RATE == 100
+
+    def test_n_model_calls_constant_positive(self) -> None:
+        """N_MODEL_CALLS must be a positive integer."""
+        assert isinstance(N_MODEL_CALLS, int)
+        assert N_MODEL_CALLS > 0

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeic64oppl5dzupxdvk4ghh33i6tzfglwrtxjezefn6kaqmcchaq3ra
+agent: valory/mech_predict:0.1.0:bafybeid532mueh7q3nbkzsfc7amgqig4daa6gznrjvcogk7gzjrrsv2vs4
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeiby6nf74ziweiyhe5on2k4mix5yhtxtsw2zxpksgpz473nwc2ygfy
+agent: valory/mech_predict:0.1.0:bafybeic64oppl5dzupxdvk4ghh33i6tzfglwrtxjezefn6kaqmcchaq3ra
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeib6vgyz52zcvjce6sydak6nydqjwdvlswqhdr6c4fcqopljsfrx7q
+agent: valory/mech_predict:0.1.0:bafybeiby6nf74ziweiyhe5on2k4mix5yhtxtsw2zxpksgpz473nwc2ygfy
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeid532mueh7q3nbkzsfc7amgqig4daa6gznrjvcogk7gzjrrsv2vs4
+agent: valory/mech_predict:0.1.0:bafybeignbzm4mmodm6ggavzuphdzq3z4znq75x6a6elkpnizz2r6mscy2m
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,8 @@ dependencies = [
     "google-api-core>=2.20.0,<3",
     "openapi-core==0.22.0",
     "httpx==0.25.2",
+    "gql>=3.5.0,<3.6",
+    "requests-toolbelt==1.0.0",
     "tqdm==4.67.1",
     "prometheus-client>=0.23.1,<0.24",
     "pebble==5.1.3",
@@ -105,7 +107,7 @@ pytest_targets_extra = ["benchmark/tests"]
 # Third-party skills/contracts on disk are synced from mech upstream;
 # tomte auto-prepends valory-xyz/open-autonomy@... and open-aea@...
 # from pyproject pins, so only the non-PyPI mech upstream needs listing.
-upstream_pins = ["valory-xyz/mech@v0.33.2"]
+upstream_pins = ["valory-xyz/mech@v0.33.3"]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"
 
 [tool.uv.build-backend]

--- a/scripts/tool_schemas.yaml
+++ b/scripts/tool_schemas.yaml
@@ -104,6 +104,42 @@ defaults:
           - result
           - prompt
 
+  propose:
+    input:
+      type: object
+      description: JSON-encoded parameters for question generation
+      schema:
+        type: object
+        properties:
+          resolution_time:
+            type: integer
+            description: Unix timestamp of the market resolution date
+          num_questions:
+            type: integer
+            description: Number of questions to generate (default 1)
+        required:
+          - resolution_time
+    output:
+      type: object
+      description: A JSON object containing proposed questions and reasoning
+      schema:
+        type: object
+        properties:
+          requestId:
+            type: integer
+            description: Unique identifier for the request
+          result:
+            type: string
+            description: Result in JSON format as a string
+            example: "{\"questions\": {}, \"reasoning\": \"...\"}"
+          prompt:
+            type: string
+            description: The prompt passed to the tool.
+        required:
+          - requestId
+          - result
+          - prompt
+
 tool_kinds:
   close_market: resolve
   resolve-market-jury-v1: resolve
@@ -116,3 +152,4 @@ tool_kinds:
   corcel-completion: chat
   gemini-prediction: prediction
   gemini-completion: chat
+  propose-question: propose

--- a/scripts/tool_schemas.yaml
+++ b/scripts/tool_schemas.yaml
@@ -104,7 +104,7 @@ defaults:
           - result
           - prompt
 
-  propose:
+  question_generation:
     input:
       type: object
       description: JSON-encoded parameters for question generation
@@ -152,4 +152,4 @@ tool_kinds:
   corcel-completion: chat
   gemini-prediction: prediction
   gemini-completion: chat
-  propose-question: propose
+  propose-question: question_generation

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,8 @@ extra_deps =
     pydantic<3.0.0,>=2.0.0
     lxml_html_clean
     typer
+    gql>=3.5.0,<3.6
+    requests-toolbelt==1.0.0
 
 extra_pylint_ignored_modules = pandas,numpy,aea_cli_ipfs,compose,multidict,gql
 
@@ -145,6 +147,9 @@ ignore_missing_imports = True
 ; Canonical config has `[mypy-requests]`, but tools import the
 ; submodule (`requests.exceptions`); the wildcard form is needed.
 [mypy-requests.*]
+ignore_missing_imports = True
+
+[mypy-gql.*]
 ignore_missing_imports = True
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -262,6 +262,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1632,6 +1641,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b0/e3/50560f6432da8c1dfbc3d1d9d465ac6069a5dd6c81fe92b98793c97e540c/googlesearch-python-1.2.3.tar.gz", hash = "sha256:38b251121dd140439bd08cdf2a05a0b195d852908ee2bfed30e57d16aa68ae5e", size = 3850, upload-time = "2023-04-04T16:57:51.101Z" }
 
 [[package]]
+name = "gql"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "backoff" },
+    { name = "graphql-core" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/ed/44ffd30b06b3afc8274ee2f38c3c1b61fe4740bf03d92083e43d2c17ac77/gql-3.5.3.tar.gz", hash = "sha256:393b8c049d58e0d2f5461b9d738a2b5f904186a40395500b4a84dd092d56e42b", size = 180504, upload-time = "2025-05-20T12:34:08.954Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/50/2f4e99b216821ac921dbebf91c644ba95818f5d07857acadee17220221f3/gql-3.5.3-py2.py3-none-any.whl", hash = "sha256:e1fcbde2893fcafdd28114ece87ff47f1cc339a31db271fc4e1d528f5a1d4fbc", size = 74348, upload-time = "2025-05-20T12:34:07.687Z" },
+]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/16/7574029da84834349b60ed71614d66ca3afe46e9bf9c7b9562102acb7d4f/graphql_core-3.2.6.tar.gz", hash = "sha256:c08eec22f9e40f0bd61d805907e3b3b1b9a320bc606e23dc145eebca07c8fbab", size = 505353, upload-time = "2025-01-26T16:36:27.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/4f/7297663840621022bc73c22d7d9d80dbc78b4db6297f764b545cd5dd462d/graphql_core-3.2.6-py3-none-any.whl", hash = "sha256:78b016718c161a6fb20a7d97bbf107f331cd1afe53e45566c59f776ed7f0b45f", size = 203416, upload-time = "2025-01-26T16:36:24.868Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.78.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2434,6 +2467,7 @@ dependencies = [
     { name = "google-api-python-client" },
     { name = "google-generativeai" },
     { name = "googlesearch-python" },
+    { name = "gql" },
     { name = "grpcio" },
     { name = "httpx" },
     { name = "hypothesis" },
@@ -2468,6 +2502,7 @@ dependencies = [
     { name = "readability-lxml" },
     { name = "replicate" },
     { name = "requests" },
+    { name = "requests-toolbelt" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "tavily-python" },
@@ -2499,6 +2534,7 @@ requires-dist = [
     { name = "google-api-python-client", specifier = "==2.95.0" },
     { name = "google-generativeai", specifier = "==0.8.6" },
     { name = "googlesearch-python", specifier = "==1.2.3" },
+    { name = "gql", specifier = ">=3.5.0,<3.6" },
     { name = "grpcio", specifier = "==1.78.0" },
     { name = "httpx", specifier = "==0.25.2" },
     { name = "hypothesis", specifier = "==6.21.6" },
@@ -2532,6 +2568,7 @@ requires-dist = [
     { name = "readability-lxml", specifier = "==0.8.1" },
     { name = "replicate", specifier = "==0.15.7" },
     { name = "requests", specifier = "==2.32.5" },
+    { name = "requests-toolbelt", specifier = "==1.0.0" },
     { name = "scipy", specifier = ">=1.11,<2" },
     { name = "tavily-python", specifier = "==0.3.3" },
     { name = "tiktoken", specifier = "==0.12.0" },


### PR DESCRIPTION
## Summary

Two coupled changes that onboard a new prediction-market **question-generation** tool to the mech:

1. **New customs tool `propose-question`** (`packages/valory/customs/propose_question/`). Ported from market-creator's inline `propose_questions` (the tool that generates daily Omen market questions): two-step LLM generation (candidate → refine) with Serper-backed source-verification and a dedup/near-dup filter. Conformed to the newest-tool shape in this repo (`prediction_request_v1` / `superforcaster_polymarket_v3`): `MechResponse` / `MechResponseWithKeys` / `MaxCostResponse` aliases, `@with_key_rotation`, `OpenAIClientManager` (no module-global client), `DEFAULT_DELIVERY_RATE`, and the `delivery_rate == 0` max-cost branch. Registered in `benchmark/tools.py` `TOOL_REGISTRY` and the `mech_predict` agent `customs:` list; `gql` + `requests-toolbelt` added to deps and a `propose-question` schema added to `scripts/tool_schemas.yaml`. KeyChain services: `openai`, `serperapi`, `newsapi`, `subgraph`. Prompt carries `{resolution_time, num_questions}` as JSON.

2. **Bump vendored mech skills to v0.33.3** — `task_execution` / `mech_abci` / `task_submission_abci` re-pinned to [`valory-xyz/mech@v0.33.3`](https://github.com/valory-xyz/mech/releases/tag/v0.33.3), and `[tool.tomte].upstream_pins -> mech@v0.33.3`. v0.33.3 adds `gpt-4.1-mini-2025-04-14` to `TOKEN_PRICES`, which is the tool's lightweight model — without it the mech's `TokenCounterCallback` rejects every `propose-question` delivery (`Model ... not supported`).

## Test plan

- [x] `tomte tox -e check-hash` / `check-packages` pass
- [x] `tomte tox -e check-third-party-hashes` passes (all third-party consistent with `open-autonomy@0.21.23`, `open-aea@2.2.7`, `mech@v0.33.3`)
- [x] `black` / `isort` / `flake8` / `mypy` / `pylint` (10.00/10) / `darglint` clean
- [x] 51 unit tests pass (incl. max-cost branch + success/error/None-output paths)
- [x] Local executor smoke test (real APIs, `AnyToolAsTask`): generates a question with `questions` + `reasoning`; `delivery_rate=0` returns a float
- [ ] After merge: cut a mech-predict release, then agent-deployments — bump the mech service hash, add `propose-question` to `TOOLS_TO_PACKAGE_HASH` + `METADATA_HASH`, and add the `subgraph` key to the mech's API keys
