### PR TITLE
Self-healing backfill for shard rows missing their tool response

### DIFF
--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -113,13 +113,17 @@ jobs:
       # This step requeries the marketplace subgraphs for such rows and
       # repairs the shards in place once the data exists; when nothing is
       # repairable yet the step is a no-op (repaired=0). It writes
-      # repaired=<n> to the step output, which the force-rebuild path
-      # below consumes.
+      # repaired=<n> AND backfill_error=<true|false> to the step output,
+      # both consumed by the force-rebuild path below (backfill_error=true
+      # means a batch/probe/shard-rewrite failed partway, so some rows may
+      # have been repaired but we cannot tell which -> force a rebuild).
+      # --max-shard-age-days bounds the scan so legacy/unhealable shards are
+      # not re-globbed and re-queried forever as logs/ grows.
       # continue-on-error: a subgraph failure must not kill the flywheel.
       - name: Backfill null tool responses (self-healing)
         id: backfill
         continue-on-error: true
-        run: python -m benchmark.datasets.backfill_responses
+        run: python -m benchmark.datasets.backfill_responses --max-shard-age-days 120
 
       # Tournament-scored data from the tournament-run job. Used as input
       # to scorer (--tournament-input) so the per-(tool, version, mode)
@@ -144,8 +148,12 @@ jobs:
       # were previously counted as invalid inside scored_row_ids.json and
       # the scores.json accumulators, so only a full rebuild rescores them
       # -- an incremental update would dedup them away as already-scored.
+      # backfill_error=='true' also forces the rebuild: the backfill may
+      # have persisted some repairs before failing partway, and we cannot
+      # tell which rows changed, so a full rebuild is the only safe way to
+      # rescore them.
       - name: Clear cached scores (force rebuild)
-        if: github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0
+        if: github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0 || steps.backfill.outputs.backfill_error == 'true'
         run: |
           rm -f benchmark/results/scores.json \
                 benchmark/results/scores_history.jsonl \
@@ -158,14 +166,16 @@ jobs:
       # Inputs routed through env (not ${{ }} interpolation in the shell script)
       # to prevent workflow_dispatch shell injection — ${{ }} is macro-expanded
       # before the shell runs, so malicious input would become part of the script.
-      # FORCE_REBUILD also flips to true when the backfill repaired rows,
-      # so this step and the Score step stay in lockstep with the wipe
-      # above (otherwise the inline fast-path would recreate scores.json
-      # from today's rows only and the Score step would skip the rebuild).
+      # FORCE_REBUILD also flips to true when the backfill repaired rows or
+      # errored partway, so this step and the Score step stay in lockstep
+      # with the wipe above (otherwise the inline fast-path would recreate
+      # scores.json from today's rows only and the Score step would skip the
+      # rebuild). The condition must stay identical to the wipe step's and
+      # the Score step's FORCE_REBUILD.
       - name: Fetch production data
         env:
           INPUT_LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '7' }}
-          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0) && 'true' || 'false' }}
+          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0 || steps.backfill.outputs.backfill_error == 'true') && 'true' || 'false' }}
         run: |
           NO_SCORE_FLAG=""
           if [ "$FORCE_REBUILD" = "true" ]; then
@@ -183,7 +193,7 @@ jobs:
       # the backfill step repaired rows (see the wipe step above for why).
       - name: Score
         env:
-          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0) && 'true' || 'false' }}
+          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0 || steps.backfill.outputs.backfill_error == 'true') && 'true' || 'false' }}
         run: |
           TOURNAMENT_FLAG=""
           if [ -f benchmark/results/tournament_scored.jsonl ]; then

--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -115,8 +115,13 @@ jobs:
       # repairable yet the step is a no-op (repaired=0). It writes
       # repaired=<n> AND backfill_error=<true|false> to the step output,
       # both consumed by the force-rebuild path below (backfill_error=true
-      # means a batch/probe/shard-rewrite failed partway, so some rows may
-      # have been repaired but we cannot tell which -> force a rebuild).
+      # means a batch/probe/shard-rewrite failed partway, or a shard was
+      # unreadable/undecodable, so some rows may have been repaired but we
+      # cannot tell which -> force a rebuild). skipped_lines=<n> is also
+      # emitted (total malformed lines quarantined) for the flywheel
+      # summary. A hard kill of this step (timeout/OOM/cancel) writes no
+      # outputs at all; the force-rebuild path additionally gates on
+      # steps.backfill.outcome == 'failure' to cover that case.
       # --max-shard-age-days bounds the scan so legacy/unhealable shards are
       # not re-globbed and re-queried forever as logs/ grows.
       # continue-on-error: a subgraph failure must not kill the flywheel.
@@ -149,11 +154,20 @@ jobs:
       # the scores.json accumulators, so only a full rebuild rescores them
       # -- an incremental update would dedup them away as already-scored.
       # backfill_error=='true' also forces the rebuild: the backfill may
-      # have persisted some repairs before failing partway, and we cannot
-      # tell which rows changed, so a full rebuild is the only safe way to
-      # rescore them.
+      # have persisted some repairs before failing partway (a subgraph
+      # batch/probe failure, an unreadable/undecodable shard, or a shard
+      # rewrite), and we cannot tell which rows changed, so a full rebuild
+      # is the only safe way to rescore them.
+      # steps.backfill.outcome == 'failure' is a THIRD trigger for the
+      # harness-boundary kills that custom outputs cannot report: a timeout,
+      # OOM, cancel, or a pre-try argparse exit terminates the process
+      # before backfill_error/repaired are ever written, and an unset output
+      # reads as '' (failing both '> 0' and "== 'true'"). GitHub Actions
+      # always sets .outcome even under continue-on-error, so gating on it
+      # too means a crash after partial repairs still forces the rebuild
+      # rather than leaving the scores permanently desynced.
       - name: Clear cached scores (force rebuild)
-        if: github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0 || steps.backfill.outputs.backfill_error == 'true'
+        if: github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0 || steps.backfill.outputs.backfill_error == 'true' || steps.backfill.outcome == 'failure'
         run: |
           rm -f benchmark/results/scores.json \
                 benchmark/results/scores_history.jsonl \
@@ -166,16 +180,17 @@ jobs:
       # Inputs routed through env (not ${{ }} interpolation in the shell script)
       # to prevent workflow_dispatch shell injection — ${{ }} is macro-expanded
       # before the shell runs, so malicious input would become part of the script.
-      # FORCE_REBUILD also flips to true when the backfill repaired rows or
-      # errored partway, so this step and the Score step stay in lockstep
-      # with the wipe above (otherwise the inline fast-path would recreate
-      # scores.json from today's rows only and the Score step would skip the
-      # rebuild). The condition must stay identical to the wipe step's and
-      # the Score step's FORCE_REBUILD.
+      # FORCE_REBUILD also flips to true when the backfill repaired rows,
+      # errored partway, or was hard-killed at the harness boundary
+      # (outcome == 'failure'), so this step and the Score step stay in
+      # lockstep with the wipe above (otherwise the inline fast-path would
+      # recreate scores.json from today's rows only and the Score step would
+      # skip the rebuild). The condition must stay identical to the wipe
+      # step's and the Score step's FORCE_REBUILD.
       - name: Fetch production data
         env:
           INPUT_LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '7' }}
-          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0 || steps.backfill.outputs.backfill_error == 'true') && 'true' || 'false' }}
+          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0 || steps.backfill.outputs.backfill_error == 'true' || steps.backfill.outcome == 'failure') && 'true' || 'false' }}
         run: |
           NO_SCORE_FLAG=""
           if [ "$FORCE_REBUILD" = "true" ]; then
@@ -193,7 +208,7 @@ jobs:
       # the backfill step repaired rows (see the wipe step above for why).
       - name: Score
         env:
-          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0 || steps.backfill.outputs.backfill_error == 'true') && 'true' || 'false' }}
+          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0 || steps.backfill.outputs.backfill_error == 'true' || steps.backfill.outcome == 'failure') && 'true' || 'false' }}
         run: |
           TOURNAMENT_FLAG=""
           if [ -f benchmark/results/tournament_scored.jsonl ]; then

--- a/.github/workflows/benchmark_flywheel.yaml
+++ b/.github/workflows/benchmark_flywheel.yaml
@@ -105,6 +105,22 @@ jobs:
           if_no_artifact_found: warn
         continue-on-error: true
 
+      # Self-healing backfill: delivery rows are occasionally written to
+      # the daily shards before their response is available upstream
+      # (indexer lag or transient subgraph failures), landing with
+      # p_yes=null and prediction_parse_status="missing_fields". The fetch
+      # is append-only (row_id dedup), so those rows are never re-fetched.
+      # This step requeries the marketplace subgraphs for such rows and
+      # repairs the shards in place once the data exists; when nothing is
+      # repairable yet the step is a no-op (repaired=0). It writes
+      # repaired=<n> to the step output, which the force-rebuild path
+      # below consumes.
+      # continue-on-error: a subgraph failure must not kill the flywheel.
+      - name: Backfill null tool responses (self-healing)
+        id: backfill
+        continue-on-error: true
+        run: python -m benchmark.datasets.backfill_responses
+
       # Tournament-scored data from the tournament-run job. Used as input
       # to scorer (--tournament-input) so the per-(tool, version, mode)
       # breakdown shows up in the unified report.
@@ -124,8 +140,12 @@ jobs:
       # persisted so deleting it here was a no-op; now that it rides in
       # the artifact, force_rebuild must explicitly clear it or the
       # rebuild runs against an empty log dir.
+      # Also fires when the backfill step above repaired rows: those rows
+      # were previously counted as invalid inside scored_row_ids.json and
+      # the scores.json accumulators, so only a full rebuild rescores them
+      # -- an incremental update would dedup them away as already-scored.
       - name: Clear cached scores (force rebuild)
-        if: github.event.inputs.force_rebuild == 'true'
+        if: github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0
         run: |
           rm -f benchmark/results/scores.json \
                 benchmark/results/scores_history.jsonl \
@@ -138,10 +158,14 @@ jobs:
       # Inputs routed through env (not ${{ }} interpolation in the shell script)
       # to prevent workflow_dispatch shell injection — ${{ }} is macro-expanded
       # before the shell runs, so malicious input would become part of the script.
+      # FORCE_REBUILD also flips to true when the backfill repaired rows,
+      # so this step and the Score step stay in lockstep with the wipe
+      # above (otherwise the inline fast-path would recreate scores.json
+      # from today's rows only and the Score step would skip the rebuild).
       - name: Fetch production data
         env:
           INPUT_LOOKBACK_DAYS: ${{ github.event.inputs.lookback_days || '7' }}
-          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild }}
+          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0) && 'true' || 'false' }}
         run: |
           NO_SCORE_FLAG=""
           if [ "$FORCE_REBUILD" = "true" ]; then
@@ -155,10 +179,11 @@ jobs:
       # missing (first run, or prior run crashed before fetch's inline
       # update), or (b) force_rebuild=true (explicit full rebuild). On
       # normal runs the fast path in fetch_production already produced
-      # scores.json, and this step is a no-op.
+      # scores.json, and this step is a no-op. The rebuild also fires when
+      # the backfill step repaired rows (see the wipe step above for why).
       - name: Score
         env:
-          FORCE_REBUILD: ${{ github.event.inputs.force_rebuild }}
+          FORCE_REBUILD: ${{ (github.event.inputs.force_rebuild == 'true' || steps.backfill.outputs.repaired > 0) && 'true' || 'false' }}
         run: |
           TOURNAMENT_FLAG=""
           if [ -f benchmark/results/tournament_scored.jsonl ]; then

--- a/benchmark/datasets/backfill_responses.py
+++ b/benchmark/datasets/backfill_responses.py
@@ -1,0 +1,457 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""
+Self-healing backfill for production-log rows with missing tool responses.
+
+Delivery rows are occasionally written to the daily shards before their
+response is available upstream (indexer lag or transient subgraph
+failures): the fetch reads the prediction from the marketplace subgraph,
+so such rows land with ``p_yes=null`` and
+``prediction_parse_status="missing_fields"``. The fetch is append-only
+(row_id dedup), so those rows are never revisited and the gap would be
+permanent. This module re-queries such rows and repairs them in place
+once the data exists, making the pipeline self-healing.
+
+Complementary to ``fetch_production.refresh_unparsed_pending``, which
+refreshes deliveries that have NOT been written to shards yet (the
+pending store); this module repairs rows ALREADY written to shards.
+
+Design:
+  1. Scan all shards in the logs directory for rows with
+     ``prediction_parse_status == "missing_fields"`` and a ``deliver_id``
+     (any platform -- the repair is platform-generic).
+  2. Batch-requery each platform's marketplace subgraph for those deliver
+     ids, using the query shape the endpoint supports (nested
+     ParsedDelivery vs legacy flat fields, probed once per endpoint via
+     ``fetch_production.detect_delivers_schema``).
+  3. Rows whose response is now available are re-parsed with the same
+     parser the fetcher uses; rows that parse to a valid prediction are
+     updated in place (p_yes, p_no, parse status, confidence when parsed).
+     Rows still missing or still unparseable stay untouched.
+  4. Each modified shard is rewritten atomically (tmp file + os.replace).
+
+Idempotent: repaired rows no longer carry ``missing_fields``, so a second
+run finds nothing to repair; running while the upstream data is still
+missing is a no-op; healthy data is never touched. Exit code is always 0
+-- repairing nothing is success -- so the daily flywheel can run it
+unconditionally.
+
+Usage:
+    python -m benchmark.datasets.backfill_responses
+    python -m benchmark.datasets.backfill_responses --logs-dir benchmark/datasets/logs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+from benchmark.datasets.fetch_production import (
+    DELIVERS_PARSED_BY_IDS_QUERY,
+    DELIVERS_SCHEMA_PARSED,
+    HTTP_TIMEOUT,
+    LOGS_DIR,
+    MECH_MARKETPLACE_GNOSIS_URL,
+    MECH_MARKETPLACE_POLYGON_URL,
+    detect_delivers_schema,
+    extract_delivery_fields,
+    parse_tool_response,
+)
+from benchmark.datasets.subgraph import post_graphql
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# Batch size for the delivers-by-ids requery. Deliver ids are long hex
+# strings, so keep the query body well below subgraph proxy limits.
+BACKFILL_BATCH_SIZE = 100
+
+# Only rows written with this parse status are repair candidates: it is
+# exactly what fetch_production records when the tool response is
+# null/empty. "malformed" and "error" rows carried a real response and
+# are not recoverable by requerying.
+CANDIDATE_PARSE_STATUS = "missing_fields"
+
+# Platform (as recorded in each row) -> marketplace subgraph endpoint.
+# The URLs come from fetch_production and therefore respect the same
+# env-var overrides (MECH_MARKETPLACE_GNOSIS_URL / _POLYGON_URL).
+PLATFORM_MARKETPLACE_URLS: dict[str, str] = {
+    "omen": MECH_MARKETPLACE_GNOSIS_URL,
+    "polymarket": MECH_MARKETPLACE_POLYGON_URL,
+}
+
+# ---------------------------------------------------------------------------
+# GraphQL query
+# ---------------------------------------------------------------------------
+
+# Legacy-schema counterpart of fetch_production.DELIVERS_PARSED_BY_IDS_QUERY:
+# re-read the flat Deliver fields for specific deliveries on endpoints that
+# do not expose the nested ParsedDelivery entity. The field shape mirrors
+# fetch_production.DELIVERS_QUERY_LEGACY so the result feeds
+# extract_delivery_fields unchanged.
+DELIVERS_LEGACY_BY_IDS_QUERY = """
+{
+  delivers(
+    first: %(first)s
+    where: { id_in: [%(ids)s] }
+  ) {
+    id
+    model
+    toolResponse
+  }
+}
+"""
+
+# ---------------------------------------------------------------------------
+# Subgraph helpers
+# ---------------------------------------------------------------------------
+
+
+def _post_graphql(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Post a GraphQL query and return the JSON response data.
+
+    Thin wrapper over the shared :func:`benchmark.datasets.subgraph.post_graphql`
+    retry helper, kept as a module-level seam for tests.
+
+    :param url: subgraph endpoint URL.
+    :param payload: GraphQL request body (``{"query": ...}``).
+    :return: the ``data`` object from the GraphQL response.
+    """
+    return post_graphql(url, payload, timeout=HTTP_TIMEOUT)
+
+
+def fetch_tool_responses(
+    marketplace_url: str,
+    deliver_ids: list[str],
+    batch_size: int = BACKFILL_BATCH_SIZE,
+) -> dict[str, Optional[str]]:
+    """Requery the marketplace subgraph for tool responses by deliver id.
+
+    The endpoint's delivers shape (nested ParsedDelivery vs legacy flat
+    fields) is probed once via :func:`detect_delivers_schema`, and every
+    returned deliver is mapped through :func:`extract_delivery_fields`, so
+    a future schema change only needs handling in ``fetch_production``.
+    Deliveries whose parsed payload has not been indexed upstream yet are
+    omitted from the result.
+
+    Queries in batches. A failed probe or batch is logged and skipped (its
+    rows simply stay unrepaired until the next run) so a subgraph failure
+    can never fail the backfill.
+
+    :param marketplace_url: subgraph endpoint URL.
+    :param deliver_ids: deliver ids to look up.
+    :param batch_size: max ids per GraphQL request.
+    :return: mapping of deliver_id to tool response (possibly None).
+    """
+    responses: dict[str, Optional[str]] = {}
+    try:
+        schema = detect_delivers_schema(marketplace_url)
+    except Exception as e:  # pylint: disable=broad-except
+        log.warning(
+            "Delivers schema probe failed against %s: %s -- skipping",
+            marketplace_url,
+            e,
+        )
+        return responses
+    query_template = (
+        DELIVERS_PARSED_BY_IDS_QUERY
+        if schema == DELIVERS_SCHEMA_PARSED
+        else DELIVERS_LEGACY_BY_IDS_QUERY
+    )
+    for i in range(0, len(deliver_ids), batch_size):
+        batch = deliver_ids[i : i + batch_size]
+        ids_str = ", ".join(f'"{did}"' for did in batch)
+        query = query_template % {"first": len(batch), "ids": ids_str}
+        try:
+            data = _post_graphql(marketplace_url, {"query": query})
+        except Exception as e:  # pylint: disable=broad-except
+            log.warning(
+                "Backfill batch of %d ids failed against %s: %s",
+                len(batch),
+                marketplace_url,
+                e,
+            )
+            continue
+        for deliver in data.get("delivers", []):
+            fields = extract_delivery_fields(deliver, schema)
+            if fields["parsed_missing"]:
+                # Parsed payload not indexed upstream yet -- leave the row
+                # a candidate for a future run.
+                continue
+            responses[deliver["id"]] = fields["tool_response"]
+    return responses
+
+
+# ---------------------------------------------------------------------------
+# Shard scanning & repair
+# ---------------------------------------------------------------------------
+
+
+def _load_shard(path: Path) -> list[dict[str, Any]]:
+    """Load all rows from one JSONL shard, skipping blank lines.
+
+    :param path: path to the shard file.
+    :return: list of row dicts in file order.
+    """
+    rows: list[dict[str, Any]] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                rows.append(json.loads(line))
+    return rows
+
+
+def _is_candidate(row: dict[str, Any]) -> bool:
+    """Return whether a row is a repair candidate.
+
+    :param row: production log row.
+    :return: True when the row lost its response and carries a deliver_id.
+    """
+    return bool(
+        row.get("prediction_parse_status") == CANDIDATE_PARSE_STATUS
+        and row.get("deliver_id")
+    )
+
+
+def repair_row(row: dict[str, Any], tool_response: Optional[str]) -> bool:
+    """Re-parse a requeried toolResponse and repair the row in place.
+
+    Only a response that parses to a *valid* prediction mutates the row;
+    still-null or still-unparseable responses leave it untouched, so the
+    row stays a candidate for future runs.
+
+    :param row: production log row (mutated in place on success).
+    :param tool_response: requeried toolResponse, possibly still None.
+    :return: True when the row was repaired.
+    """
+    if not tool_response:
+        return False
+    parsed = parse_tool_response(tool_response)
+    if parsed["prediction_parse_status"] != "valid":
+        return False
+    row["p_yes"] = parsed["p_yes"]
+    row["p_no"] = parsed["p_no"]
+    row["prediction_parse_status"] = parsed["prediction_parse_status"]
+    if parsed["confidence"] is not None:
+        row["confidence"] = parsed["confidence"]
+    return True
+
+
+def _rewrite_shard_atomic(path: Path, rows: list[dict[str, Any]]) -> None:
+    """Atomically rewrite a shard: temp file + os.replace.
+
+    Mirrors the atomic-rewrite pattern used by
+    ``score_tournament._update_predictions_file`` so a crash mid-write
+    can never corrupt a shard.
+
+    :param path: shard path to replace.
+    :param rows: full row list to write, in order.
+    """
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as tmp:
+            for row in rows:
+                tmp.write(json.dumps(row, ensure_ascii=False) + "\n")
+        os.replace(tmp_path, str(path))
+    except BaseException:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+def backfill(
+    logs_dir: Path,
+    batch_size: int = BACKFILL_BATCH_SIZE,
+) -> dict[str, Any]:
+    """Scan all shards, requery lost responses, and repair rows in place.
+
+    :param logs_dir: directory containing the daily JSONL shards.
+    :param batch_size: max deliver ids per GraphQL request.
+    :return: summary dict with ``shards_scanned``, ``candidates``,
+        ``repaired``, and a per-platform breakdown.
+    """
+    summary: dict[str, Any] = {
+        "shards_scanned": 0,
+        "candidates": 0,
+        "repaired": 0,
+        "platforms": {},
+    }
+    if not logs_dir.is_dir():
+        log.info("Logs dir %s does not exist -- nothing to backfill", logs_dir)
+        return summary
+
+    # Pass 1: scan shards, collect candidate deliver ids per platform.
+    shards: list[tuple[Path, list[dict[str, Any]]]] = []
+    ids_by_platform: dict[str, list[str]] = {}
+    for path in sorted(logs_dir.glob("*.jsonl")):
+        rows = _load_shard(path)
+        shards.append((path, rows))
+        summary["shards_scanned"] += 1
+        for row in rows:
+            if not _is_candidate(row):
+                continue
+            summary["candidates"] += 1
+            platform = row.get("platform") or "unknown"
+            plat_stats = summary["platforms"].setdefault(
+                platform, {"candidates": 0, "repaired": 0}
+            )
+            plat_stats["candidates"] += 1
+            if platform in PLATFORM_MARKETPLACE_URLS:
+                ids_by_platform.setdefault(platform, []).append(row["deliver_id"])
+
+    unknown = set(summary["platforms"]) - set(PLATFORM_MARKETPLACE_URLS)
+    if unknown:
+        log.warning("No marketplace URL for platform(s) %s -- skipped", sorted(unknown))
+
+    # Pass 2: batch-requery each platform's marketplace subgraph.
+    responses: dict[str, dict[str, Optional[str]]] = {}
+    for platform, deliver_ids in ids_by_platform.items():
+        unique_ids = sorted(set(deliver_ids))
+        log.info(
+            "%s: requerying %d deliver ids in batches of %d",
+            platform,
+            len(unique_ids),
+            batch_size,
+        )
+        responses[platform] = fetch_tool_responses(
+            PLATFORM_MARKETPLACE_URLS[platform], unique_ids, batch_size
+        )
+
+    # Pass 3: repair rows in place; rewrite only shards that changed.
+    for path, rows in shards:
+        shard_repaired = 0
+        for row in rows:
+            if not _is_candidate(row):
+                continue
+            platform = row.get("platform") or "unknown"
+            tool_response = responses.get(platform, {}).get(row["deliver_id"])
+            if repair_row(row, tool_response):
+                shard_repaired += 1
+                summary["platforms"][platform]["repaired"] += 1
+        if shard_repaired:
+            _rewrite_shard_atomic(path, rows)
+            summary["repaired"] += shard_repaired
+            log.info("Repaired %d rows in %s", shard_repaired, path.name)
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _log_summary(summary: dict[str, Any]) -> None:
+    """Log the backfill summary.
+
+    :param summary: summary dict from :func:`backfill`.
+    """
+    log.info(
+        "Backfill summary: %d shards scanned, %d candidate rows, %d repaired",
+        summary["shards_scanned"],
+        summary["candidates"],
+        summary["repaired"],
+    )
+    for platform, stats in sorted(summary["platforms"].items()):
+        log.info(
+            "  %s: %d candidates, %d repaired",
+            platform,
+            stats["candidates"],
+            stats["repaired"],
+        )
+
+
+def _emit_repaired_output(repaired: int) -> None:
+    """Emit the repaired count for workflow consumption.
+
+    Prints a ``repaired=<n>`` line to stdout and appends the same line to
+    ``$GITHUB_OUTPUT`` when that env var is set, so the flywheel step can
+    gate the force-rebuild path on it.
+
+    :param repaired: number of rows repaired this run.
+    """
+    line = f"repaired={repaired}"
+    print(line)
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with open(github_output, "a", encoding="utf-8") as f:
+            f.write(line + "\n")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser for the backfill.
+
+    :return: configured ArgumentParser.
+    """
+    parser = argparse.ArgumentParser(
+        description="Repair production-log rows whose toolResponse was lost.",
+    )
+    parser.add_argument(
+        "--logs-dir",
+        type=Path,
+        default=LOGS_DIR,
+        help="Directory containing daily production log shards",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=BACKFILL_BATCH_SIZE,
+        help="Max deliver ids per subgraph request",
+    )
+    return parser
+
+
+def main() -> None:
+    """CLI entry point. Always exits 0: repairing nothing is success."""
+    args = _build_arg_parser().parse_args()
+    repaired = 0
+    try:
+        summary = backfill(args.logs_dir, args.batch_size)
+        repaired = summary["repaired"]
+        _log_summary(summary)
+    except Exception:
+        log.exception("Backfill failed (non-fatal: the flywheel must not block)")
+    _emit_repaired_output(repaired)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/datasets/backfill_responses.py
+++ b/benchmark/datasets/backfill_responses.py
@@ -33,24 +33,43 @@ refreshes deliveries that have NOT been written to shards yet (the
 pending store); this module repairs rows ALREADY written to shards.
 
 Design:
-  1. Scan all shards in the logs directory for rows with
+  1. Scan all shards in the logs directory (bounded by
+     ``--max-shard-age-days`` so legacy/unhealable shards are not
+     re-globbed forever as ``logs/`` grows) for rows with
      ``prediction_parse_status == "missing_fields"`` and a ``deliver_id``
-     (any platform -- the repair is platform-generic).
+     (any platform -- the repair is platform-generic). Malformed JSONL
+     lines are skipped with a warning (a bad line -- exactly the failure
+     class this module heals -- must never abort the scan) and an
+     unreadable shard is isolated so it cannot sink the run.
   2. Batch-requery each platform's marketplace subgraph for those deliver
      ids, using the query shape the endpoint supports (nested
      ParsedDelivery vs legacy flat fields, probed once per endpoint via
      ``fetch_production.detect_delivers_schema``).
   3. Rows whose response is now available are re-parsed with the same
      parser the fetcher uses; rows that parse to a valid prediction are
-     updated in place (p_yes, p_no, parse status, confidence when parsed).
-     Rows still missing or still unparseable stay untouched.
-  4. Each modified shard is rewritten atomically (tmp file + os.replace).
+     updated in place (p_yes, p_no, parse status, confidence when parsed,
+     plus model/tool_version/config_hash when the row lacked them, so a
+     repaired row buckets correctly rather than under "unknown"). Rows
+     still missing or still unparseable stay untouched.
+  4. Each modified shard is rewritten atomically (tmp file + os.replace),
+     each in its own try/except so a rewrite failure on one shard cannot
+     discard the repairs already persisted to earlier shards; the
+     ``repaired`` count is accumulated as each shard succeeds.
+
+Failure isolation: ``backfill`` never raises -- a failed schema probe,
+subgraph batch, malformed line, unreadable shard, or shard rewrite is
+logged and skipped, and the partial summary (with the count of repairs
+already persisted) is RETURNED, not unwound. When any subgraph batch/probe
+or shard rewrite failed, the summary carries ``backfill_error=True`` so the
+caller (and CI) can distinguish "nothing to repair" from "crashed partway"
+and force a rebuild of the already-repaired rows.
 
 Idempotent: repaired rows no longer carry ``missing_fields``, so a second
 run finds nothing to repair; running while the upstream data is still
-missing is a no-op; healthy data is never touched. Exit code is always 0
--- repairing nothing is success -- so the daily flywheel can run it
-unconditionally.
+missing is a no-op; healthy data is never touched. Exit code: backfill
+failures (subgraph/parsing/IO errors) never raise; argument-parse errors
+and a fatal ``$GITHUB_OUTPUT`` write are the only non-zero exits -- so the
+daily flywheel can run it effectively unconditionally.
 
 Usage:
     python -m benchmark.datasets.backfill_responses
@@ -63,7 +82,9 @@ import argparse
 import json
 import logging
 import os
+import re
 import tempfile
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Any, Optional
 
@@ -74,6 +95,7 @@ from benchmark.datasets.fetch_production import (
     LOGS_DIR,
     MECH_MARKETPLACE_GNOSIS_URL,
     MECH_MARKETPLACE_POLYGON_URL,
+    _compute_config_hash,
     detect_delivers_schema,
     extract_delivery_fields,
     parse_tool_response,
@@ -100,10 +122,27 @@ log = logging.getLogger(__name__)
 BACKFILL_BATCH_SIZE = 100
 
 # Only rows written with this parse status are repair candidates: it is
-# exactly what fetch_production records when the tool response is
-# null/empty. "malformed" and "error" rows carried a real response and
-# are not recoverable by requerying.
+# exactly what fetch_production.parse_tool_response records when the tool
+# response is null/empty. "malformed" and "error" rows carried a real
+# response and are not recoverable by requerying.
+# WARNING: this bare literal must stay in lockstep with the status string
+# that fetch_production.parse_tool_response emits for empty/null input; a
+# rename there would silently zero candidates forever. The regression test
+# ``test_candidate_parse_status_matches_fetch_production`` pins that
+# contract so a future rename breaks a test here rather than in silence.
+# (A shared Literal/StrEnum in fetch_production is the cleaner long-term
+# fix but belongs to a base-branch/main change, not this PR.)
 CANDIDATE_PARSE_STATUS = "missing_fields"
+
+# Default lookback for the shard scan: shards whose filename date is older
+# than this are skipped so legacy/unhealable rows are not re-globbed and
+# re-queried forever as logs/ grows. Generous enough to cover the incident
+# window that motivated this module while still bounding the daily scan.
+DEFAULT_MAX_SHARD_AGE_DAYS = 120
+
+# Matches the daily shard filename so the scan can derive each shard's date
+# for the age bound: production_log_YYYY_MM_DD.jsonl.
+SHARD_DATE_RE = re.compile(r"production_log_(\d{4})_(\d{2})_(\d{2})\.jsonl$")
 
 # Platform (as recorded in each row) -> marketplace subgraph endpoint.
 # The URLs come from fetch_production and therefore respect the same
@@ -157,7 +196,7 @@ def fetch_tool_responses(
     marketplace_url: str,
     deliver_ids: list[str],
     batch_size: int = BACKFILL_BATCH_SIZE,
-) -> dict[str, Optional[str]]:
+) -> tuple[dict[str, dict[str, Any]], bool]:
     """Requery the marketplace subgraph for tool responses by deliver id.
 
     The endpoint's delivers shape (nested ParsedDelivery vs legacy flat
@@ -169,14 +208,17 @@ def fetch_tool_responses(
 
     Queries in batches. A failed probe or batch is logged and skipped (its
     rows simply stay unrepaired until the next run) so a subgraph failure
-    can never fail the backfill.
+    can never fail the backfill; the boolean second return value flags that
+    such a failure happened so the caller can force a rebuild.
 
     :param marketplace_url: subgraph endpoint URL.
     :param deliver_ids: deliver ids to look up.
     :param batch_size: max ids per GraphQL request.
-    :return: mapping of deliver_id to tool response (possibly None).
+    :return: ``(responses, had_error)`` where responses maps deliver_id to
+        the :func:`extract_delivery_fields` dict (model, tool_response,
+        tool_hash) and had_error is True if any probe/batch failed.
     """
-    responses: dict[str, Optional[str]] = {}
+    responses: dict[str, dict[str, Any]] = {}
     try:
         schema = detect_delivers_schema(marketplace_url)
     except Exception as e:  # pylint: disable=broad-except
@@ -185,12 +227,13 @@ def fetch_tool_responses(
             marketplace_url,
             e,
         )
-        return responses
+        return responses, True
     query_template = (
         DELIVERS_PARSED_BY_IDS_QUERY
         if schema == DELIVERS_SCHEMA_PARSED
         else DELIVERS_LEGACY_BY_IDS_QUERY
     )
+    had_error = False
     for i in range(0, len(deliver_ids), batch_size):
         batch = deliver_ids[i : i + batch_size]
         ids_str = ", ".join(f'"{did}"' for did in batch)
@@ -204,6 +247,7 @@ def fetch_tool_responses(
                 marketplace_url,
                 e,
             )
+            had_error = True
             continue
         for deliver in data.get("delivers", []):
             fields = extract_delivery_fields(deliver, schema)
@@ -211,8 +255,8 @@ def fetch_tool_responses(
                 # Parsed payload not indexed upstream yet -- leave the row
                 # a candidate for a future run.
                 continue
-            responses[deliver["id"]] = fields["tool_response"]
-    return responses
+            responses[deliver["id"]] = fields
+    return responses, had_error
 
 
 # ---------------------------------------------------------------------------
@@ -220,19 +264,53 @@ def fetch_tool_responses(
 # ---------------------------------------------------------------------------
 
 
-def _load_shard(path: Path) -> list[dict[str, Any]]:
-    """Load all rows from one JSONL shard, skipping blank lines.
+def _load_shard(path: Path) -> tuple[list[dict[str, Any]], int]:
+    """Load all rows from one JSONL shard, tolerating malformed lines.
+
+    A single corrupt/truncated JSONL line -- exactly the failure class this
+    module exists to heal -- must never abort the scan, so a bad line is
+    skipped with a warning (mirroring
+    ``fetch_production._load_ids_from_file``'s scoped except) and counted
+    rather than raised.
 
     :param path: path to the shard file.
-    :return: list of row dicts in file order.
+    :return: ``(rows, skipped)`` -- row dicts in file order and the count
+        of malformed lines skipped.
     """
     rows: list[dict[str, Any]] = []
+    skipped = 0
     with open(path, encoding="utf-8") as f:
-        for line in f:
+        for lineno, line in enumerate(f, start=1):
             line = line.strip()
-            if line:
+            if not line:
+                continue
+            try:
                 rows.append(json.loads(line))
-    return rows
+            except (json.JSONDecodeError, ValueError) as e:
+                skipped += 1
+                log.warning(
+                    "Skipping malformed line %d in shard %s: %s",
+                    lineno,
+                    path.name,
+                    e,
+                )
+    return rows, skipped
+
+
+def _shard_date(path: Path) -> Optional[date]:
+    """Parse the calendar date encoded in a daily shard filename.
+
+    :param path: shard path (``production_log_YYYY_MM_DD.jsonl``).
+    :return: the parsed date, or None when the name does not match (e.g.
+        ``production_log_legacy.jsonl``) so such shards are never age-gated.
+    """
+    match = SHARD_DATE_RE.search(path.name)
+    if match is None:
+        return None
+    try:
+        return date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    except ValueError:
+        return None
 
 
 def _is_candidate(row: dict[str, Any]) -> bool:
@@ -247,15 +325,29 @@ def _is_candidate(row: dict[str, Any]) -> bool:
     )
 
 
-def repair_row(row: dict[str, Any], tool_response: Optional[str]) -> bool:
+def repair_row(
+    row: dict[str, Any],
+    tool_response: Optional[str],
+    model: Optional[str] = None,
+    tool_hash: Optional[str] = None,
+) -> bool:
     """Re-parse a requeried toolResponse and repair the row in place.
 
     Only a response that parses to a *valid* prediction mutates the row;
     still-null or still-unparseable responses leave it untouched, so the
     row stays a candidate for future runs.
 
+    The requeried delivery's ``model`` and ``tool_hash`` (returned by
+    :func:`extract_delivery_fields` alongside the response) also backfill
+    the row's ``model`` / ``tool_version`` / ``config_hash`` when those are
+    currently null, so a repaired row buckets under its real tool version
+    in by_tool_version/by_config rather than under "unknown". Existing
+    (non-null) metadata is never overwritten.
+
     :param row: production log row (mutated in place on success).
     :param tool_response: requeried toolResponse, possibly still None.
+    :param model: requeried delivery model, if available.
+    :param tool_hash: requeried delivery tool hash, if available.
     :return: True when the row was repaired.
     """
     if not tool_response:
@@ -268,6 +360,14 @@ def repair_row(row: dict[str, Any], tool_response: Optional[str]) -> bool:
     row["prediction_parse_status"] = parsed["prediction_parse_status"]
     if parsed["confidence"] is not None:
         row["confidence"] = parsed["confidence"]
+    # Backfill bucketing metadata (fill-if-null; never overwrite). Mirror
+    # build_row: config_hash = _compute_config_hash(tool_version, model).
+    if model is not None and row.get("model") is None:
+        row["model"] = model
+    if tool_hash is not None and row.get("tool_version") is None:
+        row["tool_version"] = tool_hash
+    if tool_hash is not None and row.get("config_hash") is None:
+        row["config_hash"] = _compute_config_hash(tool_hash, row.get("model"))
     return True
 
 
@@ -296,29 +396,63 @@ def _rewrite_shard_atomic(path: Path, rows: list[dict[str, Any]]) -> None:
 def backfill(
     logs_dir: Path,
     batch_size: int = BACKFILL_BATCH_SIZE,
+    max_shard_age_days: Optional[int] = None,
 ) -> dict[str, Any]:
     """Scan all shards, requery lost responses, and repair rows in place.
 
+    Never raises: a failed probe/batch, malformed line, unreadable shard,
+    or shard-rewrite failure is logged and skipped, and the partial summary
+    (with the repairs already persisted) is returned. ``backfill_error`` in
+    the summary is True when any subgraph probe/batch or shard rewrite
+    failed, so the caller can force a rebuild of the already-repaired rows.
+
     :param logs_dir: directory containing the daily JSONL shards.
     :param batch_size: max deliver ids per GraphQL request.
+    :param max_shard_age_days: skip shards whose filename date is older
+        than this many days (None disables the bound); give-up behavior for
+        legacy/unhealable rows once they age out of the window. Shards with
+        an unparseable filename date are never age-gated.
     :return: summary dict with ``shards_scanned``, ``candidates``,
-        ``repaired``, and a per-platform breakdown.
+        ``repaired``, ``skipped_lines``, ``backfill_error``, and a
+        per-platform breakdown.
     """
     summary: dict[str, Any] = {
         "shards_scanned": 0,
         "candidates": 0,
         "repaired": 0,
+        "skipped_lines": 0,
+        "backfill_error": False,
         "platforms": {},
     }
     if not logs_dir.is_dir():
         log.info("Logs dir %s does not exist -- nothing to backfill", logs_dir)
         return summary
 
+    cutoff: Optional[date] = None
+    if max_shard_age_days is not None:
+        cutoff = date.today() - timedelta(days=max_shard_age_days)
+
     # Pass 1: scan shards, collect candidate deliver ids per platform.
     shards: list[tuple[Path, list[dict[str, Any]]]] = []
     ids_by_platform: dict[str, list[str]] = {}
     for path in sorted(logs_dir.glob("*.jsonl")):
-        rows = _load_shard(path)
+        if cutoff is not None:
+            shard_dt = _shard_date(path)
+            if shard_dt is not None and shard_dt < cutoff:
+                log.info(
+                    "Skipping shard %s older than %d days -- giving up",
+                    path.name,
+                    max_shard_age_days,
+                )
+                continue
+        try:
+            rows, skipped = _load_shard(path)
+        except OSError as e:
+            # Per-file isolation: an unreadable shard cannot sink the run.
+            log.warning("Failed to read shard %s: %s -- skipping", path.name, e)
+            summary["backfill_error"] = True
+            continue
+        summary["skipped_lines"] += skipped
         shards.append((path, rows))
         summary["shards_scanned"] += 1
         for row in rows:
@@ -338,7 +472,7 @@ def backfill(
         log.warning("No marketplace URL for platform(s) %s -- skipped", sorted(unknown))
 
     # Pass 2: batch-requery each platform's marketplace subgraph.
-    responses: dict[str, dict[str, Optional[str]]] = {}
+    responses: dict[str, dict[str, dict[str, Any]]] = {}
     for platform, deliver_ids in ids_by_platform.items():
         unique_ids = sorted(set(deliver_ids))
         log.info(
@@ -347,25 +481,54 @@ def backfill(
             len(unique_ids),
             batch_size,
         )
-        responses[platform] = fetch_tool_responses(
+        plat_responses, had_error = fetch_tool_responses(
             PLATFORM_MARKETPLACE_URLS[platform], unique_ids, batch_size
         )
+        responses[platform] = plat_responses
+        if had_error:
+            summary["backfill_error"] = True
 
-    # Pass 3: repair rows in place; rewrite only shards that changed.
+    # Pass 3: repair rows in place; rewrite only shards that changed. Each
+    # shard's repair+rewrite is isolated so a failure on one cannot discard
+    # the repairs already persisted to earlier shards. Per-shard/per-platform
+    # counts are committed to the summary only AFTER the atomic rewrite
+    # succeeds, so the returned counts reflect exactly what is on disk.
     for path, rows in shards:
-        shard_repaired = 0
-        for row in rows:
-            if not _is_candidate(row):
-                continue
-            platform = row.get("platform") or "unknown"
-            tool_response = responses.get(platform, {}).get(row["deliver_id"])
-            if repair_row(row, tool_response):
-                shard_repaired += 1
-                summary["platforms"][platform]["repaired"] += 1
-        if shard_repaired:
-            _rewrite_shard_atomic(path, rows)
-            summary["repaired"] += shard_repaired
-            log.info("Repaired %d rows in %s", shard_repaired, path.name)
+        try:
+            shard_repaired = 0
+            shard_by_platform: dict[str, int] = {}
+            for row in rows:
+                if not _is_candidate(row):
+                    continue
+                platform = row.get("platform") or "unknown"
+                fields = responses.get(platform, {}).get(row["deliver_id"])
+                if fields is None:
+                    continue
+                if repair_row(
+                    row,
+                    fields.get("tool_response"),
+                    fields.get("model"),
+                    fields.get("tool_hash"),
+                ):
+                    shard_repaired += 1
+                    shard_by_platform[platform] = shard_by_platform.get(platform, 0) + 1
+            if shard_repaired:
+                _rewrite_shard_atomic(path, rows)
+                summary["repaired"] += shard_repaired
+                for platform, count in shard_by_platform.items():
+                    summary["platforms"][platform]["repaired"] += count
+                log.info("Repaired %d rows in %s", shard_repaired, path.name)
+        except Exception as e:  # pylint: disable=broad-except
+            # Isolate this shard; already-persisted repairs are kept and a
+            # rebuild is forced (backfill_error) since we cannot tell which
+            # rows on later shards would have been repaired.
+            log.warning(
+                "Repair/rewrite failed for shard %s: %s -- continuing",
+                path.name,
+                e,
+            )
+            summary["backfill_error"] = True
+            continue
 
     return summary
 
@@ -381,10 +544,13 @@ def _log_summary(summary: dict[str, Any]) -> None:
     :param summary: summary dict from :func:`backfill`.
     """
     log.info(
-        "Backfill summary: %d shards scanned, %d candidate rows, %d repaired",
+        "Backfill summary: %d shards scanned, %d candidate rows, %d repaired, "
+        "%d malformed lines skipped, backfill_error=%s",
         summary["shards_scanned"],
         summary["candidates"],
         summary["repaired"],
+        summary.get("skipped_lines", 0),
+        summary.get("backfill_error", False),
     )
     for platform, stats in sorted(summary["platforms"].items()):
         log.info(
@@ -395,21 +561,29 @@ def _log_summary(summary: dict[str, Any]) -> None:
         )
 
 
-def _emit_repaired_output(repaired: int) -> None:
-    """Emit the repaired count for workflow consumption.
+def _emit_repaired_output(repaired: int, backfill_error: bool = False) -> None:
+    """Emit the repaired count and error flag for workflow consumption.
 
-    Prints a ``repaired=<n>`` line to stdout and appends the same line to
-    ``$GITHUB_OUTPUT`` when that env var is set, so the flywheel step can
-    gate the force-rebuild path on it.
+    Prints ``repaired=<n>`` and ``backfill_error=<true|false>`` to stdout
+    and appends the same lines to ``$GITHUB_OUTPUT`` when that env var is
+    set, so the flywheel force-rebuild path can gate on either: repaired>0
+    (rows changed) OR backfill_error (a partial rewrite/batch failure means
+    some rows may have been repaired but we cannot tell which, so rebuild).
 
     :param repaired: number of rows repaired this run.
+    :param backfill_error: True if any probe/batch/shard rewrite failed.
     """
-    line = f"repaired={repaired}"
-    print(line)
+    lines = [
+        f"repaired={repaired}",
+        f"backfill_error={'true' if backfill_error else 'false'}",
+    ]
+    for line in lines:
+        print(line)
     github_output = os.environ.get("GITHUB_OUTPUT")
     if github_output:
         with open(github_output, "a", encoding="utf-8") as f:
-            f.write(line + "\n")
+            for line in lines:
+                f.write(line + "\n")
 
 
 # ---------------------------------------------------------------------------
@@ -437,20 +611,44 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=BACKFILL_BATCH_SIZE,
         help="Max deliver ids per subgraph request",
     )
+    parser.add_argument(
+        "--max-shard-age-days",
+        type=int,
+        default=DEFAULT_MAX_SHARD_AGE_DAYS,
+        help=(
+            "Skip shards whose filename date is older than this many days "
+            "so legacy/unhealable rows are not re-globbed and re-queried "
+            "forever as logs/ grows (0 or negative disables the bound)"
+        ),
+    )
     return parser
 
 
 def main() -> None:
-    """CLI entry point. Always exits 0: repairing nothing is success."""
+    """CLI entry point.
+
+    Backfill failures (subgraph/parsing/IO errors) never raise -- they are
+    caught and reported as ``backfill_error=true`` with the repairs already
+    persisted preserved in the count. Argument-parse errors and a fatal
+    ``$GITHUB_OUTPUT`` write are the only non-zero exits.
+    """
     args = _build_arg_parser().parse_args()
+    max_age: Optional[int] = (
+        args.max_shard_age_days if args.max_shard_age_days > 0 else None
+    )
     repaired = 0
+    backfill_error = False
     try:
-        summary = backfill(args.logs_dir, args.batch_size)
+        summary = backfill(args.logs_dir, args.batch_size, max_age)
         repaired = summary["repaired"]
+        backfill_error = summary.get("backfill_error", False)
         _log_summary(summary)
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
+        # Defense in depth: backfill is designed not to raise, but if it
+        # ever does, force a rebuild rather than silently drop the signal.
         log.exception("Backfill failed (non-fatal: the flywheel must not block)")
-    _emit_repaired_output(repaired)
+        backfill_error = True
+    _emit_repaired_output(repaired, backfill_error)
 
 
 if __name__ == "__main__":

--- a/benchmark/datasets/backfill_responses.py
+++ b/benchmark/datasets/backfill_responses.py
@@ -47,7 +47,7 @@ Design:
      ``fetch_production.detect_delivers_schema``).
   3. Rows whose response is now available are re-parsed with the same
      parser the fetcher uses; rows that parse to a valid prediction are
-     updated in place (p_yes, p_no, parse status, confidence when parsed,
+     updated in place (p_yes, p_no, parse status, bucketing metadata when
      plus model/tool_version/config_hash when the row lacked them, so a
      repaired row buckets correctly rather than under "unknown"). Rows
      still missing or still unparseable stay untouched.
@@ -358,8 +358,9 @@ def repair_row(
     row["p_yes"] = parsed["p_yes"]
     row["p_no"] = parsed["p_no"]
     row["prediction_parse_status"] = parsed["prediction_parse_status"]
-    if parsed["confidence"] is not None:
-        row["confidence"] = parsed["confidence"]
+    # Deliberately NOT written: build_row discards parse_tool_response's
+    # confidence, so normal shard rows carry no confidence key -- a repaired
+    # row must match that shape exactly rather than grow an extra column.
     # Backfill bucketing metadata (fill-if-null; never overwrite). Mirror
     # build_row: config_hash = _compute_config_hash(tool_version, model).
     if model is not None and row.get("model") is None:

--- a/benchmark/datasets/backfill_responses.py
+++ b/benchmark/datasets/backfill_responses.py
@@ -40,15 +40,15 @@ Design:
      (any platform -- the repair is platform-generic). Malformed JSONL
      lines are skipped with a warning (a bad line -- exactly the failure
      class this module heals -- must never abort the scan) and an
-     unreadable shard is isolated so it cannot sink the run.
+     unreadable or undecodable shard is isolated so it cannot sink the run.
   2. Batch-requery each platform's marketplace subgraph for those deliver
      ids, using the query shape the endpoint supports (nested
      ParsedDelivery vs legacy flat fields, probed once per endpoint via
      ``fetch_production.detect_delivers_schema``).
   3. Rows whose response is now available are re-parsed with the same
      parser the fetcher uses; rows that parse to a valid prediction are
-     updated in place (p_yes, p_no, parse status, bucketing metadata when
-     plus model/tool_version/config_hash when the row lacked them, so a
+     updated in place (p_yes, p_no, parse status, and the bucketing
+     metadata model/tool_version/config_hash when the row lacked them, so a
      repaired row buckets correctly rather than under "unknown"). Rows
      still missing or still unparseable stay untouched.
   4. Each modified shard is rewritten atomically (tmp file + os.replace),
@@ -57,12 +57,13 @@ Design:
      ``repaired`` count is accumulated as each shard succeeds.
 
 Failure isolation: ``backfill`` never raises -- a failed schema probe,
-subgraph batch, malformed line, unreadable shard, or shard rewrite is
-logged and skipped, and the partial summary (with the count of repairs
-already persisted) is RETURNED, not unwound. When any subgraph batch/probe
-or shard rewrite failed, the summary carries ``backfill_error=True`` so the
-caller (and CI) can distinguish "nothing to repair" from "crashed partway"
-and force a rebuild of the already-repaired rows.
+subgraph batch, malformed line, unreadable/undecodable shard, or shard
+rewrite is logged and skipped, and the partial summary (with the count of
+repairs already persisted) is RETURNED, not unwound. When any subgraph
+batch/probe, unreadable/undecodable shard, or shard rewrite failed, the
+summary carries ``backfill_error=True`` so the caller (and CI) can
+distinguish "nothing to repair" from "crashed partway" and force a rebuild
+of the already-repaired rows.
 
 Idempotent: repaired rows no longer carry ``missing_fields``, so a second
 run finds nothing to repair; running while the upstream data is still
@@ -264,37 +265,63 @@ def fetch_tool_responses(
 # ---------------------------------------------------------------------------
 
 
-def _load_shard(path: Path) -> tuple[list[dict[str, Any]], int]:
+def _load_shard(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
     """Load all rows from one JSONL shard, tolerating malformed lines.
 
     A single corrupt/truncated JSONL line -- exactly the failure class this
     module exists to heal -- must never abort the scan, so a bad line is
     skipped with a warning (mirroring
-    ``fetch_production._load_ids_from_file``'s scoped except) and counted
-    rather than raised.
+    ``fetch_production._load_ids_from_file``'s scoped except) and its raw
+    text is captured rather than raised, so the caller can quarantine it
+    before a rewrite would otherwise delete it for good.
+
+    A truncated multi-byte line raises ``UnicodeDecodeError`` (a
+    ``ValueError`` subclass) during file iteration, BEFORE the per-line
+    json guard, so it escapes this function and is isolated by the caller's
+    ``(OSError, ValueError)`` catch.
 
     :param path: path to the shard file.
-    :return: ``(rows, skipped)`` -- row dicts in file order and the count
-        of malformed lines skipped.
+    :return: ``(rows, dropped)`` -- row dicts in file order and the raw
+        verbatim text of each malformed line skipped.
     """
     rows: list[dict[str, Any]] = []
-    skipped = 0
+    dropped: list[str] = []
     with open(path, encoding="utf-8") as f:
-        for lineno, line in enumerate(f, start=1):
-            line = line.strip()
+        for lineno, raw in enumerate(f, start=1):
+            line = raw.strip()
             if not line:
                 continue
             try:
                 rows.append(json.loads(line))
             except (json.JSONDecodeError, ValueError) as e:
-                skipped += 1
+                dropped.append(raw)
                 log.warning(
                     "Skipping malformed line %d in shard %s: %s",
                     lineno,
                     path.name,
                     e,
                 )
-    return rows, skipped
+    return rows, dropped
+
+
+def _quarantine_dropped_lines(shard_path: Path, lines: list[str]) -> None:
+    """Append verbatim dropped malformed lines to a sibling reject file.
+
+    Called just before a shard is rewritten (which drops its malformed
+    lines): without this the raw text would vanish with no forensic trail.
+    The reject file is ``<shard>.rejected.jsonl`` alongside the shard; the
+    Pass-1 scan explicitly skips ``*.rejected.jsonl`` so quarantined text is
+    never re-scanned or re-quarantined.
+
+    :param shard_path: shard being rewritten.
+    :param lines: raw verbatim malformed lines to preserve (may be empty).
+    """
+    if not lines:
+        return
+    rejected = shard_path.with_name(shard_path.name + ".rejected.jsonl")
+    with open(rejected, "a", encoding="utf-8") as f:
+        for line in lines:
+            f.write(line if line.endswith("\n") else line + "\n")
 
 
 def _shard_date(path: Path) -> Optional[date]:
@@ -310,6 +337,10 @@ def _shard_date(path: Path) -> Optional[date]:
     try:
         return date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
     except ValueError:
+        log.warning(
+            "Shard %s has an impossible date in its name -- not age-gating it",
+            path.name,
+        )
         return None
 
 
@@ -328,6 +359,7 @@ def _is_candidate(row: dict[str, Any]) -> bool:
 def repair_row(
     row: dict[str, Any],
     tool_response: Optional[str],
+    *,
     model: Optional[str] = None,
     tool_hash: Optional[str] = None,
 ) -> bool:
@@ -363,11 +395,14 @@ def repair_row(
     # row must match that shape exactly rather than grow an extra column.
     # Backfill bucketing metadata (fill-if-null; never overwrite). Mirror
     # build_row: config_hash = _compute_config_hash(tool_version, model).
-    if model is not None and row.get("model") is None:
+    # Truthiness is the presence predicate: a subgraph "" (or None) is
+    # treated as absent so an empty-string model can't fill the column with
+    # a useless value that then defeats a future fill.
+    if model and row.get("model") is None:
         row["model"] = model
-    if tool_hash is not None and row.get("tool_version") is None:
+    if tool_hash and row.get("tool_version") is None:
         row["tool_version"] = tool_hash
-    if tool_hash is not None and row.get("config_hash") is None:
+    if tool_hash and row.get("config_hash") is None:
         row["config_hash"] = _compute_config_hash(tool_hash, row.get("model"))
     return True
 
@@ -401,18 +436,21 @@ def backfill(
 ) -> dict[str, Any]:
     """Scan all shards, requery lost responses, and repair rows in place.
 
-    Never raises: a failed probe/batch, malformed line, unreadable shard,
-    or shard-rewrite failure is logged and skipped, and the partial summary
-    (with the repairs already persisted) is returned. ``backfill_error`` in
-    the summary is True when any subgraph probe/batch or shard rewrite
-    failed, so the caller can force a rebuild of the already-repaired rows.
+    Never raises: a failed probe/batch, malformed line, unreadable/
+    undecodable shard, or shard-rewrite failure is logged and skipped, and
+    the partial summary (with the repairs already persisted) is returned.
+    ``backfill_error`` in the summary is True when any subgraph probe/batch,
+    unreadable/undecodable shard, or shard rewrite failed, so the caller can
+    force a rebuild of the already-repaired rows.
 
     :param logs_dir: directory containing the daily JSONL shards.
     :param batch_size: max deliver ids per GraphQL request.
     :param max_shard_age_days: skip shards whose filename date is older
-        than this many days (None disables the bound); give-up behavior for
-        legacy/unhealable rows once they age out of the window. Shards with
-        an unparseable filename date are never age-gated.
+        than this many days; give-up behavior for legacy/unhealable rows
+        once they age out of the window. ``None`` or a value <= 0 disables
+        the bound (scan all shards) -- this "<=0 disables" translation lives
+        here so a direct caller and the CLI share one source of truth.
+        Shards with an unparseable filename date are never age-gated.
     :return: summary dict with ``shards_scanned``, ``candidates``,
         ``repaired``, ``skipped_lines``, ``backfill_error``, and a
         per-platform breakdown.
@@ -429,14 +467,23 @@ def backfill(
         log.info("Logs dir %s does not exist -- nothing to backfill", logs_dir)
         return summary
 
+    # Single source of truth for the "<=0 disables the bound" rule: a
+    # direct caller passing 0/negative gets the same scan-all behavior as
+    # the CLI, not a silent near-empty scan.
+    if max_shard_age_days is not None and max_shard_age_days <= 0:
+        max_shard_age_days = None
+
     cutoff: Optional[date] = None
     if max_shard_age_days is not None:
         cutoff = date.today() - timedelta(days=max_shard_age_days)
 
     # Pass 1: scan shards, collect candidate deliver ids per platform.
-    shards: list[tuple[Path, list[dict[str, Any]]]] = []
+    shards: list[tuple[Path, list[dict[str, Any]], list[str]]] = []
     ids_by_platform: dict[str, list[str]] = {}
     for path in sorted(logs_dir.glob("*.jsonl")):
+        # Never re-scan (or re-quarantine) our own quarantine files.
+        if path.name.endswith(".rejected.jsonl"):
+            continue
         if cutoff is not None:
             shard_dt = _shard_date(path)
             if shard_dt is not None and shard_dt < cutoff:
@@ -447,14 +494,17 @@ def backfill(
                 )
                 continue
         try:
-            rows, skipped = _load_shard(path)
-        except OSError as e:
-            # Per-file isolation: an unreadable shard cannot sink the run.
+            rows, dropped = _load_shard(path)
+        except (OSError, ValueError) as e:
+            # Per-file isolation: an unreadable shard (OSError) or an
+            # undecodable one -- a truncated multi-byte line raises
+            # UnicodeDecodeError, a ValueError subclass, during iteration
+            # before the per-line json guard -- cannot sink the run.
             log.warning("Failed to read shard %s: %s -- skipping", path.name, e)
             summary["backfill_error"] = True
             continue
-        summary["skipped_lines"] += skipped
-        shards.append((path, rows))
+        summary["skipped_lines"] += len(dropped)
+        shards.append((path, rows, dropped))
         summary["shards_scanned"] += 1
         for row in rows:
             if not _is_candidate(row):
@@ -494,7 +544,7 @@ def backfill(
     # the repairs already persisted to earlier shards. Per-shard/per-platform
     # counts are committed to the summary only AFTER the atomic rewrite
     # succeeds, so the returned counts reflect exactly what is on disk.
-    for path, rows in shards:
+    for path, rows, dropped in shards:
         try:
             shard_repaired = 0
             shard_by_platform: dict[str, int] = {}
@@ -508,12 +558,16 @@ def backfill(
                 if repair_row(
                     row,
                     fields.get("tool_response"),
-                    fields.get("model"),
-                    fields.get("tool_hash"),
+                    model=fields.get("model"),
+                    tool_hash=fields.get("tool_hash"),
                 ):
                     shard_repaired += 1
                     shard_by_platform[platform] = shard_by_platform.get(platform, 0) + 1
             if shard_repaired:
+                # The rewrite drops this shard's malformed lines; preserve
+                # their raw text first so a corrupt row is quarantined, not
+                # silently deleted.
+                _quarantine_dropped_lines(path, dropped)
                 _rewrite_shard_atomic(path, rows)
                 summary["repaired"] += shard_repaired
                 for platform, count in shard_by_platform.items():
@@ -562,21 +616,29 @@ def _log_summary(summary: dict[str, Any]) -> None:
         )
 
 
-def _emit_repaired_output(repaired: int, backfill_error: bool = False) -> None:
+def _emit_repaired_output(
+    repaired: int, backfill_error: bool = False, skipped_lines: int = 0
+) -> None:
     """Emit the repaired count and error flag for workflow consumption.
 
-    Prints ``repaired=<n>`` and ``backfill_error=<true|false>`` to stdout
-    and appends the same lines to ``$GITHUB_OUTPUT`` when that env var is
-    set, so the flywheel force-rebuild path can gate on either: repaired>0
-    (rows changed) OR backfill_error (a partial rewrite/batch failure means
-    some rows may have been repaired but we cannot tell which, so rebuild).
+    Prints ``repaired=<n>``, ``backfill_error=<true|false>`` and
+    ``skipped_lines=<n>`` to stdout and appends the same lines to
+    ``$GITHUB_OUTPUT`` when that env var is set, so the flywheel
+    force-rebuild path can gate on either: repaired>0 (rows changed) OR
+    backfill_error (a partial rewrite/batch failure, or an unreadable/
+    undecodable shard, means some rows may have been repaired but we cannot
+    tell which, so rebuild). ``skipped_lines`` is surfaced (total malformed
+    lines dropped across shards) so the flywheel summary can flag it.
 
     :param repaired: number of rows repaired this run.
-    :param backfill_error: True if any probe/batch/shard rewrite failed.
+    :param backfill_error: True if any probe/batch/shard rewrite or
+        unreadable/undecodable shard failed.
+    :param skipped_lines: total malformed lines skipped across all shards.
     """
     lines = [
         f"repaired={repaired}",
         f"backfill_error={'true' if backfill_error else 'false'}",
+        f"skipped_lines={skipped_lines}",
     ]
     for line in lines:
         print(line)
@@ -634,22 +696,24 @@ def main() -> None:
     ``$GITHUB_OUTPUT`` write are the only non-zero exits.
     """
     args = _build_arg_parser().parse_args()
-    max_age: Optional[int] = (
-        args.max_shard_age_days if args.max_shard_age_days > 0 else None
-    )
+    # Pass the raw --max-shard-age-days through: backfill() owns the
+    # "<=0 disables the bound" translation so a direct caller and the CLI
+    # share one source of truth.
     repaired = 0
     backfill_error = False
+    skipped_lines = 0
     try:
-        summary = backfill(args.logs_dir, args.batch_size, max_age)
+        summary = backfill(args.logs_dir, args.batch_size, args.max_shard_age_days)
         repaired = summary["repaired"]
         backfill_error = summary.get("backfill_error", False)
+        skipped_lines = summary.get("skipped_lines", 0)
         _log_summary(summary)
     except Exception:  # pylint: disable=broad-except
         # Defense in depth: backfill is designed not to raise, but if it
         # ever does, force a rebuild rather than silently drop the signal.
         log.exception("Backfill failed (non-fatal: the flywheel must not block)")
         backfill_error = True
-    _emit_repaired_output(repaired, backfill_error)
+    _emit_repaired_output(repaired, backfill_error, skipped_lines)
 
 
 if __name__ == "__main__":

--- a/benchmark/tests/test_backfill_responses.py
+++ b/benchmark/tests/test_backfill_responses.py
@@ -1,0 +1,639 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Tests for benchmark/datasets/backfill_responses.py"""
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+from benchmark.datasets import backfill_responses as br
+from benchmark.datasets.fetch_production import (
+    DELIVERS_SCHEMA_LEGACY,
+    DELIVERS_SCHEMA_PARSED,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+
+VALID_RESPONSE = '{"p_yes": 0.72, "p_no": 0.28, "confidence": 0.85}'
+
+
+def _row(
+    deliver_id: str,
+    platform: str = "omen",
+    status: str = "missing_fields",
+    **overrides: Any,
+) -> dict[str, Any]:
+    """Build a minimal production-log row."""
+    row: dict[str, Any] = {
+        "row_id": f"prod_{platform}_{deliver_id}",
+        "deliver_id": deliver_id,
+        "schema_version": "1.0",
+        "mode": "production_replay",
+        "platform": platform,
+        "question_text": "Will it rain tomorrow?",
+        "tool_name": "factual_research",
+        "p_yes": None,
+        "p_no": None,
+        "prediction_parse_status": status,
+        "final_outcome": True,
+        "match_confidence": 1.0,
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_shard(path: Path, rows: list[dict[str, Any]]) -> None:
+    """Write rows to a JSONL shard the same way append_jsonl does."""
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _read_shard(path: Path) -> list[dict[str, Any]]:
+    """Read all rows back from a JSONL shard."""
+    with open(path, encoding="utf-8") as f:
+        return [json.loads(line) for line in f if line.strip()]
+
+
+def _ids_in_query(query: str) -> list[str]:
+    """Extract the quoted deliver ids from a delivers-by-ids query."""
+    return re.findall(r'"(0x[0-9a-f]+)"', query)
+
+
+def _make_fake_post_graphql(
+    responses: dict[str, Optional[str]],
+    calls: Optional[list[tuple[str, list[str]]]] = None,
+    schema: str = DELIVERS_SCHEMA_LEGACY,
+) -> Any:
+    """Build a fake _post_graphql returning canned tool responses.
+
+    Serves the deliver shape matching *schema*: legacy flat
+    ``model``/``toolResponse`` fields, or the nested ``parsedDelivery``
+    entity (a None response is served as a not-yet-indexed delivery,
+    i.e. ``parsedDelivery: null``).
+
+    :param responses: deliver_id -> tool response to serve.
+    :param calls: optional list collecting (url, queried ids) per call.
+    :param schema: deliver shape to serve (legacy or parsed).
+    :return: fake function with the _post_graphql signature.
+    """
+
+    def _deliver(did: str) -> dict[str, Any]:
+        """Build one canned deliver in the configured schema shape."""
+        response = responses.get(did)
+        if schema == DELIVERS_SCHEMA_LEGACY:
+            return {"id": did, "model": None, "toolResponse": response}
+        if response is None:
+            return {"id": did, "parsedDelivery": None}
+        return {
+            "id": did,
+            "parsedDelivery": {
+                "response": response,
+                "model": "gpt-4o",
+                "tool": "factual_research",
+                "toolHash": None,
+            },
+        }
+
+    def fake(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+        """Serve canned delivers for the ids found in the query."""
+        ids = _ids_in_query(payload["query"])
+        if calls is not None:
+            calls.append((url, ids))
+        return {"delivers": [_deliver(did) for did in ids]}
+
+    return fake
+
+
+@pytest.fixture(autouse=True)
+def _stub_schema_detection(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin schema detection to legacy so no test probes the network.
+
+    Individual tests override this by re-patching
+    ``br.detect_delivers_schema`` (schema-routing tests) after the
+    fixture ran.
+
+    :param monkeypatch: pytest monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        br, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_LEGACY
+    )
+
+
+# ---------------------------------------------------------------------------
+# repair_row
+# ---------------------------------------------------------------------------
+
+
+class TestRepairRow:
+    """Tests for single-row repair."""
+
+    def test_valid_response_repairs_in_place(self) -> None:
+        """A now-present valid response updates p_yes/p_no/status/confidence."""
+        row = _row("0x01")
+        assert br.repair_row(row, VALID_RESPONSE) is True
+        assert row["p_yes"] == 0.72
+        assert row["p_no"] == 0.28
+        assert row["prediction_parse_status"] == "valid"
+        assert row["confidence"] == 0.85
+
+    def test_no_confidence_key_when_not_parsed(self) -> None:
+        """A response without confidence does not add the field."""
+        row = _row("0x01")
+        assert br.repair_row(row, '{"p_yes": 0.6, "p_no": 0.4}') is True
+        assert "confidence" not in row
+
+    def test_still_null_untouched(self) -> None:
+        """A still-null response leaves the row untouched."""
+        row = _row("0x01")
+        before = dict(row)
+        assert br.repair_row(row, None) is False
+        assert row == before
+
+    def test_still_unparseable_untouched(self) -> None:
+        """A response that parses malformed leaves the row untouched."""
+        row = _row("0x01")
+        before = dict(row)
+        assert br.repair_row(row, '{"p_yes": 0.9, "p_no": 0.9}') is False
+        assert row == before
+
+
+# ---------------------------------------------------------------------------
+# backfill: repair behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillRepairs:
+    """Tests for the end-to-end shard repair."""
+
+    def test_repairs_missing_fields_row(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Repairs the candidate row; other fields and row order untouched."""
+        shard = tmp_path / "production_log_2026_07_01.jsonl"
+        rows = [
+            _row("0xaa", status="valid", p_yes=0.5, p_no=0.5),
+            _row("0xbb"),
+            _row("0xcc", status="malformed"),
+        ]
+        _write_shard(shard, rows)
+        monkeypatch.setattr(
+            br, "_post_graphql", _make_fake_post_graphql({"0xbb": VALID_RESPONSE})
+        )
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["repaired"] == 1
+        after = _read_shard(shard)
+        # Order preserved, one row per original row
+        assert [r["deliver_id"] for r in after] == ["0xaa", "0xbb", "0xcc"]
+        repaired = after[1]
+        assert repaired["p_yes"] == 0.72
+        assert repaired["p_no"] == 0.28
+        assert repaired["prediction_parse_status"] == "valid"
+        assert repaired["confidence"] == 0.85
+        # Untouched fields survive
+        assert repaired["row_id"] == rows[1]["row_id"]
+        assert repaired["question_text"] == rows[1]["question_text"]
+        assert repaired["final_outcome"] is True
+        # Neighbour rows byte-identical
+        assert after[0] == rows[0]
+        assert after[2] == rows[2]
+
+    def test_still_null_rows_stay_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rows whose response is still null are not modified at all."""
+        shard = tmp_path / "production_log_2026_07_01.jsonl"
+        _write_shard(shard, [_row("0xbb")])
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}))
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["repaired"] == 0
+        assert summary["candidates"] == 1
+        assert _read_shard(shard) == [_row("0xbb")]
+
+    def test_malformed_rows_are_not_candidates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only missing_fields rows are candidates; malformed are skipped."""
+        shard = tmp_path / "production_log_2026_07_01.jsonl"
+        _write_shard(shard, [_row("0xdd", status="malformed")])
+        calls: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(
+            br,
+            "_post_graphql",
+            _make_fake_post_graphql({"0xdd": VALID_RESPONSE}, calls),
+        )
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["candidates"] == 0
+        assert summary["repaired"] == 0
+        assert not calls  # nothing queried at all
+
+    def test_row_without_deliver_id_not_candidate(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing_fields row without deliver_id is not a candidate."""
+        shard = tmp_path / "production_log_2026_07_01.jsonl"
+        _write_shard(shard, [_row("")])
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}))
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["candidates"] == 0
+
+    def test_atomic_rewrite_only_when_changed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The shard file is replaced only when a row was repaired."""
+        shard = tmp_path / "production_log_2026_07_01.jsonl"
+        _write_shard(shard, [_row("0xbb")])
+        inode_before = shard.stat().st_ino
+        content_before = shard.read_bytes()
+
+        # Run 1: response still null -> file untouched (same inode)
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}))
+        br.backfill(tmp_path)
+        assert shard.stat().st_ino == inode_before
+        assert shard.read_bytes() == content_before
+
+        # Run 2: response present -> file replaced (new inode, new content)
+        monkeypatch.setattr(
+            br, "_post_graphql", _make_fake_post_graphql({"0xbb": VALID_RESPONSE})
+        )
+        br.backfill(tmp_path)
+        assert shard.stat().st_ino != inode_before
+        assert shard.read_bytes() != content_before
+        # No temp files left behind
+        assert not list(tmp_path.glob("*.tmp"))
+
+    def test_idempotent_second_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second run after repair finds no candidates and changes nothing."""
+        shard = tmp_path / "production_log_2026_07_01.jsonl"
+        _write_shard(shard, [_row("0xbb")])
+        monkeypatch.setattr(
+            br, "_post_graphql", _make_fake_post_graphql({"0xbb": VALID_RESPONSE})
+        )
+
+        first = br.backfill(tmp_path)
+        assert first["repaired"] == 1
+        content_after_first = shard.read_bytes()
+
+        second = br.backfill(tmp_path)
+        assert second["candidates"] == 0
+        assert second["repaired"] == 0
+        assert shard.read_bytes() == content_after_first
+
+    def test_summary_counts(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Summary reports shards scanned, candidates, repairs per platform."""
+        _write_shard(
+            tmp_path / "production_log_2026_07_01.jsonl",
+            [_row("0x01"), _row("0x02"), _row("0x03", status="valid")],
+        )
+        _write_shard(
+            tmp_path / "production_log_2026_07_02.jsonl",
+            [_row("0x04", platform="polymarket")],
+        )
+        monkeypatch.setattr(
+            br, "_post_graphql", _make_fake_post_graphql({"0x01": VALID_RESPONSE})
+        )
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["shards_scanned"] == 2
+        assert summary["candidates"] == 3
+        assert summary["repaired"] == 1
+        assert summary["platforms"]["omen"] == {"candidates": 2, "repaired": 1}
+        assert summary["platforms"]["polymarket"] == {"candidates": 1, "repaired": 0}
+
+
+# ---------------------------------------------------------------------------
+# Batching & platform routing
+# ---------------------------------------------------------------------------
+
+
+class TestBatchingAndRouting:
+    """Tests for subgraph query batching and per-platform URL routing."""
+
+    def test_batching_splits_large_id_sets(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """More than BACKFILL_BATCH_SIZE ids are split across requests."""
+        n = br.BACKFILL_BATCH_SIZE * 2 + 50  # 250 with the default of 100
+        rows = [_row(f"0x{i:04x}") for i in range(n)]
+        _write_shard(tmp_path / "production_log_2026_07_01.jsonl", rows)
+        calls: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}, calls))
+
+        br.backfill(tmp_path)
+
+        sizes = [len(ids) for _, ids in calls]
+        assert sizes == [100, 100, 50]
+        assert sorted(did for _, ids in calls for did in ids) == sorted(
+            r["deliver_id"] for r in rows
+        )
+
+    def test_platform_routing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Omen ids go to the Gnosis URL, Polymarket ids to the Polygon URL."""
+        _write_shard(
+            tmp_path / "production_log_2026_07_01.jsonl",
+            [_row("0x01", platform="omen"), _row("0x02", platform="polymarket")],
+        )
+        calls: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}, calls))
+
+        br.backfill(tmp_path)
+
+        by_url = dict(calls)
+        assert by_url[br.MECH_MARKETPLACE_GNOSIS_URL] == ["0x01"]
+        assert by_url[br.MECH_MARKETPLACE_POLYGON_URL] == ["0x02"]
+
+    def test_unknown_platform_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Candidates on an unknown platform are counted but never queried."""
+        _write_shard(
+            tmp_path / "production_log_2026_07_01.jsonl",
+            [_row("0x01", platform="kalshi")],
+        )
+        calls: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}, calls))
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["candidates"] == 1
+        assert summary["repaired"] == 0
+        assert not calls
+
+    def test_failed_batch_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A batch that raises is skipped; the run continues and exits clean."""
+        _write_shard(tmp_path / "production_log_2026_07_01.jsonl", [_row("0x01")])
+
+        def boom(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            """Simulate a subgraph failure."""
+            raise RuntimeError("subgraph down")
+
+        monkeypatch.setattr(br, "_post_graphql", boom)
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["repaired"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Schema-aware querying (nested ParsedDelivery vs legacy flat fields)
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaRouting:
+    """Tests for per-endpoint schema detection and query-shape selection."""
+
+    def test_parsed_schema_uses_parsed_query_and_repairs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A parsed-schema endpoint is queried for parsedDelivery and repaired."""
+        shard = tmp_path / "production_log_2026_07_01.jsonl"
+        _write_shard(shard, [_row("0xbb")])
+        monkeypatch.setattr(
+            br, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
+        )
+        queries: list[str] = []
+        fake = _make_fake_post_graphql(
+            {"0xbb": VALID_RESPONSE}, schema=DELIVERS_SCHEMA_PARSED
+        )
+
+        def spy(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            """Record the query text, then serve the parsed-schema fake."""
+            queries.append(payload["query"])
+            return fake(url, payload)
+
+        monkeypatch.setattr(br, "_post_graphql", spy)
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["repaired"] == 1
+        assert all("parsedDelivery" in q for q in queries)
+        assert all("toolResponse" not in q for q in queries)
+        repaired = _read_shard(shard)[0]
+        assert repaired["p_yes"] == 0.72
+        assert repaired["prediction_parse_status"] == "valid"
+
+    def test_legacy_schema_uses_flat_query_and_repairs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A legacy-schema endpoint is queried for flat fields and repaired."""
+        shard = tmp_path / "production_log_2026_07_01.jsonl"
+        _write_shard(shard, [_row("0xbb")])
+        queries: list[str] = []
+        fake = _make_fake_post_graphql(
+            {"0xbb": VALID_RESPONSE}, schema=DELIVERS_SCHEMA_LEGACY
+        )
+
+        def spy(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            """Record the query text, then serve the legacy-schema fake."""
+            queries.append(payload["query"])
+            return fake(url, payload)
+
+        monkeypatch.setattr(br, "_post_graphql", spy)
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["repaired"] == 1
+        assert all("toolResponse" in q for q in queries)
+        assert all("parsedDelivery" not in q for q in queries)
+        repaired = _read_shard(shard)[0]
+        assert repaired["p_yes"] == 0.72
+        assert repaired["prediction_parse_status"] == "valid"
+
+    def test_parsed_delivery_not_indexed_leaves_row_untouched(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A deliver whose parsedDelivery is still null stays a candidate."""
+        shard = tmp_path / "production_log_2026_07_01.jsonl"
+        _write_shard(shard, [_row("0xbb")])
+        monkeypatch.setattr(
+            br, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
+        )
+        monkeypatch.setattr(
+            br,
+            "_post_graphql",
+            _make_fake_post_graphql({}, schema=DELIVERS_SCHEMA_PARSED),
+        )
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["repaired"] == 0
+        assert _read_shard(shard) == [_row("0xbb")]
+
+    def test_probe_failure_skips_platform(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failing schema probe skips the platform without failing the run."""
+        _write_shard(tmp_path / "production_log_2026_07_01.jsonl", [_row("0x01")])
+
+        def boom(url: str) -> str:
+            """Simulate a probe hitting an unreachable endpoint."""
+            raise RuntimeError("probe failed")
+
+        calls: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(br, "detect_delivers_schema", boom)
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}, calls))
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["repaired"] == 0
+        assert not calls  # no by-ids query was ever issued
+
+    def test_probe_once_per_platform(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Each platform's endpoint is probed exactly once per run."""
+        _write_shard(
+            tmp_path / "production_log_2026_07_01.jsonl",
+            [
+                _row("0x01", platform="omen"),
+                _row("0x02", platform="omen"),
+                _row("0x03", platform="polymarket"),
+            ],
+        )
+        probed: list[str] = []
+
+        def probe(url: str) -> str:
+            """Record the probed URL and report the legacy shape."""
+            probed.append(url)
+            return DELIVERS_SCHEMA_LEGACY
+
+        monkeypatch.setattr(br, "detect_delivers_schema", probe)
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}))
+
+        br.backfill(tmp_path)
+
+        assert sorted(probed) == sorted(
+            [br.MECH_MARKETPLACE_GNOSIS_URL, br.MECH_MARKETPLACE_POLYGON_URL]
+        )
+
+    def test_no_probe_without_candidates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Healthy shards trigger neither a schema probe nor any query."""
+        _write_shard(
+            tmp_path / "production_log_2026_07_01.jsonl",
+            [_row("0xaa", status="valid", p_yes=0.5, p_no=0.5)],
+        )
+
+        def probe(url: str) -> str:
+            """Fail the test if the probe fires on a healthy dataset."""
+            raise AssertionError("schema probe must not run")
+
+        calls: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(br, "detect_delivers_schema", probe)
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}, calls))
+
+        summary = br.backfill(tmp_path)
+
+        assert summary["candidates"] == 0
+        assert not calls
+
+
+# ---------------------------------------------------------------------------
+# CLI / GitHub output
+# ---------------------------------------------------------------------------
+
+
+class TestMainOutput:
+    """Tests for the CLI entry point and workflow output emission."""
+
+    def test_repaired_line_and_github_output(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """main() prints repaired=<n> and appends it to $GITHUB_OUTPUT."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        _write_shard(logs_dir / "production_log_2026_07_01.jsonl", [_row("0xbb")])
+        gh_output = tmp_path / "gh_output.txt"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(gh_output))
+        monkeypatch.setattr(
+            br, "_post_graphql", _make_fake_post_graphql({"0xbb": VALID_RESPONSE})
+        )
+        monkeypatch.setattr(
+            "sys.argv", ["backfill_responses", "--logs-dir", str(logs_dir)]
+        )
+
+        br.main()
+
+        assert "repaired=1" in capsys.readouterr().out
+        assert "repaired=1" in gh_output.read_text()
+
+    def test_no_github_output_env(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Without $GITHUB_OUTPUT, main() still prints the repaired line."""
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}))
+        monkeypatch.setattr(
+            "sys.argv", ["backfill_responses", "--logs-dir", str(tmp_path)]
+        )
+
+        br.main()
+
+        assert "repaired=0" in capsys.readouterr().out
+
+    def test_main_never_raises(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """An unexpected failure is swallowed and reported as repaired=0."""
+
+        def boom(logs_dir: Path, batch_size: int = 0) -> dict[str, Any]:
+            """Simulate an unexpected crash inside the backfill."""
+            raise RuntimeError("unexpected")
+
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        monkeypatch.setattr(br, "backfill", boom)
+        monkeypatch.setattr(
+            "sys.argv", ["backfill_responses", "--logs-dir", str(tmp_path)]
+        )
+
+        br.main()  # must not raise
+
+        assert "repaired=0" in capsys.readouterr().out

--- a/benchmark/tests/test_backfill_responses.py
+++ b/benchmark/tests/test_backfill_responses.py
@@ -28,6 +28,7 @@ from benchmark.datasets import backfill_responses as br
 from benchmark.datasets.fetch_production import (
     DELIVERS_SCHEMA_LEGACY,
     DELIVERS_SCHEMA_PARSED,
+    parse_tool_response,
 )
 
 # ---------------------------------------------------------------------------
@@ -177,6 +178,36 @@ class TestRepairRow:
         before = dict(row)
         assert br.repair_row(row, '{"p_yes": 0.9, "p_no": 0.9}') is False
         assert row == before
+
+    def test_backfills_bucketing_metadata_when_null(self) -> None:
+        """A repair fills model/tool_version/config_hash when they are null."""
+        row = _row("0x01")  # no model/tool_version/config_hash keys
+        assert (
+            br.repair_row(row, VALID_RESPONSE, model="gpt-4o", tool_hash="bafyabc")
+            is True
+        )
+        assert row["model"] == "gpt-4o"
+        assert row["tool_version"] == "bafyabc"
+        assert row["config_hash"] is not None
+
+    def test_does_not_overwrite_existing_metadata(self) -> None:
+        """Existing (non-null) model/tool_version/config_hash are preserved."""
+        row = _row("0x01", model="existing", tool_version="v1", config_hash="c1")
+        assert (
+            br.repair_row(row, VALID_RESPONSE, model="gpt-4o", tool_hash="bafyabc")
+            is True
+        )
+        assert row["model"] == "existing"
+        assert row["tool_version"] == "v1"
+        assert row["config_hash"] == "c1"
+
+    def test_no_metadata_added_when_not_supplied(self) -> None:
+        """Without model/tool_hash the repair adds no bucketing metadata."""
+        row = _row("0x01")
+        assert br.repair_row(row, VALID_RESPONSE) is True
+        assert "model" not in row
+        assert "tool_version" not in row
+        assert "config_hash" not in row
 
 
 # ---------------------------------------------------------------------------
@@ -624,7 +655,11 @@ class TestMainOutput:
     ) -> None:
         """An unexpected failure is swallowed and reported as repaired=0."""
 
-        def boom(logs_dir: Path, batch_size: int = 0) -> dict[str, Any]:
+        def boom(
+            logs_dir: Path,
+            batch_size: int = 0,
+            max_shard_age_days: Optional[int] = None,
+        ) -> dict[str, Any]:
             """Simulate an unexpected crash inside the backfill."""
             raise RuntimeError("unexpected")
 
@@ -637,3 +672,148 @@ class TestMainOutput:
         br.main()  # must not raise
 
         assert "repaired=0" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Status-literal contract (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestStatusLiteralContract:
+    """Pin the parse-status literal this module keys candidates on.
+
+    ``CANDIDATE_PARSE_STATUS`` is a bare string that must equal what
+    ``fetch_production.parse_tool_response`` emits for empty/null input; a
+    silent rename there would zero candidates forever. This test breaks
+    instead so the contract is enforced from within #396 without editing
+    fetch_production. (A shared Literal/StrEnum is the cleaner long-term
+    fix but belongs to a base-branch/main change.)
+    """
+
+    def test_candidate_parse_status_matches_fetch_production(self) -> None:
+        """Empty/null input yields exactly CANDIDATE_PARSE_STATUS."""
+        for empty in (None, ""):
+            result = parse_tool_response(empty)
+            assert result["prediction_parse_status"] == br.CANDIDATE_PARSE_STATUS
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation (critical-path tests)
+# ---------------------------------------------------------------------------
+
+
+class TestFailureIsolation:
+    """Highest-risk paths: a corrupt line and a partial rewrite failure."""
+
+    def test_corrupt_line_skipped_other_shards_still_repaired(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A malformed JSONL line is skipped; other shards still repair."""
+        # Shard A carries a corrupt line before a valid candidate.
+        bad = tmp_path / "production_log_2026_07_01.jsonl"
+        with open(bad, "w", encoding="utf-8") as f:
+            f.write("{ this is not valid json\n")
+            f.write(json.dumps(_row("0xaa"), ensure_ascii=False) + "\n")
+        # Shard B is clean with its own candidate.
+        good = tmp_path / "production_log_2026_07_02.jsonl"
+        _write_shard(good, [_row("0xbb")])
+        monkeypatch.setattr(
+            br,
+            "_post_graphql",
+            _make_fake_post_graphql({"0xaa": VALID_RESPONSE, "0xbb": VALID_RESPONSE}),
+        )
+
+        summary = br.backfill(tmp_path)
+
+        # Corrupt line counted, not fatal; both candidates repaired.
+        assert summary["skipped_lines"] == 1
+        assert summary["repaired"] == 2
+        assert summary["backfill_error"] is False
+        assert _read_shard(good)[0]["prediction_parse_status"] == "valid"
+        repaired_bad = _read_shard(bad)
+        assert [r["deliver_id"] for r in repaired_bad] == ["0xaa"]
+        assert repaired_bad[0]["prediction_parse_status"] == "valid"
+
+    def test_partial_rewrite_failure_reflected_in_output(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """2nd-shard rewrite raising: 1st shard's repair + error still ship."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        # Two dirty shards; sorted order rewrites 07_01 before 07_02.
+        first = logs_dir / "production_log_2026_07_01.jsonl"
+        second = logs_dir / "production_log_2026_07_02.jsonl"
+        _write_shard(first, [_row("0xaa")])
+        _write_shard(second, [_row("0xbb")])
+        gh_output = tmp_path / "gh_output.txt"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(gh_output))
+        monkeypatch.setattr(
+            br,
+            "_post_graphql",
+            _make_fake_post_graphql({"0xaa": VALID_RESPONSE, "0xbb": VALID_RESPONSE}),
+        )
+
+        real_rewrite = br._rewrite_shard_atomic  # pylint: disable=protected-access
+        state = {"n": 0}
+
+        def flaky_rewrite(path: Path, rows: list[dict[str, Any]]) -> None:
+            """Succeed on the first shard, raise on the second."""
+            state["n"] += 1
+            if state["n"] == 2:
+                raise RuntimeError("disk full")
+            real_rewrite(path, rows)
+
+        monkeypatch.setattr(br, "_rewrite_shard_atomic", flaky_rewrite)
+        monkeypatch.setattr(
+            "sys.argv", ["backfill_responses", "--logs-dir", str(logs_dir)]
+        )
+
+        br.main()  # must not raise
+
+        out = capsys.readouterr().out
+        assert "repaired=1" in out
+        assert "backfill_error=true" in out
+        text = gh_output.read_text()
+        assert "repaired=1" in text
+        assert "backfill_error=true" in text
+        # First shard was rewritten; second stayed a candidate.
+        assert _read_shard(first)[0]["prediction_parse_status"] == "valid"
+        assert _read_shard(second)[0]["prediction_parse_status"] == "missing_fields"
+
+
+# ---------------------------------------------------------------------------
+# Shard-age bound
+# ---------------------------------------------------------------------------
+
+
+class TestShardAgeBound:
+    """Tests for the --max-shard-age-days give-up bound."""
+
+    def test_old_shard_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A shard older than the bound is skipped entirely (given up on)."""
+        _write_shard(tmp_path / "production_log_2000_01_01.jsonl", [_row("0xold")])
+        calls: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}, calls))
+
+        summary = br.backfill(tmp_path, max_shard_age_days=120)
+
+        assert summary["shards_scanned"] == 0
+        assert summary["candidates"] == 0
+        assert not calls
+
+    def test_unparseable_shard_name_never_age_gated(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A shard whose name has no date is scanned regardless of the bound."""
+        _write_shard(tmp_path / "production_log_legacy.jsonl", [_row("0x01")])
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}))
+
+        summary = br.backfill(tmp_path, max_shard_age_days=1)
+
+        assert summary["shards_scanned"] == 1
+        assert summary["candidates"] == 1

--- a/benchmark/tests/test_backfill_responses.py
+++ b/benchmark/tests/test_backfill_responses.py
@@ -212,6 +212,16 @@ class TestRepairRow:
         assert "tool_version" not in row
         assert "config_hash" not in row
 
+    def test_empty_string_metadata_treated_as_absent(self) -> None:
+        """An empty-string model/tool_hash never fills the row (presence)."""
+        row = _row("0x01")
+        assert br.repair_row(row, VALID_RESPONSE, model="", tool_hash="") is True
+        # Empty strings are absent: no useless "" written that would then
+        # defeat a future fill-if-null.
+        assert "model" not in row
+        assert "tool_version" not in row
+        assert "config_hash" not in row
+
 
 # ---------------------------------------------------------------------------
 # backfill: repair behaviour
@@ -786,6 +796,69 @@ class TestFailureIsolation:
         assert _read_shard(first)[0]["prediction_parse_status"] == "valid"
         assert _read_shard(second)[0]["prediction_parse_status"] == "missing_fields"
 
+    def test_dropped_line_quarantined_when_shard_rewritten(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A dropped line is quarantined (not lost) on rewrite; skipped_lines emitted."""
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        shard = logs_dir / "production_log_2026_07_01.jsonl"
+        corrupt = "{ this is not valid json\n"
+        with open(shard, "w", encoding="utf-8") as f:
+            f.write(corrupt)
+            f.write(json.dumps(_row("0xaa"), ensure_ascii=False) + "\n")
+        gh_output = tmp_path / "gh_output.txt"
+        monkeypatch.setenv("GITHUB_OUTPUT", str(gh_output))
+        monkeypatch.setattr(
+            br, "_post_graphql", _make_fake_post_graphql({"0xaa": VALID_RESPONSE})
+        )
+        monkeypatch.setattr(
+            "sys.argv", ["backfill_responses", "--logs-dir", str(logs_dir)]
+        )
+
+        br.main()
+
+        # The repaired candidate remains; the corrupt line is gone from it.
+        after = _read_shard(shard)
+        assert [r["deliver_id"] for r in after] == ["0xaa"]
+        # ...but its raw text is preserved verbatim in the reject file.
+        rejected = logs_dir / "production_log_2026_07_01.jsonl.rejected.jsonl"
+        assert rejected.exists()
+        assert rejected.read_text(encoding="utf-8") == corrupt
+        # skipped_lines surfaced for the flywheel summary.
+        assert "skipped_lines=1" in gh_output.read_text()
+        # A second run does not re-scan or re-quarantine the reject file.
+        summary2 = br.backfill(logs_dir)
+        assert summary2["skipped_lines"] == 0
+        assert rejected.read_text(encoding="utf-8") == corrupt
+
+    def test_undecodable_shard_isolated_other_shards_repaired(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bad UTF-8 byte skips that shard; others still repair, no raise."""
+        # Shard A holds a raw invalid UTF-8 byte: iteration decodes it and
+        # raises UnicodeDecodeError before the per-line json guard.
+        bad = tmp_path / "production_log_2026_07_01.jsonl"
+        bad.write_bytes(b"\xff\xfe not valid utf-8\n")
+        # Shard B is a clean, repairable candidate.
+        good = tmp_path / "production_log_2026_07_02.jsonl"
+        _write_shard(good, [_row("0xbb")])
+        monkeypatch.setattr(
+            br, "_post_graphql", _make_fake_post_graphql({"0xbb": VALID_RESPONSE})
+        )
+
+        summary = br.backfill(tmp_path)  # must not raise
+
+        # Undecodable shard isolated + flagged; healthy shard still repaired.
+        assert summary["backfill_error"] is True
+        assert summary["repaired"] == 1
+        assert _read_shard(good)[0]["prediction_parse_status"] == "valid"
+        # The undecodable shard was left untouched (bytes unchanged).
+        assert bad.read_bytes() == b"\xff\xfe not valid utf-8\n"
+
 
 # ---------------------------------------------------------------------------
 # Shard-age bound
@@ -817,6 +890,23 @@ class TestShardAgeBound:
         monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}))
 
         summary = br.backfill(tmp_path, max_shard_age_days=1)
+
+        assert summary["shards_scanned"] == 1
+        assert summary["candidates"] == 1
+
+    @pytest.mark.parametrize("disabled", [0, -1])
+    def test_zero_or_negative_age_scans_all_shards(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        disabled: int,
+    ) -> None:
+        """max_shard_age_days <= 0 disables the bound directly in backfill()."""
+        # A very old shard that any positive bound would skip.
+        _write_shard(tmp_path / "production_log_2000_01_01.jsonl", [_row("0xold")])
+        monkeypatch.setattr(br, "_post_graphql", _make_fake_post_graphql({}))
+
+        summary = br.backfill(tmp_path, max_shard_age_days=disabled)
 
         assert summary["shards_scanned"] == 1
         assert summary["candidates"] == 1

--- a/benchmark/tests/test_backfill_responses.py
+++ b/benchmark/tests/test_backfill_responses.py
@@ -151,18 +151,21 @@ class TestRepairRow:
     """Tests for single-row repair."""
 
     def test_valid_response_repairs_in_place(self) -> None:
-        """A now-present valid response updates p_yes/p_no/status/confidence."""
+        """A now-present valid response updates p_yes/p_no/status."""
         row = _row("0x01")
         assert br.repair_row(row, VALID_RESPONSE) is True
         assert row["p_yes"] == 0.72
         assert row["p_no"] == 0.28
         assert row["prediction_parse_status"] == "valid"
-        assert row["confidence"] == 0.85
 
-    def test_no_confidence_key_when_not_parsed(self) -> None:
-        """A response without confidence does not add the field."""
+    def test_confidence_never_added(self) -> None:
+        """No confidence key is ever written.
+
+        build_row discards it, so a repaired row must match the normal shard
+        row shape even when the response carries a confidence value.
+        """
         row = _row("0x01")
-        assert br.repair_row(row, '{"p_yes": 0.6, "p_no": 0.4}') is True
+        assert br.repair_row(row, VALID_RESPONSE) is True
         assert "confidence" not in row
 
     def test_still_null_untouched(self) -> None:
@@ -243,7 +246,7 @@ class TestBackfillRepairs:
         assert repaired["p_yes"] == 0.72
         assert repaired["p_no"] == 0.28
         assert repaired["prediction_parse_status"] == "valid"
-        assert repaired["confidence"] == 0.85
+        assert "confidence" not in repaired
         # Untouched fields survive
         assert repaired["row_id"] == rows[1]["row_id"]
         assert repaired["question_text"] == rows[1]["question_text"]


### PR DESCRIPTION
Stacked on #395 (reuses its `detect_delivers_schema` / `DELIVERS_PARSED_BY_IDS_QUERY` / `extract_delivery_fields` helpers — merge #395 first).

**Problem.** The production fetch is append-only: a delivery row written while its tool response is unavailable upstream stays `missing_fields`/`p_yes=null` in the daily shards forever — no re-run repairs it, and `force_rebuild` only recomputes scores from the broken rows. Concretely: the Gnosis marketplace subgraph has served NULL `toolResponse` since 2026-06-26 ~23:00 UTC (fix in flight via autonolas-subgraph#113 + #395), so ~10k+ Omen rows (100% of factual_research/superforcaster production rows since Jun 28) are currently unscoreable — silently shrinking the daily accuracy report's Omen samples and flagging healthy tools in the ROI companion. Shorter bouts of the same signature also occurred Jun 13–14/21/24.

**Fix.** A new `benchmark/datasets/backfill_responses.py` module + one flywheel step right after the artifact download: scans shards for `missing_fields` rows, re-queries their deliveries by id (schema-aware: parsed or legacy), and repairs rows in place once data exists; `repaired > 0` triggers the existing force-rebuild path (repaired rows already sit in `scored_row_ids.json`, so only a rebuild rescores them). Complementary to #395's `refresh_unparsed_pending`, which defers not-yet-written deliveries — this repairs already-written history.

**Properties (all test-pinned; 15+6 new tests, 143 pass with fetch regression).** Idempotent; atomic shard rewrites; per-batch failure tolerance, always exits 0; healthy data = 0.2 s scan with zero network calls; live-validated today: 3,598 real candidates re-queried, repaired=0 (subgraph still legacy/null), shards byte-identical — and a simulated fixed subgraph repaired exactly the one targeted row with its real IPFS-recovered answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)