### PR TITLE
benchmark: actionable-tool set (selectable in production AND buildable here)

### DIFF
--- a/benchmark/served_tools.py
+++ b/benchmark/served_tools.py
@@ -197,7 +197,14 @@ def main() -> int:
     """
     parser = argparse.ArgumentParser(description=__doc__ or "")
     parser.add_argument(
-        "--platform", default=None, help="restrict to omen / polymarket"
+        "--platform",
+        default=None,
+        # Without `choices`, an unrecognized value resolves to no deployments,
+        # which is indistinguishable from a total discovery outage: `--platform
+        # Omen` would print UNKNOWN and exit 1 with both mechs healthy. Let
+        # argparse reject it and name the valid set instead.
+        choices=sorted(set(DEPLOYMENT_TO_PLATFORM.values())),
+        help="restrict to omen / polymarket",
     )
     parser.add_argument("--json", action="store_true", help="machine-readable output")
     args = parser.parse_args()
@@ -212,8 +219,12 @@ def main() -> int:
     # Scope the exit code to what was ASKED for: fetch_valid_tools() always
     # resolves both deployments, so judging success over the unfiltered map
     # let `--platform omen` exit 0 on a total omen failure just because
-    # polymarket happened to work.
-    resolved = served is not None
+    # polymarket happened to work. `repo` counts too -- the actionable set is
+    # unresolvable without the ledger, and a caller gating on "trust today's
+    # --json only if it exited 0" would otherwise consume `null` as an answer.
+    # A `None` roster is deliberately NOT fatal: it annotates, it does not
+    # change the actionable set.
+    resolved = served is not None and repo is not None
 
     def _roster_has(tool: str) -> Optional[bool]:
         """Roster membership across the dash/underscore namespaces.
@@ -254,8 +265,12 @@ def main() -> int:
             continue
         print(f"  {deployment} [{platform}]")
         for tool in sorted(tools):
-            known = normalize_tool_name(tool) in repo_normalized
-            print(f"      - {tool}{'' if known else '   (not shipped by this repo)'}")
+            if repo is None:
+                note = "   (shipped-here: UNKNOWN)"
+            else:
+                known = normalize_tool_name(tool) in repo_normalized
+                note = "" if known else "   (not shipped by this repo)"
+            print(f"      - {tool}{note}")
 
     print("\nACTIONABLE (selectable AND shipped by this repo)")
     if actionable is None:
@@ -270,7 +285,15 @@ def main() -> int:
             print(f"  * {tool}{tag}")
 
     print("\nNOT ACTIONABLE")
-    for tool in sorted((repo or set()) - (actionable or set())):
+    if repo is None:
+        # Every line in this section is a claim about what this repo ships, so
+        # with an unreadable ledger they would all be confident negatives read
+        # off a file we could not open -- "ships no package here" for tools
+        # that plainly do. That is the same misreading the roster's UNKNOWN
+        # state exists to prevent, one layer up.
+        print("  UNKNOWN -- packages.json unreadable; shipped set is unknown")
+        return 0 if resolved else 1
+    for tool in sorted(repo - (actionable or set())):
         in_roster = _roster_has(tool)
         where = {
             True: "tournament only",

--- a/benchmark/served_tools.py
+++ b/benchmark/served_tools.py
@@ -16,31 +16,28 @@
 #   limitations under the License.
 #
 # ------------------------------------------------------------------------------
-"""Discover which tools our mechs actually SERVE, read on-chain.
+"""Which tools are selectable in production, and which of those we can build.
 
 The triage assesses whatever appears in the scored data, which includes
-tools that live only in the tournament and are not deployed anywhere. A
-fix issue on such a tool has no validation path (its PR cannot be
-benchmarked from production rows) and no deployment consequence, so the
-triage needs to know the deployed set.
+tools that live only in the tournament and are deployed nowhere. A fix
+issue on such a tool has no validation path (its PR cannot be replayed
+from production rows) and no deployment consequence, so the triage needs
+to know the deployed set.
 
-A manifest committed here would rot on every deploy, so this module
-recomputes it per run, from chain state only:
+Discovery is delegated to :mod:`benchmark.tool_usage`, which already
+resolves it with no local manifest: latest ``valory-xyz/trader`` release
+-> each deployment's ``service.yaml`` -> its ``valid_mechs`` allow-list
+-> the mech-marketplace subgraph -> each mech's on-chain metadata CID ->
+the IPFS manifest's ``tools``. That chain answers "what can the live
+trader select?", which is the question that matters, and it needs no
+service ids, registry addresses or mech lists stored here.
 
-1. For each known mech service, read
-   ``ComplementaryServiceMetadata.mapServiceHashes(serviceId)`` -> a
-   bytes32 IPFS digest.
-2. Rebuild the CIDv1 prefix (``f01701220`` + digest) and fetch the
-   metadata manifest from the IPFS gateway.
-3. The manifest's ``tools`` array is the served-tool list -- the same
-   view the trader has when it picks a tool.
+This module adds the second half: intersect that set with the tools this
+repository can build (``benchmark/tools.py``). Only the intersection is
+actionable for the improvement loop -- a tool we cannot build cannot be
+fixed here, and a tool nobody serves has nowhere for a fix to land.
 
-The only local constants are the service registry below: chain, service
-id and the ComplementaryServiceMetadata address per mech. Those change
-approximately never (unlike tool CIDs, which churn every deploy).
-
-Read-only: one ``eth_call`` per service and one gateway GET per distinct
-manifest. No writes, no transactions, no private repo access.
+Read-only: GitHub API, subgraph and IPFS gateway GETs.
 """
 
 from __future__ import annotations
@@ -48,288 +45,122 @@ from __future__ import annotations
 import argparse
 import json
 import logging
-import os
 import re
 import sys
-import urllib.error
-import urllib.request
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set
 
-log = logging.getLogger(__name__)
-
-# The autonolas RPC/IPFS gateways reject requests without a browser-like
-# User-Agent (HTTP 403), so set one explicitly on every call.
-_USER_AGENT = "Mozilla/5.0 (mech-predict served-tools discovery)"
-
-GATEWAY = os.environ.get("IPFS_GATEWAY_URL", "https://gateway.autonolas.tech/ipfs")
-RPC_URLS: Dict[str, str] = {
-    "gnosis": os.environ.get(
-        "GNOSIS_RPC_URL", "https://rpc-gate.autonolas.tech/gnosis-rpc/"
-    ),
-    "polygon": os.environ.get(
-        "POLYGON_RPC_URL", "https://rpc-gate.autonolas.tech/polygon-rpc/"
-    ),
-    "base": os.environ.get("BASE_RPC_URL", "https://rpc-gate.autonolas.tech/base-rpc/"),
-    "optimism": os.environ.get(
-        "OPTIMISM_RPC_URL", "https://rpc-gate.autonolas.tech/optimism-rpc/"
-    ),
-}
-
-# Function selector: the first 4 bytes of the keccak-256 hash of the
-# signature mapServiceHashes(uint256), verified against the deployed
-# ComplementaryServiceMetadata contract.
-MAP_SERVICE_HASHES_SELECTOR = "0x4a086201"
-
-# Our mech services. Sourced from the deployment env files; kept here because
-# they are stable identifiers (a service id and a registry address), NOT
-# per-deploy state. Add a row when a new mech service is created.
-MECH_SERVICES: Tuple[Dict[str, str], ...] = (
-    {
-        "name": "mech_mm_predict",
-        "chain": "gnosis",
-        "service_id": "2182",
-        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
-    },
-    {
-        "name": "mech_mm_predict_clone",
-        "chain": "gnosis",
-        "service_id": "2198",
-        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
-    },
-    {
-        "name": "single_mech_mm_predict",
-        "chain": "gnosis",
-        "service_id": "2235",
-        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
-    },
-    {
-        "name": "single_mech_mm_predict_2340",
-        "chain": "gnosis",
-        "service_id": "2340",
-        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
-    },
-    {
-        "name": "single_mech_mm_predict_2359",
-        "chain": "gnosis",
-        "service_id": "2359",
-        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
-    },
-    {
-        "name": "single_mech_mm_predict_2360",
-        "chain": "gnosis",
-        "service_id": "2360",
-        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
-    },
-    {
-        "name": "nvm_native_mech_mm_predict_2469",
-        "chain": "gnosis",
-        "service_id": "2469",
-        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
-    },
-    {
-        "name": "single_polygon_mech_mm_predict_21",
-        "chain": "polygon",
-        "service_id": "21",
-        "csm": "0xDC175E77d11246c79B23D7088750eb59160DD6b7",
-    },
-    {
-        "name": "polygon_mech_mm_predict_25",
-        "chain": "polygon",
-        "service_id": "25",
-        "csm": "0xDC175E77d11246c79B23D7088750eb59160DD6b7",
-    },
-    {
-        "name": "polygon_mech_mm_predict_44",
-        "chain": "polygon",
-        "service_id": "44",
-        "csm": "0xDC175E77d11246c79B23D7088750eb59160DD6b7",
-    },
+from benchmark.tool_usage import (
+    DEPLOYMENT_TO_PLATFORM,
+    fetch_valid_tools,
+    normalize_tool_name,
 )
 
-# Platform each chain's mechs answer for, so the served set can be compared
-# against a platform-scoped triage run.
-CHAIN_PLATFORM: Dict[str, str] = {"gnosis": "omen", "polygon": "polymarket"}
+log = logging.getLogger(__name__)
 
 TOOLS_REGISTRY_PATH = Path(__file__).resolve().parent / "tools.py"
 TOURNAMENT_TOOLS_PATH = Path(__file__).resolve().parent / "tournament_tools.json"
 
-
-def _rpc_call(rpc_url: str, to: str, data: str, timeout: int = 20) -> Optional[str]:
-    """One ``eth_call``; returns the hex result or ``None`` on any failure.
-
-    :param rpc_url: JSON-RPC endpoint.
-    :param to: contract address.
-    :param data: ABI-encoded calldata.
-    :param timeout: seconds.
-    :return: hex string result, or ``None``.
-    """
-    payload = json.dumps(
-        {
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "eth_call",
-            "params": [{"to": to, "data": data}, "latest"],
-        }
-    ).encode("utf-8")
-    req = urllib.request.Request(
-        rpc_url,
-        data=payload,
-        headers={"Content-Type": "application/json", "User-Agent": _USER_AGENT},
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as response:  # nosec B310
-            body = json.loads(response.read().decode("utf-8"))
-    except (urllib.error.URLError, OSError, ValueError) as exc:
-        log.warning("eth_call failed on %s: %s", rpc_url, exc)
-        return None
-    if "error" in body:
-        log.warning("eth_call returned an error: %s", body["error"])
-        return None
-    result = body.get("result")
-    return result if isinstance(result, str) else None
-
-
-def _fetch_manifest_tools(metadata_hash: str, timeout: int = 20) -> List[str]:
-    """Fetch an IPFS metadata manifest and return its ``tools`` list.
-
-    :param metadata_hash: CIDv1 hex form (``f01701220`` + digest).
-    :param timeout: seconds.
-    :return: served tool names (empty on any failure).
-    """
-    req = urllib.request.Request(
-        f"{GATEWAY}/{metadata_hash}", headers={"User-Agent": _USER_AGENT}
-    )
-    try:
-        with urllib.request.urlopen(req, timeout=timeout) as response:  # nosec B310
-            manifest = json.loads(response.read().decode("utf-8"))
-    except (urllib.error.URLError, OSError, ValueError) as exc:
-        log.warning("IPFS fetch failed for %s: %s", metadata_hash, exc)
-        return []
-    tools = manifest.get("tools")
-    return [str(t) for t in tools] if isinstance(tools, list) else []
-
-
-def discover_served_tools(
-    services: Tuple[Dict[str, str], ...] = MECH_SERVICES,
-) -> Dict[str, Dict[str, Any]]:
-    """Read the served-tool set of every known mech service, from chain.
-
-    :param services: service registry rows (chain / service_id / csm).
-    :return: ``{service_name: {chain, platform, service_id, metadata_hash,
-        tools, error}}``; ``error`` is set when the service could not be
-        read (its ``tools`` is then empty).
-    """
-    out: Dict[str, Dict[str, Any]] = {}
-    manifest_cache: Dict[str, List[str]] = {}
-    for service in services:
-        name = service["name"]
-        chain = service["chain"]
-        entry: Dict[str, Any] = {
-            "chain": chain,
-            "platform": CHAIN_PLATFORM.get(chain, chain),
-            "service_id": service["service_id"],
-            "metadata_hash": None,
-            "tools": [],
-            "error": None,
-        }
-        rpc_url = RPC_URLS.get(chain)
-        if not rpc_url:
-            entry["error"] = f"no RPC configured for chain {chain!r}"
-            out[name] = entry
-            continue
-        # mapServiceHashes(uint256) -> bytes32
-        calldata = MAP_SERVICE_HASHES_SELECTOR + f"{int(service['service_id']):064x}"
-        raw = _rpc_call(rpc_url, service["csm"], calldata)
-        if not raw or raw == "0x" or set(raw[2:]) == {"0"}:
-            entry["error"] = "no metadata hash on chain (0x0 or unreadable)"
-            out[name] = entry
-            continue
-        metadata_hash = "f01701220" + raw[2:].rjust(64, "0")
-        entry["metadata_hash"] = metadata_hash
-        if metadata_hash not in manifest_cache:
-            manifest_cache[metadata_hash] = _fetch_manifest_tools(metadata_hash)
-        entry["tools"] = sorted(manifest_cache[metadata_hash])
-        if not entry["tools"]:
-            entry["error"] = "manifest unreadable or carries no tools"
-        out[name] = entry
-    return out
+_TOOL_SPEC_RE = re.compile(r'^\s*"([a-z0-9_.-]+)":\s*ToolSpec\(', re.M)
 
 
 def repo_tools() -> Set[str]:
     """Tool names this repository can build, from ``benchmark/tools.py``.
 
-    Parsed textually so importing the registry (and every tool module's
-    dependencies) is not required.
+    Parsed textually so the registry (and every tool module's imports) does
+    not have to be importable just to answer this.
 
     :return: registered tool names.
     """
     text = TOOLS_REGISTRY_PATH.read_text(encoding="utf-8")
-    return set(re.findall(r'^\s*"([a-z0-9_.-]+)":\s*ToolSpec\(', text, re.M))
+    return set(_TOOL_SPEC_RE.findall(text))
 
 
 def tournament_tools() -> Set[str]:
     """Tool names currently on the tournament roster.
 
-    :return: roster names (empty when the file is missing/corrupt).
+    :return: roster names; empty when the file is missing or unreadable.
     """
     try:
         data = json.loads(TOURNAMENT_TOOLS_PATH.read_text(encoding="utf-8"))
     except (OSError, ValueError):
+        log.warning("tournament roster unreadable at %s", TOURNAMENT_TOOLS_PATH)
         return set()
     return set(data) if isinstance(data, dict) else set()
 
 
-def actionable_tools(
-    served: Optional[Dict[str, Dict[str, Any]]] = None,
+def served_tools(
     platform: Optional[str] = None,
+    valid: Optional[Dict[str, Optional[List[str]]]] = None,
 ) -> Set[str]:
-    """Tools that are BOTH served on-chain and buildable from this repo.
+    """Tools selectable by the live trader, normalized for naming drift.
 
-    That intersection is the actionable set: a tool the triage can open a
-    fix issue for and whose fix has somewhere to land. Tools served but
-    absent here cannot be edited; tools present here but unserved have no
-    deployment consequence (they are tournament candidates at most).
-
-    :param served: output of :func:`discover_served_tools`; discovered when
-        omitted.
-    :param platform: restrict to mechs answering for this platform.
-    :return: tool names.
+    :param platform: restrict to deployments of this platform (``"omen"`` /
+        ``"polymarket"``); all deployments when omitted.
+    :param valid: pre-fetched :func:`benchmark.tool_usage.fetch_valid_tools`
+        result; fetched when omitted.
+    :return: served tool names (dash-normalized). A deployment whose
+        resolution failed contributes nothing and is logged.
     """
-    served = discover_served_tools() if served is None else served
-    names: Set[str] = set()
-    for entry in served.values():
-        if platform and entry.get("platform") != platform:
+    valid = fetch_valid_tools() if valid is None else valid
+    out: Set[str] = set()
+    for deployment, tools in valid.items():
+        if platform and DEPLOYMENT_TO_PLATFORM.get(deployment) != platform:
             continue
-        names.update(entry.get("tools") or [])
-    return names & repo_tools()
+        if tools is None:
+            log.warning("%s: selectable tools unavailable (fetch failed)", deployment)
+            continue
+        out.update(normalize_tool_name(tool) for tool in tools)
+    return out
+
+
+def actionable_tools(
+    platform: Optional[str] = None,
+    valid: Optional[Dict[str, Optional[List[str]]]] = None,
+) -> Set[str]:
+    """Tools BOTH selectable in production AND buildable from this repo.
+
+    This is the set the improvement loop may open fix issues for: anything
+    outside it either cannot be edited here or would have no deployment
+    consequence.
+
+    :param platform: restrict to one platform.
+    :param valid: pre-fetched selectable-tools map.
+    :return: actionable tool names, spelled as this repo spells them.
+    """
+    served = served_tools(platform, valid)
+    return {tool for tool in repo_tools() if normalize_tool_name(tool) in served}
 
 
 def main() -> int:
-    """CLI: print the served set, the repo set, and their intersection.
+    """CLI: print the selectable set, this repo's set, and their intersection.
 
-    :return: process exit code (1 if no service could be read).
+    :return: exit code (1 when no deployment could be resolved).
     """
     parser = argparse.ArgumentParser(description=__doc__ or "")
     parser.add_argument(
-        "--platform",
-        default=None,
-        help="restrict to one platform (omen / polymarket)",
+        "--platform", default=None, help="restrict to omen / polymarket"
     )
     parser.add_argument("--json", action="store_true", help="machine-readable output")
     args = parser.parse_args()
     logging.basicConfig(format="%(levelname)s %(message)s", level=logging.WARNING)
 
-    served = discover_served_tools()
+    valid = fetch_valid_tools()
     repo = repo_tools()
+    repo_normalized = {normalize_tool_name(tool) for tool in repo}
     roster = tournament_tools()
-    actionable = actionable_tools(served, args.platform)
+    served = served_tools(args.platform, valid)
+    actionable = actionable_tools(args.platform, valid)
+    resolved = any(tools is not None for tools in valid.values())
 
     if args.json:
         print(
             json.dumps(
                 {
-                    "served_by_service": served,
+                    "selectable_by_deployment": {
+                        deployment: (sorted(tools) if tools is not None else None)
+                        for deployment, tools in valid.items()
+                    },
                     "repo_tools": sorted(repo),
                     "tournament_roster": sorted(roster),
                     "actionable": sorted(actionable),
@@ -337,38 +168,33 @@ def main() -> int:
                 indent=2,
             )
         )
-        return 0 if any(e["tools"] for e in served.values()) else 1
+        return 0 if resolved else 1
 
-    print("SERVED ON-CHAIN")
-    served_all: Set[str] = set()
-    for name, entry in served.items():
-        if args.platform and entry["platform"] != args.platform:
+    print("SELECTABLE IN PRODUCTION (trader valid_mechs -> marketplace -> IPFS)")
+    for deployment, tools in valid.items():
+        platform = DEPLOYMENT_TO_PLATFORM.get(deployment, "?")
+        if args.platform and platform != args.platform:
             continue
-        head = f"  {name}  [{entry['chain']}/{entry['platform']} service={entry['service_id']}]"
-        if entry["error"]:
-            print(f"{head}  -- {entry['error']}")
+        if tools is None:
+            print(f"  {deployment} [{platform}] -- unavailable (fetch failed)")
             continue
-        print(head)
-        for tool in entry["tools"]:
-            mark = "" if tool in repo else "   (not in this repo)"
-            print(f"      - {tool}{mark}")
-        served_all.update(entry["tools"])
+        print(f"  {deployment} [{platform}]")
+        for tool in sorted(tools):
+            known = normalize_tool_name(tool) in repo_normalized
+            print(f"      - {tool}{'' if known else '   (not in this repo)'}")
 
-    print("\nACTIONABLE (served AND buildable here)")
+    print("\nACTIONABLE (selectable AND buildable here)")
     for tool in sorted(actionable):
-        tags = []
-        if tool in roster:
-            tags.append("also in tournament")
-        print(f"  * {tool}" + (f"   [{', '.join(tags)}]" if tags else ""))
+        print(f"  * {tool}{'   [also in tournament]' if tool in roster else ''}")
 
     print("\nNOT ACTIONABLE")
-    for tool in sorted(repo - served_all):
+    for tool in sorted(repo - actionable):
         where = "tournament only" if tool in roster else "repo only"
-        print(f"  - {tool}   ({where})")
-    for tool in sorted(served_all - repo):
-        print(f"  - {tool}   (served but not buildable from this repo)")
+        print(f"  - {tool}   ({where}, not selectable in production)")
+    for tool in sorted(served - repo_normalized):
+        print(f"  - {tool}   (selectable but not buildable from this repo)")
 
-    return 0 if any(e["tools"] for e in served.values()) else 1
+    return 0 if resolved else 1
 
 
 if __name__ == "__main__":

--- a/benchmark/served_tools.py
+++ b/benchmark/served_tools.py
@@ -62,9 +62,11 @@ from typing import Dict, List, Optional, Set
 
 from benchmark.tool_usage import (
     DEPLOYMENT_TO_PLATFORM,
+    deployments_for_platform,
     fetch_valid_tools,
     normalize_tool_name,
 )
+from benchmark.tournament_tools import roster_names
 
 log = logging.getLogger(__name__)
 
@@ -77,20 +79,25 @@ TOURNAMENT_TOOLS_PATH = Path(__file__).resolve().parent / "tournament_tools.json
 _CUSTOM_KEY_RE = re.compile(r"^custom/[^/]+/([^/]+)/")
 
 
-def repo_tools() -> Set[str]:
-    """Tool packages this repository ships, from ``packages/packages.json``.
+def repo_tools() -> Optional[Set[str]]:
+    """Tool packages this repository ships, or ``None`` when unknowable.
 
     The package ledger is the shipping source of truth (maintained by
     ``autonomy packages lock``, consumed by deployment), unlike
     ``benchmark/tools.py`` which only lists what the harness can run.
 
-    :return: package names of every ``custom/`` entry, in package spelling.
+    Returns ``None`` rather than an empty set when the ledger cannot be read
+    (truncated mid-``lock``, permissions, CI disk hiccup): "we ship nothing"
+    and "we could not find out" must not be the same answer, because a
+    consumer that treats them alike silently concludes nothing is actionable.
+
+    :return: package names of every ``custom/`` entry, or ``None`` on failure.
     """
     try:
         data = json.loads(PACKAGES_JSON_PATH.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         log.warning("packages.json unreadable at %s", PACKAGES_JSON_PATH)
-        return set()
+        return None
     names: Set[str] = set()
     for section in ("dev", "third_party"):
         for key in data.get(section) or {}:
@@ -100,66 +107,93 @@ def repo_tools() -> Set[str]:
     return names
 
 
-def tournament_tools() -> Set[str]:
-    """Tool names currently on the tournament roster.
+def tournament_tools() -> Optional[Set[str]]:
+    """Tool names on the tournament roster, normalized; ``None`` if unknown.
 
-    :return: roster names; empty when the file is missing or unreadable.
+    Thin delegate to :func:`benchmark.tournament_tools.roster_names` so this
+    module is not a fourth, subtly-different parse of the same file. In
+    particular the names come back in the UNDERSCORE namespace, which is what
+    makes membership tests against package names correct -- comparing raw
+    roster keys (dash spelling) to package names (underscore spelling) can
+    never match for a versioned tool.
+
+    :return: roster names folded into this module's single comparison
+        namespace (``normalize_tool_name``), or ``None`` when unknown.
     """
-    try:
-        data = json.loads(TOURNAMENT_TOOLS_PATH.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
-        log.warning("tournament roster unreadable at %s", TOURNAMENT_TOOLS_PATH)
-        return set()
-    return set(data) if isinstance(data, dict) else set()
+    raw = roster_names(TOURNAMENT_TOOLS_PATH)
+    return None if raw is None else {normalize_tool_name(n) for n in raw}
 
 
 def served_tools(
     platform: Optional[str] = None,
     valid: Optional[Dict[str, Optional[List[str]]]] = None,
-) -> Set[str]:
+) -> Optional[Set[str]]:
     """Tools selectable by the live trader, normalized for naming drift.
+
+    Returns ``None`` when every deployment IN SCOPE failed to resolve, so a
+    total discovery outage is distinguishable from "this platform genuinely
+    serves nothing". :func:`fetch_valid_tools` never raises -- a single
+    failure at the trader-release lookup nulls every deployment at once -- so
+    without this distinction a rate-limited morning is indistinguishable from
+    a quiet one, and the improvement loop would silently assess nothing.
 
     :param platform: restrict to deployments of this platform (``"omen"`` /
         ``"polymarket"``); all deployments when omitted.
     :param valid: pre-fetched :func:`benchmark.tool_usage.fetch_valid_tools`
         result; fetched when omitted.
-    :return: served tool names (dash-normalized). A deployment whose
-        resolution failed contributes nothing and is logged.
+    :return: served tool names (dash-normalized), or ``None`` when nothing in
+        scope could be resolved.
     """
     valid = fetch_valid_tools() if valid is None else valid
+    in_scope = set(deployments_for_platform(platform)) if platform else set(valid)
     out: Set[str] = set()
+    resolved_any = False
     for deployment, tools in valid.items():
-        if platform and DEPLOYMENT_TO_PLATFORM.get(deployment) != platform:
+        if deployment not in in_scope:
             continue
         if tools is None:
             log.warning("%s: selectable tools unavailable (fetch failed)", deployment)
             continue
+        resolved_any = True
         out.update(normalize_tool_name(tool) for tool in tools)
+    if not resolved_any:
+        log.warning(
+            "no deployment resolved%s; selectable set is UNKNOWN, not empty.",
+            f" for platform {platform}" if platform else "",
+        )
+        return None
     return out
 
 
 def actionable_tools(
     platform: Optional[str] = None,
     valid: Optional[Dict[str, Optional[List[str]]]] = None,
-) -> Set[str]:
+) -> Optional[Set[str]]:
     """Tools BOTH selectable in production AND buildable from this repo.
 
     This is the set the improvement loop may open fix issues for: anything
     outside it either cannot be edited here or would have no deployment
     consequence.
 
+    ``None`` propagates from either input (discovery outage, unreadable
+    ledger) and means "unknown" -- the caller must then assess everything
+    rather than silence every tool. An empty SET is a real answer.
+
     :param platform: restrict to one platform.
     :param valid: pre-fetched selectable-tools map.
-    :return: actionable tool names, spelled as this repo spells them.
+    :return: actionable tool names as this repo spells them, or ``None``.
     """
     served = served_tools(platform, valid)
-    return {tool for tool in repo_tools() if normalize_tool_name(tool) in served}
+    repo = repo_tools()
+    if served is None or repo is None:
+        return None
+    return {tool for tool in repo if normalize_tool_name(tool) in served}
 
 
 def main() -> int:
     """CLI: print the selectable set, this repo's set, and their intersection.
 
-    :return: exit code (1 when no deployment could be resolved).
+    :return: exit code (1 when nothing IN SCOPE could be resolved).
     """
     parser = argparse.ArgumentParser(description=__doc__ or "")
     parser.add_argument(
@@ -171,11 +205,25 @@ def main() -> int:
 
     valid = fetch_valid_tools()
     repo = repo_tools()
-    repo_normalized = {normalize_tool_name(tool) for tool in repo}
+    repo_normalized = {normalize_tool_name(t) for t in repo} if repo else set()
     roster = tournament_tools()
     served = served_tools(args.platform, valid)
     actionable = actionable_tools(args.platform, valid)
-    resolved = any(tools is not None for tools in valid.values())
+    # Scope the exit code to what was ASKED for: fetch_valid_tools() always
+    # resolves both deployments, so judging success over the unfiltered map
+    # let `--platform omen` exit 0 on a total omen failure just because
+    # polymarket happened to work.
+    resolved = served is not None
+
+    def _roster_has(tool: str) -> Optional[bool]:
+        """Roster membership across the dash/underscore namespaces.
+
+        :param tool: tool name in either spelling.
+        :return: membership, or ``None`` when the roster is unknown.
+        """
+        if roster is None:
+            return None
+        return normalize_tool_name(tool) in roster
 
     if args.json:
         print(
@@ -185,9 +233,11 @@ def main() -> int:
                         deployment: (sorted(tools) if tools is not None else None)
                         for deployment, tools in valid.items()
                     },
-                    "repo_tools": sorted(repo),
-                    "tournament_roster": sorted(roster),
-                    "actionable": sorted(actionable),
+                    "repo_tools": sorted(repo) if repo is not None else None,
+                    "tournament_roster": sorted(roster) if roster is not None else None,
+                    "actionable": (
+                        sorted(actionable) if actionable is not None else None
+                    ),
                 },
                 indent=2,
             )
@@ -208,15 +258,35 @@ def main() -> int:
             print(f"      - {tool}{'' if known else '   (not shipped by this repo)'}")
 
     print("\nACTIONABLE (selectable AND shipped by this repo)")
-    for tool in sorted(actionable):
-        print(f"  * {tool}{'   [also in tournament]' if tool in roster else ''}")
+    if actionable is None:
+        print("  UNKNOWN -- discovery did not resolve; assess all tools")
+    else:
+        for tool in sorted(actionable):
+            in_roster = _roster_has(tool)
+            tag = {
+                True: "   [also in tournament]",
+                None: "   [tournament UNKNOWN]",
+            }.get(in_roster, "")
+            print(f"  * {tool}{tag}")
 
     print("\nNOT ACTIONABLE")
-    for tool in sorted(repo - actionable):
-        where = "tournament only" if tool in roster else "shipped only"
+    for tool in sorted((repo or set()) - (actionable or set())):
+        in_roster = _roster_has(tool)
+        where = {
+            True: "tournament only",
+            None: "tournament membership unknown",
+        }.get(in_roster, "shipped only")
         print(f"  - {tool}   ({where}, not selectable in production)")
-    for name in sorted(served - repo_normalized):
-        print(f"  - {name}   (selectable but not shipped by this repo)")
+    for name in sorted(served or set()):
+        if name not in repo_normalized:
+            print(f"  - {name}   (selectable but not shipped by this repo)")
+    # Roster-only tools ship no package and are served by nobody, so they fall
+    # outside both sets above -- yet they are the #416 class this whole change
+    # exists for (predict-fine-tuned-calibrated among them). Omitting them from
+    # the text report while listing them in --json hides the motivating case
+    # from the only output a human reads.
+    for name in sorted((roster or set()) - repo_normalized - (served or set())):
+        print(f"  - {name}   (tournament only, ships no package here)")
 
     return 0 if resolved else 1
 

--- a/benchmark/served_tools.py
+++ b/benchmark/served_tools.py
@@ -1,0 +1,375 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Discover which tools our mechs actually SERVE, read on-chain.
+
+The triage assesses whatever appears in the scored data, which includes
+tools that live only in the tournament and are not deployed anywhere. A
+fix issue on such a tool has no validation path (its PR cannot be
+benchmarked from production rows) and no deployment consequence, so the
+triage needs to know the deployed set.
+
+A manifest committed here would rot on every deploy, so this module
+recomputes it per run, from chain state only:
+
+1. For each known mech service, read
+   ``ComplementaryServiceMetadata.mapServiceHashes(serviceId)`` -> a
+   bytes32 IPFS digest.
+2. Rebuild the CIDv1 prefix (``f01701220`` + digest) and fetch the
+   metadata manifest from the IPFS gateway.
+3. The manifest's ``tools`` array is the served-tool list -- the same
+   view the trader has when it picks a tool.
+
+The only local constants are the service registry below: chain, service
+id and the ComplementaryServiceMetadata address per mech. Those change
+approximately never (unlike tool CIDs, which churn every deploy).
+
+Read-only: one ``eth_call`` per service and one gateway GET per distinct
+manifest. No writes, no transactions, no private repo access.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+log = logging.getLogger(__name__)
+
+# The autonolas RPC/IPFS gateways reject requests without a browser-like
+# User-Agent (HTTP 403), so set one explicitly on every call.
+_USER_AGENT = "Mozilla/5.0 (mech-predict served-tools discovery)"
+
+GATEWAY = os.environ.get("IPFS_GATEWAY_URL", "https://gateway.autonolas.tech/ipfs")
+RPC_URLS: Dict[str, str] = {
+    "gnosis": os.environ.get(
+        "GNOSIS_RPC_URL", "https://rpc-gate.autonolas.tech/gnosis-rpc/"
+    ),
+    "polygon": os.environ.get(
+        "POLYGON_RPC_URL", "https://rpc-gate.autonolas.tech/polygon-rpc/"
+    ),
+    "base": os.environ.get("BASE_RPC_URL", "https://rpc-gate.autonolas.tech/base-rpc/"),
+    "optimism": os.environ.get(
+        "OPTIMISM_RPC_URL", "https://rpc-gate.autonolas.tech/optimism-rpc/"
+    ),
+}
+
+# Function selector: the first 4 bytes of the keccak-256 hash of the
+# signature mapServiceHashes(uint256), verified against the deployed
+# ComplementaryServiceMetadata contract.
+MAP_SERVICE_HASHES_SELECTOR = "0x4a086201"
+
+# Our mech services. Sourced from the deployment env files; kept here because
+# they are stable identifiers (a service id and a registry address), NOT
+# per-deploy state. Add a row when a new mech service is created.
+MECH_SERVICES: Tuple[Dict[str, str], ...] = (
+    {
+        "name": "mech_mm_predict",
+        "chain": "gnosis",
+        "service_id": "2182",
+        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
+    },
+    {
+        "name": "mech_mm_predict_clone",
+        "chain": "gnosis",
+        "service_id": "2198",
+        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
+    },
+    {
+        "name": "single_mech_mm_predict",
+        "chain": "gnosis",
+        "service_id": "2235",
+        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
+    },
+    {
+        "name": "single_mech_mm_predict_2340",
+        "chain": "gnosis",
+        "service_id": "2340",
+        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
+    },
+    {
+        "name": "single_mech_mm_predict_2359",
+        "chain": "gnosis",
+        "service_id": "2359",
+        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
+    },
+    {
+        "name": "single_mech_mm_predict_2360",
+        "chain": "gnosis",
+        "service_id": "2360",
+        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
+    },
+    {
+        "name": "nvm_native_mech_mm_predict_2469",
+        "chain": "gnosis",
+        "service_id": "2469",
+        "csm": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69",
+    },
+    {
+        "name": "single_polygon_mech_mm_predict_21",
+        "chain": "polygon",
+        "service_id": "21",
+        "csm": "0xDC175E77d11246c79B23D7088750eb59160DD6b7",
+    },
+    {
+        "name": "polygon_mech_mm_predict_25",
+        "chain": "polygon",
+        "service_id": "25",
+        "csm": "0xDC175E77d11246c79B23D7088750eb59160DD6b7",
+    },
+    {
+        "name": "polygon_mech_mm_predict_44",
+        "chain": "polygon",
+        "service_id": "44",
+        "csm": "0xDC175E77d11246c79B23D7088750eb59160DD6b7",
+    },
+)
+
+# Platform each chain's mechs answer for, so the served set can be compared
+# against a platform-scoped triage run.
+CHAIN_PLATFORM: Dict[str, str] = {"gnosis": "omen", "polygon": "polymarket"}
+
+TOOLS_REGISTRY_PATH = Path(__file__).resolve().parent / "tools.py"
+TOURNAMENT_TOOLS_PATH = Path(__file__).resolve().parent / "tournament_tools.json"
+
+
+def _rpc_call(rpc_url: str, to: str, data: str, timeout: int = 20) -> Optional[str]:
+    """One ``eth_call``; returns the hex result or ``None`` on any failure.
+
+    :param rpc_url: JSON-RPC endpoint.
+    :param to: contract address.
+    :param data: ABI-encoded calldata.
+    :param timeout: seconds.
+    :return: hex string result, or ``None``.
+    """
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "eth_call",
+            "params": [{"to": to, "data": data}, "latest"],
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        rpc_url,
+        data=payload,
+        headers={"Content-Type": "application/json", "User-Agent": _USER_AGENT},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:  # nosec B310
+            body = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        log.warning("eth_call failed on %s: %s", rpc_url, exc)
+        return None
+    if "error" in body:
+        log.warning("eth_call returned an error: %s", body["error"])
+        return None
+    result = body.get("result")
+    return result if isinstance(result, str) else None
+
+
+def _fetch_manifest_tools(metadata_hash: str, timeout: int = 20) -> List[str]:
+    """Fetch an IPFS metadata manifest and return its ``tools`` list.
+
+    :param metadata_hash: CIDv1 hex form (``f01701220`` + digest).
+    :param timeout: seconds.
+    :return: served tool names (empty on any failure).
+    """
+    req = urllib.request.Request(
+        f"{GATEWAY}/{metadata_hash}", headers={"User-Agent": _USER_AGENT}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:  # nosec B310
+            manifest = json.loads(response.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError, ValueError) as exc:
+        log.warning("IPFS fetch failed for %s: %s", metadata_hash, exc)
+        return []
+    tools = manifest.get("tools")
+    return [str(t) for t in tools] if isinstance(tools, list) else []
+
+
+def discover_served_tools(
+    services: Tuple[Dict[str, str], ...] = MECH_SERVICES,
+) -> Dict[str, Dict[str, Any]]:
+    """Read the served-tool set of every known mech service, from chain.
+
+    :param services: service registry rows (chain / service_id / csm).
+    :return: ``{service_name: {chain, platform, service_id, metadata_hash,
+        tools, error}}``; ``error`` is set when the service could not be
+        read (its ``tools`` is then empty).
+    """
+    out: Dict[str, Dict[str, Any]] = {}
+    manifest_cache: Dict[str, List[str]] = {}
+    for service in services:
+        name = service["name"]
+        chain = service["chain"]
+        entry: Dict[str, Any] = {
+            "chain": chain,
+            "platform": CHAIN_PLATFORM.get(chain, chain),
+            "service_id": service["service_id"],
+            "metadata_hash": None,
+            "tools": [],
+            "error": None,
+        }
+        rpc_url = RPC_URLS.get(chain)
+        if not rpc_url:
+            entry["error"] = f"no RPC configured for chain {chain!r}"
+            out[name] = entry
+            continue
+        # mapServiceHashes(uint256) -> bytes32
+        calldata = MAP_SERVICE_HASHES_SELECTOR + f"{int(service['service_id']):064x}"
+        raw = _rpc_call(rpc_url, service["csm"], calldata)
+        if not raw or raw == "0x" or set(raw[2:]) == {"0"}:
+            entry["error"] = "no metadata hash on chain (0x0 or unreadable)"
+            out[name] = entry
+            continue
+        metadata_hash = "f01701220" + raw[2:].rjust(64, "0")
+        entry["metadata_hash"] = metadata_hash
+        if metadata_hash not in manifest_cache:
+            manifest_cache[metadata_hash] = _fetch_manifest_tools(metadata_hash)
+        entry["tools"] = sorted(manifest_cache[metadata_hash])
+        if not entry["tools"]:
+            entry["error"] = "manifest unreadable or carries no tools"
+        out[name] = entry
+    return out
+
+
+def repo_tools() -> Set[str]:
+    """Tool names this repository can build, from ``benchmark/tools.py``.
+
+    Parsed textually so importing the registry (and every tool module's
+    dependencies) is not required.
+
+    :return: registered tool names.
+    """
+    text = TOOLS_REGISTRY_PATH.read_text(encoding="utf-8")
+    return set(re.findall(r'^\s*"([a-z0-9_.-]+)":\s*ToolSpec\(', text, re.M))
+
+
+def tournament_tools() -> Set[str]:
+    """Tool names currently on the tournament roster.
+
+    :return: roster names (empty when the file is missing/corrupt).
+    """
+    try:
+        data = json.loads(TOURNAMENT_TOOLS_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return set()
+    return set(data) if isinstance(data, dict) else set()
+
+
+def actionable_tools(
+    served: Optional[Dict[str, Dict[str, Any]]] = None,
+    platform: Optional[str] = None,
+) -> Set[str]:
+    """Tools that are BOTH served on-chain and buildable from this repo.
+
+    That intersection is the actionable set: a tool the triage can open a
+    fix issue for and whose fix has somewhere to land. Tools served but
+    absent here cannot be edited; tools present here but unserved have no
+    deployment consequence (they are tournament candidates at most).
+
+    :param served: output of :func:`discover_served_tools`; discovered when
+        omitted.
+    :param platform: restrict to mechs answering for this platform.
+    :return: tool names.
+    """
+    served = discover_served_tools() if served is None else served
+    names: Set[str] = set()
+    for entry in served.values():
+        if platform and entry.get("platform") != platform:
+            continue
+        names.update(entry.get("tools") or [])
+    return names & repo_tools()
+
+
+def main() -> int:
+    """CLI: print the served set, the repo set, and their intersection.
+
+    :return: process exit code (1 if no service could be read).
+    """
+    parser = argparse.ArgumentParser(description=__doc__ or "")
+    parser.add_argument(
+        "--platform",
+        default=None,
+        help="restrict to one platform (omen / polymarket)",
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args()
+    logging.basicConfig(format="%(levelname)s %(message)s", level=logging.WARNING)
+
+    served = discover_served_tools()
+    repo = repo_tools()
+    roster = tournament_tools()
+    actionable = actionable_tools(served, args.platform)
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "served_by_service": served,
+                    "repo_tools": sorted(repo),
+                    "tournament_roster": sorted(roster),
+                    "actionable": sorted(actionable),
+                },
+                indent=2,
+            )
+        )
+        return 0 if any(e["tools"] for e in served.values()) else 1
+
+    print("SERVED ON-CHAIN")
+    served_all: Set[str] = set()
+    for name, entry in served.items():
+        if args.platform and entry["platform"] != args.platform:
+            continue
+        head = f"  {name}  [{entry['chain']}/{entry['platform']} service={entry['service_id']}]"
+        if entry["error"]:
+            print(f"{head}  -- {entry['error']}")
+            continue
+        print(head)
+        for tool in entry["tools"]:
+            mark = "" if tool in repo else "   (not in this repo)"
+            print(f"      - {tool}{mark}")
+        served_all.update(entry["tools"])
+
+    print("\nACTIONABLE (served AND buildable here)")
+    for tool in sorted(actionable):
+        tags = []
+        if tool in roster:
+            tags.append("also in tournament")
+        print(f"  * {tool}" + (f"   [{', '.join(tags)}]" if tags else ""))
+
+    print("\nNOT ACTIONABLE")
+    for tool in sorted(repo - served_all):
+        where = "tournament only" if tool in roster else "repo only"
+        print(f"  - {tool}   ({where})")
+    for tool in sorted(served_all - repo):
+        print(f"  - {tool}   (served but not buildable from this repo)")
+
+    return 0 if any(e["tools"] for e in served.values()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/served_tools.py
+++ b/benchmark/served_tools.py
@@ -32,10 +32,20 @@ the IPFS manifest's ``tools``. That chain answers "what can the live
 trader select?", which is the question that matters, and it needs no
 service ids, registry addresses or mech lists stored here.
 
-This module adds the second half: intersect that set with the tools this
-repository can build (``benchmark/tools.py``). Only the intersection is
-actionable for the improvement loop -- a tool we cannot build cannot be
+This module adds the second half: intersect that set with the tool
+packages this repository actually ships (``packages/packages.json``,
+the ledger ``autonomy packages lock`` maintains and deployment consumes
+-- not ``benchmark/tools.py``, which is a benchmark-harness convenience
+list that drifts from what is shipped). Only the intersection is
+actionable for the improvement loop -- a tool we do not ship cannot be
 fixed here, and a tool nobody serves has nowhere for a fix to land.
+
+Mech manifests advertise tool NAMES only (no CIDs), so matching is by
+name with underscores and dashes treated as interchangeable
+(``superforcaster_full_search`` the package == ``superforcaster-full-search``
+the served tool). Version suffixes are NOT stripped: ``-v1`` and ``-v3``
+are different tools and only the ones actually advertised count as
+served.
 
 Read-only: GitHub API, subgraph and IPFS gateway GETs.
 """
@@ -58,22 +68,36 @@ from benchmark.tool_usage import (
 
 log = logging.getLogger(__name__)
 
-TOOLS_REGISTRY_PATH = Path(__file__).resolve().parent / "tools.py"
+PACKAGES_JSON_PATH = (
+    Path(__file__).resolve().parent.parent / "packages" / "packages.json"
+)
 TOURNAMENT_TOOLS_PATH = Path(__file__).resolve().parent / "tournament_tools.json"
 
-_TOOL_SPEC_RE = re.compile(r'^\s*"([a-z0-9_.-]+)":\s*ToolSpec\(', re.M)
+# packages.json keys look like ``custom/<author>/<package_name>/<version>``.
+_CUSTOM_KEY_RE = re.compile(r"^custom/[^/]+/([^/]+)/")
 
 
 def repo_tools() -> Set[str]:
-    """Tool names this repository can build, from ``benchmark/tools.py``.
+    """Tool packages this repository ships, from ``packages/packages.json``.
 
-    Parsed textually so the registry (and every tool module's imports) does
-    not have to be importable just to answer this.
+    The package ledger is the shipping source of truth (maintained by
+    ``autonomy packages lock``, consumed by deployment), unlike
+    ``benchmark/tools.py`` which only lists what the harness can run.
 
-    :return: registered tool names.
+    :return: package names of every ``custom/`` entry, in package spelling.
     """
-    text = TOOLS_REGISTRY_PATH.read_text(encoding="utf-8")
-    return set(_TOOL_SPEC_RE.findall(text))
+    try:
+        data = json.loads(PACKAGES_JSON_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        log.warning("packages.json unreadable at %s", PACKAGES_JSON_PATH)
+        return set()
+    names: Set[str] = set()
+    for section in ("dev", "third_party"):
+        for key in data.get(section) or {}:
+            match = _CUSTOM_KEY_RE.match(key)
+            if match:
+                names.add(match.group(1))
+    return names
 
 
 def tournament_tools() -> Set[str]:
@@ -181,18 +205,18 @@ def main() -> int:
         print(f"  {deployment} [{platform}]")
         for tool in sorted(tools):
             known = normalize_tool_name(tool) in repo_normalized
-            print(f"      - {tool}{'' if known else '   (not in this repo)'}")
+            print(f"      - {tool}{'' if known else '   (not shipped by this repo)'}")
 
-    print("\nACTIONABLE (selectable AND buildable here)")
+    print("\nACTIONABLE (selectable AND shipped by this repo)")
     for tool in sorted(actionable):
         print(f"  * {tool}{'   [also in tournament]' if tool in roster else ''}")
 
     print("\nNOT ACTIONABLE")
     for tool in sorted(repo - actionable):
-        where = "tournament only" if tool in roster else "repo only"
+        where = "tournament only" if tool in roster else "shipped only"
         print(f"  - {tool}   ({where}, not selectable in production)")
-    for tool in sorted(served - repo_normalized):
-        print(f"  - {tool}   (selectable but not buildable from this repo)")
+    for name in sorted(served - repo_normalized):
+        print(f"  - {name}   (selectable but not shipped by this repo)")
 
     return 0 if resolved else 1
 

--- a/benchmark/tests/test_served_tools.py
+++ b/benchmark/tests/test_served_tools.py
@@ -26,14 +26,26 @@ from benchmark import served_tools
 
 
 class TestRepoTools:
-    """The registry parse."""
+    """The packages.json parse (the shipping source of truth)."""
 
-    def test_finds_known_tools(self) -> None:
-        """Parsing tools.py yields the registered tool names."""
+    def test_finds_shipped_packages(self) -> None:
+        """Parsing packages.json yields custom/ package names."""
         tools = served_tools.repo_tools()
-        assert "superforcaster-polymarket-v1" in tools
+        assert "superforcaster_polymarket_v1" in tools
         assert "factual_research" in tools
         assert all(tool == tool.strip() for tool in tools)
+
+    def test_ignores_non_custom_entries(self) -> None:
+        """Only custom/ packages count (not agents, skills, protocols)."""
+        tools = served_tools.repo_tools()
+        assert not any("/" in tool for tool in tools)
+
+    def test_unreadable_packages_json_is_empty(
+        self, monkeypatch: Any, tmp_path: Any
+    ) -> None:
+        """A missing ledger yields an empty set rather than an exception."""
+        monkeypatch.setattr(served_tools, "PACKAGES_JSON_PATH", tmp_path / "nope.json")
+        assert served_tools.repo_tools() == set()
 
 
 class TestServedAndActionable:
@@ -43,7 +55,7 @@ class TestServedAndActionable:
         "omenstrat Pearl": ["factual_research", "superforcaster"],
         "polystrat Pearl": [
             "superforcaster-polymarket-v1",
-            "superforcaster_full_search",
+            "resolve-market-reasoning-gpt-4.1",
         ],
     }
 
@@ -66,17 +78,23 @@ class TestServedAndActionable:
     def test_name_convention_is_normalized(self) -> None:
         """Underscore/dash spellings of one tool match."""
         served = served_tools.served_tools(valid=self.VALID)
-        assert "superforcaster-full-search" in served
+        assert "factual-research" in served
 
     def test_actionable_is_the_intersection(self) -> None:
-        """Actionable = selectable AND buildable here; both exclusions hold."""
+        """Actionable = selectable AND shipped here; both exclusions hold."""
         actionable = served_tools.actionable_tools(valid=self.VALID)
-        # selectable and in this repo
-        assert "superforcaster-polymarket-v1" in actionable
-        # selectable but built elsewhere
-        assert "superforcaster_full_search" not in actionable
-        # in this repo but not selectable anywhere
-        assert "superforcaster-polymarket-v3" not in actionable
+        # selectable and shipped here (package spelling is returned)
+        assert "superforcaster_polymarket_v1" in actionable
+        # selectable but shipped by another repo
+        assert "resolve-market-reasoning-gpt-4.1" not in actionable
+        # shipped here but not selectable anywhere
+        assert "superforcaster_polymarket_v3" not in actionable
+
+    def test_versions_are_distinct_not_collapsed(self) -> None:
+        """A served -v1 must NOT make sibling -v3 look actionable."""
+        actionable = served_tools.actionable_tools(valid=self.VALID)
+        assert "factual_research_v1" not in actionable
+        assert "factual_research_v3" not in actionable
 
     def test_failed_deployment_contributes_nothing(self) -> None:
         """A None (fetch failed) deployment is skipped, not treated as empty."""

--- a/benchmark/tests/test_served_tools.py
+++ b/benchmark/tests/test_served_tools.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Tests for benchmark/served_tools.py (no network: fetches are injected)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from benchmark import served_tools
+
+
+class TestRepoTools:
+    """The registry parse."""
+
+    def test_finds_known_tools(self) -> None:
+        """Parsing tools.py yields the registered tool names."""
+        tools = served_tools.repo_tools()
+        assert "superforcaster-polymarket-v1" in tools
+        assert "factual_research" in tools
+        assert all(tool == tool.strip() for tool in tools)
+
+
+class TestServedAndActionable:
+    """Intersection semantics with an injected selectable-tools map."""
+
+    VALID: Dict[str, Optional[List[str]]] = {
+        "omenstrat Pearl": ["factual_research", "superforcaster"],
+        "polystrat Pearl": [
+            "superforcaster-polymarket-v1",
+            "superforcaster_full_search",
+        ],
+    }
+
+    def test_served_unions_all_deployments(self) -> None:
+        """Without a platform filter every deployment contributes.
+
+        Names come back normalized (underscores -> dashes), which is why
+        ``factual_research`` is asserted in its dashed form here.
+        """
+        served = served_tools.served_tools(valid=self.VALID)
+        assert "factual-research" in served
+        assert "superforcaster-polymarket-v1" in served
+
+    def test_platform_filter(self) -> None:
+        """A platform filter keeps only that platform's deployments."""
+        served = served_tools.served_tools("polymarket", self.VALID)
+        assert "superforcaster-polymarket-v1" in served
+        assert "factual-research" not in served
+
+    def test_name_convention_is_normalized(self) -> None:
+        """Underscore/dash spellings of one tool match."""
+        served = served_tools.served_tools(valid=self.VALID)
+        assert "superforcaster-full-search" in served
+
+    def test_actionable_is_the_intersection(self) -> None:
+        """Actionable = selectable AND buildable here; both exclusions hold."""
+        actionable = served_tools.actionable_tools(valid=self.VALID)
+        # selectable and in this repo
+        assert "superforcaster-polymarket-v1" in actionable
+        # selectable but built elsewhere
+        assert "superforcaster_full_search" not in actionable
+        # in this repo but not selectable anywhere
+        assert "superforcaster-polymarket-v3" not in actionable
+
+    def test_failed_deployment_contributes_nothing(self) -> None:
+        """A None (fetch failed) deployment is skipped, not treated as empty."""
+        valid: Dict[str, Optional[List[str]]] = {
+            "omenstrat Pearl": None,
+            "polystrat Pearl": ["superforcaster-polymarket-v1"],
+        }
+        served = served_tools.served_tools(valid=valid)
+        assert served == {"superforcaster-polymarket-v1"}
+
+    def test_all_failed_yields_empty(self) -> None:
+        """Everything unavailable -> empty actionable set (never a false 'none')."""
+        valid: Dict[str, Optional[List[str]]] = {
+            "omenstrat Pearl": None,
+            "polystrat Pearl": None,
+        }
+        assert served_tools.actionable_tools(valid=valid) == set()
+
+
+class TestTournamentRoster:
+    """Roster read is failure-tolerant."""
+
+    def test_missing_roster_is_empty(self, monkeypatch: Any, tmp_path: Any) -> None:
+        """An absent roster file yields an empty set, not an exception."""
+        monkeypatch.setattr(
+            served_tools, "TOURNAMENT_TOOLS_PATH", tmp_path / "nope.json"
+        )
+        assert served_tools.tournament_tools() == set()

--- a/benchmark/tests/test_served_tools.py
+++ b/benchmark/tests/test_served_tools.py
@@ -110,11 +110,6 @@ class TestRepoTools:
         )
         assert served_tools.repo_tools() == {"t"}
 
-    def test_ignores_non_custom_entries(self) -> None:
-        """Only custom/ packages count (not agents, skills, protocols)."""
-        tools = served_tools.repo_tools()
-        assert not any("/" in tool for tool in tools)
-
     def test_unreadable_packages_json_is_unknown(
         self, monkeypatch: Any, tmp_path: Any
     ) -> None:
@@ -145,23 +140,27 @@ class TestServedAndActionable:
         ``factual_research`` is asserted in its dashed form here.
         """
         served = served_tools.served_tools(valid=self.VALID)
+        assert served is not None
         assert "factual-research" in served
         assert "superforcaster-polymarket-v1" in served
 
     def test_platform_filter(self) -> None:
         """A platform filter keeps only that platform's deployments."""
         served = served_tools.served_tools("polymarket", self.VALID)
+        assert served is not None
         assert "superforcaster-polymarket-v1" in served
         assert "factual-research" not in served
 
     def test_name_convention_is_normalized(self) -> None:
         """Underscore/dash spellings of one tool match."""
         served = served_tools.served_tools(valid=self.VALID)
+        assert served is not None
         assert "factual-research" in served
 
     def test_actionable_is_the_intersection(self) -> None:
         """Actionable = selectable AND shipped here; both exclusions hold."""
         actionable = served_tools.actionable_tools(valid=self.VALID)
+        assert actionable is not None
         # selectable and shipped here (package spelling is returned)
         assert "superforcaster_polymarket_v1" in actionable
         # selectable but shipped by another repo
@@ -172,6 +171,7 @@ class TestServedAndActionable:
     def test_versions_are_distinct_not_collapsed(self) -> None:
         """A served -v1 must NOT make sibling -v3 look actionable."""
         actionable = served_tools.actionable_tools(valid=self.VALID)
+        assert actionable is not None
         assert "factual_research_v1" not in actionable
         assert "factual_research_v3" not in actionable
 

--- a/benchmark/tests/test_served_tools.py
+++ b/benchmark/tests/test_served_tools.py
@@ -24,6 +24,7 @@ import json
 import sys
 from typing import Any, Dict, List, Optional
 
+import pytest
 from benchmark import served_tools
 
 
@@ -455,3 +456,85 @@ class TestMainCli:
         )
         assert json.loads(out)["actionable"] is None
         assert code == 1
+
+    def test_unknown_ledger_never_asserts_shipped_negatives(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """An unreadable ledger must render UNKNOWN, not confident negatives.
+
+        Every line of NOT ACTIONABLE is a claim about what this repo ships.
+        Read off a file we could not open, they become "ships no package
+        here" for tools that plainly do -- the same misreading the roster's
+        UNKNOWN state exists to prevent, one layer up.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        monkeypatch.setattr(
+            served_tools,
+            "fetch_valid_tools",
+            lambda: {
+                "polystrat Pearl": ["superforcaster-polymarket-v4"],
+            },
+        )
+        monkeypatch.setattr(served_tools, "PACKAGES_JSON_PATH", tmp_path / "gone.json")
+        ros = tmp_path / "tournament_tools.json"
+        ros.write_text(
+            json.dumps({"superforcaster-polymarket-v4": "b"}), encoding="utf-8"
+        )
+        monkeypatch.setattr(served_tools, "TOURNAMENT_TOOLS_PATH", ros)
+        monkeypatch.setattr(sys, "argv", ["served_tools"])
+        code = served_tools.main()
+        out = capsys.readouterr().out
+        assert (
+            "ships no package here" not in out
+        ), "asserted a shipped-negative off an unreadable ledger"
+        assert "not shipped by this repo" not in out
+        assert "UNKNOWN -- packages.json unreadable" in out
+        assert code == 1
+
+    def test_exit_code_covers_an_unknown_ledger(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """Healthy discovery + unreadable ledger must still exit 1.
+
+        `--json` emits `"actionable": null` in that state; a caller gating on
+        "trust today's output only if it exited 0" would otherwise consume it
+        as a trustworthy answer.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        monkeypatch.setattr(
+            served_tools,
+            "fetch_valid_tools",
+            lambda: {
+                "polystrat Pearl": ["superforcaster-polymarket-v4"],
+            },
+        )
+        monkeypatch.setattr(served_tools, "PACKAGES_JSON_PATH", tmp_path / "gone.json")
+        monkeypatch.setattr(sys, "argv", ["served_tools", "--json"])
+        code = served_tools.main()
+        assert json.loads(capsys.readouterr().out)["actionable"] is None
+        assert code == 1
+
+    def test_unknown_platform_is_rejected_not_reported_as_an_outage(
+        self, monkeypatch: Any, capsys: Any
+    ) -> None:
+        """A typo'd --platform must error, not fabricate a discovery outage.
+
+        `deployments_for_platform()` returns () for an unrecognized value,
+        which flows into the total-outage path -- so `--platform Omen` would
+        print UNKNOWN and exit 1 with both mechs healthy, indistinguishable
+        from the subgraph being down.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        monkeypatch.setattr(sys, "argv", ["served_tools", "--platform", "Omen"])
+        with pytest.raises(SystemExit) as exc:
+            served_tools.main()
+        assert exc.value.code == 2, "argparse should reject the value itself"
+        assert "invalid choice" in capsys.readouterr().err

--- a/benchmark/tests/test_served_tools.py
+++ b/benchmark/tests/test_served_tools.py
@@ -20,6 +20,8 @@
 
 from __future__ import annotations
 
+import json
+import sys
 from typing import Any, Dict, List, Optional
 
 from benchmark import served_tools
@@ -28,24 +30,101 @@ from benchmark import served_tools
 class TestRepoTools:
     """The packages.json parse (the shipping source of truth)."""
 
-    def test_finds_shipped_packages(self) -> None:
-        """Parsing packages.json yields custom/ package names."""
-        tools = served_tools.repo_tools()
-        assert "superforcaster_polymarket_v1" in tools
-        assert "factual_research" in tools
-        assert all(tool == tool.strip() for tool in tools)
+    @staticmethod
+    def _ledger(tmp_path: Any, monkeypatch: Any, payload: dict) -> None:
+        """Point repo_tools() at a synthetic packages.json.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param payload: ledger contents to write.
+        """
+        path = tmp_path / "packages.json"
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        monkeypatch.setattr(served_tools, "PACKAGES_JSON_PATH", path)
+
+    def test_parses_custom_keys_across_authors(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """Any author segment is accepted; the package name is the 3rd field.
+
+        Pinned on a synthetic ledger rather than the live one: asserting that
+        a specific tool ships today couples the parse test to the roster, so
+        retiring a tool would break it for an unrelated reason.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        self._ledger(
+            tmp_path,
+            monkeypatch,
+            {
+                "dev": {
+                    "custom/valory/superforcaster_polymarket_v1/0.1.0": "bafy1",
+                    "custom/napthaai/prediction_request_rag_v1/0.1.0": "bafy2",
+                    "custom/some-other.author/odd_name_v9/1.2.3": "bafy3",
+                },
+                "third_party": {"custom/thirdparty/vendor_tool/0.1.0": "bafy4"},
+            },
+        )
+        assert served_tools.repo_tools() == {
+            "superforcaster_polymarket_v1",
+            "prediction_request_rag_v1",
+            "odd_name_v9",
+            "vendor_tool",
+        }
+
+    def test_ignores_non_custom_keys_even_when_they_contain_custom(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """Only keys STARTING with ``custom/`` count.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        self._ledger(
+            tmp_path,
+            monkeypatch,
+            {
+                "dev": {
+                    "agent/valory/custom_agent/0.1.0": "bafy1",
+                    "skill/valory/some_custom/0.1.0": "bafy2",
+                    "protocol/valory/acn/1.1.0": "bafy3",
+                    "custom/valory/real_tool/0.1.0": "bafy4",
+                }
+            },
+        )
+        assert served_tools.repo_tools() == {"real_tool"}
+
+    def test_null_and_absent_sections_are_tolerated(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """``dev: null`` and a missing ``third_party`` must not raise.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        self._ledger(tmp_path, monkeypatch, {"dev": None})
+        assert served_tools.repo_tools() == set()
+        self._ledger(
+            tmp_path, monkeypatch, {"third_party": {"custom/v/t/0.1.0": "bafy"}}
+        )
+        assert served_tools.repo_tools() == {"t"}
 
     def test_ignores_non_custom_entries(self) -> None:
         """Only custom/ packages count (not agents, skills, protocols)."""
         tools = served_tools.repo_tools()
         assert not any("/" in tool for tool in tools)
 
-    def test_unreadable_packages_json_is_empty(
+    def test_unreadable_packages_json_is_unknown(
         self, monkeypatch: Any, tmp_path: Any
     ) -> None:
-        """A missing ledger yields an empty set rather than an exception."""
+        """An unreadable ledger yields None (unknown), not an empty set.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
         monkeypatch.setattr(served_tools, "PACKAGES_JSON_PATH", tmp_path / "nope.json")
-        assert served_tools.repo_tools() == set()
+        assert served_tools.repo_tools() is None
 
 
 class TestServedAndActionable:
@@ -105,13 +184,52 @@ class TestServedAndActionable:
         served = served_tools.served_tools(valid=valid)
         assert served == {"superforcaster-polymarket-v1"}
 
-    def test_all_failed_yields_empty(self) -> None:
-        """Everything unavailable -> empty actionable set (never a false 'none')."""
+    def test_all_failed_yields_unknown_not_empty(self) -> None:
+        """Everything unavailable -> None (UNKNOWN), never a false 'nothing'.
+
+        An empty set is a real answer meaning "this platform serves nothing
+        we ship". A total discovery failure must not be spelled the same way:
+        a consumer that treats them alike silences every tool on a
+        rate-limited morning and reports it as a quiet day.
+        """
         valid: Dict[str, Optional[List[str]]] = {
             "omenstrat Pearl": None,
             "polystrat Pearl": None,
         }
+        assert served_tools.served_tools(valid=valid) is None
+        assert served_tools.actionable_tools(valid=valid) is None
+
+    def test_resolved_but_nothing_shipped_is_a_real_empty(self) -> None:
+        """Discovery worked and nothing matched -> empty set, NOT None."""
+        valid: Dict[str, Optional[List[str]]] = {
+            "polystrat Pearl": ["some-tool-we-do-not-ship"],
+        }
         assert served_tools.actionable_tools(valid=valid) == set()
+
+    def test_unknown_propagates_from_an_unreadable_ledger(
+        self, monkeypatch: Any, tmp_path: Any
+    ) -> None:
+        """An unreadable packages.json is UNKNOWN too, not 'we ship nothing'.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        monkeypatch.setattr(
+            served_tools, "PACKAGES_JSON_PATH", tmp_path / "missing.json"
+        )
+        valid: Dict[str, Optional[List[str]]] = {
+            "polystrat Pearl": ["superforcaster-polymarket-v1"],
+        }
+        assert served_tools.actionable_tools(valid=valid) is None
+
+    def test_platform_scope_ignores_other_platforms_failures(self) -> None:
+        """A resolved omen deployment must not mask a failed polymarket one."""
+        valid: Dict[str, Optional[List[str]]] = {
+            "omenstrat Pearl": ["superforcaster"],
+            "polystrat Pearl": None,
+        }
+        assert served_tools.served_tools("omen", valid) == {"superforcaster"}
+        assert served_tools.served_tools("polymarket", valid) is None
 
 
 class TestTournamentRoster:
@@ -123,3 +241,217 @@ class TestTournamentRoster:
             served_tools, "TOURNAMENT_TOOLS_PATH", tmp_path / "nope.json"
         )
         assert served_tools.tournament_tools() == set()
+
+
+class TestMainCli:
+    """The CLI: 65 lines that had no test, and where two bugs lived."""
+
+    @staticmethod
+    def _run(
+        monkeypatch: Any,
+        capsys: Any,
+        tmp_path: Any,
+        argv: list,
+        valid: Dict[str, Optional[List[str]]],
+        ledger: Optional[dict] = None,
+        roster: Optional[dict] = None,
+    ) -> tuple:
+        """Run main() against injected discovery, ledger and roster.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        :param argv: argv tail (without the program name).
+        :param valid: injected fetch_valid_tools() result.
+        :param ledger: synthetic packages.json payload.
+        :param roster: synthetic tournament_tools.json payload.
+        :return: (exit_code, stdout).
+        """
+        monkeypatch.setattr(served_tools, "fetch_valid_tools", lambda: valid)
+        pkg = tmp_path / "packages.json"
+        pkg.write_text(
+            json.dumps(ledger if ledger is not None else {"dev": {}}), encoding="utf-8"
+        )
+        monkeypatch.setattr(served_tools, "PACKAGES_JSON_PATH", pkg)
+        ros = tmp_path / "tournament_tools.json"
+        ros.write_text(json.dumps(roster or {}), encoding="utf-8")
+        monkeypatch.setattr(served_tools, "TOURNAMENT_TOOLS_PATH", ros)
+        monkeypatch.setattr(sys, "argv", ["served_tools"] + argv)
+        code = served_tools.main()
+        return code, capsys.readouterr().out
+
+    def test_roster_tag_survives_the_naming_split(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """A tool spelled with '_' here and '-' on the roster is still tagged.
+
+        The real spelling pair: packages.json says ``factual_research_v2``,
+        tournament_tools.json says ``factual_research-v2``. Comparing them
+        raw can never match, so the tag was unreachable for every versioned
+        tool on the roster.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        code, out = self._run(
+            monkeypatch,
+            capsys,
+            tmp_path,
+            [],
+            {"polystrat Pearl": ["factual-research-v2"]},
+            ledger={"dev": {"custom/valory/factual_research_v2/0.1.0": "bafy"}},
+            roster={"factual_research-v2": "bafyroster"},
+        )
+        assert code == 0
+        assert "[also in tournament]" in out
+
+    def test_tournament_only_is_not_reported_as_shipped_only(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """A shipped, rostered, unserved tool reads 'tournament only'.
+
+        'shipped only' vs 'tournament only' is what a deployment-review
+        reader uses to decide whether a tool already has a tournament slot;
+        printing it backwards actively misleads them into re-adding it.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        _, out = self._run(
+            monkeypatch,
+            capsys,
+            tmp_path,
+            [],
+            {"polystrat Pearl": ["something-else"]},
+            ledger={"dev": {"custom/valory/factual_research_v2/0.1.0": "bafy"}},
+            roster={"factual_research-v2": "bafyroster"},
+        )
+        assert "factual_research_v2   (tournament only" in out
+        assert "factual_research_v2   (shipped only" not in out
+
+    def test_roster_only_tools_appear_in_the_text_report(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """Rostered tools that ship no package must not be silently omitted.
+
+        These are the motivating '#416 class' -- they are neither in
+        ``repo - actionable`` nor in ``served - repo``, so they fell through
+        both loops and showed up only under --json.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        _, out = self._run(
+            monkeypatch,
+            capsys,
+            tmp_path,
+            [],
+            {"polystrat Pearl": ["superforcaster-polymarket-v1"]},
+            ledger={"dev": {"custom/valory/superforcaster_polymarket_v1/0.1.0": "b"}},
+            roster={"predict-fine-tuned-calibrated": "bafy"},
+        )
+        assert "predict-fine-tuned-calibrated" in out
+        assert "ships no package here" in out
+
+    def test_exit_code_is_scoped_to_the_requested_platform(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """`--platform omen` must exit 1 when omen failed, even if polymarket worked.
+
+        fetch_valid_tools() always resolves both, so judging success over the
+        unfiltered map let a total failure of the REQUESTED platform exit 0 --
+        and anything gating on the exit code then consumed an empty actionable
+        list as ground truth.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        valid: Dict[str, Optional[List[str]]] = {
+            "omenstrat Pearl": None,
+            "polystrat Pearl": ["superforcaster-polymarket-v1"],
+        }
+        code_omen, _ = self._run(
+            monkeypatch, capsys, tmp_path, ["--platform", "omen"], valid
+        )
+        assert code_omen == 1
+        code_pm, _ = self._run(
+            monkeypatch, capsys, tmp_path, ["--platform", "polymarket"], valid
+        )
+        assert code_pm == 0
+
+    def test_exit_code_when_everything_fails(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """All deployments unavailable -> exit 1 and an explicit UNKNOWN.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        code, out = self._run(
+            monkeypatch,
+            capsys,
+            tmp_path,
+            [],
+            {"omenstrat Pearl": None, "polystrat Pearl": None},
+        )
+        assert code == 1
+        assert "UNKNOWN" in out
+
+    def test_json_schema_and_null_for_unresolved(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """--json keys are stable and an unresolved deployment emits null.
+
+        Inverting the ``sorted(tools) if tools is not None else None``
+        conditional would emit null for HEALTHY deployments and TypeError on
+        the failed one; nothing pinned it.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        code, out = self._run(
+            monkeypatch,
+            capsys,
+            tmp_path,
+            ["--json"],
+            {"omenstrat Pearl": None, "polystrat Pearl": ["superforcaster"]},
+            ledger={"dev": {"custom/valory/superforcaster/0.1.0": "bafy"}},
+        )
+        payload = json.loads(out)
+        assert set(payload) == {
+            "selectable_by_deployment",
+            "repo_tools",
+            "tournament_roster",
+            "actionable",
+        }
+        assert payload["selectable_by_deployment"]["omenstrat Pearl"] is None
+        assert payload["selectable_by_deployment"]["polystrat Pearl"] == [
+            "superforcaster"
+        ]
+        assert payload["actionable"] == ["superforcaster"]
+        assert code == 0
+
+    def test_json_reports_unknown_as_null_not_empty(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """Total failure renders actionable as null, never [].
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        code, out = self._run(
+            monkeypatch,
+            capsys,
+            tmp_path,
+            ["--json"],
+            {"omenstrat Pearl": None, "polystrat Pearl": None},
+        )
+        assert json.loads(out)["actionable"] is None
+        assert code == 1

--- a/benchmark/tool_usage.py
+++ b/benchmark/tool_usage.py
@@ -130,7 +130,7 @@ _MECHES_QUERY = (
 )
 
 
-def _normalize_tool_name(name: str) -> str:
+def normalize_tool_name(name: str) -> str:
     """Return a canonical form for cross-convention tool-name matching.
 
     Mech metadata and the benchmark logs sometimes spell the same tool

--- a/benchmark/tournament_tools.py
+++ b/benchmark/tournament_tools.py
@@ -12,13 +12,61 @@ that ``benchmark.tournament`` pulls in via ``ipfs_loader`` and ``KeyChain``.
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
+from typing import Optional, Set
 
 # ---------------------------------------------------------------------------
 # Tournament tools — single source of truth (TOURNAMENT_IPFS_LOADER_SPEC §3.1)
 # ---------------------------------------------------------------------------
 
+log = logging.getLogger(__name__)
+
 TOURNAMENT_TOOLS_JSON = Path(__file__).resolve().parent / "tournament_tools.json"
+
+
+def roster_names(path: Path = TOURNAMENT_TOOLS_JSON) -> Optional[Set[str]]:
+    """Tournament roster names, normalized; ``None`` when the roster is unknown.
+
+    The canonical reader for "is this tool in the tournament". It exists here,
+    in the dependency-light source of truth, because three modules were each
+    answering that question with their own parse and disagreeing about two
+    things that matter:
+
+    * **Naming.** Package directories use underscores while registered tool
+      names use dashes, so any versioned tool is spelled BOTH ways depending
+      on where you read it. Keys come back AS WRITTEN and each caller folds
+      them with its own canonical normalizer -- deliberately not normalized
+      here, because a second normalizer folding the opposite way from
+      ``tool_usage.normalize_tool_name`` is precisely the trap that made the
+      unnormalized comparisons unreachable in the first place.
+    * **Missing vs corrupt.** A MISSING file is the legitimate "no tournament
+      configured" state and yields an empty set. An unreadable or malformed
+      file yields ``None`` -- reporting a tool as "NOT in the tournament" off
+      a corrupt roster would mislead a deployment-review reader into
+      re-adding a tool that already has a slot.
+
+    :param path: path to ``tournament_tools.json``.
+    :return: roster keys as written, ``set()`` when no roster is configured,
+        or ``None`` when the file exists but cannot be read as an object.
+    """
+    if not path.is_file():
+        return set()  # no tournament configured -- a real answer, not a failure
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        log.warning(
+            "tournament roster %s is unreadable/corrupt; membership UNKNOWN.",
+            path,
+        )
+        return None
+    if not isinstance(data, dict):
+        log.warning(
+            "tournament roster %s is not a JSON object; membership UNKNOWN.",
+            path,
+        )
+        return None
+    return {str(k) for k in data}
 
 
 def load_tournament_tools(path: Path = TOURNAMENT_TOOLS_JSON) -> dict[str, str]:


### PR DESCRIPTION
## What

Answers a question mech-predict currently cannot: **which tools can the live trader actually select, and which of those do we ship?**

```
python -m benchmark.served_tools [--platform polymarket] [--json]
```

- **Selectable side** — delegated to the existing `benchmark/tool_usage.py`, which resolves it with **no local manifest**: latest `valory-xyz/trader` release → each deployment's `service.yaml` → its `valid_mechs` allow-list → the mech-marketplace subgraph → each mech's on-chain metadata CID → the IPFS manifest's `tools[]`. No service ids, registry addresses or mech lists stored in this repo.
- **Shipped side** — `packages/packages.json` (the ledger `autonomy packages lock` maintains and deployment consumes), **not** `benchmark/tools.py`.
- **Intersection** — the actionable set.

## Why

The triage assesses whatever shows up in the scored data, including tools deployed nowhere. On the loop's first live night that produced [#416](https://github.com/valory-xyz/mech-predict/pull/416): a fix PR for `predict-fine-tuned-calibrated`, a tournament-only tool, whose benchmark failed five times identically (`0 rows for baseline`) — a tool with no production traffic has nothing to replay.

## Why packages.json and not tools.py

They disagree on 27 entries. `tools.py` **omits 15 shipped packages** — including `superforcaster_full_search` and `superforcaster_calibrated_full_search`, both actually **served**, which an earlier revision of this PR wrongly reported as "not in this repo". And it **carries 12 entries that ship no package** (`predict-base`, `predict-fine-tuned`, `predict-fine-tuned-calibrated`, assorted `-v1` variants). The ledger is the honest source.

Matching is exact on the normalized name (underscores ≡ dashes). Version suffixes are **not** stripped: `factual_research_v1` and `_v3` are different tools, and only the ones a mech actually advertises count as served (regression-tested).

## Live output (2026-07-30)

| Deployment | Selectable |
|---|---|
| omenstrat Pearl (omen) | `factual_research`, `superforcaster`, `superforcaster_calibrated_full_search`, `propose-question`, `resolve-market-jury-v1`, `resolve-market-reasoning-gpt-4.1`* |
| polystrat Pearl (polymarket) | `superforcaster-polymarket-v1`, `-v2`, `-v4`, `superforcaster_full_search`, `resolve-market-reasoning-gpt-4.1`* |

\* the only selectable tool this repo does not ship.

**Actionable (selectable AND shipped here):** `factual_research`, `propose_question`, `superforcaster`, `superforcaster_calibrated_full_search`, `superforcaster_full_search`, `superforcaster_polymarket_v1`, `_v2`, `_v4`.

**Notable exclusions:** `predict-base`, `predict-fine-tuned`, `predict-fine-tuned-calibrated` are tournament-only *and* ship no package — exactly the #416 class. `superforcaster_polymarket_v3`, `factual_research_v1/v2/v3` and 10 others are shipped but selectable nowhere. And **v4 is live on polystrat**, so its idleness is a requester/routing issue, not a deployment one.

## Scope

Discovery + reporting, with 11 tests (network injected — no live fetch in CI). Wiring it into the triage — fix issues restricted to the actionable set, undeployed tools routed to a deployment-review note — is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
