### PR TITLE
fix(benchmark): post the ROI Slack section as its own message

### DIFF
--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -399,8 +399,8 @@ def main() -> None:
         type=Path,
         default=Path("benchmark/results/roi_results.json"),
         help=(
-            "Path to roi_results.json (from benchmark.roi_sim) for the "
-            "appended ROI companion section."
+            "Path to roi_results.json (from benchmark.roi_sim) for the ROI "
+            "companion message posted after the digest."
         ),
     )
     args = parser.parse_args()

--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -448,32 +448,41 @@ def main() -> None:
     if report_url:
         summary += f"\n<{report_url}|Full report>"
 
-    # ROI companion section: appended to the end of the same per-platform
-    # message. Best-effort by design -- a broken/missing ROI section must
-    # NEVER break the daily post, so any failure here degrades to posting
-    # the summary without it. ROI_SECTION=off disables the append entirely.
+    # ROI companion section: posted as its OWN message right after the
+    # per-platform digest, NOT appended to it. A fenced code block appended
+    # to a long digest is split (and its ``` fence broken) by Slack's
+    # ~3000-char text rendering; a standalone message keeps the block intact.
+    # Best-effort by design -- a broken/missing ROI section, or a failure
+    # posting it, must NEVER break the daily digest. ROI_SECTION=off disables
+    # it entirely.
+    roi_section = None
     if os.environ.get("ROI_SECTION", "on").strip().lower() != "off":
         try:
             platform_key = _PLATFORM_KEY_BY_LABEL.get(platform_label)
-            roi_section = (
-                build_roi_section(args.roi_results, platform_key)
-                if platform_key is not None
-                else None
-            )
-            if roi_section:
-                summary += f"\n\n{roi_section}"
+            if platform_key is not None:
+                roi_section = build_roi_section(args.roi_results, platform_key)
         except Exception:  # pylint: disable=broad-except
             log.warning(
-                "ROI section build failed; posting summary without it.",
+                "ROI section build failed; posting digest without it.",
                 exc_info=True,
             )
 
     if args.dry_run:
         print(summary)
+        if roi_section:
+            print(f"\n\n{roi_section}")
         return
 
     log.info("Posting to Slack...")
     post_to_slack(webhook_url, summary)
+    if roi_section:
+        try:
+            post_to_slack(webhook_url, roi_section)
+        except Exception:  # pylint: disable=broad-except
+            log.warning(
+                "Posting the ROI section failed; digest was posted.",
+                exc_info=True,
+            )
     log.info("Done.")
 
 

--- a/benchmark/roi_slack.py
+++ b/benchmark/roi_slack.py
@@ -16,26 +16,29 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-"""Render the ROI companion section appended to the daily benchmark Slack post.
+"""Render the ROI companion section posted as its own message after the daily benchmark Slack digest.
 
 Pure builder over ``roi_results.json`` (written by ``benchmark.roi_sim``):
 no network, no LLM, stdlib only (the model display-name map is imported from
 ``benchmark.roi_sim``, itself stdlib-only). :func:`build_roi_section` returns a Slack
 mrkdwn snippet -- one intro line plus a compact fixed-width table inside a
-fenced code block -- or None when there is nothing to append (missing or
+fenced code block -- or None when there is nothing to post (missing or
 unparseable results file, or no groups for the platform). Callers treat
-None as "append nothing"; a broken ROI section must never break the daily
+None as "skip the section"; a broken ROI section must never break the daily
 post, so this module never raises for bad input data.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import re
 from pathlib import Path
 from typing import Any
 
 from benchmark.roi_sim import MODEL_DISPLAY, _is_number, roi_display_sort_key
+
+log = logging.getLogger(__name__)
 
 # Slack desktop code blocks SCROLL horizontally -- they do NOT wrap -- so a
 # wide table renders fine; MAX_LINE_WIDTH is only a truncation backstop for
@@ -348,14 +351,34 @@ def _display_sort_key(
 def _load_results(results_path: Path) -> dict[str, Any] | None:
     """Read and parse roi_results.json, tolerating any failure.
 
+    A missing file is expected (the roi_sim step may have produced no results
+    yet) and stays quiet. A present-but-unreadable or malformed file signals
+    upstream pipeline breakage (a broken roi_sim step, a truncated artifact),
+    so it is logged at WARNING -- otherwise the vanished ROI section is
+    indistinguishable from "no data yet".
+
     :param results_path: path to the results file.
     :return: parsed payload dict, or None when missing/unparseable.
     """
     try:
         payload = json.loads(results_path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError) as exc:
+        log.warning(
+            "ROI results at %s are present but unreadable (%s); "
+            "skipping the ROI section.",
+            results_path,
+            exc,
+        )
         return None
     if not isinstance(payload, dict):
+        log.warning(
+            "ROI results at %s parsed to %s, not an object; "
+            "skipping the ROI section.",
+            results_path,
+            type(payload).__name__,
+        )
         return None
     return payload
 

--- a/benchmark/tests/test_roi_slack.py
+++ b/benchmark/tests/test_roi_slack.py
@@ -22,7 +22,7 @@ import json
 import logging
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable, Optional
 
 import pytest
 from benchmark import notify_slack
@@ -799,7 +799,7 @@ class TestLineWidth:
 
 
 # ---------------------------------------------------------------------------
-# notify_slack append hook
+# notify_slack separate-message hook
 # ---------------------------------------------------------------------------
 
 
@@ -812,7 +812,7 @@ class TestNotifySlackHook:
         tmp_path: Path,
         extra_argv: list[str] | None = None,
         roi_env: str | None = None,
-        post_stub: Any = None,
+        post_stub: Optional[Callable[[str, str], None]] = None,
     ) -> list[str]:
         """Drive notify_slack.main with network + LLM stubbed; return posts.
 
@@ -842,14 +842,17 @@ class TestNotifySlackHook:
         monkeypatch.setenv("OPENAI_API_KEY", "test-key")
         monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.test/T000")
         posted: list[str] = []
+
+        def _record(url: str, text: str) -> None:
+            """Record every posted text, then delegate to ``post_stub`` if given."""
+            posted.append(text)
+            if post_stub is not None:
+                post_stub(url, text)
+
         monkeypatch.setattr(
             notify_slack, "summarize_report", lambda *a, **k: "LLM SUMMARY"
         )
-        monkeypatch.setattr(
-            notify_slack,
-            "post_to_slack",
-            post_stub or (lambda url, text: posted.append(text)),
-        )
+        monkeypatch.setattr(notify_slack, "post_to_slack", _record)
         argv = ["notify_slack", "--report", str(report)] + (extra_argv or [])
         monkeypatch.setattr(sys, "argv", argv)
         notify_slack.main()
@@ -880,6 +883,27 @@ class TestNotifySlackHook:
         assert posted[1] == "ROI_MARKER_SECTION"
         # Platform key derived from the report's platform label.
         assert calls == [(Path("benchmark/results/roi_results.json"), "omen")]
+
+    def test_dry_run_prints_digest_and_roi_section(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--dry-run prints both the digest and the ROI section and posts nothing.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        monkeypatch.setattr(
+            notify_slack, "build_roi_section", lambda *a, **k: "ROI_MARKER_SECTION"
+        )
+        posted = self._run_main(monkeypatch, tmp_path, extra_argv=["--dry-run"])
+        out = capsys.readouterr().out
+        assert "LLM SUMMARY" in out
+        assert "ROI_MARKER_SECTION" in out
+        assert posted == []  # dry-run must never call post_to_slack
 
     def test_roi_post_failure_never_breaks_digest(
         self,

--- a/benchmark/tests/test_roi_slack.py
+++ b/benchmark/tests/test_roi_slack.py
@@ -804,7 +804,7 @@ class TestLineWidth:
 
 
 class TestNotifySlackHook:
-    """notify_slack appends the ROI section without ever breaking the post."""
+    """notify_slack posts the ROI section as its own best-effort message."""
 
     @staticmethod
     def _run_main(
@@ -812,6 +812,7 @@ class TestNotifySlackHook:
         tmp_path: Path,
         extra_argv: list[str] | None = None,
         roi_env: str | None = None,
+        post_stub: Any = None,
     ) -> list[str]:
         """Drive notify_slack.main with network + LLM stubbed; return posts.
 
@@ -819,6 +820,8 @@ class TestNotifySlackHook:
         :param tmp_path: pytest tmp_path fixture.
         :param extra_argv: extra CLI arguments appended after --report.
         :param roi_env: value for the ROI_SECTION env var, or None to leave it unset.
+        :param post_stub: optional post_to_slack replacement (url, text) -> None;
+            defaults to one that records the posted text.
         :return: texts posted to the Slack webhook stub.
         """
         report = tmp_path / "report_omen.md"
@@ -843,17 +846,22 @@ class TestNotifySlackHook:
             notify_slack, "summarize_report", lambda *a, **k: "LLM SUMMARY"
         )
         monkeypatch.setattr(
-            notify_slack, "post_to_slack", lambda url, text: posted.append(text)
+            notify_slack,
+            "post_to_slack",
+            post_stub or (lambda url, text: posted.append(text)),
         )
         argv = ["notify_slack", "--report", str(report)] + (extra_argv or [])
         monkeypatch.setattr(sys, "argv", argv)
         notify_slack.main()
         return posted
 
-    def test_section_appended_after_summary(
+    def test_section_posted_as_separate_message(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """The builder's text lands at the end of the posted message.
+        """The ROI section is a second, standalone message after the digest.
+
+        Posting it separately keeps its fenced code block from being split by
+        Slack's long-text rendering when the digest is large.
 
         :param monkeypatch: pytest monkeypatch fixture.
         :param tmp_path: pytest tmp_path fixture.
@@ -866,11 +874,40 @@ class TestNotifySlackHook:
 
         monkeypatch.setattr(notify_slack, "build_roi_section", _fake_builder)
         posted = self._run_main(monkeypatch, tmp_path)
-        assert len(posted) == 1
-        assert posted[0].index("LLM SUMMARY") < posted[0].index("ROI_MARKER_SECTION")
-        assert posted[0].endswith("ROI_MARKER_SECTION")
+        assert len(posted) == 2
+        assert "LLM SUMMARY" in posted[0]
+        assert "ROI_MARKER_SECTION" not in posted[0]
+        assert posted[1] == "ROI_MARKER_SECTION"
         # Platform key derived from the report's platform label.
         assert calls == [(Path("benchmark/results/roi_results.json"), "omen")]
+
+    def test_roi_post_failure_never_breaks_digest(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A failure posting the ROI message leaves the digest post intact.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        :param caplog: pytest caplog fixture.
+        """
+        monkeypatch.setattr(
+            notify_slack, "build_roi_section", lambda *a, **k: "ROI_MARKER_SECTION"
+        )
+        posted: list[str] = []
+
+        def _post(url: str, text: str) -> None:
+            posted.append(text)
+            if text == "ROI_MARKER_SECTION":
+                raise RuntimeError("slack down")
+
+        with caplog.at_level(logging.WARNING, logger="benchmark.notify_slack"):
+            self._run_main(monkeypatch, tmp_path, post_stub=_post)
+        assert "LLM SUMMARY" in posted[0]
+        assert posted[1] == "ROI_MARKER_SECTION"
+        assert "Posting the ROI section failed" in caplog.text
 
     def test_roi_results_flag_passed_through(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/benchmark/tests/test_roi_slack.py
+++ b/benchmark/tests/test_roi_slack.py
@@ -903,7 +903,7 @@ class TestNotifySlackHook:
         out = capsys.readouterr().out
         assert "LLM SUMMARY" in out
         assert "ROI_MARKER_SECTION" in out
-        assert posted == []  # dry-run must never call post_to_slack
+        assert not posted  # dry-run must never call post_to_slack
 
     def test_roi_post_failure_never_breaks_digest(
         self,


### PR DESCRIPTION
## What
Posts the ROI companion section as its **own** Slack message right after each platform's daily digest, instead of appending it to the digest text.

## Why
The ROI section is a fenced code block. Appended to a **long** digest, Slack's ~3000-char text rendering splits the message at a line boundary that can land **inside** the code block — breaking the ``` fence and slicing the table in two.

Observed live on today's post: **Polystrat** (large digest — Top/Worst tools, Tool×Category, Version Deltas, 4 tournament callouts, Diagnostics) rendered the ROI table split and mis-fenced; **Omenstrat** rendered fine only because its digest was short (subgraph incident → "no eligible tools").

This isn't ROI-specific — any fenced block in a long message hits it — so the robust fix is at the posting layer.

## Change (minimal)
- `notify_slack.main()`: build the ROI section as before, but `post_to_slack` it as a separate message after the digest; wrapped so a failed ROI post can never break the digest post. Dry-run prints both.
- Trade-off: two messages per platform (digest, then ROI) instead of one.

## Tests
- `test_section_posted_as_separate_message` (was `_appended_after_summary`): asserts two messages — ROI marker absent from the digest, present as the standalone second post.
- New `test_roi_post_failure_never_breaks_digest`: a failing ROI post leaves the digest post intact + logs a warning.
- None / `ROI_SECTION=off` / build-exception paths unchanged. 151 tests pass; all tomte lint envs green.

## Follow-up (not here)
A single-message solution via Block-Kit row-boundary chunking would also fix #381's digest tables — best folded into #381.

🤖 Generated with [Claude Code](https://claude.com/claude-code)