### PR TITLE
chore(propose-question): post-merge review nits (logging->print, test cleanups)

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -25,9 +25,9 @@
         "custom/valory/factual_research_v2/0.1.0": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
         "custom/valory/finetuned_prediction/0.1.0": "bafybeifetvtalxnw3y7epqspyxotrls4wl7eoffsiaglxp52nca7ozurv4",
-        "custom/valory/propose_question/0.1.0": "bafybeiccetbcycilqs4zkcxmkjehkjrpmugn3ulolb6m2zjz6ghm5s2swa",
-        "agent/valory/mech_predict/0.1.0": "bafybeignbzm4mmodm6ggavzuphdzq3z4znq75x6a6elkpnizz2r6mscy2m",
-        "service/valory/mech_predict/0.1.0": "bafybeiczjcmbzwbgaszsju567nuyr46tcj3xxic43mj44x66t7jwsv3d7y"
+        "custom/valory/propose_question/0.1.0": "bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi",
+        "agent/valory/mech_predict/0.1.0": "bafybeianosa353fsaxgs6sktbz6owvv5cwdlcsc3o6qqqh3apbinmad3iq",
+        "service/valory/mech_predict/0.1.0": "bafybeihx5nu3git6fqykq3wlihzvbpguq6afsicllhyvpdkt3ox6z2xjai"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -70,7 +70,7 @@ customs:
 - nickcom007/prediction_request_sme:0.1.0:bafybeifsk4og24t22agcrj7mm6fz3wxwfbdg554yjhc6odpxal5ofg22ti
 - valory/factual_research:0.1.0:bafybeidcxmqemvzm7cz2ydyjsmu53zflsqpcj2gpco5kwn3ldvf22rqx4i
 - valory/factual_research_v3:0.1.0:bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa
-- valory/propose_question:0.1.0:bafybeiccetbcycilqs4zkcxmkjehkjrpmugn3ulolb6m2zjz6ghm5s2swa
+- valory/propose_question:0.1.0:bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/customs/propose_question/component.yaml
+++ b/packages/valory/customs/propose_question/component.yaml
@@ -8,9 +8,9 @@ license: Apache-2.0
 aea_version: '>=1.0.0, <2.0.0'
 fingerprint:
   __init__.py: bafybeic4s7syxr2m2q3wtta3pzkqmw4usib3ji5v6ziae2kxprz2swvoje
-  propose_question.py: bafybeiactuhrqoedvn4h2lbk6b2mol3sop7k4shpgipii2ktoakomlz5ei
+  propose_question.py: bafybeia53jkkh47lkoyd2ec2ntv7a6cvu5xg6nh65ekpz32bgvkfh7jtd4
   tests/__init__.py: bafybeierlyi65bbyvrmmzse4s3j53ht54cpn3kwnt5ptgcwnqhuim25bvu
-  tests/test_propose_question.py: bafybeifkum73ur5rnmwbmd5gaylhp5i5sausoysbcsxfr3cifqeripj2qy
+  tests/test_propose_question.py: bafybeihky4j2zl26m675vxxndp6qgtweg3pxxrvo3ugk7rjcn4a5wdej7m
 fingerprint_ignore_patterns: []
 entry_point: propose_question.py
 callable: run

--- a/packages/valory/customs/propose_question/propose_question.py
+++ b/packages/valory/customs/propose_question/propose_question.py
@@ -20,7 +20,6 @@
 
 import functools
 import json
-import logging
 import random
 import re
 import uuid
@@ -33,8 +32,6 @@ from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 from openai import OpenAI
 from pydantic import BaseModel
-
-_logger = logging.getLogger(__name__)
 
 NEWSAPI_TOP_HEADLINES_URL = "https://newsapi.org/v2/top-headlines"
 NEWSAPI_DEFAULT_NEWS_SOURCES = [
@@ -796,10 +793,10 @@ def scrape_url(serper_api_key: str, url: str) -> Optional[dict]:
         print(f"Successfully scraped URL: {url}")
         return scraped_data
     except requests.RequestException as exc:
-        _logger.warning("scrape_url request error for %s: %s", url, exc)
+        print(f"scrape_url request error for {url}: {exc}")
         return None
     except json.JSONDecodeError as exc:
-        _logger.warning("scrape_url JSON decode error for %s: %s", url, exc)
+        print(f"scrape_url JSON decode error for {url}: {exc}")
         return None
 
 
@@ -1052,7 +1049,7 @@ def run(**kwargs: Any) -> Union[MaxCostResponse, MechResponse]:
                     if not mod.results[0].flagged:
                         clean_articles.append(article)
                 except Exception as exc:  # noqa: BLE001
-                    _logger.warning("Moderation pre-filter error (fail-open): %s", exc)
+                    print(f"Moderation pre-filter error (fail-open): {exc}")
                     clean_articles.append(article)
             n_dropped = len(articles) - len(clean_articles)
             if n_dropped > 0:

--- a/packages/valory/customs/propose_question/tests/test_propose_question.py
+++ b/packages/valory/customs/propose_question/tests/test_propose_question.py
@@ -133,7 +133,8 @@ class TestValidatequestionDates:
     def test_past_date_rejected(self) -> None:
         """A question referencing a past date is rejected."""
         resolution_ts = int(time.time()) + 86400 * 60
-        question = "Will something happen on January 1, 2020, according to Reuters?"
+        past = format_utc_timestamp(int(time.time()) - 2 * 86400)
+        question = f"Will something happen on {past}, according to Reuters?"
         result = validate_question_dates(question, resolution_ts)
         assert result is not None
         assert "past" in result
@@ -1139,7 +1140,6 @@ class TestWithKeyRotation:
         """Build a minimal KeyChain-like mock."""
         keys = MagicMock()
         keys.max_retries.return_value = {"openai": n_openai}
-        keys.__add__ = lambda self, other: other  # for tuple concat in decorator
         return keys
 
     def test_rate_limit_rotates_and_retries(self) -> None:

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeignbzm4mmodm6ggavzuphdzq3z4znq75x6a6elkpnizz2r6mscy2m
+agent: valory/mech_predict:0.1.0:bafybeianosa353fsaxgs6sktbz6owvv5cwdlcsc3o6qqqh3apbinmad3iq
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Summary

Follow-up addressing the three non-blocking nits from the #370 review (which merged with these deferred):

1. **Fail-open logging actually surfaces now.** The `scrape_url` / moderation-pre-filter fail-open paths used `logging.getLogger(__name__).warning(...)`, but the mech executor captures **stdout** (`print`), and that logger has no handler configured — so the warnings were silently dropped. Switched to `print(...)` (matching peer tools) and removed the now-unused `logging` import. This matters in practice: transient Serper scrape 500s do occur, and they should be visible in the mech logs.
2. **Dropped a dead `KeyChain.__add__` override** in the test helper — the `@with_key_rotation` decorator does `result + (api_keys,)`, i.e. `tuple.__add__`, so the keychain's `__add__` is never invoked.
3. **Past-date test is now relative** — `format_utc_timestamp(now - 2d)` instead of a hardcoded `"January 1, 2020"`, so it's self-documenting and immune to any future change in `validate_question_dates`' past-date window.

No behavior change to question generation. 62 tests pass; black/isort/flake8/mypy/pylint/darglint, check-hash, check-third-party-hashes all green.
