### PR TITLE
fix(mech_predict): override kv_store store_path so the connection inits

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -27,7 +27,7 @@
         "custom/valory/finetuned_prediction/0.1.0": "bafybeifetvtalxnw3y7epqspyxotrls4wl7eoffsiaglxp52nca7ozurv4",
         "custom/valory/propose_question/0.1.0": "bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi",
         "agent/valory/mech_predict/0.1.0": "bafybeierkwlngcwzwhb3tupgrp6xjzzs32y6eswdhshm5mutn6k4c6fqnm",
-        "service/valory/mech_predict/0.1.0": "bafybeifkkr6ox7ki4b7smgizls3acaog42rfv3b4pg2paoyqjsfllbkxry"
+        "service/valory/mech_predict/0.1.0": "bafybeibq5nc4payfteomyo2xwvhr5bf24dlhus4yg6htpgkivifqs3nl4u"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -26,8 +26,8 @@
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
         "custom/valory/finetuned_prediction/0.1.0": "bafybeifetvtalxnw3y7epqspyxotrls4wl7eoffsiaglxp52nca7ozurv4",
         "custom/valory/propose_question/0.1.0": "bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi",
-        "agent/valory/mech_predict/0.1.0": "bafybeiehpcc6qia3qnosw32zzx2jyprtky4x5zoqef55cmiavacbgqkxae",
-        "service/valory/mech_predict/0.1.0": "bafybeiczqwfdpg3cck3elgxtz56cnnd6qab4k7u3ulq3dtii3kdfqt7gmq"
+        "agent/valory/mech_predict/0.1.0": "bafybeierkwlngcwzwhb3tupgrp6xjzzs32y6eswdhshm5mutn6k4c6fqnm",
+        "service/valory/mech_predict/0.1.0": "bafybeifkkr6ox7ki4b7smgizls3acaog42rfv3b4pg2paoyqjsfllbkxry"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -334,3 +334,8 @@ config:
   host: ${str:0.0.0.0}
   target_skill_id: valory/mech_abci:0.1.0
 is_abstract: false
+---
+public_id: valory/kv_store:0.1.0
+type: connection
+config:
+  store_path: ${str:/data}

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeiehpcc6qia3qnosw32zzx2jyprtky4x5zoqef55cmiavacbgqkxae
+agent: valory/mech_predict:0.1.0:bafybeierkwlngcwzwhb3tupgrp6xjzzs32y6eswdhshm5mutn6k4c6fqnm
 number_of_agents: 1
 deployment:
   agent:
@@ -516,3 +516,18 @@ type: skill
     params:
       args:
         use_polling: ${USE_POLLING:str:false}
+---
+public_id: valory/kv_store:0.1.0
+type: connection
+0:
+  config:
+    store_path: ${KV_STORE_PATH_0:str:/data}
+1:
+  config:
+    store_path: ${KV_STORE_PATH_1:str:/data}
+2:
+  config:
+    store_path: ${KV_STORE_PATH_2:str:/data}
+3:
+  config:
+    store_path: ${KV_STORE_PATH_3:str:/data}

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -519,15 +519,5 @@ type: skill
 ---
 public_id: valory/kv_store:0.1.0
 type: connection
-0:
-  config:
-    store_path: ${KV_STORE_PATH_0:str:/data}
-1:
-  config:
-    store_path: ${KV_STORE_PATH_1:str:/data}
-2:
-  config:
-    store_path: ${KV_STORE_PATH_2:str:/data}
-3:
-  config:
-    store_path: ${KV_STORE_PATH_3:str:/data}
+config:
+  store_path: ${STORE_PATH:str:/data}


### PR DESCRIPTION
## Summary

Override \`store_path\` for the \`valory/kv_store\` connection at the agent + service level so the connection actually initialises on deploy.

## Why

The upstream mech \`kv_store\` connection.yaml has \`store_path: null\`. The connection's \`__init__\` does:

\`\`\`python
store_path = Path(self.configuration.config.get("store_path", "/data"))
\`\`\`

\`dict.get(key, default)\` returns the default only when the key is **absent**, not when its value is \`None\`. So with the YAML \`null\`, \`config.get("store_path", "/data")\` returns \`None\` and \`Path(None)\` crashes with \`TypeError: expected str, bytes or os.PathLike object, not NoneType\` — the agent never starts.

This surfaced when mech 195 redeployed against the new optimism-enabled service hash from #376, because the bumped task_execution/task_submission_abci skills pulled in \`kv_store\` for the first time in mech-predict.

## Fix

Adds a top-level kv_store override in both \`aea-config.yaml\` and \`service.yaml\` with \`store_path: \${STORE_PATH:str:/data}\`. Matches optimus's existing pattern.

## Hashes
- agent: \`bafybeierkwlngcwzwhb3tupgrp6xjzzs32y6eswdhshm5mutn6k4c6fqnm\`
- service: \`bafybeibq5nc4payfteomyo2xwvhr5bf24dlhus4yg6htpgkivifqs3nl4u\`

## Test plan
- [x] \`autonomy packages lock --check\` passes
- [x] \`autonomy push-all\` published the new hashes
- [ ] Redeploy mech 195 on Propel against the new service hash and confirm the agent boots past kv_store init

🤖 Generated with [Claude Code](https://claude.com/claude-code)