### PR TITLE
feat: add Optimism ledger support

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -26,8 +26,8 @@
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
         "custom/valory/finetuned_prediction/0.1.0": "bafybeifetvtalxnw3y7epqspyxotrls4wl7eoffsiaglxp52nca7ozurv4",
         "custom/valory/propose_question/0.1.0": "bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi",
-        "agent/valory/mech_predict/0.1.0": "bafybeianosa353fsaxgs6sktbz6owvv5cwdlcsc3o6qqqh3apbinmad3iq",
-        "service/valory/mech_predict/0.1.0": "bafybeihx5nu3git6fqykq3wlihzvbpguq6afsicllhyvpdkt3ox6z2xjai"
+        "agent/valory/mech_predict/0.1.0": "bafybeiehpcc6qia3qnosw32zzx2jyprtky4x5zoqef55cmiavacbgqkxae",
+        "service/valory/mech_predict/0.1.0": "bafybeiczqwfdpg3cck3elgxtz56cnnd6qab4k7u3ulq3dtii3kdfqt7gmq"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -37,6 +37,7 @@
         "protocol/valory/contract_api/1.0.0": "bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la",
         "protocol/valory/http/1.0.0": "bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy",
         "protocol/valory/ipfs/0.1.0": "bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam",
+        "protocol/valory/kv_store/0.1.0": "bafybeidlfrgv5rc7m7kj3j6u6umogmpy5bgcdzqtnsy3v75wn3likvyt6m",
         "protocol/valory/ledger_api/1.0.0": "bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi",
         "protocol/valory/tendermint/0.1.0": "bafybeihzb7e32f7jcrzvubilqaxzmyk7ea6ss3pg3tliatdlrr76qeknyq",
         "protocol/valory/websocket_client/0.1.0": "bafybeig6omutaqt5rbvidju4zc7pwwdi6tkagwu3dwiirosadyoo534v3q",
@@ -57,6 +58,7 @@
         "connection/valory/http_server/0.22.0": "bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle",
         "connection/valory/abci/0.1.0": "bafybeiafvaguchnkp2fmhf6gtayc3gpnxkglagghb4ukbqtouni5tveigi",
         "connection/valory/ipfs/0.1.0": "bafybeihxytzo7tunodztv424xsnnufewbowucdsxtdzdcik2rskcn7plta",
+        "connection/valory/kv_store/0.1.0": "bafybeib2tvoui6kndvrd2gpvs55rizpjee7mqjtjsfbr6fdp5hxslh6gd4",
         "skill/valory/contract_subscription/0.1.0": "bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q",
         "skill/valory/websocket_client/0.1.0": "bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay",
         "skill/valory/abstract_abci/0.1.0": "bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi",
@@ -66,8 +68,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki",
         "skill/valory/termination_abci/0.1.0": "bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeidjjknxrn4ldakdeq7azuffe4a76oi2vladmjkb57z3fmeg3z5g6a",
-        "skill/valory/task_execution/0.1.0": "bafybeibhf7ou4cqn4v65wptogxckolzpalnrzy4g7romb63jpxe3qrrexe",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeihskhun5iy3qd2kyslg4rtppiupx6rpikklhmci5b5fjgr65ynpzq"
+        "skill/valory/mech_abci/0.1.0": "bafybeidhjps2ctsggi3dpexdmuftfnvsgm2lgrotss3azsjufufpy2yfqu",
+        "skill/valory/task_execution/0.1.0": "bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4"
     }
 }

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -11,6 +11,7 @@ connections:
 - valory/http_client:0.23.0:bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4
 - valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
 - valory/ipfs:0.1.0:bafybeihxytzo7tunodztv424xsnnufewbowucdsxtdzdcik2rskcn7plta
+- valory/kv_store:0.1.0:bafybeib2tvoui6kndvrd2gpvs55rizpjee7mqjtjsfbr6fdp5hxslh6gd4
 - valory/ledger:0.19.0:bafybeicynh5l5f5f5jpx72qwzis7jvmxk5p4eqltk32uxbj2pgu2x4rqz4
 - valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
 - valory/websocket_client:0.1.0:bafybeid4cnbjpmzcsw3usg7umufgqyod2u3xfw5uso3vukt3n5hfuxvdea
@@ -33,6 +34,7 @@ protocols:
 - valory/contract_api:1.0.0:bafybeibld2xb5m7kyluiptkamp4nrt6oeomkohz7a3yppbv2oo7qw2e4la
 - valory/http:1.0.0:bafybeidxkp3vga7t6x2pbt2tpkgyaxa5bgpdgryao54py7w3yxyzr7neoy
 - valory/ipfs:0.1.0:bafybeibz5xqhxdbuvba7nuw2w6ardjermtcoqercopnypdplnaekf3joam
+- valory/kv_store:0.1.0:bafybeidlfrgv5rc7m7kj3j6u6umogmpy5bgcdzqtnsy3v75wn3likvyt6m
 - valory/ledger_api:1.0.0:bafybeiecq56phjfws36rgrefw6niyo4ezesloodsfis647mpm5ygqo4ysi
 - valory/tendermint:0.1.0:bafybeihzb7e32f7jcrzvubilqaxzmyk7ea6ss3pg3tliatdlrr76qeknyq
 - valory/websocket_client:0.1.0:bafybeig6omutaqt5rbvidju4zc7pwwdi6tkagwu3dwiirosadyoo534v3q
@@ -40,12 +42,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeidjjknxrn4ldakdeq7azuffe4a76oi2vladmjkb57z3fmeg3z5g6a
+- valory/mech_abci:0.1.0:bafybeidhjps2ctsggi3dpexdmuftfnvsgm2lgrotss3azsjufufpy2yfqu
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
-- valory/task_execution:0.1.0:bafybeibhf7ou4cqn4v65wptogxckolzpalnrzy4g7romb63jpxe3qrrexe
-- valory/task_submission_abci:0.1.0:bafybeihskhun5iy3qd2kyslg4rtppiupx6rpikklhmci5b5fjgr65ynpzq
+- valory/task_execution:0.1.0:bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq
+- valory/task_submission_abci:0.1.0:bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay
@@ -290,6 +292,7 @@ models:
       gnosis_ledger_rpc: ${str:http://localhost:8545}
       polygon_ledger_rpc: ${str:http://localhost:8545}
       base_ledger_rpc: ${str:http://localhost:8545}
+      optimism_ledger_rpc: ${str:http://localhost:8545}
 ---
 public_id: valory/ledger:0.19.0
 type: connection
@@ -319,6 +322,11 @@ config:
             maxFeePerGas: ${int:20000000000}
             maxPriorityFeePerGas: ${int:3000000000}
           priority_fee_increase_boundary: ${int:200}
+    optimism:
+      address: ${str:http://localhost:8545}
+      chain_id: ${int:10}
+      poa_chain: ${bool:false}
+      default_gas_price_strategy: ${str:eip1559}
 ---
 public_id: valory/http_server:0.22.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq
 type: connection

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeianosa353fsaxgs6sktbz6owvv5cwdlcsc3o6qqqh3apbinmad3iq
+agent: valory/mech_predict:0.1.0:bafybeiehpcc6qia3qnosw32zzx2jyprtky4x5zoqef55cmiavacbgqkxae
 number_of_agents: 1
 deployment:
   agent:
@@ -220,6 +220,7 @@ type: skill
         gnosis_ledger_rpc: ${GNOSIS_LEDGER_RPC_0:str:http://host.docker.internal:8545}
         polygon_ledger_rpc: ${POLYGON_LEDGER_RPC_0:str:http://host.docker.internal:8545}
         base_ledger_rpc: ${BASE_LEDGER_RPC_0:str:http://host.docker.internal:8545}
+        optimism_ledger_rpc: ${OPTIMISM_LEDGER_RPC_0:str:http://host.docker.internal:8545}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
 1:
   models:
@@ -242,6 +243,7 @@ type: skill
         gnosis_ledger_rpc: ${GNOSIS_LEDGER_RPC_1:str:http://host.docker.internal:8545}
         polygon_ledger_rpc: ${POLYGON_LEDGER_RPC_1:str:http://host.docker.internal:8545}
         base_ledger_rpc: ${BASE_LEDGER_RPC_1:str:http://host.docker.internal:8545}
+        optimism_ledger_rpc: ${OPTIMISM_LEDGER_RPC_1:str:http://host.docker.internal:8545}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
 2:
   models:
@@ -264,6 +266,7 @@ type: skill
         gnosis_ledger_rpc: ${GNOSIS_LEDGER_RPC_2:str:http://host.docker.internal:8545}
         polygon_ledger_rpc: ${POLYGON_LEDGER_RPC_2:str:http://host.docker.internal:8545}
         base_ledger_rpc: ${BASE_LEDGER_RPC_2:str:http://host.docker.internal:8545}
+        optimism_ledger_rpc: ${OPTIMISM_LEDGER_RPC_2:str:http://host.docker.internal:8545}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
 3:
   models:
@@ -286,6 +289,7 @@ type: skill
         gnosis_ledger_rpc: ${GNOSIS_LEDGER_RPC_3:str:http://host.docker.internal:8545}
         polygon_ledger_rpc: ${POLYGON_LEDGER_RPC_3:str:http://host.docker.internal:8545}
         base_ledger_rpc: ${BASE_LEDGER_RPC_3:str:http://host.docker.internal:8545}
+        optimism_ledger_rpc: ${OPTIMISM_LEDGER_RPC_3:str:http://host.docker.internal:8545}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
 ---
 public_id: valory/ledger:0.19.0
@@ -320,6 +324,11 @@ type: connection
               maxFeePerGas: ${POLYGON_MAX_FEE_PER_GAS:int:20000000000}
               maxPriorityFeePerGas: ${POLYGON_MAX_PRIORITY_FEE_PER_GAS:int:3000000000}
             priority_fee_increase_boundary: ${POLYGON_PRIORITY_FEE_INCREASE_BOUNDARY:int:200}
+      optimism:
+        address: ${OPTIMISM_LEDGER_RPC_0:str:http://host.docker.internal:8545}
+        chain_id: ${OPTIMISM_LEDGER_CHAIN_ID:int:10}
+        poa_chain: ${OPTIMISM_LEDGER_IS_POA_CHAIN:bool:false}
+        default_gas_price_strategy: ${OPTIMISM_LEDGER_PRICING:str:eip1559}
 1:
   config:
     ledger_apis:
@@ -350,6 +359,11 @@ type: connection
               maxFeePerGas: ${POLYGON_MAX_FEE_PER_GAS:int:20000000000}
               maxPriorityFeePerGas: ${POLYGON_MAX_PRIORITY_FEE_PER_GAS:int:3000000000}
             priority_fee_increase_boundary: ${POLYGON_PRIORITY_FEE_INCREASE_BOUNDARY:int:200}
+      optimism:
+        address: ${OPTIMISM_LEDGER_RPC_1:str:http://host.docker.internal:8545}
+        chain_id: ${OPTIMISM_LEDGER_CHAIN_ID:int:10}
+        poa_chain: ${OPTIMISM_LEDGER_IS_POA_CHAIN:bool:false}
+        default_gas_price_strategy: ${OPTIMISM_LEDGER_PRICING:str:eip1559}
 2:
   config:
     ledger_apis:
@@ -380,6 +394,11 @@ type: connection
               maxFeePerGas: ${POLYGON_MAX_FEE_PER_GAS:int:20000000000}
               maxPriorityFeePerGas: ${POLYGON_MAX_PRIORITY_FEE_PER_GAS:int:3000000000}
             priority_fee_increase_boundary: ${POLYGON_PRIORITY_FEE_INCREASE_BOUNDARY:int:200}
+      optimism:
+        address: ${OPTIMISM_LEDGER_RPC_2:str:http://host.docker.internal:8545}
+        chain_id: ${OPTIMISM_LEDGER_CHAIN_ID:int:10}
+        poa_chain: ${OPTIMISM_LEDGER_IS_POA_CHAIN:bool:false}
+        default_gas_price_strategy: ${OPTIMISM_LEDGER_PRICING:str:eip1559}
 3:
   config:
     ledger_apis:
@@ -410,6 +429,11 @@ type: connection
               maxFeePerGas: ${POLYGON_MAX_FEE_PER_GAS:int:20000000000}
               maxPriorityFeePerGas: ${POLYGON_MAX_PRIORITY_FEE_PER_GAS:int:3000000000}
             priority_fee_increase_boundary: ${POLYGON_PRIORITY_FEE_INCREASE_BOUNDARY:int:200}
+      optimism:
+        address: ${OPTIMISM_LEDGER_RPC_3:str:http://host.docker.internal:8545}
+        chain_id: ${OPTIMISM_LEDGER_CHAIN_ID:int:10}
+        poa_chain: ${OPTIMISM_LEDGER_IS_POA_CHAIN:bool:false}
+        default_gas_price_strategy: ${OPTIMISM_LEDGER_PRICING:str:eip1559}
 ---
 public_id: valory/p2p_libp2p_client:0.1.0
 type: connection

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ pytest_targets_extra = ["benchmark/tests"]
 # Third-party skills/contracts on disk are synced from mech upstream;
 # tomte auto-prepends valory-xyz/open-autonomy@... and open-aea@...
 # from pyproject pins, so only the non-PyPI mech upstream needs listing.
-upstream_pins = ["valory-xyz/mech@v0.33.3"]
+upstream_pins = ["valory-xyz/mech@v0.34.0"]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"
 
 [tool.uv.build-backend]

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@
 ; string-strict matching so the form must agree on both sides. Plus
 ; lint-only werkzeug/attrs not in pyproject.
 extra_deps =
+    peewee<4,>=3.17
+    eth-utils==6.0.0
     protobuf<7,>=5
     web3<8,>=7.0.0
     fastapi==0.110.3


### PR DESCRIPTION
## Summary

- Bumps mech third-party skills (`task_execution`, `task_submission_abci`, `mech_abci`) to the versions that wire `optimism` into `task_execution`'s chain-aware RPC lookup (`getattr(params, f"{chain}_ledger_rpc")`) and the `ChainId` enum.
- Adds the matching `kv_store` connection + protocol that the bumped skills now depend on (third-party only; not committed).
- Plumbs `optimism_ledger_rpc` + the `optimism:` ledger_apis block through both the agent override (`aea-config.yaml`) and `service.yaml` (one per agent index, 4×), so a mech-predict deployment targeting an Optimism-bound mech (e.g. service 195) no longer falls back to `localhost:8545` on `eth_call`.

### Onchain flow safety
The mech bumps also pull in the new offchain/PostTxSettlement code path, but that path is feature-flagged:
- `mech_events_enabled` defaults to `False` in `task_execution/models.py` and `task_submission_abci/models.py`
- Onchain delivery short-circuits via three guards in `_do_wildcard_write_best_effort` when the flag is off
- All new kwargs (`mech_events_chain_id`, `payment_type_to_asset_address`, `use_offchain`, `preimage_*`) are `kwargs.get(..., <default>)` — no required-arg breakage for existing deployments

## Hashes
- agent: `bafybeiehpcc6qia3qnosw32zzx2jyprtky4x5zoqef55cmiavacbgqkxae`
- service: `bafybeiczqwfdpg3cck3elgxtz56cnnd6qab4k7u3ulq3dtii3kdfqt7gmq`

## Test plan
- [x] `autonomy packages lock --check` — third-party deps all verify
- [x] `autonomy push-all` — published to IPFS
- [ ] Local agent-runner test against an Optimism RPC to confirm `eth_call` no longer hits `127.0.0.1:8545`
- [ ] After merge + release tag, bump `agent-deployments/deployments/single_optimism_mech_195.env` PROPEL_SERVICE_HASH_ID to the new service hash and confirm mech 195 delivers

🤖 Generated with [Claude Code](https://claude.com/claude-code)