### PR TITLE
Migrate flywheel to the subgraph's nested `parsedDelivery`

### DIFF
--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -1011,15 +1011,25 @@ def _parse_request_context(content_str: str) -> dict[str, Any]:
 def fetch_deliveries(
     marketplace_url: str,
     timestamp_gt: int,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], Optional[int]]:
     """Bulk fetch all recent deliveries with prediction data.
 
     Skips deliveries with null parsedRequest (IPFS failures on subgraph side).
     Extracts market_id from request_context when available (schema v2.0+).
 
+    ParsedRequest is written by the same async file-data-source as
+    ParsedDelivery, so a freshly-indexed deliver can have a null
+    parsedRequest purely due to indexing lag. Those recent skips return a
+    cursor cap (one below the youngest such deliver) so the caller keeps
+    the delivery cursor behind them and they are refetched next run once
+    the file handler catches up. Skips older than
+    ``PARSED_DELIVERY_GRACE_SECONDS`` are permanently-unparseable request
+    files; they never cap the cursor, or one bad upload would pin it
+    forever.
+
     :param marketplace_url: GraphQL endpoint for the marketplace subgraph.
     :param timestamp_gt: only fetch deliveries after this UNIX timestamp.
-    :return: list of delivery dicts.
+    :return: tuple of (delivery dicts, delivery-cursor cap or None).
     """
     schema = detect_delivers_schema(marketplace_url)
     query_template = (
@@ -1034,11 +1044,21 @@ def fetch_deliveries(
 
     deliveries = []
     skipped = 0
+    unparsed_request_cap: Optional[int] = None
+    now_ts = int(time.time())
     for d in raw:
         request = d.get("request") or {}
         parsed = request.get("parsedRequest")
         if not parsed:
             skipped += 1
+            delivery_ts = int(d["blockTimestamp"])
+            if now_ts - delivery_ts < PARSED_DELIVERY_GRACE_SECONDS:
+                cap = delivery_ts - 1
+                unparsed_request_cap = (
+                    cap
+                    if unparsed_request_cap is None
+                    else min(unparsed_request_cap, cap)
+                )
             continue
 
         question_title = _extract_question_title(parsed.get("questionTitle", ""))
@@ -1073,7 +1093,7 @@ def fetch_deliveries(
     if deliveries:
         log.info("  %d/%d deliveries have market_id", has_market_id, len(deliveries))
 
-    return deliveries
+    return deliveries, unparsed_request_cap
 
 
 # ---------------------------------------------------------------------------
@@ -2194,7 +2214,9 @@ def process_platform(
 
     # 2. Fetch and process new deliveries
     log.info("%s: fetching deliveries...", platform)
-    new_deliveries = fetch_deliveries(marketplace_url, delivery_ts_gt)
+    new_deliveries, unparsed_request_cap = fetch_deliveries(
+        marketplace_url, delivery_ts_gt
+    )
     log.info(
         "%s: %d new deliveries, %d resolved markets, %d pending from before",
         platform,
@@ -2219,6 +2241,15 @@ def process_platform(
             max_delivery_ts,
             max_resolved_ts,
         ) = _match_and_build(new_deliveries, resolved_markets, existing_ids, platform)
+
+    # Hold the delivery cursor behind delivers skipped for a (recent) null
+    # parsedRequest so they are refetched once the async file handler has
+    # indexed them, instead of being lost when a newer row advances the
+    # cursor past them this run.
+    if unparsed_request_cap is not None and (
+        not max_delivery_ts or unparsed_request_cap < max_delivery_ts
+    ):
+        max_delivery_ts = unparsed_request_cap
 
     all_rows = rows_from_pending + rows_from_new
     all_pending = _dedup_pending(remaining_pending + new_pending)

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -1809,12 +1809,29 @@ def _dedup_pending(pending: list[dict[str, Any]]) -> list[dict[str, Any]]:
     The fetch cursor only advances past matched deliveries, so unresolved
     deliveries are refetched on every run and would otherwise accumulate as
     duplicate snapshots. Last copy wins: a refetched delivery carries the
-    freshest parsed fields.
+    freshest parsed fields. A ``deferred_market`` snapshot is carried over
+    from earlier copies — the refetched copy cannot re-match the market
+    (its resolution left the cursor window), so dropping the snapshot
+    would strand the delivery in pending permanently.
 
     :param pending: pending delivery dicts, possibly with duplicates.
     :return: deduplicated list (insertion order of first occurrence).
     """
-    return list({d.get("deliver_id"): d for d in pending}.values())
+    merged: dict[str, dict[str, Any]] = {}
+    for delivery in pending:
+        key = delivery.get("deliver_id")
+        previous = merged.get(key)
+        if (
+            previous is not None
+            and previous.get("deferred_market")
+            and not delivery.get("deferred_market")
+        ):
+            delivery = {
+                **delivery,
+                "deferred_market": previous["deferred_market"],
+            }
+        merged[key] = delivery
+    return list(merged.values())
 
 
 def _match_and_build(
@@ -1849,14 +1866,37 @@ def _match_and_build(
 
         market, confidence = _match_delivery(delivery, resolved_markets)
         if market is None:
-            still_pending.append(delivery)
-            continue
+            # A market matched in an earlier run leaves the resolved-markets
+            # window once the resolution cursor advances past it. Deferred
+            # entries carry a snapshot of that match so they can still build
+            # a row (healed or grace-expired) instead of stranding in
+            # pending until the max-age prune drops them.
+            snapshot = delivery.get("deferred_market")
+            if snapshot is None:
+                still_pending.append(delivery)
+                continue
+            market = {
+                "outcome": snapshot["outcome"],
+                "resolved_at_ts": snapshot["resolved_at_ts"],
+            }
+            confidence = snapshot.get("match_confidence", 1.0)
 
         # The market resolved but the subgraph's async file handler has not
         # indexed the ParsedDelivery yet — wait for it instead of writing a
         # permanently-invalid row (rows are deduped and never revisited).
+        # The matched market is snapshotted onto the deferred entry because
+        # it may no longer be fetchable when the entry is retried.
         if _should_defer_unparsed(delivery):
-            still_pending.append(delivery)
+            still_pending.append(
+                {
+                    **delivery,
+                    "deferred_market": {
+                        "outcome": market["outcome"],
+                        "resolved_at_ts": market["resolved_at_ts"],
+                        "match_confidence": confidence,
+                    },
+                }
+            )
             continue
 
         if delivery.get("market_id") and confidence == 1.0:

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -1837,9 +1837,9 @@ def _dedup_pending(pending: list[dict[str, Any]]) -> list[dict[str, Any]]:
     :param pending: pending delivery dicts, possibly with duplicates.
     :return: deduplicated list (insertion order of first occurrence).
     """
-    merged: dict[str, dict[str, Any]] = {}
+    merged: dict[Optional[str], dict[str, Any]] = {}
     for delivery in pending:
-        key = delivery.get("deliver_id")
+        key: Optional[str] = delivery.get("deliver_id")
         previous = merged.get(key)
         if (
             previous is not None

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -107,6 +107,13 @@ LOGS_DIR = Path(__file__).parent / "logs"
 LEGACY_LOG_PATH = Path(__file__).parent / "production_log.jsonl"
 DEDUP_LOOKBACK_DAYS = 7  # how many daily files to scan on state-loss recovery
 
+# Normal-case dedup lookback. A lagging-parsedRequest deliver can hold the
+# delivery cursor back up to PARSED_DELIVERY_GRACE_SECONDS, so deliveries
+# whose rows were already written within that window are legitimately
+# refetched on later runs; the dedup scan must cover the whole grace
+# window (+1 for today's partial day) or they are rebuilt as duplicates.
+GRACE_DEDUP_LOOKBACK_DAYS = PARSED_DELIVERY_GRACE_SECONDS // 86400 + 1
+
 # Category keywords for classifying prediction market questions.
 # Matched using word boundaries (\b) to avoid substring false positives.
 # Falls back to "other" if no keywords match.
@@ -1707,21 +1714,19 @@ def load_existing_row_ids(
 ) -> set[str]:
     """Load existing row IDs from daily log files for deduplication.
 
-    Normal case: reads only today's file (handles cursor overlap and
-    same-day reruns).  State-loss recovery: reads the last
-    ``DEDUP_LOOKBACK_DAYS`` daily files to catch duplicates across
-    the lookback window.
+    Normal case: reads the last ``GRACE_DEDUP_LOOKBACK_DAYS`` daily files —
+    the delivery cursor can be held back up to the parsedRequest grace
+    window, so rows built within it can be refetched on later runs and
+    must dedup against more than today's file. State-loss recovery: reads
+    the last ``DEDUP_LOOKBACK_DAYS`` daily files to catch duplicates
+    across the whole lookback window.
 
     :param logs_dir: directory containing daily log files.
     :param state_loss: if True, widen dedup scope to last 7 days.
     :return: set of row IDs already written.
     """
-    if state_loss:
-        files = _daily_log_files(logs_dir, DEDUP_LOOKBACK_DAYS)
-    else:
-        files = [daily_log_path(logs_dir)]
-        if not files[0].exists():
-            files = []
+    lookback = DEDUP_LOOKBACK_DAYS if state_loss else GRACE_DEDUP_LOOKBACK_DAYS
+    files = _daily_log_files(logs_dir, lookback)
     ids: set[str] = set()
     for path in files:
         ids |= _load_ids_from_file(path)

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -1790,8 +1790,7 @@ def refresh_unparsed_pending(
     refreshed = [
         (
             {**entry, **fetched[entry["deliver_id"]]}
-            if entry.get("tool_response") is None
-            and entry.get("deliver_id") in fetched
+            if entry.get("tool_response") is None and entry.get("deliver_id") in fetched
             else entry
         )
         for entry in pending

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -1083,7 +1083,9 @@ def fetch_deliveries(
                 "timestamp": delivery_ts,
                 "request_timestamp": request_ts,
                 **extract_delivery_fields(d, schema),
-                "tool": parsed.get("tool") or "unknown",
+                # parsedRequest.tool uses the same sentinel convention as
+                # ParsedDelivery — collapse it into the "unknown" bucket.
+                "tool": _normalize_subgraph_string(parsed.get("tool")) or "unknown",
                 "question_title": question_title,
                 "market_id": ctx.get("market_id"),
                 "market_prob": ctx.get("market_prob"),

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -2171,7 +2171,7 @@ def process_platform(
 
     # 1. Retry pending deliveries from previous runs
     rows_from_pending: list[dict[str, Any]] = []
-    remaining_pending: list[dict[str, Any]] = []
+    remaining_pending: list[dict[str, Any]]
     if pending_deliveries and resolved_markets:
         rows_from_pending, remaining_pending, _, _, _, _ = _match_and_build(
             pending_deliveries,
@@ -2185,6 +2185,12 @@ def process_platform(
                 platform,
                 len(rows_from_pending),
             )
+    else:
+        # No resolved markets this run: skip the matching work but carry
+        # the pending store forward — the platform state is overwritten
+        # with remaining_pending + new_pending below, so leaving this
+        # empty would silently wipe every previously-pending delivery.
+        remaining_pending = pending_deliveries
 
     # 2. Fetch and process new deliveries
     log.info("%s: fetching deliveries...", platform)

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -58,6 +58,23 @@ DEFAULT_BATCH_SIZE = 1000
 HTTP_TIMEOUT = 60
 PROBABILITY_SUM_TOLERANCE = 0.05
 
+# Sentinel the marketplace subgraph writes into ParsedDelivery's non-null
+# String fields when the payload omits the key or is unparseable
+# (valory-xyz/autonolas-subgraph#113).
+SUBGRAPH_UNHANDLED_TYPE = "[unhandled type]"
+
+# ParsedDelivery is written by an async file-data-source handler, so it can
+# lag the on-chain Deliver entity. A matched delivery whose ParsedDelivery
+# has not been indexed yet is deferred to the pending store for this long
+# before being written as a permanently-invalid missing_fields row.
+PARSED_DELIVERY_GRACE_SECONDS = 2 * 86400
+
+# delivers query shapes: nested ParsedDelivery (new marketplace schema) vs
+# flat Deliver.model/toolResponse (legacy schema, e.g. the polygon
+# deployment until it is redeployed with the new indexing approach).
+DELIVERS_SCHEMA_PARSED = "parsed"
+DELIVERS_SCHEMA_LEGACY = "legacy"
+
 # Max age for pending deliveries (days). Deliveries older than this
 # are dropped from the pending store to keep the state file small.
 PENDING_MAX_AGE_DAYS = 90
@@ -650,8 +667,43 @@ CATEGORY_KEYWORDS: dict[str, list[str]] = {
 # GraphQL queries
 # ---------------------------------------------------------------------------
 
-# Marketplace: bulk fetch all recent deliveries with prediction data
+# Marketplace: bulk fetch all recent deliveries with prediction data.
+# New schema: the IPFS-parsed response/model/toolHash live on the nested
+# ParsedDelivery entity (the flat Deliver.model/toolResponse fields were
+# removed in valory-xyz/autonolas-subgraph#113).
 DELIVERS_QUERY = """
+{
+  delivers(
+    first: %(first)s
+    skip: %(skip)s
+    orderBy: blockTimestamp
+    orderDirection: desc
+    where: { blockTimestamp_gt: %(timestamp_gt)s }
+  ) {
+    id
+    blockTimestamp
+    parsedDelivery {
+      response
+      model
+      tool
+      toolHash
+    }
+    request {
+      id
+      blockTimestamp
+      parsedRequest {
+        questionTitle
+        tool
+        content
+      }
+    }
+  }
+}
+"""
+
+# Legacy schema variant for endpoints not yet redeployed with the nested
+# ParsedDelivery (selected at runtime via detect_delivers_schema).
+DELIVERS_QUERY_LEGACY = """
 {
   delivers(
     first: %(first)s
@@ -672,6 +724,24 @@ DELIVERS_QUERY = """
         tool
         content
       }
+    }
+  }
+}
+"""
+
+# Re-read the parsed fields for specific deliveries (pending-store refresh).
+DELIVERS_PARSED_BY_IDS_QUERY = """
+{
+  delivers(
+    first: %(first)s
+    where: { id_in: [%(ids)s] }
+  ) {
+    id
+    parsedDelivery {
+      response
+      model
+      tool
+      toolHash
     }
   }
 }
@@ -792,6 +862,120 @@ def _paginated_fetch(
 
 
 # ---------------------------------------------------------------------------
+# delivers schema detection (nested ParsedDelivery vs legacy flat fields)
+# ---------------------------------------------------------------------------
+
+# Per-endpoint schema, probed once per process. The gnosis and polygon
+# marketplace subgraphs migrate to the nested ParsedDelivery shape at
+# different times, so the shape must be detected per URL.
+_DELIVERS_SCHEMA_CACHE: dict[str, str] = {}
+
+# Lowercase markers of a GraphQL unknown-field validation error. graph-node
+# phrases these as e.g. 'Type `Deliver` has no field `parsedDelivery`' or
+# 'Cannot query field "parsedDelivery" on type "Deliver"'.
+_UNKNOWN_FIELD_MARKERS = ("has no field", "cannot query field")
+
+
+def _is_unknown_field_error(exc: RuntimeError) -> bool:
+    """Return whether a GraphQL error indicates an unknown schema field.
+
+    :param exc: the RuntimeError raised by :func:`post_graphql`.
+    :return: True when the error is a schema-validation (unknown field)
+        error, i.e. the endpoint does not support the queried shape.
+    """
+    message = str(exc).lower()
+    return any(marker in message for marker in _UNKNOWN_FIELD_MARKERS)
+
+
+def detect_delivers_schema(marketplace_url: str) -> str:
+    """Detect which delivers query shape *marketplace_url* supports.
+
+    Probes with a one-row nested-ParsedDelivery query. An unknown-field
+    validation error means the endpoint still runs the legacy schema with
+    flat ``Deliver.model``/``toolResponse`` fields. Any other error
+    propagates — a transient failure must not silently lock the process
+    into the wrong shape. The result is cached per URL for the process
+    lifetime.
+
+    :param marketplace_url: subgraph endpoint URL.
+    :return: ``DELIVERS_SCHEMA_PARSED`` or ``DELIVERS_SCHEMA_LEGACY``.
+    """
+    cached = _DELIVERS_SCHEMA_CACHE.get(marketplace_url)
+    if cached is not None:
+        return cached
+
+    probe = DELIVERS_QUERY % {"first": 1, "skip": 0, "timestamp_gt": 0}
+    try:
+        _post_graphql(marketplace_url, {"query": probe})
+        schema = DELIVERS_SCHEMA_PARSED
+    except RuntimeError as exc:
+        if not _is_unknown_field_error(exc):
+            raise
+        log.info(
+            "delivers schema: %s has no parsedDelivery — using legacy fields",
+            marketplace_url,
+        )
+        schema = DELIVERS_SCHEMA_LEGACY
+
+    _DELIVERS_SCHEMA_CACHE[marketplace_url] = schema
+    return schema
+
+
+def _normalize_subgraph_string(value: Optional[str]) -> Optional[str]:
+    """Map the subgraph's ``[unhandled type]`` sentinel (and None) to None.
+
+    :param value: raw field value from the subgraph.
+    :return: the value, or None when absent or sentinel.
+    """
+    if value is None or value == SUBGRAPH_UNHANDLED_TYPE:
+        return None
+    return value
+
+
+def extract_delivery_fields(deliver: dict[str, Any], schema: str) -> dict[str, Any]:
+    """Extract the IPFS-parsed fields from a raw deliver, either schema shape.
+
+    Maps both shapes onto the same internal delivery keys so everything
+    downstream of the fetch boundary is schema-agnostic:
+
+    - ``tool_response``: raw ``result`` string. The ``[unhandled type]``
+      sentinel is passed through — :func:`parse_tool_response` classifies
+      it as malformed (payload existed but had no parseable result).
+    - ``model`` / ``tool_hash``: sentinel-normalized to None.
+    - ``parsed_missing``: True only when the new schema's ParsedDelivery
+      entity has not been indexed yet (async file-data-source lag) — the
+      signal for deferring row construction rather than recording a
+      permanently-invalid row.
+
+    :param deliver: raw deliver dict from the subgraph.
+    :param schema: ``DELIVERS_SCHEMA_PARSED`` or ``DELIVERS_SCHEMA_LEGACY``.
+    :return: dict with model, tool_response, tool_hash, parsed_missing.
+    """
+    if schema == DELIVERS_SCHEMA_LEGACY:
+        return {
+            "model": _normalize_subgraph_string(deliver.get("model")),
+            "tool_response": deliver.get("toolResponse"),
+            "tool_hash": None,
+            "parsed_missing": False,
+        }
+
+    parsed = deliver.get("parsedDelivery")
+    if parsed is None:
+        return {
+            "model": None,
+            "tool_response": None,
+            "tool_hash": None,
+            "parsed_missing": True,
+        }
+    return {
+        "model": _normalize_subgraph_string(parsed.get("model")),
+        "tool_response": parsed.get("response"),
+        "tool_hash": _normalize_subgraph_string(parsed.get("toolHash")),
+        "parsed_missing": False,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Fetch deliveries (marketplace subgraphs)
 # ---------------------------------------------------------------------------
 
@@ -837,9 +1021,13 @@ def fetch_deliveries(
     :param timestamp_gt: only fetch deliveries after this UNIX timestamp.
     :return: list of delivery dicts.
     """
+    schema = detect_delivers_schema(marketplace_url)
+    query_template = (
+        DELIVERS_QUERY if schema == DELIVERS_SCHEMA_PARSED else DELIVERS_QUERY_LEGACY
+    )
     raw = _paginated_fetch(
         marketplace_url,
-        DELIVERS_QUERY,
+        query_template,
         "delivers",
         {"timestamp_gt": timestamp_gt},
     )
@@ -867,8 +1055,7 @@ def fetch_deliveries(
                 "deliver_id": d["id"],
                 "timestamp": delivery_ts,
                 "request_timestamp": request_ts,
-                "model": d.get("model"),
-                "tool_response": d.get("toolResponse"),
+                **extract_delivery_fields(d, schema),
                 "tool": parsed.get("tool") or "unknown",
                 "question_title": question_title,
                 "market_id": ctx.get("market_id"),
@@ -1171,6 +1358,16 @@ def parse_tool_response(tool_response: Optional[str]) -> dict[str, Any]:
             "prediction_parse_status": "missing_fields",
         }
 
+    # Subgraph sentinel: the payload was fetched and indexed, but had no
+    # parseable `result` — malformed output, not a missing delivery.
+    if tool_response == SUBGRAPH_UNHANDLED_TYPE:
+        return {
+            "p_yes": None,
+            "p_no": None,
+            "confidence": None,
+            "prediction_parse_status": "malformed",
+        }
+
     # Check for known IPFS retrieval error messages (only short non-JSON responses)
     if len(tool_response) < 300 and tool_response.lstrip()[:1] != "{":
         lower = tool_response.lower()
@@ -1365,10 +1562,14 @@ def build_row(
     if request_ts and delivery_ts and delivery_ts > request_ts:
         latency_s = delivery_ts - request_ts
 
-    # Extract tool_version and config_hash from IPFS metadata if available
+    # tool_version: prefer the exact per-delivery hash from the subgraph's
+    # ParsedDelivery.toolHash; fall back to sampled IPFS metadata.
     tool_version: Optional[str] = None
     config_hash: Optional[str] = None
-    if ipfs_metadata:
+    if delivery.get("tool_hash"):
+        tool_version = delivery["tool_hash"]
+        config_hash = _compute_config_hash(tool_version, delivery.get("model"))
+    elif ipfs_metadata:
         tool_version = ipfs_metadata.get("tool_hash")
         params = ipfs_metadata.get("params") or {}
         config_hash = _compute_config_hash(
@@ -1517,6 +1718,106 @@ def append_rows(output_path: Path, rows: list[dict[str, Any]]) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _should_defer_unparsed(
+    delivery: dict[str, Any],
+    now: Optional[int] = None,
+) -> bool:
+    """Return whether a matched delivery should wait for its ParsedDelivery.
+
+    True only when the new schema reported the ParsedDelivery entity as not
+    yet indexed (``parsed_missing``) and the delivery is younger than
+    ``PARSED_DELIVERY_GRACE_SECONDS``. Once the grace period expires the
+    delivery is written as-is (missing_fields) so pipeline failures stay
+    visible in the reliability tables instead of vanishing. Legacy-schema
+    nulls never defer — they cannot heal, so deferral would only delay the
+    identical outcome.
+
+    :param delivery: delivery dict (needs ``parsed_missing``, ``timestamp``).
+    :param now: current UNIX timestamp; defaults to the wall clock.
+    :return: True when row construction should be deferred to pending.
+    """
+    if not delivery.get("parsed_missing"):
+        return False
+    now_ts = int(time.time()) if now is None else now
+    return (now_ts - (delivery.get("timestamp") or 0)) < PARSED_DELIVERY_GRACE_SECONDS
+
+
+def refresh_unparsed_pending(
+    pending: list[dict[str, Any]],
+    marketplace_url: str,
+) -> list[dict[str, Any]]:
+    """Re-read parsed fields for pending entries that lack a tool response.
+
+    Pending entries snapshot the delivery at fetch time; when a delivery was
+    fetched before the subgraph's async file handler indexed its payload,
+    the snapshot holds nulls forever. This re-queries those deliveries by id
+    (new schema only) and returns a new list with refreshed copies — stale
+    values self-heal once the ParsedDelivery lands. Entries are never
+    mutated in place; batch failures keep the affected entries unchanged.
+
+    :param pending: pending delivery snapshots from the fetch state.
+    :param marketplace_url: subgraph endpoint URL.
+    :return: new pending list with refreshed entries where available.
+    """
+    stale_ids = [
+        d["deliver_id"]
+        for d in pending
+        if d.get("tool_response") is None and d.get("deliver_id")
+    ]
+    if not stale_ids:
+        return pending
+    if detect_delivers_schema(marketplace_url) != DELIVERS_SCHEMA_PARSED:
+        return pending
+
+    fetched: dict[str, dict[str, Any]] = {}
+    for i in range(0, len(stale_ids), DEFAULT_BATCH_SIZE):
+        batch = stale_ids[i : i + DEFAULT_BATCH_SIZE]
+        ids_str = ", ".join(f'"{did}"' for did in batch)
+        query = DELIVERS_PARSED_BY_IDS_QUERY % {"first": len(batch), "ids": ids_str}
+        try:
+            data = _post_graphql(marketplace_url, {"query": query})
+        except (RuntimeError, requests.exceptions.RequestException) as e:
+            log.warning("pending refresh: batch failed (%s), keeping stale", e)
+            continue
+        for d in data.get("delivers", []):
+            fields = extract_delivery_fields(d, DELIVERS_SCHEMA_PARSED)
+            if not fields["parsed_missing"]:
+                fetched[d["id"]] = fields
+
+    if not fetched:
+        return pending
+
+    refreshed = [
+        (
+            {**entry, **fetched[entry["deliver_id"]]}
+            if entry.get("tool_response") is None
+            and entry.get("deliver_id") in fetched
+            else entry
+        )
+        for entry in pending
+    ]
+    log.info(
+        "pending refresh: %d/%d unparsed entries updated",
+        len(fetched),
+        len(set(stale_ids)),
+    )
+    return refreshed
+
+
+def _dedup_pending(pending: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Deduplicate pending deliveries by deliver_id, keeping the last copy.
+
+    The fetch cursor only advances past matched deliveries, so unresolved
+    deliveries are refetched on every run and would otherwise accumulate as
+    duplicate snapshots. Last copy wins: a refetched delivery carries the
+    freshest parsed fields.
+
+    :param pending: pending delivery dicts, possibly with duplicates.
+    :return: deduplicated list (insertion order of first occurrence).
+    """
+    return list({d.get("deliver_id"): d for d in pending}.values())
+
+
 def _match_and_build(
     deliveries: list[dict[str, Any]],
     resolved_markets: ResolvedMarkets,
@@ -1549,6 +1850,13 @@ def _match_and_build(
 
         market, confidence = _match_delivery(delivery, resolved_markets)
         if market is None:
+            still_pending.append(delivery)
+            continue
+
+        # The market resolved but the subgraph's async file handler has not
+        # indexed the ParsedDelivery yet — wait for it instead of writing a
+        # permanently-invalid row (rows are deduped and never revisited).
+        if _should_defer_unparsed(delivery):
             still_pending.append(delivery)
             continue
 
@@ -1710,6 +2018,20 @@ def _enrich_rows_with_ipfs_metadata(
     if not rows:
         return
 
+    # Rows already versioned via ParsedDelivery.toolHash skip the sampled
+    # IPFS lookup — the subgraph value is exact and per-delivery.
+    unresolved = [r for r in rows if not r.get("tool_version")]
+    prefilled = len(rows) - len(unresolved)
+    if prefilled:
+        log.info(
+            "IPFS enrichment: %d/%d rows already versioned via subgraph",
+            prefilled,
+            len(rows),
+        )
+    rows = unresolved
+    if not rows:
+        return
+
     # Step 1: Batch fetch IPFS hashes + mech addresses from subgraph
     deliver_ids = [r["deliver_id"] for r in rows if r.get("deliver_id")]
     if not deliver_ids:
@@ -1804,6 +2126,10 @@ def process_platform(
     :return: tuple of (rows, still_pending, max_delivery_timestamp,
         max_resolved_timestamp).
     """
+    # 0. Refresh parsed fields for pending entries snapshotted before the
+    #    subgraph's async file handler indexed their payload.
+    pending_deliveries = refresh_unparsed_pending(pending_deliveries, marketplace_url)
+
     # 1. Retry pending deliveries from previous runs
     rows_from_pending: list[dict[str, Any]] = []
     remaining_pending: list[dict[str, Any]] = []
@@ -1850,7 +2176,7 @@ def process_platform(
         ) = _match_and_build(new_deliveries, resolved_markets, existing_ids, platform)
 
     all_rows = rows_from_pending + rows_from_new
-    all_pending = remaining_pending + new_pending
+    all_pending = _dedup_pending(remaining_pending + new_pending)
 
     # 3. Enrich matched rows with IPFS metadata (tool_version, config_hash)
     _enrich_rows_with_ipfs_metadata(all_rows, marketplace_url)

--- a/benchmark/datasets/fetch_replay.py
+++ b/benchmark/datasets/fetch_replay.py
@@ -42,11 +42,14 @@ from pathlib import Path
 from typing import Any, Optional
 
 from benchmark.datasets.fetch_production import (
+    DELIVERS_SCHEMA_PARSED,
     IPFS_FETCH_DELAY,
     MECH_MARKETPLACE_GNOSIS_URL,
     MECH_MARKETPLACE_POLYGON_URL,
     QUESTION_DATA_SEPARATOR,
     classify_category,
+    detect_delivers_schema,
+    extract_delivery_fields,
     fetch_omen_resolved,
     fetch_polymarket_resolved,
     parse_tool_response,
@@ -78,8 +81,45 @@ log = logging.getLogger(__name__)
 HTTP_TIMEOUT = 60
 DEFAULT_BATCH_SIZE = 1000
 
-# Delivery query that includes ipfsHashBytes in the same call
+# Delivery query that includes ipfsHashBytes in the same call. New schema:
+# the IPFS-parsed response/model/toolHash live on the nested ParsedDelivery
+# (valory-xyz/autonolas-subgraph#113).
 DELIVERS_WITH_IPFS_QUERY = """
+{
+  delivers(
+    first: %(first)s
+    skip: %(skip)s
+    orderBy: blockTimestamp
+    orderDirection: desc
+    where: { blockTimestamp_gt: %(timestamp_gt)s }
+  ) {
+    id
+    blockTimestamp
+    parsedDelivery {
+      response
+      model
+      tool
+      toolHash
+    }
+    marketplaceDelivery {
+      ipfsHashBytes
+    }
+    request {
+      id
+      blockTimestamp
+      parsedRequest {
+        questionTitle
+        tool
+        content
+      }
+    }
+  }
+}
+"""
+
+# Legacy variant for endpoints not yet redeployed with ParsedDelivery
+# (selected at runtime via detect_delivers_schema).
+DELIVERS_WITH_IPFS_QUERY_LEGACY = """
 {
   delivers(
     first: %(first)s
@@ -169,9 +209,15 @@ def fetch_deliveries(
     tool_filter: str,
 ) -> list[dict[str, Any]]:
     """Fetch deliveries for a specific tool, including IPFS hashes."""
+    schema = detect_delivers_schema(marketplace_url)
+    query_template = (
+        DELIVERS_WITH_IPFS_QUERY
+        if schema == DELIVERS_SCHEMA_PARSED
+        else DELIVERS_WITH_IPFS_QUERY_LEGACY
+    )
     raw = _paginated_fetch(
         marketplace_url,
-        DELIVERS_WITH_IPFS_QUERY,
+        query_template,
         {"timestamp_gt": timestamp_gt},
     )
 
@@ -210,8 +256,7 @@ def fetch_deliveries(
                 "deliver_id": d["id"],
                 "timestamp": int(d["blockTimestamp"]),
                 "request_timestamp": int(request.get("blockTimestamp") or 0) or None,
-                "model": d.get("model"),
-                "tool_response": d.get("toolResponse"),
+                **extract_delivery_fields(d, schema),
                 "tool": tool,
                 "question_title": question_title,
                 "market_id": market_id,

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -27,9 +27,14 @@ from typing import Any
 import pytest
 from benchmark.datasets.fetch_production import (
     DEDUP_LOOKBACK_DAYS,
+    DELIVERS_SCHEMA_LEGACY,
+    DELIVERS_SCHEMA_PARSED,
+    PARSED_DELIVERY_GRACE_SECONDS,
     PENDING_MAX_AGE_DAYS,
+    SUBGRAPH_UNHANDLED_TYPE,
     ResolvedMarkets,
     _compute_config_hash,
+    _dedup_pending,
     _extract_question_title,
     _load_ids_from_file,
     _make_row_id,
@@ -37,13 +42,17 @@ from benchmark.datasets.fetch_production import (
     _match_delivery,
     _migrate_legacy_log,
     _parse_request_context,
+    _should_defer_unparsed,
     append_rows,
     build_row,
     classify_category,
     daily_log_path,
+    detect_delivers_schema,
+    extract_delivery_fields,
     load_existing_row_ids,
     load_fetch_state,
     parse_tool_response,
+    refresh_unparsed_pending,
     save_fetch_state,
 )
 
@@ -133,6 +142,13 @@ class TestParseToolResponse:
         """Regex path should also reject incoherent probabilities."""
         resp = parse_tool_response('Result: {"p_yes": 0.8, "p_no": 0.8}')
         assert resp["prediction_parse_status"] == "malformed"
+
+    def test_unhandled_type_sentinel_is_malformed(self) -> None:
+        """The subgraph's ``[unhandled type]`` sentinel means the payload was
+        fetched but had no parseable ``result`` — malformed, not missing."""
+        result = parse_tool_response(SUBGRAPH_UNHANDLED_TYPE)
+        assert result["prediction_parse_status"] == "malformed"
+        assert result["p_yes"] is None
 
     def test_unparseable_garbage(self) -> None:
         """Test unparseable garbage input."""
@@ -605,6 +621,50 @@ class TestBuildRow:
         row = build_row(delivery, market, 1.0, "polymarket")
         assert row["latency_s"] is None
         assert row["requested_at"] is None
+
+    def test_tool_hash_from_delivery_sets_version_and_config(self) -> None:
+        """A delivery-level tool_hash (ParsedDelivery.toolHash) populates
+        tool_version and config_hash without IPFS metadata."""
+        delivery = {
+            "deliver_id": "0xghi",
+            "timestamp": 1000,
+            "request_timestamp": None,
+            "model": "gpt-4.1",
+            "tool_response": '{"p_yes": 0.5, "p_no": 0.5}',
+            "tool_hash": "bafytoolhash",
+            "tool": "test-tool",
+            "question_title": "Will something happen?",
+            "market_id": None,
+            "market_prob": None,
+            "market_liquidity_usd": None,
+            "market_close_at": None,
+        }
+        market = {"outcome": False, "resolved_at_ts": 2000}
+        row = build_row(delivery, market, 1.0, "omen")
+        assert row["tool_version"] == "bafytoolhash"
+        assert row["config_hash"] == _compute_config_hash("bafytoolhash", "gpt-4.1")
+
+    def test_tool_hash_takes_priority_over_ipfs_metadata(self) -> None:
+        """The exact per-delivery hash wins over the sampled IPFS metadata."""
+        delivery = {
+            "deliver_id": "0xjkl",
+            "timestamp": 1000,
+            "request_timestamp": None,
+            "model": "gpt-4.1",
+            "tool_response": '{"p_yes": 0.5, "p_no": 0.5}',
+            "tool_hash": "bafyexact",
+            "tool": "test-tool",
+            "question_title": "Will something happen?",
+            "market_id": None,
+            "market_prob": None,
+            "market_liquidity_usd": None,
+            "market_close_at": None,
+        }
+        market = {"outcome": False, "resolved_at_ts": 2000}
+        row = build_row(
+            delivery, market, 1.0, "omen", ipfs_metadata={"tool_hash": "bafysampled"}
+        )
+        assert row["tool_version"] == "bafyexact"
 
 
 # ---------------------------------------------------------------------------
@@ -1198,3 +1258,490 @@ class TestNoScoreFlag:
         assert len(calls) == 1
         rows, _scores, _history = calls[0]
         assert rows == [{"row_id": "r1", "prediction_parse_status": "valid"}]
+
+
+# ---------------------------------------------------------------------------
+# parsedDelivery schema migration (autonolas-subgraph PR #113)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(name="clear_schema_cache", autouse=False)
+def _clear_schema_cache_fixture() -> Any:
+    """Reset the per-URL delivers-schema cache around a test."""
+    # pylint: disable-next=import-outside-toplevel
+    from benchmark.datasets import fetch_production as fp
+
+    fp._DELIVERS_SCHEMA_CACHE.clear()  # pylint: disable=protected-access
+    yield
+    fp._DELIVERS_SCHEMA_CACHE.clear()  # pylint: disable=protected-access
+
+
+class TestExtractDeliveryFields:
+    """Tests for extract_delivery_fields (both schema shapes)."""
+
+    @pytest.mark.parametrize(
+        ("deliver", "schema", "expected"),
+        [
+            # New schema: fields relocate to the nested ParsedDelivery entity.
+            (
+                {
+                    "id": "0x1",
+                    "parsedDelivery": {
+                        "response": '{"p_yes": 0.8, "p_no": 0.2}',
+                        "model": "gpt-4.1",
+                        "tool": "superforcaster",
+                        "toolHash": "bafytool",
+                    },
+                },
+                DELIVERS_SCHEMA_PARSED,
+                {
+                    "model": "gpt-4.1",
+                    "tool_response": '{"p_yes": 0.8, "p_no": 0.2}',
+                    "tool_hash": "bafytool",
+                    "parsed_missing": False,
+                },
+            ),
+            # New schema: sentinel model/toolHash normalize to None; the
+            # sentinel response passes through for parse_tool_response.
+            (
+                {
+                    "id": "0x2",
+                    "parsedDelivery": {
+                        "response": SUBGRAPH_UNHANDLED_TYPE,
+                        "model": SUBGRAPH_UNHANDLED_TYPE,
+                        "tool": SUBGRAPH_UNHANDLED_TYPE,
+                        "toolHash": SUBGRAPH_UNHANDLED_TYPE,
+                    },
+                },
+                DELIVERS_SCHEMA_PARSED,
+                {
+                    "model": None,
+                    "tool_response": SUBGRAPH_UNHANDLED_TYPE,
+                    "tool_hash": None,
+                    "parsed_missing": False,
+                },
+            ),
+            # New schema: ParsedDelivery not yet indexed (async FDS lag).
+            (
+                {"id": "0x3", "parsedDelivery": None},
+                DELIVERS_SCHEMA_PARSED,
+                {
+                    "model": None,
+                    "tool_response": None,
+                    "tool_hash": None,
+                    "parsed_missing": True,
+                },
+            ),
+            # Legacy schema: flat fields, no tool_hash, never "missing".
+            (
+                {
+                    "id": "0x4",
+                    "model": "gpt-4.1",
+                    "toolResponse": '{"p_yes": 0.1, "p_no": 0.9}',
+                },
+                DELIVERS_SCHEMA_LEGACY,
+                {
+                    "model": "gpt-4.1",
+                    "tool_response": '{"p_yes": 0.1, "p_no": 0.9}',
+                    "tool_hash": None,
+                    "parsed_missing": False,
+                },
+            ),
+            # Legacy schema: sentinel model normalizes to None here too.
+            (
+                {"id": "0x5", "model": SUBGRAPH_UNHANDLED_TYPE, "toolResponse": None},
+                DELIVERS_SCHEMA_LEGACY,
+                {
+                    "model": None,
+                    "tool_response": None,
+                    "tool_hash": None,
+                    "parsed_missing": False,
+                },
+            ),
+        ],
+        ids=[
+            "parsed_full",
+            "parsed_sentinels",
+            "parsed_not_indexed",
+            "legacy_full",
+            "legacy_sentinel_model",
+        ],
+    )
+    def test_extraction(
+        self, deliver: dict[str, Any], schema: str, expected: dict[str, Any]
+    ) -> None:
+        """Both shapes map into the same internal delivery keys."""
+        assert extract_delivery_fields(deliver, schema) == expected
+
+
+@pytest.mark.usefixtures("clear_schema_cache")
+class TestDetectDeliversSchema:
+    """Tests for the per-endpoint schema probe with legacy fallback."""
+
+    def test_parsed_schema_when_probe_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A successful parsedDelivery probe selects the new shape."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        monkeypatch.setattr(fp, "_post_graphql", lambda url, payload: {"delivers": []})
+        assert detect_delivers_schema("http://gnosis") == DELIVERS_SCHEMA_PARSED
+
+    def test_legacy_fallback_on_unknown_field_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unknown-field validation error falls back to the legacy shape."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        def fail(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError(
+                "GraphQL errors from http://polygon: Type `Deliver` "
+                "has no field `parsedDelivery`"
+            )
+
+        monkeypatch.setattr(fp, "_post_graphql", fail)
+        assert detect_delivers_schema("http://polygon") == DELIVERS_SCHEMA_LEGACY
+
+    def test_other_graphql_errors_propagate(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-validation errors are not mistaken for a legacy schema."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        def fail(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("GraphQL errors from http://gnosis: store error")
+
+        monkeypatch.setattr(fp, "_post_graphql", fail)
+        with pytest.raises(RuntimeError, match="store error"):
+            detect_delivers_schema("http://gnosis")
+
+    def test_result_is_cached_per_url(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The probe runs once per endpoint per process."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        calls: list[str] = []
+
+        def probe(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            calls.append(url)
+            return {"delivers": []}
+
+        monkeypatch.setattr(fp, "_post_graphql", probe)
+        detect_delivers_schema("http://gnosis")
+        detect_delivers_schema("http://gnosis")
+        assert len(calls) == 1
+
+
+@pytest.mark.usefixtures("clear_schema_cache")
+class TestFetchDeliveriesSchemaShapes:
+    """fetch_deliveries selects the query by detected schema."""
+
+    @staticmethod
+    def _raw_deliver(parsed_delivery: Any) -> dict[str, Any]:
+        """Build a raw subgraph deliver dict with the given parsedDelivery."""
+        return {
+            "id": "0xdeliver",
+            "blockTimestamp": "1700000100",
+            "parsedDelivery": parsed_delivery,
+            "request": {
+                "id": "0xreq",
+                "blockTimestamp": "1700000000",
+                "parsedRequest": {
+                    "questionTitle": "Will X happen?",
+                    "tool": "superforcaster",
+                    "content": "",
+                },
+            },
+        }
+
+    def test_parsed_schema_maps_nested_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """parsedDelivery.response/model/toolHash land on the delivery dict."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        captured: dict[str, Any] = {}
+
+        def fake_paginated(
+            url: str,
+            query: str,
+            entity_key: str,
+            template_vars: dict[str, Any],
+            **_kwargs: Any,
+        ) -> list[dict[str, Any]]:
+            captured["query"] = query
+            return [
+                self._raw_deliver(
+                    {
+                        "response": '{"p_yes": 0.7, "p_no": 0.3}',
+                        "model": "gpt-4.1",
+                        "tool": "superforcaster",
+                        "toolHash": "bafytool",
+                    }
+                )
+            ]
+
+        monkeypatch.setattr(
+            fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
+        )
+        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
+
+        deliveries = fp.fetch_deliveries("http://gnosis", 0)
+        assert "parsedDelivery" in captured["query"]
+        assert "toolResponse" not in captured["query"]
+        assert deliveries[0]["tool_response"] == '{"p_yes": 0.7, "p_no": 0.3}'
+        assert deliveries[0]["model"] == "gpt-4.1"
+        assert deliveries[0]["tool_hash"] == "bafytool"
+        assert deliveries[0]["parsed_missing"] is False
+
+    def test_legacy_schema_maps_flat_fields(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The legacy query keeps working against the polygon subgraph."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        captured: dict[str, Any] = {}
+
+        def fake_paginated(
+            url: str,
+            query: str,
+            entity_key: str,
+            template_vars: dict[str, Any],
+            **_kwargs: Any,
+        ) -> list[dict[str, Any]]:
+            captured["query"] = query
+            raw = self._raw_deliver(None)
+            del raw["parsedDelivery"]
+            raw["model"] = "gpt-4.1"
+            raw["toolResponse"] = '{"p_yes": 0.2, "p_no": 0.8}'
+            return [raw]
+
+        monkeypatch.setattr(
+            fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_LEGACY
+        )
+        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
+
+        deliveries = fp.fetch_deliveries("http://polygon", 0)
+        assert "toolResponse" in captured["query"]
+        assert "parsedDelivery" not in captured["query"]
+        assert deliveries[0]["tool_response"] == '{"p_yes": 0.2, "p_no": 0.8}'
+        assert deliveries[0]["tool_hash"] is None
+
+
+class TestDeferUnparsedDeliveries:
+    """Deliveries without an indexed ParsedDelivery defer instead of
+    becoming permanently-invalid rows."""
+
+    @staticmethod
+    def _delivery(ts: int, parsed_missing: bool) -> dict[str, Any]:
+        """Build a matched-able delivery dict."""
+        return {
+            "deliver_id": f"0x{ts}",
+            "timestamp": ts,
+            "request_timestamp": ts - 10,
+            "model": None,
+            "tool_response": None,
+            "tool": "superforcaster",
+            "question_title": "Will the parsed delivery arrive?",
+            "market_id": "0xmarket",
+            "market_prob": None,
+            "market_liquidity_usd": None,
+            "market_close_at": None,
+            "parsed_missing": parsed_missing,
+        }
+
+    @staticmethod
+    def _markets() -> ResolvedMarkets:
+        """One resolved market matching the delivery by id."""
+        markets = ResolvedMarkets()
+        markets.add(
+            "0xmarket",
+            "will the parsed delivery arrive?",
+            {"outcome": True, "resolved_at_ts": int(time.time())},
+        )
+        return markets
+
+    @pytest.mark.parametrize(
+        ("age_seconds", "parsed_missing", "expect_deferred"),
+        [
+            (3600, True, True),  # recent + unindexed -> wait for the FDS
+            (PARSED_DELIVERY_GRACE_SECONDS + 3600, True, False),  # grace expired
+            (3600, False, False),  # legacy null response -> build immediately
+        ],
+        ids=["recent_unindexed", "grace_expired", "legacy_null"],
+    )
+    def test_deferral(
+        self, age_seconds: int, parsed_missing: bool, expect_deferred: bool
+    ) -> None:
+        """Matched-but-unindexed deliveries defer only within the grace period."""
+        delivery = self._delivery(int(time.time()) - age_seconds, parsed_missing)
+        rows, still_pending, *_ = _match_and_build(
+            [delivery], self._markets(), set(), "omen"
+        )
+        if expect_deferred:
+            assert rows == []
+            assert still_pending == [delivery]
+        else:
+            assert len(rows) == 1
+            assert rows[0]["prediction_parse_status"] == "missing_fields"
+            assert still_pending == []
+
+    def test_should_defer_unparsed_explicit_now(self) -> None:
+        """_should_defer_unparsed honors the injected clock."""
+        delivery = self._delivery(1000, True)
+        assert _should_defer_unparsed(delivery, now=1000 + 60) is True
+        assert (
+            _should_defer_unparsed(
+                delivery, now=1000 + PARSED_DELIVERY_GRACE_SECONDS + 1
+            )
+            is False
+        )
+
+
+@pytest.mark.usefixtures("clear_schema_cache")
+class TestRefreshUnparsedPending:
+    """Pending entries missing a tool response get re-read from the subgraph."""
+
+    @staticmethod
+    def _pending(deliver_id: str, tool_response: Any) -> dict[str, Any]:
+        """Build a minimal pending-store entry."""
+        return {
+            "deliver_id": deliver_id,
+            "timestamp": 1000,
+            "tool_response": tool_response,
+            "model": None,
+            "tool": "superforcaster",
+            "question_title": "q",
+            "parsed_missing": tool_response is None,
+        }
+
+    def test_refreshes_stale_entries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Null-response entries pick up the now-indexed ParsedDelivery."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        monkeypatch.setattr(
+            fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
+        )
+
+        def fake_post(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            assert '"0xstale"' in payload["query"]
+            return {
+                "delivers": [
+                    {
+                        "id": "0xstale",
+                        "parsedDelivery": {
+                            "response": '{"p_yes": 0.6, "p_no": 0.4}',
+                            "model": "gpt-4.1",
+                            "tool": "superforcaster",
+                            "toolHash": "bafytool",
+                        },
+                    }
+                ]
+            }
+
+        monkeypatch.setattr(fp, "_post_graphql", fake_post)
+
+        stale = self._pending("0xstale", None)
+        fresh = self._pending("0xfresh", '{"p_yes": 0.9, "p_no": 0.1}')
+        refreshed = refresh_unparsed_pending([stale, fresh], "http://gnosis")
+
+        by_id = {d["deliver_id"]: d for d in refreshed}
+        assert by_id["0xstale"]["tool_response"] == '{"p_yes": 0.6, "p_no": 0.4}'
+        assert by_id["0xstale"]["tool_hash"] == "bafytool"
+        assert by_id["0xstale"]["parsed_missing"] is False
+        # Untouched entries are passed through unchanged (and not mutated).
+        assert by_id["0xfresh"] is fresh
+        assert stale["tool_response"] is None  # original dict not mutated
+
+    def test_still_unindexed_entries_stay_pending(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Entries whose ParsedDelivery is still absent are kept as-is."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        monkeypatch.setattr(
+            fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
+        )
+        monkeypatch.setattr(
+            fp,
+            "_post_graphql",
+            lambda url, payload: {
+                "delivers": [{"id": "0xstale", "parsedDelivery": None}]
+            },
+        )
+        stale = self._pending("0xstale", None)
+        refreshed = refresh_unparsed_pending([stale], "http://gnosis")
+        assert refreshed == [stale]
+
+    def test_noop_on_legacy_schema(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Legacy endpoints have nothing to refresh from."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        monkeypatch.setattr(
+            fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_LEGACY
+        )
+
+        def boom(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            raise AssertionError("must not query on legacy schema")
+
+        monkeypatch.setattr(fp, "_post_graphql", boom)
+        pending = [self._pending("0xstale", None)]
+        assert refresh_unparsed_pending(pending, "http://polygon") == pending
+
+    def test_noop_without_stale_entries(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No probe and no query when every entry already has a response."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        def boom(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            raise AssertionError("must not query without stale entries")
+
+        monkeypatch.setattr(fp, "_post_graphql", boom)
+        pending = [self._pending("0xfresh", '{"p_yes": 0.9, "p_no": 0.1}')]
+        assert refresh_unparsed_pending(pending, "http://gnosis") == pending
+
+
+class TestDedupPending:
+    """Pending deliveries deduplicate by deliver_id, keeping the freshest."""
+
+    def test_last_copy_wins(self) -> None:
+        """Refetched copies of the same delivery replace stale snapshots."""
+        stale = {"deliver_id": "0xdup", "tool_response": None}
+        fresh = {"deliver_id": "0xdup", "tool_response": '{"p_yes": 0.5}'}
+        other = {"deliver_id": "0xother", "tool_response": None}
+        result = _dedup_pending([stale, other, fresh])
+        assert len(result) == 2
+        by_id = {d["deliver_id"]: d for d in result}
+        assert by_id["0xdup"] is fresh
+        assert by_id["0xother"] is other
+
+
+class TestEnrichmentSkipsPrefilled:
+    """IPFS enrichment skips rows already versioned via ParsedDelivery."""
+
+    def test_all_prefilled_rows_skip_subgraph(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No subgraph or IPFS traffic when every row has tool_version."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        def boom(*_args: Any, **_kwargs: Any) -> Any:
+            raise AssertionError("prefilled rows must not hit the subgraph")
+
+        monkeypatch.setattr(fp, "_fetch_delivery_info", boom)
+        rows = [{"deliver_id": "0x1", "tool_version": "bafyexact", "tool_name": "t"}]
+        fp._enrich_rows_with_ipfs_metadata(  # pylint: disable=protected-access
+            rows, "http://gnosis"
+        )
+        assert rows[0]["tool_version"] == "bafyexact"

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -31,8 +31,8 @@ from benchmark.datasets.fetch_production import (
     DELIVERS_SCHEMA_PARSED,
     PARSED_DELIVERY_GRACE_SECONDS,
     PENDING_MAX_AGE_DAYS,
-    SUBGRAPH_UNHANDLED_TYPE,
     ResolvedMarkets,
+    SUBGRAPH_UNHANDLED_TYPE,
     _compute_config_hash,
     _dedup_pending,
     _extract_question_title,
@@ -144,8 +144,11 @@ class TestParseToolResponse:
         assert resp["prediction_parse_status"] == "malformed"
 
     def test_unhandled_type_sentinel_is_malformed(self) -> None:
-        """The subgraph's ``[unhandled type]`` sentinel means the payload was
-        fetched but had no parseable ``result`` — malformed, not missing."""
+        """Test a malformed unhandled type sentinel.
+
+        The subgraph's ``[unhandled type]`` sentinel means the payload was
+        fetched but had no parseable ``result`` — malformed, not missing.
+        """
         result = parse_tool_response(SUBGRAPH_UNHANDLED_TYPE)
         assert result["prediction_parse_status"] == "malformed"
         assert result["p_yes"] is None
@@ -623,8 +626,11 @@ class TestBuildRow:
         assert row["requested_at"] is None
 
     def test_tool_hash_from_delivery_sets_version_and_config(self) -> None:
-        """A delivery-level tool_hash (ParsedDelivery.toolHash) populates
-        tool_version and config_hash without IPFS metadata."""
+        """Test that the tool hash from delivery sets version and config.
+
+        A delivery-level tool_hash (ParsedDelivery.toolHash) populates
+        tool_version and config_hash without IPFS metadata.
+        """
         delivery = {
             "deliver_id": "0xghi",
             "timestamp": 1000,
@@ -1534,8 +1540,11 @@ class TestFetchDeliveriesSchemaShapes:
 
 
 class TestDeferUnparsedDeliveries:
-    """Deliveries without an indexed ParsedDelivery defer instead of
-    becoming permanently-invalid rows."""
+    """Test that Deliveries without an indexed ParsedDelivery defer.
+
+    Deliveries without an indexed ParsedDelivery defer instead of
+    becoming permanently-invalid rows.
+    """
 
     @staticmethod
     def _delivery(ts: int, parsed_missing: bool) -> dict[str, Any]:
@@ -1584,12 +1593,12 @@ class TestDeferUnparsedDeliveries:
             [delivery], self._markets(), set(), "omen"
         )
         if expect_deferred:
-            assert rows == []
+            assert not rows
             assert still_pending == [delivery]
         else:
             assert len(rows) == 1
             assert rows[0]["prediction_parse_status"] == "missing_fields"
-            assert still_pending == []
+            assert not still_pending
 
     def test_should_defer_unparsed_explicit_now(self) -> None:
         """_should_defer_unparsed honors the injected clock."""
@@ -1696,9 +1705,7 @@ class TestRefreshUnparsedPending:
         pending = [self._pending("0xstale", None)]
         assert refresh_unparsed_pending(pending, "http://polygon") == pending
 
-    def test_noop_without_stale_entries(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_noop_without_stale_entries(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """No probe and no query when every entry already has a response."""
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import requests
 from benchmark.datasets.fetch_production import (
     DEDUP_LOOKBACK_DAYS,
     DELIVERS_SCHEMA_LEGACY,
@@ -1763,6 +1764,38 @@ class TestRefreshUnparsedPending:
         stale = self._pending("0xstale", None)
         refreshed = refresh_unparsed_pending([stale], "http://gnosis")
         assert refreshed == [stale]
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            RuntimeError("GraphQL errors from http://gnosis: store error"),
+            requests.exceptions.ConnectionError("connection refused"),
+        ],
+        ids=["graphql_error", "network_error"],
+    )
+    def test_batch_failure_keeps_stale_entries(
+        self, monkeypatch: pytest.MonkeyPatch, exc: Exception
+    ) -> None:
+        """A failed refresh batch keeps the stale entries unchanged instead
+        of crashing the run or dropping them."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        monkeypatch.setattr(
+            fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
+        )
+
+        def fail(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            raise exc
+
+        monkeypatch.setattr(fp, "_post_graphql", fail)
+
+        stale = self._pending("0xstale", None)
+        pending = [stale]
+        result = refresh_unparsed_pending(pending, "http://gnosis")
+        assert result == pending
+        assert result[0] is stale  # same object — kept, not rebuilt
+        assert stale["tool_response"] is None  # and not mutated
 
     def test_noop_on_legacy_schema(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Legacy endpoints have nothing to refresh from."""

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -916,6 +916,8 @@ class TestDailyLogRotation:
         The delivery cursor can lag by the parsedRequest grace period, so
         rows built within it are refetched and must dedup against the
         files of those days — not just today's.
+
+        :param tmp_path: pytest tmp_path fixture.
         """
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir()

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -1828,6 +1828,54 @@ class TestDedupPending:
         assert refetched.get("deferred_market") is None  # input not mutated
 
 
+class TestPendingSurvivesQuietRun:
+    """The pending store must not be wiped by a run with no resolutions."""
+
+    def test_pending_survives_run_without_resolved_markets(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A run with zero newly-resolved markets must carry the pending
+        store forward, not overwrite it with just the new deliveries."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        old_pending = {
+            "deliver_id": "0xold",
+            # Recent enough to survive the PENDING_MAX_AGE_DAYS prune.
+            "timestamp": int(time.time()) - 3600,
+            "tool_response": '{"p_yes": 0.5, "p_no": 0.5}',  # no refresh needed
+            "question_title": "old pending question",
+            "market_id": None,
+        }
+        new_delivery = {
+            "deliver_id": "0xnew",
+            "timestamp": int(time.time()),
+            "request_timestamp": None,
+            "model": None,
+            "tool_response": None,
+            "tool": "superforcaster",
+            "question_title": "new unmatched question",
+            "market_id": None,
+            "market_prob": None,
+            "market_liquidity_usd": None,
+            "market_close_at": None,
+            "parsed_missing": False,
+        }
+        monkeypatch.setattr(fp, "fetch_deliveries", lambda url, ts: [new_delivery])
+
+        rows, all_pending, _, _ = fp.process_platform(
+            "omen",
+            "http://gnosis",
+            ResolvedMarkets(),  # nothing resolved this run
+            0,
+            set(),
+            [old_pending],
+        )
+        assert not rows
+        pending_ids = {d["deliver_id"] for d in all_pending}
+        assert pending_ids == {"0xold", "0xnew"}
+
+
 class TestEnrichmentSkipsPrefilled:
     """IPFS enrichment skips rows already versioned via ParsedDelivery."""
 

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -1496,7 +1496,8 @@ class TestFetchDeliveriesSchemaShapes:
         )
         monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
 
-        deliveries = fp.fetch_deliveries("http://gnosis", 0)
+        deliveries, unparsed_cap = fp.fetch_deliveries("http://gnosis", 0)
+        assert unparsed_cap is None
         assert "parsedDelivery" in captured["query"]
         assert "toolResponse" not in captured["query"]
         assert deliveries[0]["tool_response"] == '{"p_yes": 0.7, "p_no": 0.3}'
@@ -1532,7 +1533,7 @@ class TestFetchDeliveriesSchemaShapes:
         )
         monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
 
-        deliveries = fp.fetch_deliveries("http://polygon", 0)
+        deliveries, _ = fp.fetch_deliveries("http://polygon", 0)
         assert "toolResponse" in captured["query"]
         assert "parsedDelivery" not in captured["query"]
         assert deliveries[0]["tool_response"] == '{"p_yes": 0.2, "p_no": 0.8}'
@@ -1828,6 +1829,93 @@ class TestDedupPending:
         assert refetched.get("deferred_market") is None  # input not mutated
 
 
+@pytest.mark.usefixtures("clear_schema_cache")
+class TestUnparsedRequestCursorCap:
+    """Delivers skipped for a lagging parsedRequest hold the delivery cursor."""
+
+    @staticmethod
+    def _raw_deliver(ts: int, parsed_request: Any) -> dict[str, Any]:
+        """Build a raw subgraph deliver with the given parsedRequest."""
+        return {
+            "id": f"0x{ts}",
+            "blockTimestamp": str(ts),
+            "parsedDelivery": None,
+            "request": {
+                "id": "0xreq",
+                "blockTimestamp": str(ts - 10),
+                "parsedRequest": parsed_request,
+            },
+        }
+
+    @pytest.mark.parametrize(
+        ("age_seconds", "expect_cap"),
+        [
+            (3600, True),  # recent skip: FDS lag -> hold the cursor
+            (PARSED_DELIVERY_GRACE_SECONDS + 3600, False),  # permanent skip
+        ],
+        ids=["recent_lag", "permanently_unparseable"],
+    )
+    def test_null_parsed_request_caps_cursor_within_grace(
+        self, monkeypatch: pytest.MonkeyPatch, age_seconds: int, expect_cap: bool
+    ) -> None:
+        """Only grace-fresh null-parsedRequest delivers return a cursor cap."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        ts = int(time.time()) - age_seconds
+        monkeypatch.setattr(
+            fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
+        )
+        monkeypatch.setattr(
+            fp,
+            "_paginated_fetch",
+            lambda *a, **k: [self._raw_deliver(ts, None)],
+        )
+        deliveries, cap = fp.fetch_deliveries("http://gnosis", 0)
+        assert deliveries == []
+        assert cap == (ts - 1 if expect_cap else None)
+
+    def test_cap_holds_platform_delivery_cursor(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The cap wins over a newer built row's delivery timestamp."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        now = int(time.time())
+        matched = {
+            "deliver_id": "0xmatched",
+            "timestamp": now,  # newer than the lagging deliver
+            "request_timestamp": now - 10,
+            "model": "gpt-4.1",
+            "tool_response": '{"p_yes": 0.5, "p_no": 0.5}',
+            "tool": "superforcaster",
+            "question_title": "will it match?",
+            "market_id": "0xmarket",
+            "market_prob": None,
+            "market_liquidity_usd": None,
+            "market_close_at": None,
+            "parsed_missing": False,
+        }
+        markets = ResolvedMarkets()
+        markets.add(
+            "0xmarket", "will it match?", {"outcome": True, "resolved_at_ts": now}
+        )
+        lagging_cap = now - 600
+        monkeypatch.setattr(
+            fp, "fetch_deliveries", lambda url, ts: ([matched], lagging_cap)
+        )
+        monkeypatch.setattr(
+            fp, "_enrich_rows_with_ipfs_metadata", lambda rows, url: None
+        )
+
+        rows, _, max_delivery_ts, _ = fp.process_platform(
+            "omen", "http://gnosis", markets, 0, set(), []
+        )
+        assert len(rows) == 1
+        assert max_delivery_ts == lagging_cap
+
+
 class TestPendingSurvivesQuietRun:
     """The pending store must not be wiped by a run with no resolutions."""
 
@@ -1861,7 +1949,9 @@ class TestPendingSurvivesQuietRun:
             "market_close_at": None,
             "parsed_missing": False,
         }
-        monkeypatch.setattr(fp, "fetch_deliveries", lambda url, ts: [new_delivery])
+        monkeypatch.setattr(
+            fp, "fetch_deliveries", lambda url, ts: ([new_delivery], None)
+        )
 
         rows, all_pending, _, _ = fp.process_platform(
             "omen",

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -1511,6 +1511,34 @@ class TestFetchDeliveriesSchemaShapes:
         assert deliveries[0]["tool_hash"] == "bafytool"
         assert deliveries[0]["parsed_missing"] is False
 
+    def test_sentinel_request_tool_maps_to_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sentinel parsedRequest.tool collapses into the "unknown" bucket.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        raw = self._raw_deliver(
+            {
+                "response": '{"p_yes": 0.7, "p_no": 0.3}',
+                "model": "gpt-4.1",
+                "tool": "superforcaster",
+                "toolHash": "bafytool",
+            }
+        )
+        raw["request"]["parsedRequest"]["tool"] = SUBGRAPH_UNHANDLED_TYPE
+
+        monkeypatch.setattr(
+            fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
+        )
+        monkeypatch.setattr(fp, "_paginated_fetch", lambda *a, **k: [raw])
+
+        deliveries, _ = fp.fetch_deliveries("http://gnosis", 0)
+        assert deliveries[0]["tool"] == "unknown"
+
     def test_legacy_schema_maps_flat_fields(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -30,6 +30,7 @@ from benchmark.datasets.fetch_production import (
     DEDUP_LOOKBACK_DAYS,
     DELIVERS_SCHEMA_LEGACY,
     DELIVERS_SCHEMA_PARSED,
+    GRACE_DEDUP_LOOKBACK_DAYS,
     PARSED_DELIVERY_GRACE_SECONDS,
     PENDING_MAX_AGE_DAYS,
     ResolvedMarkets,
@@ -909,22 +910,26 @@ class TestDailyLogRotation:
         lines = output.read_text().strip().split("\n")
         assert len(lines) == 2
 
-    def test_dedup_reads_todays_file_only(self, tmp_path: Path) -> None:
-        """Normal dedup (state_loss=False) reads only today's file."""
+    def test_dedup_covers_grace_window(self, tmp_path: Path) -> None:
+        """Normal dedup reads the grace window of daily files.
 
+        The delivery cursor can lag by the parsedRequest grace period, so
+        rows built within it are refetched and must dedup against the
+        files of those days — not just today's.
+        """
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir()
-        # Write to yesterday's file
-        yesterday = datetime.now(timezone.utc) - timedelta(days=1)
-        old_path = daily_log_path(logs_dir, yesterday)
-        old_path.write_text('{"row_id": "old_row"}\n')
-        # Write to today's file
-        today_path = daily_log_path(logs_dir)
-        today_path.write_text('{"row_id": "today_row"}\n')
+        now = datetime.now(timezone.utc)
+        for i in range(GRACE_DEDUP_LOOKBACK_DAYS + 1):
+            p = daily_log_path(logs_dir, now - timedelta(days=i))
+            p.write_text(f'{{"row_id": "row_day_{i}"}}\n')
 
         ids = load_existing_row_ids(logs_dir, state_loss=False)
-        assert "today_row" in ids
-        assert "old_row" not in ids
+        # Days inside the grace window are deduped ...
+        for i in range(GRACE_DEDUP_LOOKBACK_DAYS):
+            assert f"row_day_{i}" in ids
+        # ... the day just outside it is not.
+        assert f"row_day_{GRACE_DEDUP_LOOKBACK_DAYS}" not in ids
 
     def test_dedup_reads_7_days_on_state_loss(self, tmp_path: Path) -> None:
         """State-loss recovery reads the last DEDUP_LOOKBACK_DAYS files."""

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -1608,8 +1608,10 @@ class TestDeferUnparsedDeliveries:
             assert not still_pending
 
     def test_deferred_entry_builds_after_market_leaves_cursor(self) -> None:
-        """Two-run strand scenario: deferred in run 1, market no longer
-        fetchable in run 2 — the snapshot still produces a row."""
+        """Two-run strand scenario: the snapshot still produces a row.
+
+        Deferred in run 1; the market is no longer fetchable in run 2.
+        """
         now = int(time.time())
         delivery = self._delivery(now - 3600, True)
 
@@ -1637,8 +1639,11 @@ class TestDeferUnparsedDeliveries:
         assert rows[0]["prediction_parse_status"] == "valid"
 
     def test_deferred_entry_expires_after_market_leaves_cursor(self) -> None:
-        """A never-healed deferred entry still surfaces as missing_fields
-        once grace expires, even without a fetchable market."""
+        """A never-healed deferred entry still surfaces as missing_fields.
+
+        Grace expired and the market is no longer fetchable — the snapshot
+        alone must be enough to build the row.
+        """
         now = int(time.time())
         expired = {
             **self._delivery(now - PARSED_DELIVERY_GRACE_SECONDS - 3600, True),
@@ -1658,8 +1663,11 @@ class TestDeferUnparsedDeliveries:
         assert rows[0]["match_confidence"] == 0.8
 
     def test_deferred_entry_redefers_within_grace(self) -> None:
-        """Still-unindexed, still-recent entries keep waiting (with their
-        snapshot) when the market is no longer fetchable."""
+        """Still-unindexed, still-recent entries keep waiting.
+
+        The re-deferred entry retains its market snapshot even when the
+        market is no longer fetchable.
+        """
         now = int(time.time())
         deferred = {
             **self._delivery(now - 3600, True),
@@ -1776,8 +1784,13 @@ class TestRefreshUnparsedPending:
     def test_batch_failure_keeps_stale_entries(
         self, monkeypatch: pytest.MonkeyPatch, exc: Exception
     ) -> None:
-        """A failed refresh batch keeps the stale entries unchanged instead
-        of crashing the run or dropping them."""
+        """A failed refresh batch keeps the stale entries unchanged.
+
+        Neither exception type may crash the run or drop pending entries.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param exc: the exception the refresh query raises.
+        """
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
@@ -1841,8 +1854,11 @@ class TestDedupPending:
         assert by_id["0xother"] is other
 
     def test_deferred_market_snapshot_survives_refetch(self) -> None:
-        """A refetched copy (no snapshot) must not clobber the deferred
-        market snapshot — the market is no longer re-matchable."""
+        """A refetched copy must not clobber the deferred market snapshot.
+
+        The refetched copy has no snapshot of its own, and the market is
+        no longer re-matchable.
+        """
         snapshot = {"outcome": True, "resolved_at_ts": 123, "match_confidence": 1.0}
         deferred = {
             "deliver_id": "0xdup",
@@ -1905,7 +1921,7 @@ class TestUnparsedRequestCursorCap:
             lambda *a, **k: [self._raw_deliver(ts, None)],
         )
         deliveries, cap = fp.fetch_deliveries("http://gnosis", 0)
-        assert deliveries == []
+        assert not deliveries
         assert cap == (ts - 1 if expect_cap else None)
 
     def test_cap_holds_platform_delivery_cursor(
@@ -1955,8 +1971,13 @@ class TestPendingSurvivesQuietRun:
     def test_pending_survives_run_without_resolved_markets(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A run with zero newly-resolved markets must carry the pending
-        store forward, not overwrite it with just the new deliveries."""
+        """A quiet run must carry the pending store forward.
+
+        Zero newly-resolved markets must not overwrite the state with
+        just the new deliveries.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -1594,11 +1594,85 @@ class TestDeferUnparsedDeliveries:
         )
         if expect_deferred:
             assert not rows
-            assert still_pending == [delivery]
+            # The deferred entry snapshots the matched market so it can
+            # still build once the market leaves the resolution cursor.
+            assert len(still_pending) == 1
+            snapshot = still_pending[0]["deferred_market"]
+            assert snapshot["outcome"] is True
+            assert snapshot["match_confidence"] == 1.0
         else:
             assert len(rows) == 1
             assert rows[0]["prediction_parse_status"] == "missing_fields"
             assert not still_pending
+
+    def test_deferred_entry_builds_after_market_leaves_cursor(self) -> None:
+        """Two-run strand scenario: deferred in run 1, market no longer
+        fetchable in run 2 — the snapshot still produces a row."""
+        now = int(time.time())
+        delivery = self._delivery(now - 3600, True)
+
+        # Run 1: matched but unindexed -> deferred with market snapshot.
+        rows, still_pending, *_ = _match_and_build(
+            [delivery], self._markets(), set(), "omen"
+        )
+        assert not rows
+        deferred = still_pending[0]
+
+        # Run 2: the refresh healed the parsed fields; the resolved-markets
+        # cursor has advanced, so the market is gone from the fetch.
+        healed = {
+            **deferred,
+            "tool_response": '{"p_yes": 0.7, "p_no": 0.3}',
+            "parsed_missing": False,
+        }
+        rows, still_pending, *_ = _match_and_build(
+            [healed], ResolvedMarkets(), set(), "omen"
+        )
+        assert not still_pending
+        assert len(rows) == 1
+        assert rows[0]["p_yes"] == 0.7
+        assert rows[0]["final_outcome"] is True
+        assert rows[0]["prediction_parse_status"] == "valid"
+
+    def test_deferred_entry_expires_after_market_leaves_cursor(self) -> None:
+        """A never-healed deferred entry still surfaces as missing_fields
+        once grace expires, even without a fetchable market."""
+        now = int(time.time())
+        expired = {
+            **self._delivery(now - PARSED_DELIVERY_GRACE_SECONDS - 3600, True),
+            "deferred_market": {
+                "outcome": False,
+                "resolved_at_ts": now - PARSED_DELIVERY_GRACE_SECONDS,
+                "match_confidence": 0.8,
+            },
+        }
+        rows, still_pending, *_ = _match_and_build(
+            [expired], ResolvedMarkets(), set(), "omen"
+        )
+        assert not still_pending
+        assert len(rows) == 1
+        assert rows[0]["prediction_parse_status"] == "missing_fields"
+        assert rows[0]["final_outcome"] is False
+        assert rows[0]["match_confidence"] == 0.8
+
+    def test_deferred_entry_redefers_within_grace(self) -> None:
+        """Still-unindexed, still-recent entries keep waiting (with their
+        snapshot) when the market is no longer fetchable."""
+        now = int(time.time())
+        deferred = {
+            **self._delivery(now - 3600, True),
+            "deferred_market": {
+                "outcome": True,
+                "resolved_at_ts": now,
+                "match_confidence": 1.0,
+            },
+        }
+        rows, still_pending, *_ = _match_and_build(
+            [deferred], ResolvedMarkets(), set(), "omen"
+        )
+        assert not rows
+        assert len(still_pending) == 1
+        assert still_pending[0]["deferred_market"]["outcome"] is True
 
     def test_should_defer_unparsed_explicit_now(self) -> None:
         """_should_defer_unparsed honors the injected clock."""
@@ -1731,6 +1805,27 @@ class TestDedupPending:
         by_id = {d["deliver_id"]: d for d in result}
         assert by_id["0xdup"] is fresh
         assert by_id["0xother"] is other
+
+    def test_deferred_market_snapshot_survives_refetch(self) -> None:
+        """A refetched copy (no snapshot) must not clobber the deferred
+        market snapshot — the market is no longer re-matchable."""
+        snapshot = {"outcome": True, "resolved_at_ts": 123, "match_confidence": 1.0}
+        deferred = {
+            "deliver_id": "0xdup",
+            "tool_response": None,
+            "deferred_market": snapshot,
+        }
+        refetched = {
+            "deliver_id": "0xdup",
+            "tool_response": '{"p_yes": 0.5, "p_no": 0.5}',
+        }
+        result = _dedup_pending([deferred, refetched])
+        assert len(result) == 1
+        merged = result[0]
+        # Fresh parsed fields win; the snapshot is carried over.
+        assert merged["tool_response"] == '{"p_yes": 0.5, "p_no": 0.5}'
+        assert merged["deferred_market"] == snapshot
+        assert refetched.get("deferred_market") is None  # input not mutated
 
 
 class TestEnrichmentSkipsPrefilled:


### PR DESCRIPTION
The marketplace subgraph's new IPFS indexing ([autonolas-subgraph#113](https://github.com/valory-xyz/autonolas-subgraph/pull/113)) removes the flat Deliver.model/toolResponse fields; the parsed payload now lives on the nested `ParsedDelivery` entity.