### PR TITLE
ROI companion: append per-platform ROI section to the daily Slack messages

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -232,6 +232,29 @@ jobs:
         if: always() && !cancelled()
         run: python -m benchmark.analyze --platform polymarket --include-tournament
 
+      # Companion ROI simulation over the same data the benchmark job just
+      # fetched/scored. continue-on-error: the companion must not fail the
+      # flywheel -- when it breaks, the daily Slack posts simply go out
+      # without the ROI section (notify_slack degrades gracefully when
+      # roi_results.json is missing).
+      - name: Simulate trader ROI (companion)
+        if: always() && !cancelled()
+        continue-on-error: true
+        run: |
+          TOURNAMENT_FLAG=""
+          if [ -f benchmark/results/tournament_scored.jsonl ]; then
+            TOURNAMENT_FLAG="--tournament-input benchmark/results/tournament_scored.jsonl"
+          fi
+          python -m benchmark.roi_sim \
+            --logs-dir benchmark/datasets/logs/ \
+            $TOURNAMENT_FLAG
+          for report in benchmark/results/report_roi_omen.md benchmark/results/report_roi_polymarket.md; do
+            if [ -f "$report" ]; then
+              cat "$report" >> "$GITHUB_STEP_SUMMARY"
+              echo "" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
       # Upload state + scores (small, needed for next run).
       # include-hidden-files: true is required so .fetch_state.json
       # (leading dot = hidden under v4's default filter) actually ships
@@ -257,6 +280,9 @@ jobs:
             benchmark/results/scored_row_ids.json
             benchmark/results/report_omen.md
             benchmark/results/report_polymarket.md
+            benchmark/results/roi_results.json
+            benchmark/results/report_roi_omen.md
+            benchmark/results/report_roi_polymarket.md
             benchmark/results/tool_improvement_triage_state.json
           retention-days: 90
 

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -33,6 +33,7 @@ from benchmark.analyze import (
     ROLLING_WINDOW_DAYS,
     VERSION_DELTA_LOW_SAMPLE_STRICT,
 )
+from benchmark.roi_slack import build_roi_section
 from benchmark.scorer import MIN_SAMPLE_SIZE
 from benchmark.tools import TOOL_REGISTRY
 
@@ -354,6 +355,12 @@ _PLATFORM_LABEL_BY_STEM: Mapping[str, str] = MappingProxyType(
     {f"report_{key}": label for key, label in PLATFORM_LABELS.items()}
 )
 
+# Reverse of PLATFORM_LABELS: deployment label -> platform key, used to
+# look up the platform's groups in roi_results.json.
+_PLATFORM_KEY_BY_LABEL: Mapping[str, str] = MappingProxyType(
+    {label: key for key, label in PLATFORM_LABELS.items()}
+)
+
 
 def _infer_platform_label(report_path: Path) -> str | None:
     """Derive the deployment label from the report filename.
@@ -382,6 +389,15 @@ def main() -> None:
     )
     parser.add_argument(
         "--dry-run", action="store_true", help="Print summary without posting to Slack"
+    )
+    parser.add_argument(
+        "--roi-results",
+        type=Path,
+        default=Path("benchmark/results/roi_results.json"),
+        help=(
+            "Path to roi_results.json (from benchmark.roi_sim) for the "
+            "appended ROI companion section."
+        ),
     )
     args = parser.parse_args()
 
@@ -427,6 +443,26 @@ def main() -> None:
     report_url = _build_report_url()
     if report_url:
         summary += f"\n<{report_url}|Full report>"
+
+    # ROI companion section: appended to the end of the same per-platform
+    # message. Best-effort by design -- a broken/missing ROI section must
+    # NEVER break the daily post, so any failure here degrades to posting
+    # the summary without it. ROI_SECTION=off disables the append entirely.
+    if os.environ.get("ROI_SECTION", "on").strip().lower() != "off":
+        try:
+            platform_key = _PLATFORM_KEY_BY_LABEL.get(platform_label)
+            roi_section = (
+                build_roi_section(args.roi_results, platform_key)
+                if platform_key is not None
+                else None
+            )
+            if roi_section:
+                summary += f"\n\n{roi_section}"
+        except Exception:  # pylint: disable=broad-except
+            log.warning(
+                "ROI section build failed; posting summary without it.",
+                exc_info=True,
+            )
 
     if args.dry_run:
         print(summary)

--- a/benchmark/roi_slack.py
+++ b/benchmark/roi_slack.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Render the ROI companion section appended to the daily benchmark Slack post.
+
+Pure builder over ``roi_results.json`` (written by ``benchmark.roi_sim``):
+no network, no LLM, stdlib only. :func:`build_roi_section` returns a Slack
+mrkdwn snippet -- one intro line plus a compact fixed-width table inside a
+fenced code block -- or None when there is nothing to append (missing or
+unparseable results file, or no groups for the platform). Callers treat
+None as "append nothing"; a broken ROI section must never break the daily
+post, so this module never raises for bad input data.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, TypeGuard
+
+# Slack renders ~monospace code blocks without wrapping up to roughly this
+# width on a desktop client; every table line is kept at or under it.
+MAX_LINE_WIDTH = 100
+
+# Truncation guard for very wide deployments: keep the top rows by staked
+# capital and point at the full report for the rest.
+MAX_TABLE_ROWS = 14
+
+_HEADERS = ("tool", "mode", "preds", "bets", "ROI (95% CI)", "w/costs", "flags")
+# Per-column width caps; actual widths are content-driven up to these.
+_CAPS = (28, 5, 6, 5, 20, 8, 22)
+
+# Abbreviated mode labels keep the width budget for the tool column.
+_MODE_SHORT = {"production": "prod", "tournament": "tourn"}
+
+# Compact spellings for the roi_sim flags; the full text stays in the report.
+_FLAG_SHORT = {
+    "few bets - anecdotal": "few bets",
+    "low sample": "low n",
+    "no eligible rows in window": "no eligible",
+}
+_PARSE_RELIABILITY_RE = re.compile(r"(\d+)% parse reliability")
+_SEP = " | "
+# When the capped widths still exceed MAX_LINE_WIDTH, shrink the tool
+# column first (down to this floor), then the flags column.
+_TOOL_MIN = 12
+_FLAGS_MIN = 6
+
+_ELLIPSIS = "…"
+
+
+def _is_num(value: object) -> TypeGuard[float]:
+    """Return True for a real (non-bool) int/float.
+
+    The TypeGuard narrows the value to float for the caller's arithmetic
+    (mirrors ``benchmark.roi_sim._is_number``).
+
+    :param value: candidate value.
+    :return: True when usable as a number.
+    """
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _as_int(value: object) -> int:
+    """Coerce a JSON count field to int, defaulting to 0.
+
+    :param value: candidate value.
+    :return: integer value, or 0 when not a number.
+    """
+    return int(value) if _is_num(value) else 0
+
+
+def _as_float(value: object) -> float:
+    """Coerce a JSON numeric field to float, defaulting to 0.0.
+
+    :param value: candidate value.
+    :return: float value, or 0.0 when not a number.
+    """
+    return float(value) if _is_num(value) else 0.0
+
+
+def _fmt_signed(value: float) -> str:
+    """Format a signed percentage figure compactly.
+
+    One decimal below 100 in magnitude, none above -- keeps worst-case
+    cell width bounded for the fixed-width table.
+
+    :param value: percentage value.
+    :return: signed display string (no % suffix).
+    """
+    return f"{value:+.0f}" if abs(value) >= 100 else f"{value:+.1f}"
+
+
+def _fmt_roi_ci(roi: object, ci: object) -> str:
+    """Format the "ROI (95% CI)" table cell.
+
+    :param roi: pooled ROI in percent, or None.
+    :param ci: [low, high] CI bounds, or None.
+    :return: display string, e.g. ``+12.3% (+4.1,+20.9)``.
+    """
+    if not _is_num(roi):
+        return "n/a"
+    roi_text = f"{_fmt_signed(float(roi))}%"
+    if isinstance(ci, list) and len(ci) == 2 and _is_num(ci[0]) and _is_num(ci[1]):
+        return f"{roi_text} ({_fmt_signed(float(ci[0]))},{_fmt_signed(float(ci[1]))})"
+    return roi_text
+
+
+def _fmt_roi_point(roi: object) -> str:
+    """Format the "w/costs" table cell (point estimate only).
+
+    The haircut CI stays in the full report; the compact table keeps
+    the with-costs column to the point value so lines fit the width cap.
+
+    :param roi: haircut ROI in percent, or None.
+    :return: display string.
+    """
+    if not _is_num(roi):
+        return "n/a"
+    return f"{_fmt_signed(float(roi))}%"
+
+
+def _compact_flags(flags: object) -> str:
+    """Compress a group's flags list into a short cell.
+
+    Known roi_sim flags map to short spellings (``few bets - anecdotal``
+    -> ``few bets``, the parse-reliability warning -> ``⚠ parse NN%``);
+    unknown flags keep only their lead phrase (text before an em- or
+    hyphen-dash separator).
+
+    :param flags: raw flags value from the group dict.
+    :return: comma-joined compact flag text (empty when no flags).
+    """
+    if not isinstance(flags, list):
+        return ""
+    parts = []
+    for flag in flags:
+        text = str(flag)
+        reliability = _PARSE_RELIABILITY_RE.search(text)
+        if reliability:
+            text = f"⚠ parse {reliability.group(1)}%"
+        else:
+            text = _FLAG_SHORT.get(text, text.split(" — ")[0].split(" - ")[0]).strip()
+        if text:
+            parts.append(text)
+    return ", ".join(parts)
+
+
+def _fit(text: str, width: int) -> str:
+    """Truncate *text* to *width* characters, marking cuts with an ellipsis.
+
+    :param text: cell text.
+    :param width: maximum width in characters.
+    :return: text of length <= width.
+    """
+    if len(text) <= width:
+        return text
+    if width <= 1:
+        return text[:width]
+    return text[: width - 1] + _ELLIPSIS
+
+
+def _format_line(cells: tuple[str, ...], widths: list[int]) -> str:
+    """Render one table line: fitted, padded cells joined by the separator.
+
+    :param cells: one string per column.
+    :param widths: column widths (same length as cells).
+    :return: single table line (trailing whitespace stripped).
+    """
+    padded = [_fit(cell, width).ljust(width) for cell, width in zip(cells, widths)]
+    return _SEP.join(padded).rstrip()
+
+
+def _render_table(rows: list[tuple[str, ...]]) -> list[str]:
+    """Render header + divider + data lines, all within MAX_LINE_WIDTH.
+
+    Widths are content-driven up to the per-column caps; if the capped
+    total still exceeds the width budget the tool column shrinks first,
+    then flags -- both truncations are marked with an ellipsis.
+
+    :param rows: pre-formatted cell tuples, one per table row.
+    :return: table lines (no code-block fences).
+    """
+    widths = [
+        min(
+            cap,
+            max(len(header), *(len(row[i]) for row in rows)),
+        )
+        for i, (header, cap) in enumerate(zip(_HEADERS, _CAPS))
+    ]
+    overflow = sum(widths) + len(_SEP) * (len(_HEADERS) - 1) - MAX_LINE_WIDTH
+    if overflow > 0:
+        take = min(overflow, widths[0] - _TOOL_MIN)
+        widths[0] -= take
+        overflow -= take
+    if overflow > 0:
+        widths[-1] = max(_FLAGS_MIN, widths[-1] - overflow)
+    lines = [
+        _format_line(_HEADERS, widths),
+        _format_line(tuple("-" * width for width in widths), widths),
+    ]
+    lines.extend(_format_line(row, widths) for row in rows)
+    return lines
+
+
+def _row_cells(group: dict[str, Any]) -> tuple[str, ...]:
+    """Build the table cells for one bet-carrying group.
+
+    :param group: group dict from roi_results.json.
+    :return: one string per table column.
+    """
+    mode = str(group.get("mode") or "")
+    return (
+        str(group.get("tool_name") or "unknown"),
+        _MODE_SHORT.get(mode, mode),
+        str(_as_int(group.get("n_eligible"))),
+        str(_as_int(group.get("n_bets"))),
+        _fmt_roi_ci(group.get("roi_mid"), group.get("roi_ci")),
+        _fmt_roi_point(group.get("roi_haircut")),
+        _compact_flags(group.get("flags")),
+    )
+
+
+def _display_sort_key(group: dict[str, Any]) -> tuple[int, int, str]:
+    """Table display order: production first, then bet count descending.
+
+    :param group: group dict from roi_results.json.
+    :return: sort key tuple.
+    """
+    return (
+        0 if group.get("mode") == "production" else 1,
+        -_as_int(group.get("n_bets")),
+        str(group.get("tool_name") or ""),
+    )
+
+
+def _load_results(results_path: Path) -> dict[str, Any] | None:
+    """Read and parse roi_results.json, tolerating any failure.
+
+    :param results_path: path to the results file.
+    :return: parsed payload dict, or None when missing/unparseable.
+    """
+    try:
+        payload = json.loads(results_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def build_roi_section(results_path: Path, platform: str) -> str | None:
+    """Build the Slack mrkdwn ROI companion section for one platform.
+
+    :param results_path: path to roi_results.json (from benchmark.roi_sim).
+    :param platform: platform key ("omen" / "polymarket").
+    :return: mrkdwn section text, or None when the results file is
+        missing/unparseable or carries no groups for the platform --
+        callers then append nothing.
+    """
+    payload = _load_results(results_path)
+    if payload is None:
+        return None
+    groups = payload.get("groups")
+    if not isinstance(groups, list):
+        return None
+    platform_groups = [
+        group
+        for group in groups
+        if isinstance(group, dict) and group.get("platform") == platform
+    ]
+    if not platform_groups:
+        return None
+
+    window_days = payload.get("window_days")
+    window_text = (
+        f"trailing {int(window_days)}d" if _is_num(window_days) else "trailing window"
+    )
+    lines = [
+        f"*Simulated trader ROI* — {window_text}, same decision rules for "
+        "every tool (companion sim; full report in the benchmark-data artifact):"
+    ]
+
+    prediction_groups = [g for g in platform_groups if g.get("is_prediction_tool")]
+    bet_groups = [g for g in prediction_groups if _as_int(g.get("n_bets")) > 0]
+    if bet_groups:
+        extra = 0
+        if len(bet_groups) > MAX_TABLE_ROWS:
+            extra = len(bet_groups) - MAX_TABLE_ROWS
+            bet_groups = sorted(bet_groups, key=lambda g: -_as_float(g.get("staked")))[
+                :MAX_TABLE_ROWS
+            ]
+        bet_groups.sort(key=_display_sort_key)
+        lines.append("```")
+        lines.extend(_render_table([_row_cells(g) for g in bet_groups]))
+        if extra:
+            lines.append(f"{_ELLIPSIS} +{extra} more rows in the full report")
+        lines.append("```")
+
+    # A tool counts as zero-bet only when NONE of its groups (any mode)
+    # placed a bet -- a tool betting in one mode must not be listed as idle.
+    betting_tools = {
+        str(g.get("tool_name") or "unknown")
+        for g in prediction_groups
+        if _as_int(g.get("n_bets")) > 0
+    }
+    zero_bet_tools = sorted(
+        {
+            str(g.get("tool_name") or "unknown")
+            for g in prediction_groups
+            if _as_int(g.get("n_bets")) == 0
+        }
+        - betting_tools
+    )
+    if zero_bet_tools:
+        lines.append("no bets in window: " + ", ".join(zero_bet_tools))
+
+    excluded_tools = {
+        str(g.get("tool_name") or "unknown")
+        for g in platform_groups
+        if not g.get("is_prediction_tool")
+    }
+    if excluded_tools:
+        lines.append(
+            f"excluded non-prediction tools: {len(excluded_tools)} " "— see report"
+        )
+    return "\n".join(lines)

--- a/benchmark/roi_slack.py
+++ b/benchmark/roi_slack.py
@@ -156,7 +156,8 @@ def _compact_flags(flags: object) -> str:
         if reliability:
             text = f"⚠ parse {reliability.group(1)}%"
         else:
-            text = _FLAG_SHORT.get(text, text.split(" — ")[0].split(" - ")[0]).strip()
+            short = text.split(" — ", maxsplit=1)[0].split(" - ", maxsplit=1)[0]
+            text = _FLAG_SHORT.get(text, short).strip()
         if text:
             parts.append(text)
     return ", ".join(parts)

--- a/benchmark/tests/test_roi_slack.py
+++ b/benchmark/tests/test_roi_slack.py
@@ -1,0 +1,551 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Tests for benchmark/roi_slack.py — the ROI companion Slack section."""
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from benchmark import notify_slack
+from benchmark.roi_slack import (
+    MAX_LINE_WIDTH,
+    MAX_TABLE_ROWS,
+    build_roi_section,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _group(
+    tool: str = "test-tool",
+    platform: str = "omen",
+    mode: str = "production",
+    n_eligible: int = 40,
+    n_bets: int = 20,
+    staked: float = 25.0,
+    roi_mid: Any = 12.3,
+    roi_ci: Any = None,
+    roi_haircut: Any = 8.4,
+    roi_haircut_ci: Any = None,
+    flags: Any = None,
+    is_prediction_tool: bool = True,
+    parse_reliability: Any = 1.0,
+) -> dict[str, Any]:
+    """Build a minimal roi_results.json group entry."""
+    return {
+        "platform": platform,
+        "tool_name": tool,
+        "mode": mode,
+        "n_eligible": n_eligible,
+        "n_bets": n_bets,
+        "staked": staked,
+        "roi_mid": roi_mid,
+        "roi_ci": roi_ci if roi_ci is not None else [4.1, 20.9],
+        "roi_haircut": roi_haircut,
+        "roi_haircut_ci": (
+            roi_haircut_ci if roi_haircut_ci is not None else [-1.2, 18.0]
+        ),
+        "flags": flags or [],
+        "is_prediction_tool": is_prediction_tool,
+        "parse_reliability": parse_reliability,
+    }
+
+
+def _write_results(
+    tmp_path: Path,
+    groups: list[dict[str, Any]],
+    window_days: int = 90,
+) -> Path:
+    """Write a roi_results.json fixture and return its path."""
+    path = tmp_path / "roi_results.json"
+    payload = {
+        "as_of": "2026-07-06",
+        "window_days": window_days,
+        "window_start": "2026-04-08T00:00:00+00:00",
+        "window_end": "2026-07-07T00:00:00+00:00",
+        "groups": groups,
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _code_block_lines(section: str) -> list[str]:
+    """Extract the lines inside the fenced code block of a section."""
+    lines = section.splitlines()
+    fences = [i for i, line in enumerate(lines) if line == "```"]
+    assert len(fences) == 2, f"expected one fenced code block, got {section!r}"
+    return lines[fences[0] + 1 : fences[1]]
+
+
+# ---------------------------------------------------------------------------
+# build_roi_section — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRoiSectionHappyPath:
+    """The section renders intro + code-block table for bet-carrying groups."""
+
+    def test_intro_line_and_window_days(self, tmp_path: Path) -> None:
+        """First line is the bold intro citing the window from the json."""
+        path = _write_results(tmp_path, [_group()], window_days=21)
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        first = section.splitlines()[0]
+        assert first.startswith("*Simulated trader ROI*")
+        assert "trailing 21d" in first
+
+    def test_code_block_carries_all_columns(self, tmp_path: Path) -> None:
+        """Header row inside the code block names every column."""
+        path = _write_results(tmp_path, [_group()])
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        header = _code_block_lines(section)[0]
+        for column in (
+            "tool",
+            "mode",
+            "preds",
+            "bets",
+            "ROI (95% CI)",
+            "w/costs",
+            "flags",
+        ):
+            assert column in header, f"missing column: {column}"
+
+    def test_row_renders_counts_roi_and_ci(self, tmp_path: Path) -> None:
+        """A data row shows n_eligible, n_bets, and the ROI with its CI."""
+        path = _write_results(
+            tmp_path,
+            [
+                _group(
+                    tool="alpha",
+                    n_eligible=40,
+                    n_bets=20,
+                    roi_mid=12.3,
+                    roi_ci=[4.1, 20.9],
+                )
+            ],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        rows = _code_block_lines(section)[2:]
+        assert len(rows) == 1
+        assert "alpha" in rows[0]
+        assert "40" in rows[0]
+        assert "20" in rows[0]
+        assert "+12.3% (+4.1,+20.9)" in rows[0]
+
+    def test_production_sorts_before_tournament(self, tmp_path: Path) -> None:
+        """Production rows precede tournament rows regardless of bet count."""
+        path = _write_results(
+            tmp_path,
+            [
+                _group(tool="t-big", mode="tournament", n_bets=99),
+                _group(tool="p-small", mode="production", n_bets=5),
+            ],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        rows = _code_block_lines(section)[2:]
+        assert "p-small" in rows[0]
+        assert "t-big" in rows[1]
+
+    def test_within_mode_sorted_by_bets_desc(self, tmp_path: Path) -> None:
+        """Within one mode, more bets rank higher."""
+        path = _write_results(
+            tmp_path,
+            [
+                _group(tool="few", n_bets=3),
+                _group(tool="many", n_bets=30),
+            ],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        rows = _code_block_lines(section)[2:]
+        assert "many" in rows[0]
+        assert "few" in rows[1]
+
+    def test_zero_bet_groups_stay_out_of_table(self, tmp_path: Path) -> None:
+        """Groups with n_bets == 0 never occupy a table row."""
+        path = _write_results(
+            tmp_path,
+            [_group(tool="bettor", n_bets=10), _group(tool="idle", n_bets=0)],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        rows = _code_block_lines(section)
+        assert not any("idle" in row for row in rows)
+
+    def test_other_platform_groups_ignored(self, tmp_path: Path) -> None:
+        """Only the requested platform's groups render."""
+        path = _write_results(
+            tmp_path,
+            [
+                _group(tool="omen-tool", platform="omen"),
+                _group(tool="poly-tool", platform="polymarket"),
+            ],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        assert "omen-tool" in section
+        assert "poly-tool" not in section
+
+    def test_flags_compacted(self, tmp_path: Path) -> None:
+        """Verbose flags render as their short spellings in the flags cell."""
+        path = _write_results(
+            tmp_path,
+            [_group(flags=["few bets - anecdotal", "low sample"])],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        rows = _code_block_lines(section)[2:]
+        assert "few bets, low n" in rows[0]
+        assert "anecdotal" not in rows[0]
+
+    def test_parse_reliability_flag_compacted(self, tmp_path: Path) -> None:
+        """The parse-reliability warning compacts to '⚠ parse NN%'."""
+        long_flag = "⚠ 45% parse reliability — possible response-format gap"
+        path = _write_results(tmp_path, [_group(flags=[long_flag])])
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        rows = _code_block_lines(section)[2:]
+        assert "⚠ parse 45%" in rows[0]
+        assert "response-format" not in rows[0]
+
+    def test_mode_labels_abbreviated(self, tmp_path: Path) -> None:
+        """Modes render as 'prod' / 'tourn' to keep the table narrow."""
+        path = _write_results(
+            tmp_path,
+            [
+                _group(tool="p-tool", mode="production"),
+                _group(tool="t-tool", mode="tournament"),
+            ],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        rows = _code_block_lines(section)[2:]
+        assert "prod" in rows[0] and "production" not in rows[0]
+        assert "tourn" in rows[1] and "tournament" not in rows[1]
+
+
+# ---------------------------------------------------------------------------
+# Zero-bet and excluded lines
+# ---------------------------------------------------------------------------
+
+
+class TestZeroBetLine:
+    """Prediction tools with zero bets are listed on one compact line."""
+
+    def test_zero_bet_tools_listed(self, tmp_path: Path) -> None:
+        """Zero-bet prediction tools appear comma-joined after the block."""
+        path = _write_results(
+            tmp_path,
+            [
+                _group(tool="bettor", n_bets=10),
+                _group(tool="idle-b", n_bets=0),
+                _group(tool="idle-a", n_bets=0),
+            ],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        assert "no bets in window: idle-a, idle-b" in section
+
+    def test_line_omitted_when_all_tools_bet(self, tmp_path: Path) -> None:
+        """No zero-bet line when every prediction tool placed bets."""
+        path = _write_results(tmp_path, [_group()])
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        assert "no bets in window" not in section
+
+    def test_tool_betting_in_any_mode_not_listed(self, tmp_path: Path) -> None:
+        """A tool with bets in one mode is not idle, even if another of its
+        groups has zero bets."""
+        path = _write_results(
+            tmp_path,
+            [
+                _group(tool="multi", mode="production", n_bets=0),
+                _group(tool="multi", mode="tournament", n_bets=8),
+            ],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        assert "no bets in window" not in section
+
+
+class TestExcludedLine:
+    """Non-prediction tools are summarized as a count only."""
+
+    def test_excluded_count_rendered(self, tmp_path: Path) -> None:
+        """Count of distinct non-prediction tools, names omitted."""
+        path = _write_results(
+            tmp_path,
+            [
+                _group(),
+                _group(tool="question-gen", is_prediction_tool=False, n_bets=0),
+                _group(tool="service-mech", is_prediction_tool=False, n_bets=0),
+            ],
+        )
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        assert "excluded non-prediction tools: 2 — see report" in section
+        assert "question-gen" not in section
+
+    def test_line_omitted_when_none_excluded(self, tmp_path: Path) -> None:
+        """No excluded line when every group is a prediction tool."""
+        path = _write_results(tmp_path, [_group()])
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        assert "excluded non-prediction tools" not in section
+
+
+# ---------------------------------------------------------------------------
+# None returns
+# ---------------------------------------------------------------------------
+
+
+class TestReturnsNone:
+    """Callers append nothing when there is nothing to render."""
+
+    def test_missing_file(self, tmp_path: Path) -> None:
+        """Missing results file -> None."""
+        assert build_roi_section(tmp_path / "absent.json", "omen") is None
+
+    def test_unparseable_file(self, tmp_path: Path) -> None:
+        """Corrupt JSON -> None."""
+        path = tmp_path / "roi_results.json"
+        path.write_text("{not json", encoding="utf-8")
+        assert build_roi_section(path, "omen") is None
+
+    def test_non_dict_payload(self, tmp_path: Path) -> None:
+        """A JSON list payload -> None."""
+        path = tmp_path / "roi_results.json"
+        path.write_text("[1, 2]", encoding="utf-8")
+        assert build_roi_section(path, "omen") is None
+
+    def test_no_groups_for_platform(self, tmp_path: Path) -> None:
+        """Groups exist but none on the requested platform -> None."""
+        path = _write_results(tmp_path, [_group(platform="polymarket")])
+        assert build_roi_section(path, "omen") is None
+
+    def test_empty_groups(self, tmp_path: Path) -> None:
+        """Empty groups list -> None."""
+        path = _write_results(tmp_path, [])
+        assert build_roi_section(path, "omen") is None
+
+
+# ---------------------------------------------------------------------------
+# Truncation + width bounds
+# ---------------------------------------------------------------------------
+
+
+class TestTruncation:
+    """Wide deployments keep the top rows by staked and point at the report."""
+
+    def test_more_than_max_rows_truncates(self, tmp_path: Path) -> None:
+        """17 bet groups -> MAX_TABLE_ROWS rows + '+N more' line."""
+        groups = [
+            _group(tool=f"tool-{i:02d}", n_bets=10 + i, staked=float(i))
+            for i in range(MAX_TABLE_ROWS + 3)
+        ]
+        path = _write_results(tmp_path, groups)
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        rows = _code_block_lines(section)
+        # header + divider + MAX_TABLE_ROWS data rows + "+N more" line
+        assert len(rows) == 2 + MAX_TABLE_ROWS + 1
+        assert "+3 more rows in the full report" in rows[-1]
+
+    def test_kept_rows_are_top_by_staked(self, tmp_path: Path) -> None:
+        """The lowest-staked groups are the ones dropped."""
+        groups = [
+            _group(tool=f"tool-{i:02d}", staked=float(i))
+            for i in range(MAX_TABLE_ROWS + 2)
+        ]
+        path = _write_results(tmp_path, groups)
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        assert "tool-00" not in section
+        assert "tool-01" not in section
+        assert f"tool-{MAX_TABLE_ROWS + 1:02d}" in section
+
+    def test_at_max_rows_no_truncation(self, tmp_path: Path) -> None:
+        """Exactly MAX_TABLE_ROWS groups render fully with no more-line."""
+        groups = [_group(tool=f"tool-{i:02d}") for i in range(MAX_TABLE_ROWS)]
+        path = _write_results(tmp_path, groups)
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        assert "more rows in the full report" not in section
+
+
+class TestLineWidth:
+    """Every code-block line stays within the Slack-friendly width cap."""
+
+    def test_long_names_and_flags_fit(self, tmp_path: Path) -> None:
+        """Very long tool names / flags are truncated, not overflowed."""
+        long_flag = "⚠ 45% parse reliability — possible response-format gap"
+        groups = [
+            _group(
+                tool="a-very-long-tool-name-that-exceeds-the-column-cap-x" * 2,
+                n_eligible=99999,
+                n_bets=88888,
+                roi_mid=-100.0,
+                roi_ci=[-1234.5, 6789.0],
+                roi_haircut=-100.0,
+                flags=[long_flag, "few bets - anecdotal", "low sample"],
+            )
+        ]
+        path = _write_results(tmp_path, groups)
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        for line in _code_block_lines(section):
+            assert len(line) <= MAX_LINE_WIDTH, f"too wide: {line!r}"
+
+    def test_typical_rows_fit(self, tmp_path: Path) -> None:
+        """A realistic multi-row table also honors the width cap."""
+        groups = [
+            _group(tool="prediction-request-reasoning", n_bets=120),
+            _group(tool="prediction-online", mode="tournament", n_bets=40),
+        ]
+        path = _write_results(tmp_path, groups)
+        section = build_roi_section(path, "omen")
+        assert section is not None
+        for line in _code_block_lines(section):
+            assert len(line) <= MAX_LINE_WIDTH, f"too wide: {line!r}"
+
+
+# ---------------------------------------------------------------------------
+# notify_slack append hook
+# ---------------------------------------------------------------------------
+
+
+class TestNotifySlackHook:
+    """notify_slack appends the ROI section without ever breaking the post."""
+
+    @staticmethod
+    def _run_main(
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        extra_argv: list[str] | None = None,
+        roi_env: str | None = None,
+    ) -> list[str]:
+        """Drive notify_slack.main with network + LLM stubbed; return posts."""
+        report = tmp_path / "report_omen.md"
+        report.write_text(
+            "# Benchmark Report (Omenstrat) — 2026-07-06\n\nbody\n",
+            encoding="utf-8",
+        )
+        for var in (
+            "REPORT_ARTIFACT_URL",
+            "GITHUB_SERVER_URL",
+            "GITHUB_REPOSITORY",
+            "GITHUB_RUN_ID",
+            "ROI_SECTION",
+        ):
+            monkeypatch.delenv(var, raising=False)
+        if roi_env is not None:
+            monkeypatch.setenv("ROI_SECTION", roi_env)
+        monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+        monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/T000")
+        posted: list[str] = []
+        monkeypatch.setattr(
+            notify_slack, "summarize_report", lambda *a, **k: "LLM SUMMARY"
+        )
+        monkeypatch.setattr(
+            notify_slack, "post_to_slack", lambda url, text: posted.append(text)
+        )
+        argv = ["notify_slack", "--report", str(report)] + (extra_argv or [])
+        monkeypatch.setattr(sys, "argv", argv)
+        notify_slack.main()
+        return posted
+
+    def test_section_appended_after_summary(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """The builder's text lands at the end of the posted message."""
+        calls: list[tuple[Path, str]] = []
+
+        def _fake_builder(results_path: Path, platform: str) -> str:
+            calls.append((results_path, platform))
+            return "ROI_MARKER_SECTION"
+
+        monkeypatch.setattr(notify_slack, "build_roi_section", _fake_builder)
+        posted = self._run_main(monkeypatch, tmp_path)
+        assert len(posted) == 1
+        assert posted[0].index("LLM SUMMARY") < posted[0].index("ROI_MARKER_SECTION")
+        assert posted[0].endswith("ROI_MARKER_SECTION")
+        # Platform key derived from the report's platform label.
+        assert calls == [(Path("benchmark/results/roi_results.json"), "omen")]
+
+    def test_roi_results_flag_passed_through(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """--roi-results overrides the default results path."""
+        calls: list[Path] = []
+        monkeypatch.setattr(
+            notify_slack,
+            "build_roi_section",
+            lambda results_path, platform: calls.append(results_path),
+        )
+        custom = tmp_path / "custom_roi.json"
+        self._run_main(monkeypatch, tmp_path, ["--roi-results", str(custom)])
+        assert calls == [custom]
+
+    def test_builder_none_appends_nothing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A None from the builder leaves the summary untouched."""
+        monkeypatch.setattr(notify_slack, "build_roi_section", lambda *a, **k: None)
+        posted = self._run_main(monkeypatch, tmp_path)
+        assert len(posted) == 1
+        assert posted[0].rstrip().endswith("LLM SUMMARY")
+
+    def test_builder_exception_never_breaks_post(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An exploding builder logs a warning; the post still goes out."""
+
+        def _boom(results_path: Path, platform: str) -> str:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(notify_slack, "build_roi_section", _boom)
+        with caplog.at_level(logging.WARNING, logger="benchmark.notify_slack"):
+            posted = self._run_main(monkeypatch, tmp_path)
+        assert len(posted) == 1
+        assert "LLM SUMMARY" in posted[0]
+        assert "ROI section build failed" in caplog.text
+
+    def test_env_var_off_disables_section(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """ROI_SECTION=off skips the builder entirely."""
+
+        def _must_not_run(results_path: Path, platform: str) -> str:
+            raise AssertionError("builder must not be called when ROI_SECTION=off")
+
+        monkeypatch.setattr(notify_slack, "build_roi_section", _must_not_run)
+        posted = self._run_main(monkeypatch, tmp_path, roi_env="off")
+        assert len(posted) == 1
+        assert "LLM SUMMARY" in posted[0]

--- a/benchmark/tests/test_roi_slack.py
+++ b/benchmark/tests/test_roi_slack.py
@@ -278,8 +278,10 @@ class TestZeroBetLine:
         assert "no bets in window" not in section
 
     def test_tool_betting_in_any_mode_not_listed(self, tmp_path: Path) -> None:
-        """A tool with bets in one mode is not idle, even if another of its
-        groups has zero bets."""
+        """Keep a tool off the idle line when any of its modes has bets.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
         path = _write_results(
             tmp_path,
             [


### PR DESCRIPTION
Stacked on #387. Each platform's existing daily Slack message gains the ROI companion at the end — no extra messages, no change to the Slack post steps.

- `benchmark/roi_slack.py` (new): pure stdlib builder — per-platform mrkdwn section: intro line + fixed-width table in a code block (prediction tools with bets, production first) + one-liners for zero-bet tools and the excluded non-prediction count. Returns `None` on any problem.
- `benchmark/notify_slack.py`: minimal hook after the summary — wrapped in try/except so a broken ROI section can never block the daily post; `ROI_SECTION=off` kill switch; `--roi-results` flag.
- `benchmark_flywheel.yaml`: one `continue-on-error` step running the (stdlib, no-secrets, no-LLM) simulator on the job's already-downloaded data right before the Slack posts + ROI outputs added to the `benchmark-data` artifact + reports in the run step summary. Slack post steps untouched.
- 21 new tests (`test_roi_slack.py`); full suite 192 pass; tomte-parity lint all green; actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)