### PR TITLE
chore(mech): bump mech_abci + task_submission_abci to v0.34.1

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -27,8 +27,8 @@
         "custom/valory/finetuned_prediction/0.1.0": "bafybeifetvtalxnw3y7epqspyxotrls4wl7eoffsiaglxp52nca7ozurv4",
         "custom/valory/propose_question/0.1.0": "bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi",
         "custom/valory/superforcaster_polymarket_v4/0.1.0": "bafybeidjysuvmooxvtx5lhswtit7qzenotxiwjso3kvvnxhqulr2ic26f4",
-        "agent/valory/mech_predict/0.1.0": "bafybeieyimcmjltc62yzjxdytrae2uod3iodaaxkfwpj7ffh7azl2fyikq",
-        "service/valory/mech_predict/0.1.0": "bafybeih2du22mioa7lg4bdmmaolwclzgtpy2dsxddz36wojkhrygx4djda"
+        "agent/valory/mech_predict/0.1.0": "bafybeihdu4ribjfksgyvqbeeuar2tfwqrzepqluljuy5vap3yz2szamsh4",
+        "service/valory/mech_predict/0.1.0": "bafybeihpp3lykmtgrjl3bnxbptskg5bqozliydyyds4t2yjpbywxmsonwy"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -69,8 +69,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki",
         "skill/valory/termination_abci/0.1.0": "bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4",
-        "skill/valory/mech_abci/0.1.0": "bafybeidhjps2ctsggi3dpexdmuftfnvsgm2lgrotss3azsjufufpy2yfqu",
+        "skill/valory/mech_abci/0.1.0": "bafybeifqmjqfdhs3beaswozr6zugsst43tq6ias7chg5tjayekcr7e45ai",
         "skill/valory/task_execution/0.1.0": "bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4"
+        "skill/valory/task_submission_abci/0.1.0": "bafybeict3okafrtmy3hjnz2rlrcjjf5e2y7goqy5zr4svrvic2mlt54q2u"
     }
 }

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -42,12 +42,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeicioxhbhnsoqyqvkeevd7df7r2vubbiglyf7ucps2el73objazjsq
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeidhjps2ctsggi3dpexdmuftfnvsgm2lgrotss3azsjufufpy2yfqu
+- valory/mech_abci:0.1.0:bafybeifqmjqfdhs3beaswozr6zugsst43tq6ias7chg5tjayekcr7e45ai
 - valory/registration_abci:0.1.0:bafybeihjhbn5seffyu5cwugvm26fkamp3svhggmtzh577daijgl2ksxs3e
 - valory/reset_pause_abci:0.1.0:bafybeihc4ruh25s7wuunfy2b3k2n4eypyhvtry3usgom44wsymagbcr3ki
 - valory/delivery_rate_abci:0.1.0:bafybeiaefr3eiajklnb6m4jtl7rpxr5t2lmrpizfy7gqkjem3qiewo7cz4
 - valory/task_execution:0.1.0:bafybeifc56wu5xwjpjhfstgm6wbf6yptshhfbpqji7dsrtrdukkumiwwpq
-- valory/task_submission_abci:0.1.0:bafybeidzqkqghem72wyluktwe3qhtdruphrksx4qayoengjmprnkrh4dk4
+- valory/task_submission_abci:0.1.0:bafybeict3okafrtmy3hjnz2rlrcjjf5e2y7goqy5zr4svrvic2mlt54q2u
 - valory/termination_abci:0.1.0:bafybeibnnzry5kknci3z46gcjgutv4jid3ir6xn6a5adq3tx6v2e25augq
 - valory/transaction_settlement_abci:0.1.0:bafybeibv3tycpdhphlblu62zpcbjsj7hnwkutexxqagorkelhjlt4t4fii
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeieyimcmjltc62yzjxdytrae2uod3iodaaxkfwpj7ffh7azl2fyikq
+agent: valory/mech_predict:0.1.0:bafybeihdu4ribjfksgyvqbeeuar2tfwqrzepqluljuy5vap3yz2szamsh4
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ pytest_targets_extra = ["benchmark/tests"]
 # Third-party skills/contracts on disk are synced from mech upstream;
 # tomte auto-prepends valory-xyz/open-autonomy@... and open-aea@...
 # from pyproject pins, so only the non-PyPI mech upstream needs listing.
-upstream_pins = ["valory-xyz/mech@v0.34.0"]
+upstream_pins = ["valory-xyz/mech@v0.34.1"]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"
 
 [tool.uv.build-backend]


### PR DESCRIPTION
## Summary

- Bumps the two `third_party` mech hashes that changed in mech v0.34.1: `skill/valory/mech_abci` and `skill/valory/task_submission_abci`. `packages.json`, `agent/mech_predict/aea-config.yaml`, `service/mech_predict/service.yaml` re-locked accordingly.
- Picks up valory-xyz/mech#462 (`fix(task_submission): preserve done_tasks across PostTxSettlementRound`).

## Why

Without the mech fix, the FSM was clearing `synchronized_data.done_tasks` at the end of every settlement cycle, which stopped `TaskPoolingBehaviour.handle_submitted_tasks` from pruning delivered request_ids out of `shared_state[DONE_TASKS]`. Result on the live single-agent Polygon mech: the batch of "done" tasks grew monotonically, the same request_ids were re-pooled and re-submitted every cycle. Safe `execTransaction` succeeded each time but `mech.deliverMulti` reverted on the already-delivered ids, so gas got burned on redundant txs without emitting new `Deliver` events. Observed delivery rate ~55% instead of near-100%.

## Scope of change

Only the two skills that shipped in mech v0.34.1 have new hashes. All other mech third-party hashes are unchanged:

- `task_execution` — untouched by mech#462
- `delivery_rate_abci`, `contract_subscription`, `websocket_client`, `balance_tracker`, `hash_checkpoint`, `olas_mech`, `complementary_service_metadata` — untouched

## Reference

mech v0.34.1 — https://github.com/valory-xyz/mech/releases/tag/v0.34.1

## Test plan

- [x] `autonomy packages lock --check` clean
- [x] `autonomy packages sync --update-packages` completes
- [ ] Deploy to Polygon mech_predict, confirm `Marketplace Tasks Found: N` starts tracking new task arrivals only (grows then drains) instead of growing monotonically
- [ ] Confirm on Polygonscan that redundant Safe `execTransaction` calls stop (no more `ExecutionFailure` on internal txs)
- [ ] 30-60 min prod watch, expect delivery rate to recover from ~55% toward baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)