### PR TITLE
chore(mech-predict): add offchain-events config + pin mech #468 hashes

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,7 +8,7 @@
         "custom/napthaai/resolve_market_reasoning/0.1.0": "bafybeidji6or6kpmawho64tc7qetinykhrklvv2gmnqfcd6ejmg43j3i7q",
         "custom/nickcom007/prediction_request_sme/0.1.0": "bafybeifsk4og24t22agcrj7mm6fz3wxwfbdg554yjhc6odpxal5ofg22ti",
         "custom/valory/prediction_langchain/0.1.0": "bafybeieirig3irwmfubxjoxcujiwxxb7knl3c3amhqhjy7bxvo2tdvybpm",
-        "custom/valory/prediction_request_v1/0.1.0": "bafybeifgxisrmslzwcmk4dhn5vkyygfeyhdrktxjzkmex5eyl2oiibw5ce",
+        "custom/valory/prediction_request_v1/0.1.0": "bafybeie23dpatwki6odlv7nnlwibuq6jbdonsmu5mszsgitlwghzpiesam",
         "custom/valory/prepare_tx/0.1.0": "bafybeidpvkwtn5m5yjp5mr2tn6f52btmlki32syahvkkuvlw3oq5eee3di",
         "custom/valory/resolve_market/0.1.0": "bafybeiaozazbggoglwrnfyn5v2qebyn4y4jpaxxbdodi3bd5eyieo4a55i",
         "custom/valory/superforcaster/0.1.0": "bafybeidkraklf5c6rkv6g7y7lqj2woy4j5u5dmupjez6mtjhdek3lzbmki",
@@ -27,8 +27,8 @@
         "custom/valory/finetuned_prediction/0.1.0": "bafybeiclpkn4sqvri7k5aiklt5fm6hnt3tgo4qxtrkzxe4fwzfs2plgbk4",
         "custom/valory/propose_question/0.1.0": "bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi",
         "custom/valory/superforcaster_polymarket_v4/0.1.0": "bafybeidjysuvmooxvtx5lhswtit7qzenotxiwjso3kvvnxhqulr2ic26f4",
-        "agent/valory/mech_predict/0.1.0": "bafybeie3a6ewceppujeapz6xpdjrt45yosbmeyhifspgq2e2ed6ghegvoq",
-        "service/valory/mech_predict/0.1.0": "bafybeihmsmnnarqtgls625kzaxmsyvywmiwid4y6f3gqmnb2qzbnliwl4q"
+        "agent/valory/mech_predict/0.1.0": "bafybeiaxert25hamnwihtainshczmek7ntgijt7mmqyuviwra7tau5535a",
+        "service/valory/mech_predict/0.1.0": "bafybeienwgi2gmquwca35iy7cs2ak4tyuiu2syjklf6cup7wddbwwjwrcu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -27,8 +27,8 @@
         "custom/valory/finetuned_prediction/0.1.0": "bafybeiclpkn4sqvri7k5aiklt5fm6hnt3tgo4qxtrkzxe4fwzfs2plgbk4",
         "custom/valory/propose_question/0.1.0": "bafybeifs2tczqwrbyi6nyhonvnbllz6nxbe2xoo4lslc6aeudi4waufzyi",
         "custom/valory/superforcaster_polymarket_v4/0.1.0": "bafybeidjysuvmooxvtx5lhswtit7qzenotxiwjso3kvvnxhqulr2ic26f4",
-        "agent/valory/mech_predict/0.1.0": "bafybeigxxneyoepkjj6mmgd6vtwxnwlsovamgeoyugvl3hsw42o6gddwoq",
-        "service/valory/mech_predict/0.1.0": "bafybeieqtzusj4v6onl6zk33blks65iw6p24m2mw5oufrxmfj265l6y4fy"
+        "agent/valory/mech_predict/0.1.0": "bafybeie3a6ewceppujeapz6xpdjrt45yosbmeyhifspgq2e2ed6ghegvoq",
+        "service/valory/mech_predict/0.1.0": "bafybeihmsmnnarqtgls625kzaxmsyvywmiwid4y6f3gqmnb2qzbnliwl4q"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -69,8 +69,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeib33ygqjlxsw4sl7t56zdlsui6kukk2wz6gspddrof2c3pjeisyem",
-        "skill/valory/task_execution/0.1.0": "bafybeib4ca677b4fbvtcf2zpfxjr7aob55qeuo7hhqjeenvhfs7ob7cujq",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeie4gnqfzbizxqgpn56qgqkw76z23cj3kuued2dsysoampe7s4y5ou"
+        "skill/valory/mech_abci/0.1.0": "bafybeigdwb6lsnj46goll73qzkeqcyffpv7sixf5oqwlfthl43htsybjia",
+        "skill/valory/task_execution/0.1.0": "bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu"
     }
 }

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -42,12 +42,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeib33ygqjlxsw4sl7t56zdlsui6kukk2wz6gspddrof2c3pjeisyem
+- valory/mech_abci:0.1.0:bafybeigdwb6lsnj46goll73qzkeqcyffpv7sixf5oqwlfthl43htsybjia
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeib4ca677b4fbvtcf2zpfxjr7aob55qeuo7hhqjeenvhfs7ob7cujq
-- valory/task_submission_abci:0.1.0:bafybeie4gnqfzbizxqgpn56qgqkw76z23cj3kuued2dsysoampe7s4y5ou
+- valory/task_execution:0.1.0:bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y
+- valory/task_submission_abci:0.1.0:bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay
@@ -264,6 +264,12 @@ models:
         safe_contract_address: ${str:0x9e9d95A2a3dF7CF20a8ac1422a6D1A2DB3B15565}
         consensus_threshold: ${int:null}
       default_chain_id: ${str:gnosis}
+      use_offchain: ${bool:false}
+      predict_api_events_url: ${str:https://mpp.autonolas.tech/mech/events}
+      predict_api_events_timeout_seconds: ${float:5.0}
+      mech_events_sweep_pending_enabled: ${bool:false}
+      mech_events_sweep_max_age_seconds: ${float:3600.0}
+      mech_events_chain_id: ${int:0}
   randomness_api:
     args:
       method: ${str:GET}
@@ -296,6 +302,8 @@ models:
       polygon_ledger_rpc: ${str:http://localhost:8545}
       base_ledger_rpc: ${str:http://localhost:8545}
       optimism_ledger_rpc: ${str:http://localhost:8545}
+      use_offchain: ${bool:false}
+      mech_events_chain_id: ${int:0}
 ---
 public_id: valory/ledger:0.19.0
 type: connection

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -54,7 +54,7 @@ skills:
 customs:
 - valory/resolve_market:0.1.0:bafybeiaozazbggoglwrnfyn5v2qebyn4y4jpaxxbdodi3bd5eyieo4a55i
 - valory/resolve_market_jury:0.1.0:bafybeigdv6zbbuf2flnti7hfwbotagnqz43g76v2jfhcuk4ancucxmg5gi
-- valory/prediction_request_v1:0.1.0:bafybeifgxisrmslzwcmk4dhn5vkyygfeyhdrktxjzkmex5eyl2oiibw5ce
+- valory/prediction_request_v1:0.1.0:bafybeie23dpatwki6odlv7nnlwibuq6jbdonsmu5mszsgitlwghzpiesam
 - napthaai/resolve_market_reasoning:0.1.0:bafybeidji6or6kpmawho64tc7qetinykhrklvv2gmnqfcd6ejmg43j3i7q
 - napthaai/prediction_request_rag_v1:0.1.0:bafybeiesnbru6o3ochjn6s72iumcwmq2klgb3doa5pmleyt6psa52kxmjm
 - napthaai/prediction_request_reasoning_v1:0.1.0:bafybeigpzvqh2gbcqurqaefoopqpgmqu3dpy6p36l42pvfyx2iyy2ebvka

--- a/packages/valory/customs/prediction_request_v1/component.yaml
+++ b/packages/valory/customs/prediction_request_v1/component.yaml
@@ -9,7 +9,7 @@ fingerprint:
   __init__.py: bafybeifzgdvca4otrxpkemcj5334vc3uqo4k22mqxp3z3pvqzkw6tqunse
   prediction_request_v1.py: bafybeidnv6tal2vjw3aevsmda2izdouo7g76k6g7bx5tf6xb6fk2crs6je
   tests/__init__.py: bafybeib7h3aalw6bzylqazc3mefunk3n3d65pyzfck4qb33slesscud25m
-  tests/test_prediction_request_v1.py: bafybeiddzn256zanypjkibvfzfvt24z5deofzqgktc6tttaxefktnsgzpm
+  tests/test_prediction_request_v1.py: bafybeiagujjp6jzun2vqhelqi5jp45gkyieidzeerbtveafk47tzykjmsu
 fingerprint_ignore_patterns: []
 entry_point: prediction_request_v1.py
 callable: run

--- a/packages/valory/customs/prediction_request_v1/tests/test_prediction_request_v1.py
+++ b/packages/valory/customs/prediction_request_v1/tests/test_prediction_request_v1.py
@@ -82,6 +82,11 @@ class TestLLMClientManager:
         ``__enter__`` gets a distinct client without relying on patch
         sequencing.
         """
+        # Retain live references, not just ``id(client)``. Once the ``with mgr``
+        # block exits, ``client`` is unreachable and CPython's allocator can
+        # reuse its memory address for the next thread's MagicMock — CI hit
+        # exactly this on 3.13 (two distinct MagicMocks, same ``id``). Holding
+        # the objects here keeps ``id`` a real identity signal.
         clients_seen: list = []
 
         with patch(
@@ -93,7 +98,7 @@ class TestLLMClientManager:
                 mock_keys: Any = {"openai": f"sk-{key_suffix}"}
                 mgr = LLMClientManager(api_keys=mock_keys, model="gpt-4o-2024-08-06")
                 with mgr as client:
-                    clients_seen.append(id(client))
+                    clients_seen.append(client)
 
             with ThreadPoolExecutor(max_workers=2) as pool:
                 futures = [pool.submit(create_and_record, s) for s in ("a", "b")]
@@ -101,7 +106,7 @@ class TestLLMClientManager:
                     f.result()
 
         assert (
-            len(set(clients_seen)) == 2
+            len({id(c) for c in clients_seen}) == 2
         ), "Concurrent contexts must get independent clients"
 
 

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeigxxneyoepkjj6mmgd6vtwxnwlsovamgeoyugvl3hsw42o6gddwoq
+agent: valory/mech_predict:0.1.0:bafybeie3a6ewceppujeapz6xpdjrt45yosbmeyhifspgq2e2ed6ghegvoq
 number_of_agents: 1
 deployment:
   agent:
@@ -69,6 +69,12 @@ type: skill
         mech_staking_instance_address: ${MECH_STAKING_INSTANCE_ADDRESS:str:0x0000000000000000000000000000000000000000}
         service_owner_share: ${SERVICE_SHARE:int:0}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
+        use_offchain: ${USE_OFFCHAIN:bool:false}
+        predict_api_events_url: ${PREDICT_API_EVENTS_URL:str:https://mpp.autonolas.tech/mech/events}
+        predict_api_events_timeout_seconds: ${PREDICT_API_EVENTS_TIMEOUT_SECONDS:float:5.0}
+        mech_events_sweep_pending_enabled: ${MECH_EVENTS_SWEEP_PENDING_ENABLED:bool:false}
+        mech_events_sweep_max_age_seconds: ${MECH_EVENTS_SWEEP_MAX_AGE_SECONDS:float:3600.0}
+        mech_events_chain_id: ${MECH_EVENTS_CHAIN_ID:int:0}
     randomness_api: &id002
       args:
         method: ${RANDOMNESS_API_METHOD:str:GET}
@@ -115,6 +121,12 @@ type: skill
         mech_staking_instance_address: ${MECH_STAKING_INSTANCE_ADDRESS:str:0x0000000000000000000000000000000000000000}
         service_owner_share: ${SERVICE_SHARE:int:0}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
+        use_offchain: ${USE_OFFCHAIN:bool:false}
+        predict_api_events_url: ${PREDICT_API_EVENTS_URL:str:https://mpp.autonolas.tech/mech/events}
+        predict_api_events_timeout_seconds: ${PREDICT_API_EVENTS_TIMEOUT_SECONDS:float:5.0}
+        mech_events_sweep_pending_enabled: ${MECH_EVENTS_SWEEP_PENDING_ENABLED:bool:false}
+        mech_events_sweep_max_age_seconds: ${MECH_EVENTS_SWEEP_MAX_AGE_SECONDS:float:3600.0}
+        mech_events_chain_id: ${MECH_EVENTS_CHAIN_ID:int:0}
     randomness_api: *id002
 2:
   models:
@@ -155,6 +167,12 @@ type: skill
         mech_staking_instance_address: ${MECH_STAKING_INSTANCE_ADDRESS:str:0x0000000000000000000000000000000000000000}
         service_owner_share: ${SERVICE_SHARE:int:0}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
+        use_offchain: ${USE_OFFCHAIN:bool:false}
+        predict_api_events_url: ${PREDICT_API_EVENTS_URL:str:https://mpp.autonolas.tech/mech/events}
+        predict_api_events_timeout_seconds: ${PREDICT_API_EVENTS_TIMEOUT_SECONDS:float:5.0}
+        mech_events_sweep_pending_enabled: ${MECH_EVENTS_SWEEP_PENDING_ENABLED:bool:false}
+        mech_events_sweep_max_age_seconds: ${MECH_EVENTS_SWEEP_MAX_AGE_SECONDS:float:3600.0}
+        mech_events_chain_id: ${MECH_EVENTS_CHAIN_ID:int:0}
     randomness_api: *id002
 3:
   models:
@@ -195,6 +213,12 @@ type: skill
         mech_staking_instance_address: ${MECH_STAKING_INSTANCE_ADDRESS:str:0x0000000000000000000000000000000000000000}
         service_owner_share: ${SERVICE_SHARE:int:0}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
+        use_offchain: ${USE_OFFCHAIN:bool:false}
+        predict_api_events_url: ${PREDICT_API_EVENTS_URL:str:https://mpp.autonolas.tech/mech/events}
+        predict_api_events_timeout_seconds: ${PREDICT_API_EVENTS_TIMEOUT_SECONDS:float:5.0}
+        mech_events_sweep_pending_enabled: ${MECH_EVENTS_SWEEP_PENDING_ENABLED:bool:false}
+        mech_events_sweep_max_age_seconds: ${MECH_EVENTS_SWEEP_MAX_AGE_SECONDS:float:3600.0}
+        mech_events_chain_id: ${MECH_EVENTS_CHAIN_ID:int:0}
     randomness_api: *id002
 ---
 public_id: valory/task_execution:0.1.0
@@ -222,6 +246,8 @@ type: skill
         base_ledger_rpc: ${BASE_LEDGER_RPC_0:str:http://host.docker.internal:8545}
         optimism_ledger_rpc: ${OPTIMISM_LEDGER_RPC_0:str:http://host.docker.internal:8545}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
+        use_offchain: ${USE_OFFCHAIN:bool:false}
+        mech_events_chain_id: ${MECH_EVENTS_CHAIN_ID:int:0}
 1:
   models:
     params:
@@ -245,6 +271,8 @@ type: skill
         base_ledger_rpc: ${BASE_LEDGER_RPC_1:str:http://host.docker.internal:8545}
         optimism_ledger_rpc: ${OPTIMISM_LEDGER_RPC_1:str:http://host.docker.internal:8545}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
+        use_offchain: ${USE_OFFCHAIN:bool:false}
+        mech_events_chain_id: ${MECH_EVENTS_CHAIN_ID:int:0}
 2:
   models:
     params:
@@ -268,6 +296,8 @@ type: skill
         base_ledger_rpc: ${BASE_LEDGER_RPC_2:str:http://host.docker.internal:8545}
         optimism_ledger_rpc: ${OPTIMISM_LEDGER_RPC_2:str:http://host.docker.internal:8545}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
+        use_offchain: ${USE_OFFCHAIN:bool:false}
+        mech_events_chain_id: ${MECH_EVENTS_CHAIN_ID:int:0}
 3:
   models:
     params:
@@ -291,6 +321,8 @@ type: skill
         base_ledger_rpc: ${BASE_LEDGER_RPC_3:str:http://host.docker.internal:8545}
         optimism_ledger_rpc: ${OPTIMISM_LEDGER_RPC_3:str:http://host.docker.internal:8545}
         default_chain_id: ${DEFAULT_CHAIN_ID:str:gnosis}
+        use_offchain: ${USE_OFFCHAIN:bool:false}
+        mech_events_chain_id: ${MECH_EVENTS_CHAIN_ID:int:0}
 ---
 public_id: valory/ledger:0.19.0
 type: connection

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeie3a6ewceppujeapz6xpdjrt45yosbmeyhifspgq2e2ed6ghegvoq
+agent: valory/mech_predict:0.1.0:bafybeiaxert25hamnwihtainshczmek7ntgijt7mmqyuviwra7tau5535a
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,7 @@ pytest_targets_extra = ["benchmark/tests"]
 # tomte auto-prepends valory-xyz/open-autonomy@... and open-aea@...
 # from pyproject pins, so only the non-PyPI mech upstream needs listing.
 upstream_pins = [
-    "valory-xyz/mech@v0.34.2",
+    "valory-xyz/mech@v0.34.3",
     "valory-xyz/kv-store@v0.7.1",
 ]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"


### PR DESCRIPTION
## Summary

Consumes the mech offchain-events / on-chain-write-path skill changes from
[valory-xyz/mech#468](https://github.com/valory-xyz/mech/pull/468) (branch head
`9b09e65b`). Ships as **draft** until mech #468 merges and a new mech tag is cut.

## Changes

- `packages/packages.json` — bump the 3 third-party mech skill hashes to the
  PR #468 branch heads (`mech_abci`, `task_execution`, `task_submission_abci`).
  `mech_predict` agent + service hashes regenerated via `autonomy packages lock`.
- `agents/mech_predict/aea-config.yaml` — add 6 new `mech_abci` params
  (`use_offchain`, `predict_api_events_url`, `predict_api_events_timeout_seconds`,
  `mech_events_sweep_pending_enabled`, `mech_events_sweep_max_age_seconds`,
  `mech_events_chain_id`) and 2 new `task_execution` params (`use_offchain`,
  `mech_events_chain_id`).
- `services/mech_predict/service.yaml` — same additions across all 4 agent slots
  (`0`/`1`/`2`/`3`) for both skills, with env-var expansion
  (`${USE_OFFCHAIN:bool:false}`, `${MECH_EVENTS_CHAIN_ID:int:0}`, etc.) so a
  single per-deploy env-var flips the mech into the predict-api pipeline.

## Defaults

Match the mech skill.yaml on-disk defaults:

- `use_offchain=false` — out-of-the-box mech does no off-mech HTTP work and does
  not accept off-chain requests
- `mech_events_chain_id=0` — analytics writes short-circuit at the chain-id
  guard until an operator sets a value matching the target chain
- `predict_api_events_url=https://mpp.autonolas.tech/mech/events` — production
  predict-api endpoint

## Blocking chain

1. **[blocked on]** mech #468 merges
2. mech cuts a new tag (e.g. v0.34.3 / v0.35.0) including migration 008 + the
   dual-purpose `use_offchain` flag
3. This PR: bump `pyproject.toml` `upstream_pins` to the new mech tag. Skill
   content on disk doesn't change post-merge, so `autonomy packages lock` is a
   no-op and the hashes already pinned here should carry over
4. Un-draft and merge

## Test plan

- [ ] Full CI green (expected red on `check-third-party-hashes` until the mech
      tag bump in step 3 above, since `upstream_pins` still points at v0.34.2)
- [ ] Post-tag: verify `autonomy packages lock` is a no-op after the pin bump
- [ ] Local integration smoke: run one agent slot with `USE_OFFCHAIN=true`,
      `MECH_EVENTS_CHAIN_ID=100`, and confirm settlement rounds POST to the
      predict-api endpoint