### PR TITLE
feat(customs): promote full-search prediction tools to production

### DIFF
--- a/benchmark/tournament_tools.json
+++ b/benchmark/tournament_tools.json
@@ -1,7 +1,5 @@
 {
   "factual_research-v2": "bafybeidgo3jesmvuwa64ooij7mywk7hf7ls5len2sf7cbcjwt3t6r5u6qm",
-  "superforcaster_full_search": "bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm",
-  "superforcaster_calibrated_full_search": "bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe",
   "predict-base": "bafybeifetvtalxnw3y7epqspyxotrls4wl7eoffsiaglxp52nca7ozurv4",
   "predict-fine-tuned": "bafybeifetvtalxnw3y7epqspyxotrls4wl7eoffsiaglxp52nca7ozurv4"
 }

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -26,8 +26,8 @@
         "custom/valory/factual_research_v3/0.1.0": "bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa",
         "custom/valory/finetuned_prediction/0.1.0": "bafybeifetvtalxnw3y7epqspyxotrls4wl7eoffsiaglxp52nca7ozurv4",
         "custom/valory/propose_question/0.1.0": "bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi",
-        "agent/valory/mech_predict/0.1.0": "bafybeierkwlngcwzwhb3tupgrp6xjzzs32y6eswdhshm5mutn6k4c6fqnm",
-        "service/valory/mech_predict/0.1.0": "bafybeibq5nc4payfteomyo2xwvhr5bf24dlhus4yg6htpgkivifqs3nl4u"
+        "agent/valory/mech_predict/0.1.0": "bafybeieu4tuiksj7yiqcw7hvrpx55n3woia3uxgjgavzdtfgajeflbsaxa",
+        "service/valory/mech_predict/0.1.0": "bafybeihvy7ehzwoeryjfcircyosmmirbxnbljbdykilcgvyhfsa4b2ah4a"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -73,6 +73,8 @@ customs:
 - valory/factual_research:0.1.0:bafybeidcxmqemvzm7cz2ydyjsmu53zflsqpcj2gpco5kwn3ldvf22rqx4i
 - valory/factual_research_v3:0.1.0:bafybeiboyjc2u42lcsi7er6hywwdz27ae6r57y3jnqck5nk7tj4qosoyqa
 - valory/propose_question:0.1.0:bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi
+- valory/superforcaster_full_search:0.1.0:bafybeihba6ch6g7gndfwv75dtpfrpnvg4dw6wq6lxexch5h3n3vjafuxsm
+- valory/superforcaster_calibrated_full_search:0.1.0:bafybeialuhbtfumvlbdtzimfn7wdacqwccn2ny5cbhi4tkri6iih6pfgxe
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeierkwlngcwzwhb3tupgrp6xjzzs32y6eswdhshm5mutn6k4c6fqnm
+agent: valory/mech_predict:0.1.0:bafybeieu4tuiksj7yiqcw7hvrpx55n3woia3uxgjgavzdtfgajeflbsaxa
 number_of_agents: 1
 deployment:
   agent:


### PR DESCRIPTION
## Goal

Promote the **best-Brier tournament tool per platform** (lower Brier = better) into the **mech_predict** production service customs, so the deployment can serve them. One tool per platform.

## Selection — lowest Brier per platform

Ranked from the daily benchmark tournament (latest flywheel run; rankings stable across 2026-06-26 → 06-30):

**Polymarket**
| Tool | Brier | n |
|---|--:|--:|
| **`superforcaster_full_search`** | **0.1167** | 58 |
| `superforcaster_calibrated_full_search` | 0.1575 | 60 |
| `predict-fine-tuned` | 0.3013 | 8 |
| `predict-base` | 0.3609 | 8 |
| `factual_research-v2` | 0.3672 | 9 |

**Omen**
| Tool | Brier | n |
|---|--:|--:|
| **`superforcaster_calibrated_full_search`** | **0.1857** | 665 |
| `predict-fine-tuned` | 0.1881 | 90 |
| `factual_research-v2` | 0.1898 | 221 |
| `predict-base` | 0.1904 | 87 |
| `superforcaster_full_search` | 0.2217 | 653 |

→ Promote **`superforcaster_full_search`** (best on Polymarket) and **`superforcaster_calibrated_full_search`** (best on Omen).

## Data period & sample

Tournament Brier is **all-time cumulative** over each tool's scored markets (not a fixed window), so `n` differs by platform. Both tournaments began ~2026-05-23:

- **Polymarket** (`superforcaster_full_search`): **n=58** markets, resolved **2026-05-26 → 06-30** — still accruing (low Polymarket market volume → small sample, so treat the Brier as provisional).
- **Omen** (`superforcaster_calibrated_full_search`): **n=665** markets, resolved **2026-05-28 → 06-25** — predictions stopped accruing ~06-20, so the Omen aggregates have been frozen/identical across the last 5 daily runs.

Rankings (best Brier per platform) held identical across all 5 runs 06-26 → 06-30.

## Changes

- `aea-config.yaml`: add both tools to the agent `customs:` list.
- `benchmark/tournament_tools.json`: **remove both promoted tools** — they graduate from the tournament on promotion (`factual_research-v2`, `predict-base`, `predict-fine-tuned` remain under evaluation).
- `packages.json` + `service.yaml`: `autonomy packages lock` cascade (agent + service CIDs only — no third-party drift).

## Prechecks

- Both default to `gpt-4.1-2025-04-14` — already priced in `mech` `TOKEN_PRICES`.
- Both descriptions satisfy the trader's `is_prediction_tool` predicate.

## Next (separate PR, agent-deployments)

Bump `PROPEL_SERVICE_HASH_ID` to the released service CID, add each tool to the relevant mechs' `TOOLS_TO_PACKAGE_HASH`, and republish `METADATA_HASH`:

- Polymarket mechs (21/25/44) → `superforcaster_full_search`
- Omen mechs → `superforcaster_calibrated_full_search`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
