### PR TITLE
ci(benchmark-replay): notify on the PR when a run is cancelled/failed/timed-out

### DIFF
--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -299,19 +299,21 @@ jobs:
           PR_NUMBER: ${{ github.event.issue.number || github.event.inputs.pr }}
           # The triggering /benchmark comment (empty for workflow_dispatch).
           TRIGGER_COMMENT_URL: ${{ github.event.comment.html_url }}
-          # 'true' on a cancellation (manual / superseded / 6h timeout), 'false'
-          # when a step errored -- lets the notice name the actual reason.
-          IS_CANCELLED: ${{ cancelled() }}
         run: |
           [ -n "$PR_NUMBER" ] || { echo "No PR to notify; skipping."; exit 0; }
-          # Explicit reason: a cancellation, or the specific step that errored
-          # (named via the jobs API -- no per-step id needed).
-          if [ "$IS_CANCELLED" = "true" ]; then
+          # Explicit reason derived from this run's recorded step conclusions
+          # (the jobs API): name the step that errored, or report a cancellation.
+          # cancelled() is only valid in an if:, so we read the outcomes here
+          # instead of using a status function in env.
+          JOBS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" 2>/dev/null)
+          FAILED_STEPS=$(printf '%s' "$JOBS" | jq -r '[.jobs[].steps[] | select(.conclusion == "failure") | .name] | join(", ")')
+          CANCELLED_COUNT=$(printf '%s' "$JOBS" | jq -r '[.jobs[].steps[] | select(.conclusion == "cancelled")] | length')
+          if [ -n "$FAILED_STEPS" ]; then
+            REASON="it **errored** at the **$FAILED_STEPS** step."
+          elif [ "${CANCELLED_COUNT:-0}" -gt 0 ]; then
             REASON="it was **cancelled** -- manually, superseded by a newer run, or the 6h job timeout was reached."
           else
-            FAILED_STEPS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" \
-              --jq '[.jobs[].steps[] | select(.conclusion == "failure") | .name] | join(", ")' 2>/dev/null)
-            REASON="it **errored** at the **${FAILED_STEPS:-unknown}** step."
+            REASON="it did not finish (no verdict was produced)."
           fi
           # Link back to the request when we have it (issue_comment trigger).
           if [ -n "$TRIGGER_COMMENT_URL" ]; then

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -279,3 +279,34 @@ jobs:
               --candidate benchmark/results/ci_replay/candidate.jsonl \
               --seed "${{ steps.parse.outputs.seed }}"
           fi
+
+      # If the run did NOT complete (cancelled, the 6h timeout, or an
+      # enrich/replay error), post a notice on the PR so the outcome is visible
+      # in the thread instead of only in the Actions logs. The "Post benchmark
+      # report" step above carries an implicit success(), so it silently skips on
+      # a bad outcome; this step is its failure/cancel counterpart (the two are
+      # mutually exclusive). It inherits the job's /benchmark authorization guard,
+      # so it only ever fires on a real benchmark run -- never on other comments.
+      - name: Notify on incomplete benchmark
+        if: ${{ failure() || cancelled() }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # issue_comment always carries the PR number; workflow_dispatch falls
+          # back to the optional --pr input (empty -> nothing to comment on).
+          PR_NUMBER: ${{ github.event.issue.number || github.event.inputs.pr }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          [ -n "$PR_NUMBER" ] || { echo "No PR to notify; skipping."; exit 0; }
+          printf '%s\n' \
+            '<!-- benchmark-incomplete -->' \
+            '## :warning: Benchmark did not complete' \
+            '' \
+            'The benchmark replay did not finish, so no verdict was posted. This' \
+            'usually means the run was cancelled, hit the 6h timeout, or errored in' \
+            'the enrich/replay steps -- it is not a tool regression.' \
+            '' \
+            "- Run log: $RUN_URL" \
+            '- Re-trigger when ready with a new comment:' \
+            '  /benchmark <tool> [--candidate-tool <tool>] [--platform omen|polymarket] [--sample N]' \
+            > "$RUNNER_TEMP/incomplete.md"
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/incomplete.md"

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -302,18 +302,24 @@ jobs:
         run: |
           [ -n "$PR_NUMBER" ] || { echo "No PR to notify; skipping."; exit 0; }
           # Explicit reason derived from this run's recorded step conclusions
-          # (the jobs API): name the step that errored, or report a cancellation.
-          # cancelled() is only valid in an if:, so we read the outcomes here
-          # instead of using a status function in env.
-          JOBS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" 2>/dev/null)
-          FAILED_STEPS=$(printf '%s' "$JOBS" | jq -r '[.jobs[].steps[] | select(.conclusion == "failure") | .name] | join(", ")')
-          CANCELLED_COUNT=$(printf '%s' "$JOBS" | jq -r '[.jobs[].steps[] | select(.conclusion == "cancelled")] | length')
+          # (the jobs API). cancelled() is only valid in an if:, so we read the
+          # step outcomes here instead. Retry briefly: a just-failed step's
+          # conclusion can lag a few seconds behind in the API.
+          FAILED_STEPS=""
+          CANCELLED_COUNT=0
+          for _ in 1 2 3 4 5 6; do
+            JOBS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" 2>/dev/null)
+            FAILED_STEPS=$(printf '%s' "$JOBS" | jq -r '[.jobs[].steps[] | select(.conclusion == "failure") | .name] | join(", ")')
+            CANCELLED_COUNT=$(printf '%s' "$JOBS" | jq -r '[.jobs[].steps[] | select(.conclusion == "cancelled")] | length')
+            if [ -n "$FAILED_STEPS" ] || [ "${CANCELLED_COUNT:-0}" -gt 0 ]; then break; fi
+            sleep 3
+          done
           if [ -n "$FAILED_STEPS" ]; then
             REASON="it **errored** at the **$FAILED_STEPS** step."
           elif [ "${CANCELLED_COUNT:-0}" -gt 0 ]; then
             REASON="it was **cancelled** -- manually, superseded by a newer run, or the 6h job timeout was reached."
           else
-            REASON="it did not finish (no verdict was produced)."
+            REASON="it did not finish; see the run log below."
           fi
           # Link back to the request when we have it (issue_comment trigger).
           if [ -n "$TRIGGER_COMMENT_URL" ]; then

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -284,11 +284,13 @@ jobs:
       # enrich/replay error), post a notice on the PR so the outcome is visible
       # in the thread instead of only in the Actions logs. The "Post benchmark
       # report" step above carries an implicit success(), so it silently skips on
-      # a bad outcome; this step is its failure/cancel counterpart (the two are
-      # mutually exclusive). It inherits the job's /benchmark authorization guard,
+      # a bad outcome; this step is its failure/cancel counterpart -- mutually
+      # exclusive for failures upstream of "Post benchmark report" (if that report
+      # step itself fails, both run and this notice names it). It inherits the
+      # job's /benchmark authorization guard,
       # so it only ever fires on a real benchmark run -- never on other comments.
       - name: Notify on incomplete benchmark
-        if: ${{ failure() || cancelled() }}
+        if: failure() || cancelled()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
@@ -301,27 +303,35 @@ jobs:
           TRIGGER_COMMENT_URL: ${{ github.event.comment.html_url }}
         run: |
           [ -n "$PR_NUMBER" ] || { echo "No PR to notify; skipping."; exit 0; }
-          # Explicit reason derived from this run's recorded step conclusions
-          # (the jobs API). cancelled() is only valid in an if:, so we read the
-          # step outcomes here instead. Retry briefly: a just-failed step's
-          # conclusion can lag a few seconds behind in the API.
+          # The status functions return only a boolean; to name the failed step
+          # we query the jobs API for this run's recorded step conclusions. Retry
+          # briefly: a just-concluded step's conclusion can lag a few seconds in
+          # the API.
           FAILED_STEPS=""
           CANCELLED_COUNT=0
           for _ in 1 2 3 4 5 6; do
-            JOBS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" 2>/dev/null)
+            # gh api exits non-zero on a transient error; under the Actions
+            # bash -e default that would abort the step before gh pr comment,
+            # so no notice would post. Tolerate it, surface it, and keep JOBS
+            # valid JSON so the jq below can't error on null.
+            JOBS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" 2>"$RUNNER_TEMP/jobs_err") || {
+              echo "::warning::could not query the jobs API: $(tr '\n' ' ' < "$RUNNER_TEMP/jobs_err" 2>/dev/null)"
+              JOBS='{"jobs":[]}'
+            }
             FAILED_STEPS=$(printf '%s' "$JOBS" | jq -r '[.jobs[].steps[] | select(.conclusion == "failure") | .name] | join(", ")')
             CANCELLED_COUNT=$(printf '%s' "$JOBS" | jq -r '[.jobs[].steps[] | select(.conclusion == "cancelled")] | length')
-            if [ -n "$FAILED_STEPS" ] || [ "${CANCELLED_COUNT:-0}" -gt 0 ]; then break; fi
+            if [ -n "$FAILED_STEPS" ] || [ "$CANCELLED_COUNT" -gt 0 ]; then break; fi
             sleep 3
           done
+          # Failure takes priority over cancellation -- an errored step is more
+          # actionable than a downstream cancel, so check it first.
           if [ -n "$FAILED_STEPS" ]; then
             REASON="it **errored** at the **$FAILED_STEPS** step."
-          elif [ "${CANCELLED_COUNT:-0}" -gt 0 ]; then
+          elif [ "$CANCELLED_COUNT" -gt 0 ]; then
             REASON="it was **cancelled** (a manual cancel from the Actions tab, or the 6h job-timeout was hit)."
           else
             REASON="the cause could not be determined; see the run log below."
           fi
-          # Link back to the request when we have it (issue_comment trigger).
           if [ -n "$TRIGGER_COMMENT_URL" ]; then
             LEAD="The [benchmark replay requested]($TRIGGER_COMMENT_URL) did not finish: $REASON"
           else

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -317,15 +317,15 @@ jobs:
           if [ -n "$FAILED_STEPS" ]; then
             REASON="it **errored** at the **$FAILED_STEPS** step."
           elif [ "${CANCELLED_COUNT:-0}" -gt 0 ]; then
-            REASON="it was **cancelled** -- manually, superseded by a newer run, or the 6h job timeout was reached."
+            REASON="it was **cancelled** (a manual cancel from the Actions tab, or the 6h job-timeout was hit)."
           else
-            REASON="it did not finish; see the run log below."
+            REASON="the cause could not be determined; see the run log below."
           fi
           # Link back to the request when we have it (issue_comment trigger).
           if [ -n "$TRIGGER_COMMENT_URL" ]; then
-            LEAD="The [benchmark replay requested here]($TRIGGER_COMMENT_URL) did not finish -- $REASON"
+            LEAD="The [benchmark replay requested]($TRIGGER_COMMENT_URL) did not finish: $REASON"
           else
-            LEAD="The benchmark replay did not finish -- $REASON"
+            LEAD="The benchmark replay did not finish: $REASON"
           fi
           {
             echo '<!-- benchmark-incomplete -->'

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -333,8 +333,6 @@ jobs:
             echo ''
             echo "$LEAD"
             echo ''
-            echo 'No verdict was posted. This is a pipeline/run outcome, **not** a tool regression.'
-            echo ''
             echo "- Run log: $RUN_URL"
             echo '- Re-trigger when ready with a new comment:'
             echo '  /benchmark <tool> [--candidate-tool <tool>] [--platform omen|polymarket] [--sample N]'

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -291,22 +291,44 @@ jobs:
         if: ${{ failure() || cancelled() }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           # issue_comment always carries the PR number; workflow_dispatch falls
           # back to the optional --pr input (empty -> nothing to comment on).
           PR_NUMBER: ${{ github.event.issue.number || github.event.inputs.pr }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # The triggering /benchmark comment (empty for workflow_dispatch).
+          TRIGGER_COMMENT_URL: ${{ github.event.comment.html_url }}
+          # 'true' on a cancellation (manual / superseded / 6h timeout), 'false'
+          # when a step errored -- lets the notice name the actual reason.
+          IS_CANCELLED: ${{ cancelled() }}
         run: |
           [ -n "$PR_NUMBER" ] || { echo "No PR to notify; skipping."; exit 0; }
-          printf '%s\n' \
-            '<!-- benchmark-incomplete -->' \
-            '## :warning: Benchmark did not complete' \
-            '' \
-            'The benchmark replay did not finish, so no verdict was posted. This' \
-            'usually means the run was cancelled, hit the 6h timeout, or errored in' \
-            'the enrich/replay steps -- it is not a tool regression.' \
-            '' \
-            "- Run log: $RUN_URL" \
-            '- Re-trigger when ready with a new comment:' \
-            '  /benchmark <tool> [--candidate-tool <tool>] [--platform omen|polymarket] [--sample N]' \
-            > "$RUNNER_TEMP/incomplete.md"
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body-file "$RUNNER_TEMP/incomplete.md"
+          # Explicit reason: a cancellation, or the specific step that errored
+          # (named via the jobs API -- no per-step id needed).
+          if [ "$IS_CANCELLED" = "true" ]; then
+            REASON="it was **cancelled** -- manually, superseded by a newer run, or the 6h job timeout was reached."
+          else
+            FAILED_STEPS=$(gh api "repos/$REPO/actions/runs/$RUN_ID/jobs" \
+              --jq '[.jobs[].steps[] | select(.conclusion == "failure") | .name] | join(", ")' 2>/dev/null)
+            REASON="it **errored** at the **${FAILED_STEPS:-unknown}** step."
+          fi
+          # Link back to the request when we have it (issue_comment trigger).
+          if [ -n "$TRIGGER_COMMENT_URL" ]; then
+            LEAD="The [benchmark replay requested here]($TRIGGER_COMMENT_URL) did not finish -- $REASON"
+          else
+            LEAD="The benchmark replay did not finish -- $REASON"
+          fi
+          {
+            echo '<!-- benchmark-incomplete -->'
+            echo '## :warning: Benchmark did not complete'
+            echo ''
+            echo "$LEAD"
+            echo ''
+            echo 'No verdict was posted. This is a pipeline/run outcome, **not** a tool regression.'
+            echo ''
+            echo "- Run log: $RUN_URL"
+            echo '- Re-trigger when ready with a new comment:'
+            echo '  /benchmark <tool> [--candidate-tool <tool>] [--platform omen|polymarket] [--sample N]'
+          } > "$RUNNER_TEMP/incomplete.md"
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$RUNNER_TEMP/incomplete.md"


### PR DESCRIPTION
## What

The `benchmark-replay` workflow posts its verdict from the **Post benchmark report** step, which has no `if:` and therefore an implicit `success()`. When a run is **cancelled, hits the 6h timeout, or errors during enrich/replay**, that step is skipped and **nothing is posted** — the outcome is only visible in the Actions logs, indistinguishable from a run still in progress.

This adds a final step in the `replay` job, guarded by `if: ${{ failure() || cancelled() }}`, that posts a `<!-- benchmark-incomplete -->` notice on the PR with a link to the run and the re-trigger command.

## Why

A silently-skipped verdict forces a manual log check to tell a dead run apart from a running one. An explicit incomplete-notice makes the outcome self-evident in the PR thread.

## Safety / scope

- The step lives **inside the existing `replay` job**, so it inherits the job's `/benchmark`-comment authorization guard — it cannot fire on non-benchmark comments.
- Mutually exclusive with the success-path report step (`success()` vs `failure() || cancelled()`) — no double-posting.
- No attacker-controlled input is interpolated; `PR_NUMBER` (from `github.event.issue.number`) and `RUN_URL` are passed via `env:`.
- Workflow-only change — no packages/customs touched.
