### PR TITLE
Join `ParsedDelivery` by id instead of nested read

### DIFF
--- a/benchmark/datasets/backfill_responses.py
+++ b/benchmark/datasets/backfill_responses.py
@@ -96,11 +96,10 @@ from benchmark.datasets.fetch_production import (
     LOGS_DIR,
     MECH_MARKETPLACE_GNOSIS_URL,
     MECH_MARKETPLACE_POLYGON_URL,
-    PARSED_DELIVERIES_BY_IDS_QUERY,
     _compute_config_hash,
-    _parsed_delivery_extra_fields,
     detect_delivers_schema,
     extract_delivery_fields,
+    fetch_parsed_deliveries,
     parse_tool_response,
 )
 from benchmark.datasets.subgraph import post_graphql
@@ -203,13 +202,13 @@ def fetch_tool_responses(
     """Requery the marketplace subgraph for tool responses by deliver id.
 
     The endpoint's delivers shape is probed once via
-    :func:`detect_delivers_schema`: on the parsed schema the payload lives
-    in the separate top-level ParsedDelivery entity (same id as the
-    Deliver, queried via ``id_in``; ``tool``/``toolHash`` selected only
-    where deployed), on the legacy schema in the flat Deliver fields.
-    Every returned row is mapped through
-    :func:`extract_delivery_fields`, so a future schema change only needs
-    handling in ``fetch_production``. Deliveries whose parsed payload has
+    :func:`detect_delivers_schema`. On the parsed schema the payload lives
+    in the separate top-level ParsedDelivery entity, fetched via
+    :func:`fetch_parsed_deliveries` — the single owner of that query
+    shape — so a future schema change only needs handling in
+    ``fetch_production``. On the legacy schema the flat Deliver fields are
+    batch-requeried here. Every returned row is mapped through
+    :func:`extract_delivery_fields`. Deliveries whose parsed payload has
     not been indexed upstream yet are absent from the result.
 
     Queries in batches. A failed probe or batch is logged and skipped (its
@@ -227,11 +226,6 @@ def fetch_tool_responses(
     responses: dict[str, dict[str, Any]] = {}
     try:
         schema = detect_delivers_schema(marketplace_url)
-        extra_fields = (
-            _parsed_delivery_extra_fields(marketplace_url)
-            if schema == DELIVERS_SCHEMA_PARSED
-            else ""
-        )
     except Exception as e:  # pylint: disable=broad-except
         log.warning(
             "Delivers schema probe failed against %s: %s -- skipping",
@@ -239,21 +233,34 @@ def fetch_tool_responses(
             e,
         )
         return responses, True
+
+    if schema == DELIVERS_SCHEMA_PARSED:
+        try:
+            parsed_map, had_error = fetch_parsed_deliveries(
+                marketplace_url, deliver_ids, batch_size=batch_size
+            )
+        except Exception as e:  # pylint: disable=broad-except
+            # The optional-fields probe inside fetch_parsed_deliveries
+            # propagates non-schema errors; treat it like a failed probe.
+            log.warning(
+                "ParsedDelivery fields probe failed against %s: %s -- skipping",
+                marketplace_url,
+                e,
+            )
+            return responses, True
+        # Ids without a ParsedDelivery row yet are absent from the map --
+        # their rows stay candidates for a future run.
+        responses = {
+            pid: extract_delivery_fields({"parsedDelivery": row}, schema)
+            for pid, row in parsed_map.items()
+        }
+        return responses, had_error
+
     had_error = False
     for i in range(0, len(deliver_ids), batch_size):
         batch = deliver_ids[i : i + batch_size]
         ids_str = ", ".join(f'"{did}"' for did in batch)
-        if schema == DELIVERS_SCHEMA_PARSED:
-            query = PARSED_DELIVERIES_BY_IDS_QUERY % {
-                "first": len(batch),
-                "ids": ids_str,
-                "extra_fields": extra_fields,
-            }
-        else:
-            query = DELIVERS_LEGACY_BY_IDS_QUERY % {
-                "first": len(batch),
-                "ids": ids_str,
-            }
+        query = DELIVERS_LEGACY_BY_IDS_QUERY % {"first": len(batch), "ids": ids_str}
         try:
             data = _post_graphql(marketplace_url, {"query": query})
         except Exception as e:  # pylint: disable=broad-except
@@ -265,16 +272,8 @@ def fetch_tool_responses(
             )
             had_error = True
             continue
-        if schema == DELIVERS_SCHEMA_PARSED:
-            # Ids without a ParsedDelivery row yet simply don't come back
-            # -- their rows stay candidates for a future run.
-            for row in data.get("parsedDeliveries", []):
-                responses[row["id"]] = extract_delivery_fields(
-                    {"parsedDelivery": row}, schema
-                )
-        else:
-            for deliver in data.get("delivers", []):
-                responses[deliver["id"]] = extract_delivery_fields(deliver, schema)
+        for deliver in data.get("delivers", []):
+            responses[deliver["id"]] = extract_delivery_fields(deliver, schema)
     return responses, had_error
 
 

--- a/benchmark/datasets/backfill_responses.py
+++ b/benchmark/datasets/backfill_responses.py
@@ -42,8 +42,9 @@ Design:
      class this module heals -- must never abort the scan) and an
      unreadable or undecodable shard is isolated so it cannot sink the run.
   2. Batch-requery each platform's marketplace subgraph for those deliver
-     ids, using the query shape the endpoint supports (nested
-     ParsedDelivery vs legacy flat fields, probed once per endpoint via
+     ids, using the query shape the endpoint supports (the separate
+     top-level ParsedDelivery entity, joined by id, vs legacy flat
+     Deliver fields — probed once per endpoint via
      ``fetch_production.detect_delivers_schema``).
   3. Rows whose response is now available are re-parsed with the same
      parser the fetcher uses; rows that parse to a valid prediction are
@@ -90,13 +91,14 @@ from pathlib import Path
 from typing import Any, Optional
 
 from benchmark.datasets.fetch_production import (
-    DELIVERS_PARSED_BY_IDS_QUERY,
     DELIVERS_SCHEMA_PARSED,
     HTTP_TIMEOUT,
     LOGS_DIR,
     MECH_MARKETPLACE_GNOSIS_URL,
     MECH_MARKETPLACE_POLYGON_URL,
+    PARSED_DELIVERIES_BY_IDS_QUERY,
     _compute_config_hash,
+    _parsed_delivery_extra_fields,
     detect_delivers_schema,
     extract_delivery_fields,
     parse_tool_response,
@@ -157,9 +159,9 @@ PLATFORM_MARKETPLACE_URLS: dict[str, str] = {
 # GraphQL query
 # ---------------------------------------------------------------------------
 
-# Legacy-schema counterpart of fetch_production.DELIVERS_PARSED_BY_IDS_QUERY:
+# Legacy-schema counterpart of fetch_production.PARSED_DELIVERIES_BY_IDS_QUERY:
 # re-read the flat Deliver fields for specific deliveries on endpoints that
-# do not expose the nested ParsedDelivery entity. The field shape mirrors
+# do not expose the ParsedDelivery entity. The field shape mirrors
 # fetch_production.DELIVERS_QUERY_LEGACY so the result feeds
 # extract_delivery_fields unchanged.
 DELIVERS_LEGACY_BY_IDS_QUERY = """
@@ -200,12 +202,15 @@ def fetch_tool_responses(
 ) -> tuple[dict[str, dict[str, Any]], bool]:
     """Requery the marketplace subgraph for tool responses by deliver id.
 
-    The endpoint's delivers shape (nested ParsedDelivery vs legacy flat
-    fields) is probed once via :func:`detect_delivers_schema`, and every
-    returned deliver is mapped through :func:`extract_delivery_fields`, so
-    a future schema change only needs handling in ``fetch_production``.
-    Deliveries whose parsed payload has not been indexed upstream yet are
-    omitted from the result.
+    The endpoint's delivers shape is probed once via
+    :func:`detect_delivers_schema`: on the parsed schema the payload lives
+    in the separate top-level ParsedDelivery entity (same id as the
+    Deliver, queried via ``id_in``; ``tool``/``toolHash`` selected only
+    where deployed), on the legacy schema in the flat Deliver fields.
+    Every returned row is mapped through
+    :func:`extract_delivery_fields`, so a future schema change only needs
+    handling in ``fetch_production``. Deliveries whose parsed payload has
+    not been indexed upstream yet are absent from the result.
 
     Queries in batches. A failed probe or batch is logged and skipped (its
     rows simply stay unrepaired until the next run) so a subgraph failure
@@ -222,6 +227,11 @@ def fetch_tool_responses(
     responses: dict[str, dict[str, Any]] = {}
     try:
         schema = detect_delivers_schema(marketplace_url)
+        extra_fields = (
+            _parsed_delivery_extra_fields(marketplace_url)
+            if schema == DELIVERS_SCHEMA_PARSED
+            else ""
+        )
     except Exception as e:  # pylint: disable=broad-except
         log.warning(
             "Delivers schema probe failed against %s: %s -- skipping",
@@ -229,16 +239,21 @@ def fetch_tool_responses(
             e,
         )
         return responses, True
-    query_template = (
-        DELIVERS_PARSED_BY_IDS_QUERY
-        if schema == DELIVERS_SCHEMA_PARSED
-        else DELIVERS_LEGACY_BY_IDS_QUERY
-    )
     had_error = False
     for i in range(0, len(deliver_ids), batch_size):
         batch = deliver_ids[i : i + batch_size]
         ids_str = ", ".join(f'"{did}"' for did in batch)
-        query = query_template % {"first": len(batch), "ids": ids_str}
+        if schema == DELIVERS_SCHEMA_PARSED:
+            query = PARSED_DELIVERIES_BY_IDS_QUERY % {
+                "first": len(batch),
+                "ids": ids_str,
+                "extra_fields": extra_fields,
+            }
+        else:
+            query = DELIVERS_LEGACY_BY_IDS_QUERY % {
+                "first": len(batch),
+                "ids": ids_str,
+            }
         try:
             data = _post_graphql(marketplace_url, {"query": query})
         except Exception as e:  # pylint: disable=broad-except
@@ -250,13 +265,16 @@ def fetch_tool_responses(
             )
             had_error = True
             continue
-        for deliver in data.get("delivers", []):
-            fields = extract_delivery_fields(deliver, schema)
-            if fields["parsed_missing"]:
-                # Parsed payload not indexed upstream yet -- leave the row
-                # a candidate for a future run.
-                continue
-            responses[deliver["id"]] = fields
+        if schema == DELIVERS_SCHEMA_PARSED:
+            # Ids without a ParsedDelivery row yet simply don't come back
+            # -- their rows stay candidates for a future run.
+            for row in data.get("parsedDeliveries", []):
+                responses[row["id"]] = extract_delivery_fields(
+                    {"parsedDelivery": row}, schema
+                )
+        else:
+            for deliver in data.get("delivers", []):
+                responses[deliver["id"]] = extract_delivery_fields(deliver, schema)
     return responses, had_error
 
 

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -899,12 +899,13 @@ def _is_unknown_field_error(exc: RuntimeError) -> bool:
 def detect_delivers_schema(marketplace_url: str) -> str:
     """Detect which delivers query shape *marketplace_url* supports.
 
-    Probes with a one-row nested-ParsedDelivery query. An unknown-field
-    validation error means the endpoint still runs the legacy schema with
-    flat ``Deliver.model``/``toolResponse`` fields. Any other error
-    propagates — a transient failure must not silently lock the process
-    into the wrong shape. The result is cached per URL for the process
-    lifetime.
+    Probes with a one-row query against the top-level ``parsedDeliveries``
+    collection. An unknown-field validation error means the endpoint does
+    not expose the ParsedDelivery entity, i.e. it still runs the legacy
+    schema with flat ``Deliver.model``/``toolResponse`` fields. Any other
+    error propagates — a transient failure must not silently lock the
+    process into the wrong shape. The result is cached per URL for the
+    process lifetime.
 
     :param marketplace_url: subgraph endpoint URL.
     :return: ``DELIVERS_SCHEMA_PARSED`` or ``DELIVERS_SCHEMA_LEGACY``.

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -968,7 +968,8 @@ def _parsed_delivery_extra_fields(marketplace_url: str) -> str:
 def fetch_parsed_deliveries(
     marketplace_url: str,
     deliver_ids: list[str],
-) -> dict[str, dict[str, Any]]:
+    batch_size: int = DEFAULT_BATCH_SIZE,
+) -> tuple[dict[str, dict[str, Any]], bool]:
     """Batch-fetch ParsedDelivery rows for *deliver_ids*, keyed by id.
 
     ParsedDelivery is a separate top-level entity that shares its id with
@@ -976,19 +977,26 @@ def fetch_parsed_deliveries(
     Deliver, so the parsed payload is joined in a second query by id.
     Batch failures are logged and skipped; ids missing from the result are
     treated by callers as "not indexed yet" (async file-data-source lag).
+    The returned flag reports whether any batch failed, for callers that
+    must distinguish "not indexed" from "could not ask" (e.g. the shard
+    backfill's force-rebuild gating); callers whose retry semantics make
+    the distinction irrelevant simply ignore it.
 
     :param marketplace_url: subgraph endpoint URL.
     :param deliver_ids: deliver ids to look up (duplicates are collapsed).
-    :return: mapping of id to raw ParsedDelivery row.
+    :param batch_size: max ids per GraphQL request.
+    :return: ``(rows, had_error)`` — mapping of id to raw ParsedDelivery
+        row, and True when at least one batch failed.
     """
     result: dict[str, dict[str, Any]] = {}
     if not deliver_ids:
-        return result
+        return result, False
 
     extra_fields = _parsed_delivery_extra_fields(marketplace_url)
     unique_ids = list(dict.fromkeys(deliver_ids))
-    for i in range(0, len(unique_ids), DEFAULT_BATCH_SIZE):
-        batch = unique_ids[i : i + DEFAULT_BATCH_SIZE]
+    had_error = False
+    for i in range(0, len(unique_ids), batch_size):
+        batch = unique_ids[i : i + batch_size]
         ids_str = ", ".join(f'"{did}"' for did in batch)
         query = PARSED_DELIVERIES_BY_IDS_QUERY % {
             "first": len(batch),
@@ -999,11 +1007,12 @@ def fetch_parsed_deliveries(
             data = _post_graphql(marketplace_url, {"query": query})
         except (RuntimeError, requests.exceptions.RequestException) as e:
             log.warning("parsedDeliveries batch failed (%s), skipping batch", e)
+            had_error = True
             continue
         for row in data.get("parsedDeliveries", []):
             result[row["id"]] = row
 
-    return result
+    return result, had_error
 
 
 def _normalize_subgraph_string(value: Optional[str]) -> Optional[str]:
@@ -1179,9 +1188,11 @@ def fetch_deliveries(
         deliveries.append(entry)
 
     # Parsed schema: the ParsedDelivery rows live in a separate entity —
-    # join them by id in a second batched query.
+    # join them by id in a second batched query. Batch failures are
+    # deliberately ignored: affected delivers surface as parsed_missing
+    # and the deferral machinery retries them next run.
     if schema == DELIVERS_SCHEMA_PARSED and deliveries:
-        parsed_map = fetch_parsed_deliveries(
+        parsed_map, _ = fetch_parsed_deliveries(
             marketplace_url, [e["deliver_id"] for e in deliveries]
         )
         deliveries = [
@@ -1896,7 +1907,9 @@ def refresh_unparsed_pending(
     if detect_delivers_schema(marketplace_url) != DELIVERS_SCHEMA_PARSED:
         return pending
 
-    parsed_map = fetch_parsed_deliveries(marketplace_url, stale_ids)
+    # Batch failures are deliberately ignored: affected entries simply
+    # stay stale and are retried on the next run.
+    parsed_map, _ = fetch_parsed_deliveries(marketplace_url, stale_ids)
     fetched = {
         pid: extract_delivery_fields({"parsedDelivery": row}, DELIVERS_SCHEMA_PARSED)
         for pid, row in parsed_map.items()

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -675,9 +675,10 @@ CATEGORY_KEYWORDS: dict[str, list[str]] = {
 # ---------------------------------------------------------------------------
 
 # Marketplace: bulk fetch all recent deliveries with prediction data.
-# New schema: the IPFS-parsed response/model/toolHash live on the nested
-# ParsedDelivery entity (the flat Deliver.model/toolResponse fields were
-# removed in valory-xyz/autonolas-subgraph#113).
+# New schema: the IPFS-parsed response/model live on the separate top-level
+# ParsedDelivery entity, which shares its id with the Deliver it parses but
+# is NOT reachable as a nested field on Deliver — the parsed payload is
+# joined in a second query by id (see PARSED_DELIVERIES_BY_IDS_QUERY).
 DELIVERS_QUERY = """
 {
   delivers(
@@ -689,12 +690,6 @@ DELIVERS_QUERY = """
   ) {
     id
     blockTimestamp
-    parsedDelivery {
-      response
-      model
-      tool
-      toolHash
-    }
     request {
       id
       blockTimestamp
@@ -736,23 +731,30 @@ DELIVERS_QUERY_LEGACY = """
 }
 """
 
-# Re-read the parsed fields for specific deliveries (pending-store refresh).
-DELIVERS_PARSED_BY_IDS_QUERY = """
+# Batch-fetch ParsedDelivery rows by their ids (== the Deliver ids). Used
+# by the delivers join and the pending-store refresh. %(extra_fields)s is
+# filled per endpoint: tool/toolHash exist only once autonolas-subgraph#113
+# is deployed there (see _parsed_delivery_extra_fields).
+PARSED_DELIVERIES_BY_IDS_QUERY = """
 {
-  delivers(
+  parsedDeliveries(
     first: %(first)s
     where: { id_in: [%(ids)s] }
   ) {
     id
-    parsedDelivery {
-      response
-      model
-      tool
-      toolHash
-    }
+    response
+    model%(extra_fields)s
   }
 }
 """
+
+# One-row probes for per-endpoint schema detection.
+PARSED_DELIVERIES_PROBE_QUERY = "{ parsedDeliveries(first: 1) { id } }"
+PARSED_FIELDS_PROBE_QUERY = "{ parsedDeliveries(first: 1) { id tool toolHash } }"
+
+# Optional ParsedDelivery selection, present only on schema versions with
+# autonolas-subgraph#113 deployed. Indentation matches the query template.
+PARSED_DELIVERY_EXTRA_FIELDS = "\n    tool\n    toolHash"
 
 DELIVERS_BY_IDS_QUERY = """
 {
@@ -911,21 +913,96 @@ def detect_delivers_schema(marketplace_url: str) -> str:
     if cached is not None:
         return cached
 
-    probe = DELIVERS_QUERY % {"first": 1, "skip": 0, "timestamp_gt": 0}
     try:
-        _post_graphql(marketplace_url, {"query": probe})
+        _post_graphql(marketplace_url, {"query": PARSED_DELIVERIES_PROBE_QUERY})
         schema = DELIVERS_SCHEMA_PARSED
     except RuntimeError as exc:
         if not _is_unknown_field_error(exc):
             raise
         log.info(
-            "delivers schema: %s has no parsedDelivery — using legacy fields",
+            "delivers schema: %s has no parsedDeliveries — using legacy fields",
             marketplace_url,
         )
         schema = DELIVERS_SCHEMA_LEGACY
 
     _DELIVERS_SCHEMA_CACHE[marketplace_url] = schema
     return schema
+
+
+# Per-endpoint optional ParsedDelivery selection, probed once per process.
+_PARSED_FIELDS_CACHE: dict[str, str] = {}
+
+
+def _parsed_delivery_extra_fields(marketplace_url: str) -> str:
+    """Return the optional ParsedDelivery field selection for the endpoint.
+
+    ``tool``/``toolHash`` exist only on schema versions with
+    autonolas-subgraph#113 deployed. Probing once per endpoint lets the
+    fetcher select them where available and upgrade automatically on
+    deploy day without a code change.
+
+    :param marketplace_url: subgraph endpoint URL.
+    :return: ``PARSED_DELIVERY_EXTRA_FIELDS`` or an empty string.
+    """
+    cached = _PARSED_FIELDS_CACHE.get(marketplace_url)
+    if cached is not None:
+        return cached
+
+    try:
+        _post_graphql(marketplace_url, {"query": PARSED_FIELDS_PROBE_QUERY})
+        fields = PARSED_DELIVERY_EXTRA_FIELDS
+    except RuntimeError as exc:
+        if not _is_unknown_field_error(exc):
+            raise
+        log.info(
+            "delivers schema: %s has no ParsedDelivery.tool/toolHash yet",
+            marketplace_url,
+        )
+        fields = ""
+
+    _PARSED_FIELDS_CACHE[marketplace_url] = fields
+    return fields
+
+
+def fetch_parsed_deliveries(
+    marketplace_url: str,
+    deliver_ids: list[str],
+) -> dict[str, dict[str, Any]]:
+    """Batch-fetch ParsedDelivery rows for *deliver_ids*, keyed by id.
+
+    ParsedDelivery is a separate top-level entity that shares its id with
+    the Deliver it parses — it is NOT reachable as a nested field on
+    Deliver, so the parsed payload is joined in a second query by id.
+    Batch failures are logged and skipped; ids missing from the result are
+    treated by callers as "not indexed yet" (async file-data-source lag).
+
+    :param marketplace_url: subgraph endpoint URL.
+    :param deliver_ids: deliver ids to look up (duplicates are collapsed).
+    :return: mapping of id to raw ParsedDelivery row.
+    """
+    result: dict[str, dict[str, Any]] = {}
+    if not deliver_ids:
+        return result
+
+    extra_fields = _parsed_delivery_extra_fields(marketplace_url)
+    unique_ids = list(dict.fromkeys(deliver_ids))
+    for i in range(0, len(unique_ids), DEFAULT_BATCH_SIZE):
+        batch = unique_ids[i : i + DEFAULT_BATCH_SIZE]
+        ids_str = ", ".join(f'"{did}"' for did in batch)
+        query = PARSED_DELIVERIES_BY_IDS_QUERY % {
+            "first": len(batch),
+            "ids": ids_str,
+            "extra_fields": extra_fields,
+        }
+        try:
+            data = _post_graphql(marketplace_url, {"query": query})
+        except (RuntimeError, requests.exceptions.RequestException) as e:
+            log.warning("parsedDeliveries batch failed (%s), skipping batch", e)
+            continue
+        for row in data.get("parsedDeliveries", []):
+            result[row["id"]] = row
+
+    return result
 
 
 def _normalize_subgraph_string(value: Optional[str]) -> Optional[str]:
@@ -954,7 +1031,12 @@ def extract_delivery_fields(deliver: dict[str, Any], schema: str) -> dict[str, A
       signal for deferring row construction rather than recording a
       permanently-invalid row.
 
-    :param deliver: raw deliver dict from the subgraph.
+    For the parsed schema the ParsedDelivery row is fetched separately
+    (see :func:`fetch_parsed_deliveries`) and attached under the
+    ``parsedDelivery`` key of *deliver* by the caller before this runs.
+
+    :param deliver: deliver dict — raw from the subgraph (legacy), or with
+        the joined ParsedDelivery row attached (parsed).
     :param schema: ``DELIVERS_SCHEMA_PARSED`` or ``DELIVERS_SCHEMA_LEGACY``.
     :return: dict with model, tool_response, tool_hash, parsed_missing.
     """
@@ -1077,23 +1159,40 @@ def fetch_deliveries(
         delivery_ts = int(d["blockTimestamp"])
         ctx = _parse_request_context(parsed.get("content", ""))
 
-        deliveries.append(
-            {
-                "deliver_id": d["id"],
-                "timestamp": delivery_ts,
-                "request_timestamp": request_ts,
-                **extract_delivery_fields(d, schema),
-                # parsedRequest.tool uses the same sentinel convention as
-                # ParsedDelivery — collapse it into the "unknown" bucket.
-                "tool": _normalize_subgraph_string(parsed.get("tool")) or "unknown",
-                "question_title": question_title,
-                "market_id": ctx.get("market_id"),
-                "market_prob": ctx.get("market_prob"),
-                "market_liquidity_usd": ctx.get("market_liquidity_usd"),
-                "market_close_at": ctx.get("market_close_at"),
-                "market_spread": ctx.get("market_spread"),
-            }
+        entry = {
+            "deliver_id": d["id"],
+            "timestamp": delivery_ts,
+            "request_timestamp": request_ts,
+            # parsedRequest.tool uses the same sentinel convention as
+            # ParsedDelivery — collapse it into the "unknown" bucket.
+            "tool": _normalize_subgraph_string(parsed.get("tool")) or "unknown",
+            "question_title": question_title,
+            "market_id": ctx.get("market_id"),
+            "market_prob": ctx.get("market_prob"),
+            "market_liquidity_usd": ctx.get("market_liquidity_usd"),
+            "market_close_at": ctx.get("market_close_at"),
+            "market_spread": ctx.get("market_spread"),
+        }
+        if schema == DELIVERS_SCHEMA_LEGACY:
+            entry.update(extract_delivery_fields(d, schema))
+        deliveries.append(entry)
+
+    # Parsed schema: the ParsedDelivery rows live in a separate entity —
+    # join them by id in a second batched query.
+    if schema == DELIVERS_SCHEMA_PARSED and deliveries:
+        parsed_map = fetch_parsed_deliveries(
+            marketplace_url, [e["deliver_id"] for e in deliveries]
         )
+        deliveries = [
+            {
+                **entry,
+                **extract_delivery_fields(
+                    {"parsedDelivery": parsed_map.get(entry["deliver_id"])},
+                    schema,
+                ),
+            }
+            for entry in deliveries
+        ]
 
     if skipped:
         log.info("  skipped %d deliveries with null parsedRequest", skipped)
@@ -1796,20 +1895,11 @@ def refresh_unparsed_pending(
     if detect_delivers_schema(marketplace_url) != DELIVERS_SCHEMA_PARSED:
         return pending
 
-    fetched: dict[str, dict[str, Any]] = {}
-    for i in range(0, len(stale_ids), DEFAULT_BATCH_SIZE):
-        batch = stale_ids[i : i + DEFAULT_BATCH_SIZE]
-        ids_str = ", ".join(f'"{did}"' for did in batch)
-        query = DELIVERS_PARSED_BY_IDS_QUERY % {"first": len(batch), "ids": ids_str}
-        try:
-            data = _post_graphql(marketplace_url, {"query": query})
-        except (RuntimeError, requests.exceptions.RequestException) as e:
-            log.warning("pending refresh: batch failed (%s), keeping stale", e)
-            continue
-        for d in data.get("delivers", []):
-            fields = extract_delivery_fields(d, DELIVERS_SCHEMA_PARSED)
-            if not fields["parsed_missing"]:
-                fetched[d["id"]] = fields
+    parsed_map = fetch_parsed_deliveries(marketplace_url, stale_ids)
+    fetched = {
+        pid: extract_delivery_fields({"parsedDelivery": row}, DELIVERS_SCHEMA_PARSED)
+        for pid, row in parsed_map.items()
+    }
 
     if not fetched:
         return pending

--- a/benchmark/datasets/fetch_replay.py
+++ b/benchmark/datasets/fetch_replay.py
@@ -51,6 +51,7 @@ from benchmark.datasets.fetch_production import (
     detect_delivers_schema,
     extract_delivery_fields,
     fetch_omen_resolved,
+    fetch_parsed_deliveries,
     fetch_polymarket_resolved,
     parse_tool_response,
 )
@@ -82,8 +83,9 @@ HTTP_TIMEOUT = 60
 DEFAULT_BATCH_SIZE = 1000
 
 # Delivery query that includes ipfsHashBytes in the same call. New schema:
-# the IPFS-parsed response/model/toolHash live on the nested ParsedDelivery
-# (valory-xyz/autonolas-subgraph#113).
+# the IPFS-parsed response/model live on the separate top-level
+# ParsedDelivery entity (same id as the Deliver, not nested under it) and
+# are joined in a second query via fetch_parsed_deliveries.
 DELIVERS_WITH_IPFS_QUERY = """
 {
   delivers(
@@ -95,12 +97,6 @@ DELIVERS_WITH_IPFS_QUERY = """
   ) {
     id
     blockTimestamp
-    parsedDelivery {
-      response
-      model
-      tool
-      toolHash
-    }
     marketplaceDelivery {
       ipfsHashBytes
     }
@@ -251,18 +247,34 @@ def fetch_deliveries(
         except (json.JSONDecodeError, TypeError):
             pass
 
-        deliveries.append(
-            {
-                "deliver_id": d["id"],
-                "timestamp": int(d["blockTimestamp"]),
-                "request_timestamp": int(request.get("blockTimestamp") or 0) or None,
-                **extract_delivery_fields(d, schema),
-                "tool": tool,
-                "question_title": question_title,
-                "market_id": market_id,
-                "ipfs_hash": ipfs_hash,
-            }
+        entry = {
+            "deliver_id": d["id"],
+            "timestamp": int(d["blockTimestamp"]),
+            "request_timestamp": int(request.get("blockTimestamp") or 0) or None,
+            "tool": tool,
+            "question_title": question_title,
+            "market_id": market_id,
+            "ipfs_hash": ipfs_hash,
+        }
+        if schema != DELIVERS_SCHEMA_PARSED:
+            entry.update(extract_delivery_fields(d, schema))
+        deliveries.append(entry)
+
+    # Parsed schema: join the separately-stored ParsedDelivery rows by id.
+    if schema == DELIVERS_SCHEMA_PARSED and deliveries:
+        parsed_map = fetch_parsed_deliveries(
+            marketplace_url, [e["deliver_id"] for e in deliveries]
         )
+        deliveries = [
+            {
+                **entry,
+                **extract_delivery_fields(
+                    {"parsedDelivery": parsed_map.get(entry["deliver_id"])},
+                    schema,
+                ),
+            }
+            for entry in deliveries
+        ]
 
     if skipped:
         log.info("  skipped %d deliveries (null parsedRequest or title)", skipped)

--- a/benchmark/datasets/fetch_replay.py
+++ b/benchmark/datasets/fetch_replay.py
@@ -261,8 +261,9 @@ def fetch_deliveries(
         deliveries.append(entry)
 
     # Parsed schema: join the separately-stored ParsedDelivery rows by id.
+    # Batch failures are ignored — affected rows just parse as missing.
     if schema == DELIVERS_SCHEMA_PARSED and deliveries:
-        parsed_map = fetch_parsed_deliveries(
+        parsed_map, _ = fetch_parsed_deliveries(
             marketplace_url, [e["deliver_id"] for e in deliveries]
         )
         deliveries = [

--- a/benchmark/datasets/fetch_replay.py
+++ b/benchmark/datasets/fetch_replay.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from benchmark.datasets.fetch_production import (
+    DELIVERS_SCHEMA_LEGACY,
     DELIVERS_SCHEMA_PARSED,
     IPFS_FETCH_DELAY,
     MECH_MARKETPLACE_GNOSIS_URL,
@@ -256,7 +257,7 @@ def fetch_deliveries(
             "market_id": market_id,
             "ipfs_hash": ipfs_hash,
         }
-        if schema != DELIVERS_SCHEMA_PARSED:
+        if schema == DELIVERS_SCHEMA_LEGACY:
             entry.update(extract_delivery_fields(d, schema))
         deliveries.append(entry)
 

--- a/benchmark/tests/test_backfill_responses.py
+++ b/benchmark/tests/test_backfill_responses.py
@@ -89,40 +89,44 @@ def _make_fake_post_graphql(
 ) -> Any:
     """Build a fake _post_graphql returning canned tool responses.
 
-    Serves the deliver shape matching *schema*: legacy flat
-    ``model``/``toolResponse`` fields, or the nested ``parsedDelivery``
-    entity (a None response is served as a not-yet-indexed delivery,
-    i.e. ``parsedDelivery: null``).
+    Serves the entity shape matching *schema*: legacy flat
+    ``model``/``toolResponse`` fields under ``delivers``, or top-level
+    ``parsedDeliveries`` rows joined by id (a None response is served as a
+    not-yet-indexed delivery, i.e. its id is absent from the result --
+    exactly how the real entity behaves).
 
     :param responses: deliver_id -> tool response to serve.
     :param calls: optional list collecting (url, queried ids) per call.
-    :param schema: deliver shape to serve (legacy or parsed).
+    :param schema: entity shape to serve (legacy or parsed).
     :return: fake function with the _post_graphql signature.
     """
 
-    def _deliver(did: str) -> dict[str, Any]:
-        """Build one canned deliver in the configured schema shape."""
-        response = responses.get(did)
-        if schema == DELIVERS_SCHEMA_LEGACY:
-            return {"id": did, "model": None, "toolResponse": response}
-        if response is None:
-            return {"id": did, "parsedDelivery": None}
+    def _legacy_deliver(did: str) -> dict[str, Any]:
+        """Build one canned legacy-shape deliver."""
+        return {"id": did, "model": None, "toolResponse": responses.get(did)}
+
+    def _parsed_row(did: str) -> dict[str, Any]:
+        """Build one canned ParsedDelivery row."""
         return {
             "id": did,
-            "parsedDelivery": {
-                "response": response,
-                "model": "gpt-4o",
-                "tool": "factual_research",
-                "toolHash": None,
-            },
+            "response": responses[did],
+            "model": "gpt-4o",
+            "tool": "factual_research",
+            "toolHash": None,
         }
 
     def fake(url: str, payload: dict[str, Any]) -> dict[str, Any]:
-        """Serve canned delivers for the ids found in the query."""
+        """Serve canned rows for the ids found in the query."""
         ids = _ids_in_query(payload["query"])
         if calls is not None:
             calls.append((url, ids))
-        return {"delivers": [_deliver(did) for did in ids]}
+        if schema == DELIVERS_SCHEMA_LEGACY:
+            return {"delivers": [_legacy_deliver(did) for did in ids]}
+        return {
+            "parsedDeliveries": [
+                _parsed_row(did) for did in ids if responses.get(did) is not None
+            ]
+        }
 
     return fake
 
@@ -140,6 +144,9 @@ def _stub_schema_detection(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         br, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_LEGACY
     )
+    # Pin the optional-fields probe too, so parsed-schema tests don't emit
+    # a probe call that would pollute per-test call recording.
+    monkeypatch.setattr(br, "_parsed_delivery_extra_fields", lambda url: "")
 
 
 # ---------------------------------------------------------------------------
@@ -457,7 +464,7 @@ class TestBatchingAndRouting:
 
 
 # ---------------------------------------------------------------------------
-# Schema-aware querying (nested ParsedDelivery vs legacy flat fields)
+# Schema-aware querying (separate ParsedDelivery entity vs legacy flat fields)
 # ---------------------------------------------------------------------------
 
 
@@ -467,7 +474,7 @@ class TestSchemaRouting:
     def test_parsed_schema_uses_parsed_query_and_repairs(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A parsed-schema endpoint is queried for parsedDelivery and repaired."""
+        """A parsed-schema endpoint is queried via parsedDeliveries and repaired."""
         shard = tmp_path / "production_log_2026_07_01.jsonl"
         _write_shard(shard, [_row("0xbb")])
         monkeypatch.setattr(
@@ -488,7 +495,7 @@ class TestSchemaRouting:
         summary = br.backfill(tmp_path)
 
         assert summary["repaired"] == 1
-        assert all("parsedDelivery" in q for q in queries)
+        assert all("parsedDeliveries(" in q for q in queries)
         assert all("toolResponse" not in q for q in queries)
         repaired = _read_shard(shard)[0]
         assert repaired["p_yes"] == 0.72
@@ -524,7 +531,7 @@ class TestSchemaRouting:
     def test_parsed_delivery_not_indexed_leaves_row_untouched(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A deliver whose parsedDelivery is still null stays a candidate."""
+        """A deliver with no ParsedDelivery row yet stays a candidate."""
         shard = tmp_path / "production_log_2026_07_01.jsonl"
         _write_shard(shard, [_row("0xbb")])
         monkeypatch.setattr(

--- a/benchmark/tests/test_backfill_responses.py
+++ b/benchmark/tests/test_backfill_responses.py
@@ -25,6 +25,7 @@ from typing import Any, Optional
 
 import pytest
 from benchmark.datasets import backfill_responses as br
+from benchmark.datasets import fetch_production as fp
 from benchmark.datasets.fetch_production import (
     DELIVERS_SCHEMA_LEGACY,
     DELIVERS_SCHEMA_PARSED,
@@ -144,9 +145,10 @@ def _stub_schema_detection(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         br, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_LEGACY
     )
-    # Pin the optional-fields probe too, so parsed-schema tests don't emit
-    # a probe call that would pollute per-test call recording.
-    monkeypatch.setattr(br, "_parsed_delivery_extra_fields", lambda url: "")
+    # Pin the optional-fields probe too (it lives in fetch_production and
+    # runs inside fetch_parsed_deliveries), so parsed-schema tests don't
+    # emit a probe call that would pollute per-test call recording.
+    monkeypatch.setattr(fp, "_parsed_delivery_extra_fields", lambda url: "")
 
 
 # ---------------------------------------------------------------------------
@@ -490,7 +492,9 @@ class TestSchemaRouting:
             queries.append(payload["query"])
             return fake(url, payload)
 
-        monkeypatch.setattr(br, "_post_graphql", spy)
+        # Parsed-schema queries flow through fetch_production's
+        # fetch_parsed_deliveries, so patch that module's seam.
+        monkeypatch.setattr(fp, "_post_graphql", spy)
 
         summary = br.backfill(tmp_path)
 
@@ -538,7 +542,7 @@ class TestSchemaRouting:
             br, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
         )
         monkeypatch.setattr(
-            br,
+            fp,
             "_post_graphql",
             _make_fake_post_graphql({}, schema=DELIVERS_SCHEMA_PARSED),
         )

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -31,6 +31,7 @@ from benchmark.datasets.fetch_production import (
     DELIVERS_SCHEMA_LEGACY,
     DELIVERS_SCHEMA_PARSED,
     GRACE_DEDUP_LOOKBACK_DAYS,
+    PARSED_DELIVERY_EXTRA_FIELDS,
     PARSED_DELIVERY_GRACE_SECONDS,
     PENDING_MAX_AGE_DAYS,
     ResolvedMarkets,
@@ -1281,13 +1282,15 @@ class TestNoScoreFlag:
 
 @pytest.fixture(name="clear_schema_cache", autouse=False)
 def _clear_schema_cache_fixture() -> Any:
-    """Reset the per-URL delivers-schema cache around a test."""
+    """Reset the per-URL delivers-schema and fields caches around a test."""
     # pylint: disable-next=import-outside-toplevel
     from benchmark.datasets import fetch_production as fp
 
     fp._DELIVERS_SCHEMA_CACHE.clear()  # pylint: disable=protected-access
+    fp._PARSED_FIELDS_CACHE.clear()  # pylint: disable=protected-access
     yield
     fp._DELIVERS_SCHEMA_CACHE.clear()  # pylint: disable=protected-access
+    fp._PARSED_FIELDS_CACHE.clear()  # pylint: disable=protected-access
 
 
 class TestExtractDeliveryFields:
@@ -1411,8 +1414,8 @@ class TestDetectDeliversSchema:
 
         def fail(url: str, payload: dict[str, Any]) -> dict[str, Any]:
             raise RuntimeError(
-                "GraphQL errors from http://polygon: Type `Deliver` "
-                "has no field `parsedDelivery`"
+                "GraphQL errors from http://polygon: Type `Query` "
+                "has no field `parsedDeliveries`"
             )
 
         monkeypatch.setattr(fp, "_post_graphql", fail)
@@ -1454,12 +1457,11 @@ class TestFetchDeliveriesSchemaShapes:
     """fetch_deliveries selects the query by detected schema."""
 
     @staticmethod
-    def _raw_deliver(parsed_delivery: Any) -> dict[str, Any]:
-        """Build a raw subgraph deliver dict with the given parsedDelivery."""
+    def _raw_deliver(deliver_id: str = "0xdeliver") -> dict[str, Any]:
+        """Build a raw subgraph deliver dict (parsed-schema shape)."""
         return {
-            "id": "0xdeliver",
+            "id": deliver_id,
             "blockTimestamp": "1700000100",
-            "parsedDelivery": parsed_delivery,
             "request": {
                 "id": "0xreq",
                 "blockTimestamp": "1700000000",
@@ -1471,10 +1473,15 @@ class TestFetchDeliveriesSchemaShapes:
             },
         }
 
-    def test_parsed_schema_maps_nested_fields(
+    def test_parsed_schema_joins_parsed_deliveries_by_id(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """parsedDelivery.response/model/toolHash land on the delivery dict."""
+        """The parsed payload is joined from the separate entity by id.
+
+        Delivers without a `ParsedDelivery` row become parsed_missing.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
@@ -1488,30 +1495,41 @@ class TestFetchDeliveriesSchemaShapes:
             **_kwargs: Any,
         ) -> list[dict[str, Any]]:
             captured["query"] = query
-            return [
-                self._raw_deliver(
-                    {
-                        "response": '{"p_yes": 0.7, "p_no": 0.3}',
-                        "model": "gpt-4.1",
-                        "tool": "superforcaster",
-                        "toolHash": "bafytool",
-                    }
-                )
-            ]
+            return [self._raw_deliver("0xdeliver"), self._raw_deliver("0xlagging")]
+
+        def fake_parsed(url: str, ids: list[str]) -> dict[str, dict[str, Any]]:
+            captured["ids"] = ids
+            return {
+                "0xdeliver": {
+                    "id": "0xdeliver",
+                    "response": '{"p_yes": 0.7, "p_no": 0.3}',
+                    "model": "gpt-4.1",
+                    "tool": "superforcaster",
+                    "toolHash": "bafytool",
+                }
+            }
 
         monkeypatch.setattr(
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
         )
         monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
+        monkeypatch.setattr(fp, "fetch_parsed_deliveries", fake_parsed)
 
         deliveries, unparsed_cap = fp.fetch_deliveries("http://gnosis", 0)
         assert unparsed_cap is None
-        assert "parsedDelivery" in captured["query"]
+        # The delivers query no longer selects any parsed-payload fields.
+        assert "parsedDelivery" not in captured["query"]
         assert "toolResponse" not in captured["query"]
-        assert deliveries[0]["tool_response"] == '{"p_yes": 0.7, "p_no": 0.3}'
-        assert deliveries[0]["model"] == "gpt-4.1"
-        assert deliveries[0]["tool_hash"] == "bafytool"
-        assert deliveries[0]["parsed_missing"] is False
+        assert captured["ids"] == ["0xdeliver", "0xlagging"]
+
+        joined = {d["deliver_id"]: d for d in deliveries}
+        assert joined["0xdeliver"]["tool_response"] == '{"p_yes": 0.7, "p_no": 0.3}'
+        assert joined["0xdeliver"]["model"] == "gpt-4.1"
+        assert joined["0xdeliver"]["tool_hash"] == "bafytool"
+        assert joined["0xdeliver"]["parsed_missing"] is False
+        # Not yet indexed by the async file handler -> defer-eligible.
+        assert joined["0xlagging"]["tool_response"] is None
+        assert joined["0xlagging"]["parsed_missing"] is True
 
     def test_sentinel_request_tool_maps_to_unknown(
         self, monkeypatch: pytest.MonkeyPatch
@@ -1523,20 +1541,14 @@ class TestFetchDeliveriesSchemaShapes:
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
-        raw = self._raw_deliver(
-            {
-                "response": '{"p_yes": 0.7, "p_no": 0.3}',
-                "model": "gpt-4.1",
-                "tool": "superforcaster",
-                "toolHash": "bafytool",
-            }
-        )
+        raw = self._raw_deliver()
         raw["request"]["parsedRequest"]["tool"] = SUBGRAPH_UNHANDLED_TYPE
 
         monkeypatch.setattr(
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
         )
         monkeypatch.setattr(fp, "_paginated_fetch", lambda *a, **k: [raw])
+        monkeypatch.setattr(fp, "fetch_parsed_deliveries", lambda url, ids: {})
 
         deliveries, _ = fp.fetch_deliveries("http://gnosis", 0)
         assert deliveries[0]["tool"] == "unknown"
@@ -1544,7 +1556,7 @@ class TestFetchDeliveriesSchemaShapes:
     def test_legacy_schema_maps_flat_fields(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The legacy query keeps working against the polygon subgraph."""
+        """The legacy flat-field query needs no second parsed-join query."""
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
@@ -1558,16 +1570,19 @@ class TestFetchDeliveriesSchemaShapes:
             **_kwargs: Any,
         ) -> list[dict[str, Any]]:
             captured["query"] = query
-            raw = self._raw_deliver(None)
-            del raw["parsedDelivery"]
+            raw = self._raw_deliver()
             raw["model"] = "gpt-4.1"
             raw["toolResponse"] = '{"p_yes": 0.2, "p_no": 0.8}'
             return [raw]
+
+        def boom(url: str, ids: list[str]) -> dict[str, dict[str, Any]]:
+            raise AssertionError("legacy schema must not query parsedDeliveries")
 
         monkeypatch.setattr(
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_LEGACY
         )
         monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
+        monkeypatch.setattr(fp, "fetch_parsed_deliveries", boom)
 
         deliveries, _ = fp.fetch_deliveries("http://polygon", 0)
         assert "toolResponse" in captured["query"]
@@ -1757,23 +1772,19 @@ class TestRefreshUnparsedPending:
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
         )
 
-        def fake_post(url: str, payload: dict[str, Any]) -> dict[str, Any]:
-            assert '"0xstale"' in payload["query"]
+        def fake_parsed(url: str, ids: list[str]) -> dict[str, dict[str, Any]]:
+            assert ids == ["0xstale"]  # only stale entries are re-queried
             return {
-                "delivers": [
-                    {
-                        "id": "0xstale",
-                        "parsedDelivery": {
-                            "response": '{"p_yes": 0.6, "p_no": 0.4}',
-                            "model": "gpt-4.1",
-                            "tool": "superforcaster",
-                            "toolHash": "bafytool",
-                        },
-                    }
-                ]
+                "0xstale": {
+                    "id": "0xstale",
+                    "response": '{"p_yes": 0.6, "p_no": 0.4}',
+                    "model": "gpt-4.1",
+                    "tool": "superforcaster",
+                    "toolHash": "bafytool",
+                }
             }
 
-        monkeypatch.setattr(fp, "_post_graphql", fake_post)
+        monkeypatch.setattr(fp, "fetch_parsed_deliveries", fake_parsed)
 
         stale = self._pending("0xstale", None)
         fresh = self._pending("0xfresh", '{"p_yes": 0.9, "p_no": 0.1}')
@@ -1790,60 +1801,18 @@ class TestRefreshUnparsedPending:
     def test_still_unindexed_entries_stay_pending(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Entries whose ParsedDelivery is still absent are kept as-is."""
+        """Entries with no ParsedDelivery yet (or a failed batch) stay as-is."""
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
         monkeypatch.setattr(
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
         )
-        monkeypatch.setattr(
-            fp,
-            "_post_graphql",
-            lambda url, payload: {
-                "delivers": [{"id": "0xstale", "parsedDelivery": None}]
-            },
-        )
+        monkeypatch.setattr(fp, "fetch_parsed_deliveries", lambda url, ids: {})
         stale = self._pending("0xstale", None)
         refreshed = refresh_unparsed_pending([stale], "http://gnosis")
         assert refreshed == [stale]
-
-    @pytest.mark.parametrize(
-        "exc",
-        [
-            RuntimeError("GraphQL errors from http://gnosis: store error"),
-            requests.exceptions.ConnectionError("connection refused"),
-        ],
-        ids=["graphql_error", "network_error"],
-    )
-    def test_batch_failure_keeps_stale_entries(
-        self, monkeypatch: pytest.MonkeyPatch, exc: Exception
-    ) -> None:
-        """A failed refresh batch keeps the stale entries unchanged.
-
-        Neither exception type may crash the run or drop pending entries.
-
-        :param monkeypatch: pytest monkeypatch fixture.
-        :param exc: the exception the refresh query raises.
-        """
-        # pylint: disable-next=import-outside-toplevel
-        from benchmark.datasets import fetch_production as fp
-
-        monkeypatch.setattr(
-            fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
-        )
-
-        def fail(url: str, payload: dict[str, Any]) -> dict[str, Any]:
-            raise exc
-
-        monkeypatch.setattr(fp, "_post_graphql", fail)
-
-        stale = self._pending("0xstale", None)
-        pending = [stale]
-        result = refresh_unparsed_pending(pending, "http://gnosis")
-        assert result == pending
-        assert result[0] is stale  # same object — kept, not rebuilt
-        assert stale["tool_response"] is None  # and not mutated
+        assert refreshed[0] is stale  # same object — kept, not rebuilt
 
     def test_noop_on_legacy_schema(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Legacy endpoints have nothing to refresh from."""
@@ -1854,10 +1823,10 @@ class TestRefreshUnparsedPending:
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_LEGACY
         )
 
-        def boom(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+        def boom(url: str, ids: list[str]) -> dict[str, dict[str, Any]]:
             raise AssertionError("must not query on legacy schema")
 
-        monkeypatch.setattr(fp, "_post_graphql", boom)
+        monkeypatch.setattr(fp, "fetch_parsed_deliveries", boom)
         pending = [self._pending("0xstale", None)]
         assert refresh_unparsed_pending(pending, "http://polygon") == pending
 
@@ -1872,6 +1841,132 @@ class TestRefreshUnparsedPending:
         monkeypatch.setattr(fp, "_post_graphql", boom)
         pending = [self._pending("0xfresh", '{"p_yes": 0.9, "p_no": 0.1}')]
         assert refresh_unparsed_pending(pending, "http://gnosis") == pending
+
+
+@pytest.mark.usefixtures("clear_schema_cache")
+class TestFetchParsedDeliveries:
+    """Batch fetch of the separately-stored ParsedDelivery entity."""
+
+    def test_builds_id_keyed_map(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Rows come back keyed by id, queried via id_in.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        monkeypatch.setattr(fp, "_parsed_delivery_extra_fields", lambda url: "")
+
+        def fake_post(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            assert "parsedDeliveries" in payload["query"]
+            assert '"0xa"' in payload["query"] and '"0xb"' in payload["query"]
+            return {
+                "parsedDeliveries": [
+                    {"id": "0xa", "response": '{"p_yes": 0.6}', "model": "gpt-4.1"}
+                ]
+            }
+
+        monkeypatch.setattr(fp, "_post_graphql", fake_post)
+        # Duplicate ids collapse; ids missing upstream are absent from the map.
+        result = fp.fetch_parsed_deliveries("http://gnosis", ["0xa", "0xb", "0xa"])
+        assert set(result) == {"0xa"}
+        assert result["0xa"]["response"] == '{"p_yes": 0.6}'
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            RuntimeError("GraphQL errors from http://gnosis: store error"),
+            requests.exceptions.ConnectionError("connection refused"),
+        ],
+        ids=["graphql_error", "network_error"],
+    )
+    def test_batch_failure_skips_batch(
+        self, monkeypatch: pytest.MonkeyPatch, exc: Exception
+    ) -> None:
+        """A failed batch is skipped instead of crashing the run.
+
+        Callers treat the missing ids as "not indexed yet", so pending
+        entries stay stale rather than being dropped.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param exc: the exception the batch query raises.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        monkeypatch.setattr(fp, "_parsed_delivery_extra_fields", lambda url: "")
+
+        def fail(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            raise exc
+
+        monkeypatch.setattr(fp, "_post_graphql", fail)
+        assert not fp.fetch_parsed_deliveries("http://gnosis", ["0xa"])
+
+    def test_no_ids_no_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty id list makes no network calls at all."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        def boom(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            raise AssertionError("must not query without ids")
+
+        monkeypatch.setattr(fp, "_post_graphql", boom)
+        assert not fp.fetch_parsed_deliveries("http://gnosis", [])
+
+
+@pytest.mark.usefixtures("clear_schema_cache")
+class TestParsedDeliveryFieldsProbe:
+    """Per-endpoint probe for the optional tool/toolHash selection."""
+
+    @pytest.mark.parametrize(
+        ("probe_error", "expected"),
+        [
+            # Fields deployed (autonolas-subgraph#113) -> select them.
+            (None, PARSED_DELIVERY_EXTRA_FIELDS),
+            # Transitional schema without them -> basic selection.
+            (
+                RuntimeError("Type `ParsedDelivery` has no field `toolHash`"),
+                "",
+            ),
+        ],
+        ids=["fields_deployed", "fields_missing"],
+    )
+    def test_probe_grades_selection(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        probe_error: Exception,
+        expected: str,
+    ) -> None:
+        """The selection follows what the endpoint's schema supports.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param probe_error: exception the probe raises, or None for success.
+        :param expected: expected field-selection string.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        def fake_post(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            if probe_error is not None:
+                raise probe_error
+            return {"parsedDeliveries": []}
+
+        monkeypatch.setattr(fp, "_post_graphql", fake_post)
+        # pylint: disable-next=protected-access
+        assert fp._parsed_delivery_extra_fields("http://gnosis") == expected
+
+    def test_other_errors_propagate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Transient errors must not silently lock in the basic selection."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        def fail(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("GraphQL errors from http://gnosis: store error")
+
+        monkeypatch.setattr(fp, "_post_graphql", fail)
+        with pytest.raises(RuntimeError, match="store error"):
+            # pylint: disable-next=protected-access
+            fp._parsed_delivery_extra_fields("http://gnosis")
 
 
 class TestDedupPending:

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -1497,7 +1497,9 @@ class TestFetchDeliveriesSchemaShapes:
             captured["query"] = query
             return [self._raw_deliver("0xdeliver"), self._raw_deliver("0xlagging")]
 
-        def fake_parsed(url: str, ids: list[str]) -> dict[str, dict[str, Any]]:
+        def fake_parsed(
+            url: str, ids: list[str]
+        ) -> tuple[dict[str, dict[str, Any]], bool]:
             captured["ids"] = ids
             return {
                 "0xdeliver": {
@@ -1507,7 +1509,7 @@ class TestFetchDeliveriesSchemaShapes:
                     "tool": "superforcaster",
                     "toolHash": "bafytool",
                 }
-            }
+            }, False
 
         monkeypatch.setattr(
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
@@ -1548,7 +1550,7 @@ class TestFetchDeliveriesSchemaShapes:
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
         )
         monkeypatch.setattr(fp, "_paginated_fetch", lambda *a, **k: [raw])
-        monkeypatch.setattr(fp, "fetch_parsed_deliveries", lambda url, ids: {})
+        monkeypatch.setattr(fp, "fetch_parsed_deliveries", lambda url, ids: ({}, False))
 
         deliveries, _ = fp.fetch_deliveries("http://gnosis", 0)
         assert deliveries[0]["tool"] == "unknown"
@@ -1772,7 +1774,9 @@ class TestRefreshUnparsedPending:
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
         )
 
-        def fake_parsed(url: str, ids: list[str]) -> dict[str, dict[str, Any]]:
+        def fake_parsed(
+            url: str, ids: list[str]
+        ) -> tuple[dict[str, dict[str, Any]], bool]:
             assert ids == ["0xstale"]  # only stale entries are re-queried
             return {
                 "0xstale": {
@@ -1782,7 +1786,7 @@ class TestRefreshUnparsedPending:
                     "tool": "superforcaster",
                     "toolHash": "bafytool",
                 }
-            }
+            }, False
 
         monkeypatch.setattr(fp, "fetch_parsed_deliveries", fake_parsed)
 
@@ -1808,7 +1812,7 @@ class TestRefreshUnparsedPending:
         monkeypatch.setattr(
             fp, "detect_delivers_schema", lambda url: DELIVERS_SCHEMA_PARSED
         )
-        monkeypatch.setattr(fp, "fetch_parsed_deliveries", lambda url, ids: {})
+        monkeypatch.setattr(fp, "fetch_parsed_deliveries", lambda url, ids: ({}, False))
         stale = self._pending("0xstale", None)
         refreshed = refresh_unparsed_pending([stale], "http://gnosis")
         assert refreshed == [stale]
@@ -1868,9 +1872,33 @@ class TestFetchParsedDeliveries:
 
         monkeypatch.setattr(fp, "_post_graphql", fake_post)
         # Duplicate ids collapse; ids missing upstream are absent from the map.
-        result = fp.fetch_parsed_deliveries("http://gnosis", ["0xa", "0xb", "0xa"])
+        result, had_error = fp.fetch_parsed_deliveries(
+            "http://gnosis", ["0xa", "0xb", "0xa"]
+        )
         assert set(result) == {"0xa"}
         assert result["0xa"]["response"] == '{"p_yes": 0.6}'
+        assert had_error is False
+
+    def test_batch_size_splits_queries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The batch_size override splits the ids across queries.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        monkeypatch.setattr(fp, "_parsed_delivery_extra_fields", lambda url: "")
+        queries: list[str] = []
+
+        def fake_post(url: str, payload: dict[str, Any]) -> dict[str, Any]:
+            queries.append(payload["query"])
+            return {"parsedDeliveries": []}
+
+        monkeypatch.setattr(fp, "_post_graphql", fake_post)
+        fp.fetch_parsed_deliveries("http://gnosis", ["0xa", "0xb"], batch_size=1)
+        assert len(queries) == 2
+        assert '"0xa"' in queries[0]
+        assert '"0xb"' in queries[1]
 
     @pytest.mark.parametrize(
         "exc",
@@ -1900,7 +1928,7 @@ class TestFetchParsedDeliveries:
             raise exc
 
         monkeypatch.setattr(fp, "_post_graphql", fail)
-        assert not fp.fetch_parsed_deliveries("http://gnosis", ["0xa"])
+        assert fp.fetch_parsed_deliveries("http://gnosis", ["0xa"]) == ({}, True)
 
     def test_no_ids_no_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """An empty id list makes no network calls at all."""
@@ -1911,7 +1939,7 @@ class TestFetchParsedDeliveries:
             raise AssertionError("must not query without ids")
 
         monkeypatch.setattr(fp, "_post_graphql", boom)
-        assert not fp.fetch_parsed_deliveries("http://gnosis", [])
+        assert fp.fetch_parsed_deliveries("http://gnosis", []) == ({}, False)
 
 
 @pytest.mark.usefixtures("clear_schema_cache")


### PR DESCRIPTION
This is a workaround applied until the subgraph version with the nested `parsedDelivery` is fully indexed.