### PR TITLE
triage: fire only on actionable tools; benchmark: tournament fallback

### DIFF
--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -172,6 +172,21 @@ jobs:
           workflow: benchmark_flywheel.yaml
           if_no_artifact_found: fail
 
+      # The tournament arm is enrich's fallback source when a tool has no
+      # replayable production deliveries (the mech-predict#416 case: a
+      # tournament-only tool can never be validated from production rows).
+      # benchmark/results/ is gitignored, so without this download the
+      # fallback finds nothing and the feature is inert in CI.
+      # NOT fatal if absent: a tool with production rows must still benchmark.
+      - name: Download tournament arm (enrich fallback source)
+        uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe  # v3
+        continue-on-error: true
+        with:
+          name: tournament-predictions
+          path: benchmark/results/
+          workflow: benchmark_flywheel.yaml
+          if_no_artifact_found: warn
+
       # Combine the full pool of daily log shards into one file. Enrich
       # stratified-samples before the IPFS fetch, so a large pool costs nothing
       # extra; it just gives sparse baselines (e.g. superforcaster-polymarket-v1)

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -226,7 +226,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: benchmark/results/ci_enriched/
-          key: benchmark-enriched-${{ steps.parse.outputs.tool }}-${{ steps.parse.outputs.platform }}-${{ steps.parse.outputs.sample }}-${{ steps.parse.outputs.seed }}-${{ hashFiles(steps.log.outputs.path) }}
+          key: benchmark-enriched-${{ steps.parse.outputs.tool }}-${{ steps.parse.outputs.platform }}-${{ steps.parse.outputs.sample }}-${{ steps.parse.outputs.seed }}-${{ hashFiles(steps.log.outputs.path) }}-${{ hashFiles('benchmark/results/tournament_scored.jsonl') }}
 
       - name: Enrich dataset
         if: steps.cache.outputs.cache-hit != 'true'

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -173,10 +173,23 @@ def _fmt_metric_row(
     return f"| {name} | {b_str} | {c_str} | {delta} |"
 
 
-def _metrics_table(baseline: dict[str, Any], candidate: dict[str, Any]) -> str:
-    """Build a markdown comparison table from two metric dicts."""
+def _metrics_table(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    source: str = "production",
+) -> str:
+    """Build a markdown comparison table from two metric dicts.
+
+    :param baseline: baseline metrics.
+    :param candidate: candidate metrics.
+    :param source: which arm the rows came from; a tournament-sourced run
+        must not be captioned "prod" -- the baseline p_yes then comes from
+        the tournament model, not a production delivery.
+    :return: the rendered table.
+    """
+    baseline_label = "Baseline (prod)" if source == "production" else "Baseline (tourn)"
     lines = [
-        "| Metric | Baseline (prod) | Candidate (PR) | Delta |",
+        f"| Metric | {baseline_label} | Candidate (PR) | Delta |",
         "|--------|-----------------|----------------|-------|",
         _fmt_metric_row(
             "Brier score",
@@ -265,7 +278,21 @@ def _format_reliability_block(
         breakdown_str = ", ".join(f"{k}={bd[k]}" for k in PARSE_STATUS_BUCKETS)
         lines.append(f"  - Breakdown: {breakdown_str}")
 
-    if filter_stats is not None:
+    if filter_stats is not None and filter_stats.get("source") == "tournament":
+        # The rows did not come from production at all, so a "production
+        # parse rate" computed from them is meaningless. Say where they came
+        # from instead -- a reviewer reading a parse rate assumes deliveries.
+        attempt = filter_stats.get("production_attempt") or {}
+        lines.append(
+            "- ⚠️ Rows replayed from the **tournament arm** "
+            f"({filter_stats.get('fallback_reason', 'no production rows')}); "
+            f"the production pool yielded {attempt.get('accepted', 0)}."
+        )
+        lines.append(
+            "  Baseline p_yes is the tournament model's prediction, not a "
+            "production delivery."
+        )
+    elif filter_stats is not None:
         r = filter_stats.get("rejected", {}) or {}
         accepted = filter_stats.get("accepted", 0)
         not_valid = r.get("not_valid_parse", 0)
@@ -330,11 +357,16 @@ def format_report(
     :param failure_rows: optional parse-failure rows loaded from
         candidate_failures.jsonl. When non-empty, bodies are inlined in a
         collapsed <details> block.
-    :param filter_stats: optional ``{accepted, rejected}`` dict from
-        filter_stats.json sidecar. When present, a Production parse rate line
-        is rendered showing how many in-scope production deliveries parsed.
+    :param filter_stats: optional ``{source, accepted, rejected}`` dict from
+        the filter_stats.json sidecar. ``source`` decides the captions: a
+        tournament-sourced run must not be labelled "prod" nor given a
+        production parse rate computed from tournament rows.
     :return: markdown string.
     """
+    # Which arm the replayed rows came from. The sidecar records it; the
+    # caption must follow it, or a tournament-sourced run renders as
+    # production data in the one artifact a reviewer acts on.
+    _src = (filter_stats or {}).get("source", "production")
     tool = meta.get("tool", "unknown")
 
     # Platforms present in the scored data. A run scoped to one platform
@@ -351,7 +383,7 @@ def format_report(
         f"<!-- benchmark-result:{tool} -->",
         f"## Benchmark: {tool} — {platform_label}",
         "",
-        _metrics_table(baseline, candidate),
+        _metrics_table(baseline, candidate, _src),
         "",
     ]
     parts.extend(_format_reliability_block(candidate, failure_rows or [], filter_stats))
@@ -383,14 +415,17 @@ def format_report(
             )
             detail_lines.append(f"### {plat.title()} (n={b_plat['n']})")
             detail_lines.append("")
-            detail_lines.append(_metrics_table(b_plat, c_plat))
+            detail_lines.append(_metrics_table(b_plat, c_plat, _src))
             detail_lines.append("")
         detail_lines.append("</details>")
         parts.extend(detail_lines)
         parts.append("")
 
     # Footer
-    footer_parts = [f"{baseline['n']} deliveries"]
+    footer_parts = [
+        f"{baseline['n']} "
+        + ("deliveries" if _src == "production" else "tournament rows")
+    ]
     if meta.get("seed"):
         footer_parts.append(f"seed {meta['seed']}")
     if meta.get("phase"):

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -243,15 +243,23 @@ def _format_reliability_block(
     failure_rows: list[dict[str, Any]],
     filter_stats: Optional[dict[str, Any]] = None,
 ) -> list[str]:
-    """Render the Reliability section: candidate parse rate + production parse rate.
-
-    The two observations here are one-sided:
+    """Render the Reliability section. Two shapes, chosen by the row source.
 
     - candidate parse rate: did the PR's code produce parseable responses?
-    - production parse rate: of the in-scope production deliveries, how many
-      parsed before enrich dropped the rest. Tells reviewers how noisy
-      production was. The scored baseline is 100% valid by construction (enrich
-      drops the non-parseable rows), so only that pre-drop ratio is informative.
+      Always rendered.
+    - ``source == "production"``: plus the production parse rate -- of the
+      in-scope deliveries, how many parsed before enrich dropped the rest --
+      and the rejection breakdown. The scored baseline is 100% valid by
+      construction (enrich drops the non-parseable rows), so only that
+      pre-drop ratio is informative.
+    - ``source == "tournament"``: NEITHER of those. The rows did not come
+      from production, so a production parse rate computed from them means
+      nothing; a provenance note is rendered instead.
+
+    An unrecognised ``source`` falls to the production branch here while
+    :func:`_metrics_table` treats it as tournament -- a ``Literal
+    ["production", "tournament"]`` on the sidecar would make the two agree by
+    construction.
 
     :param candidate: metrics dict including ``parse_reliability``.
     :param failure_rows: rows from ``candidate_failures.jsonl`` (may be empty).

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -647,20 +647,42 @@ def _render_tournament_evidence(tool_name: str, source_content: Any) -> Optional
         module = importlib.import_module(spec.module)
         formatter = module.format_sources_data
         max_sources = getattr(module, "MAX_SOURCES", 5)
-    except (ImportError, AttributeError):
-        # No formatter to reproduce the tool's own rendering: dropping the row
-        # is the only honest option -- replaying it would silently benchmark
-        # the candidate on different evidence than the baseline saw.
+        # The formatter call belongs INSIDE the guard: a captured payload can
+        # be structurally wrong in ways that raise rather than return
+        # nothing -- `{"organic": null}` makes `.get("organic", [])` return
+        # None (the default only applies to a MISSING key), and a list of
+        # strings breaks `item.get(...)` inside the formatter. Left outside,
+        # each of those took down the whole enrich run instead of dropping
+        # one row, which is what the `unrenderable` counter exists for.
+        rendered = formatter(
+            (serper.get("organic") or [])[:max_sources],
+            serper.get("peopleAlsoAsk") or [],
+        )
+    except (ImportError, AttributeError, TypeError, KeyError, IndexError):
         log.warning(
-            "no format_sources_data for %r; tournament rows cannot be "
-            "rendered faithfully and will be dropped",
+            "cannot render tournament evidence for %r the way the tool does; "
+            "row dropped",
             tool_name,
         )
         return None
-    rendered = formatter(
-        serper.get("organic", [])[:max_sources], serper.get("peopleAlsoAsk", [])
-    )
     return rendered or None
+
+
+def _write_replay_rows(output: Path, rows: list[dict[str, Any]]) -> None:
+    """Write enriched rows as JSONL.
+
+    Both the production and tournament paths end by writing the same shape;
+    a shared writer keeps their on-disk bytes from drifting. Deliberately not
+    ``benchmark.io.write_jsonl``: that uses ``ensure_ascii=False``, which
+    would change the encoding of non-ASCII question text.
+
+    :param output: destination path.
+    :param rows: rows to write.
+    """
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with open(output, "w", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row) + "\n")
 
 
 def _load_tournament_rows(
@@ -668,7 +690,7 @@ def _load_tournament_rows(
     platform_filter: Optional[str],
     scored_path: Optional[Path] = None,
     predictions_path: Optional[Path] = None,
-) -> list[dict[str, Any]]:
+) -> tuple[list[dict[str, Any]], dict[str, int]]:
     """Build replay-ready rows for a tool from the tournament arm.
 
     A tournament-only tool has no production deliveries, so the usual
@@ -684,12 +706,15 @@ def _load_tournament_rows(
     :param tool_filter: tool name to keep.
     :param platform_filter: platform to keep, or ``None`` for all.
     :param scored_path: path to ``tournament_scored.jsonl``; the module
-        default is read at CALL time (not bound at import) so a caller --
-        or the workflow, pointing at the downloaded artifact -- can
-        override it.
+        default is read at CALL time (not bound at import) so a Python
+        caller can override it. NOTE: ``enrich`` exposes no CLI flag for
+        this, so the workflow relies on the artifact landing at the module
+        default (``benchmark/results/``).
     :param predictions_path: path to ``tournament_predictions.jsonl``,
         same resolution rule.
-    :return: enriched rows (empty when either file is missing or nothing matches).
+    :return: ``(rows, dropped)`` -- replayable rows plus per-reason drop
+        counts, so the sidecar can report why a pool shrank instead of
+        asserting it did not.
     """
     scored_path = DEFAULT_TOURNAMENT_SCORED if scored_path is None else scored_path
     predictions_path = (
@@ -701,7 +726,7 @@ def _load_tournament_rows(
             scored_path,
             predictions_path,
         )
-        return []
+        return [], {}
 
     evidence: dict[str, str] = {}
     with open(predictions_path, encoding="utf-8") as handle:
@@ -720,7 +745,21 @@ def _load_tournament_rows(
 
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
-    unrenderable = 0
+    # Per-reason drop counts, mirroring the production loader. Reporting
+    # `rejected: {}` while silently dropping through bare `continue`s would
+    # let a schema regression (e.g. the flywheel ceasing to write `p_no`)
+    # discard 95% of a pool and still render as a clean sample.
+    dropped: dict[str, int] = {
+        "bad_json": 0,
+        "wrong_tool": 0,
+        "wrong_platform": 0,
+        "no_outcome_or_probs": 0,
+        "no_row_id": 0,
+        "duplicate": 0,
+        "no_question": 0,
+        "no_evidence": 0,
+        "unrenderable": 0,
+    }
     with open(scored_path, encoding="utf-8") as handle:
         for line in handle:
             line = line.strip()
@@ -729,10 +768,13 @@ def _load_tournament_rows(
             try:
                 row = json.loads(line)
             except ValueError:
+                dropped["bad_json"] += 1
                 continue
             if row.get("tool") != tool_filter and row.get("tool_name") != tool_filter:
+                dropped["wrong_tool"] += 1
                 continue
             if platform_filter and row.get("platform") != platform_filter:
+                dropped["wrong_platform"] += 1
                 continue
             # p_no as well as p_yes: replay's baseline arm copies both
             # verbatim, so a row missing either KeyErrors mid-run -- after
@@ -742,19 +784,31 @@ def _load_tournament_rows(
                 or row.get("p_yes") is None
                 or row.get("p_no") is None
             ):
+                dropped["no_outcome_or_probs"] += 1
                 continue
             row_id = row.get("row_id")
-            if not row_id or row_id in seen:
+            if not row_id:
+                dropped["no_row_id"] += 1
+                continue
+            if row_id in seen:
+                dropped["duplicate"] += 1
                 continue
             raw_content = evidence.get(row_id)
+            if not row.get("question_text"):
+                # Its three siblings above get explicit drops; without this a
+                # row replays with an empty {question}, the model still
+                # returns a parseable p_yes, and it scores as normal data.
+                dropped["no_question"] += 1
+                continue
             if not raw_content:
-                continue  # no captured evidence -> nothing to replay against
+                dropped["no_evidence"] += 1
+                continue  # nothing to replay against
             content = _render_tournament_evidence(tool_filter, raw_content)
             if not content:
                 # Unrenderable evidence is dropped rather than replayed: a
                 # dict repr in the prompt would score, silently, as if it
                 # were the sources the baseline saw.
-                unrenderable += 1
+                dropped["unrenderable"] += 1
                 continue
             seen.add(row_id)
             rows.append(
@@ -775,12 +829,12 @@ def _load_tournament_rows(
                     "extracted_today": _tournament_today(row),
                 }
             )
-    if unrenderable:
+    if any(dropped.values()):
         log.warning(
-            "Tournament fallback: dropped %d row(s) whose captured evidence "
-            "could not be rendered the way %s renders it",
-            unrenderable,
+            "Tournament fallback: dropped %d row(s) for %s (%s)",
+            sum(dropped.values()),
             tool_filter,
+            ", ".join(f"{k}={v}" for k, v in dropped.items() if v),
         )
     log.info(
         "Tournament fallback: %d replay rows for %s (evidence available for "
@@ -789,7 +843,7 @@ def _load_tournament_rows(
         tool_filter,
         len(evidence),
     )
-    return rows
+    return rows, dropped
 
 
 def enrich(
@@ -825,6 +879,12 @@ def enrich(
     rows, rejected, no_row_id = _load_and_filter_rows(
         production_log, tool_filter, last_days, platform_filter
     )
+    # Snapshot BEFORE stratified_sample reassigns `rows`. The fallback closure
+    # reads this for the sidecar's production_attempt; using `rows` there
+    # reported the post-sample count, so a 500-row pool sampled to 50 was
+    # rendered as "the production pool yielded 50" -- the same provenance
+    # dishonesty this PR exists to remove, one layer in.
+    production_accepted = len(rows)
     log.info(
         "Loaded %d %s rows with deliver_id + valid predictions + known outcome",
         len(rows),
@@ -871,7 +931,7 @@ def enrich(
         :return: whether replayable rows were written.
         """
         log.warning("%s for %r%s; trying the tournament arm", why, tool_filter, scope)
-        fallback_rows = _load_tournament_rows(
+        fallback_rows, fallback_dropped = _load_tournament_rows(
             tool_filter, platform_filter, tournament_scored, tournament_predictions
         )
         if not fallback_rows:
@@ -879,10 +939,7 @@ def enrich(
         if sample_per_platform is not None:
             fallback_rows = stratified_sample(fallback_rows, sample_per_platform, seed)
         _log_platform_breakdown(fallback_rows)
-        output.parent.mkdir(parents=True, exist_ok=True)
-        with open(output, "w", encoding="utf-8") as handle:
-            for row in fallback_rows:
-                handle.write(json.dumps(row) + "\n")
+        _write_replay_rows(output, fallback_rows)
         # Rewrite the sidecar: it was written from the PRODUCTION pool above,
         # but the dataset now holds tournament rows. Leaving it would caption
         # the human-facing verdict with rejection counts for a population that
@@ -893,10 +950,10 @@ def enrich(
                 {
                     "source": "tournament",
                     "accepted": len(fallback_rows),
-                    "rejected": {},
-                    "no_row_id": 0,
+                    "rejected": {k: v for k, v in fallback_dropped.items() if v},
+                    "no_row_id": fallback_dropped.get("no_row_id", 0),
                     "production_attempt": {
-                        "accepted": len(rows),
+                        "accepted": production_accepted,
                         "rejected": rejected,
                         "no_row_id": no_row_id,
                     },
@@ -960,7 +1017,7 @@ def enrich(
         # an empty file here would hand the replay stage a silently zero-row
         # benchmark -- worse than #416's loud failure. Try the tournament arm.
         if _tournament_fallback(
-            f"{len(rows)} production rows but 0 survived IPFS enrichment"
+            f"{production_accepted} production rows but 0 survived IPFS " "enrichment"
         ):
             return
         raise SystemExit(
@@ -1930,6 +1987,21 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
         PREDICTION_PROMPT = ""
         system_prompt = ""
     elif is_reasoning_tool:
+        # Same class as the factual_research guard below: the two-stage family
+        # reads row["extracted_reasoning"] unguarded in prediction-only phase,
+        # and the tournament loader never emits that key -- so a
+        # tournament-sourced dataset would KeyError mid-loop, after earlier
+        # rows had been paid for. Latent today (no reasoning tool is on the
+        # roster) but reachable, since the widen-sample note's first suggested
+        # action is to add a tool to the tournament.
+        if sampled and "extracted_reasoning" not in sampled[0]:
+            raise ValueError(
+                f"cannot replay {candidate_tool_name!r}: it is a two-stage "
+                "(reasoning) tool, but the enriched rows carry no "
+                "'extracted_reasoning' -- tournament-sourced rows never do. "
+                "Replay this family from production rows, or thread the "
+                "field through the tournament loader first."
+            )
         PREDICTION_PROMPT = candidate_module.PREDICTION_PROMPT
         REASONING_PROMPT = candidate_module.REASONING_PROMPT
         parser_reasoning_response = candidate_module.parser_reasoning_response

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -38,6 +38,7 @@ import logging
 import os
 import random
 import re
+import string
 import time
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -602,6 +603,66 @@ DEFAULT_TOURNAMENT_PREDICTIONS = (
 )
 
 
+def _tournament_today(row: dict[str, Any]) -> str:
+    """The date the tournament row was predicted on, as the tool would say it.
+
+    :param row: a tournament scored row.
+    :return: ISO date string, or empty when the timestamp is unusable.
+    """
+    stamp = row.get("predicted_at") or ""
+    return stamp[:10] if len(stamp) >= 10 else ""
+
+
+def _render_tournament_evidence(tool_name: str, source_content: Any) -> Optional[str]:
+    """Render a tournament row's captured evidence as the TOOL rendered it.
+
+    The tournament arm stores ``used_params["source_content"]``, which every
+    capturing tool writes as ``{"mode": ..., "serper_response": <raw Serper
+    JSON>}`` -- the payload BEFORE formatting. The production path stores the
+    already-rendered ``<background>`` text, i.e. the output of the tool's own
+    ``format_sources_data(organic[:MAX_SOURCES], peopleAlsoAsk)``.
+
+    Passing the dict through would put a Python dict repr into the prompt --
+    valid Python, unusable evidence -- while the baseline's ``p_yes`` came
+    from clean formatted sources. The head-to-head Brier delta would then
+    measure evidence-format drift rather than the change under test, with no
+    error anywhere.
+
+    :param tool_name: baseline tool whose module owns the formatter.
+    :param source_content: the captured value from the tournament row.
+    :return: rendered evidence, or ``None`` when it cannot be rendered
+        faithfully (the row must then be dropped, never replayed as-is).
+    """
+    if isinstance(source_content, str):
+        return source_content or None  # already rendered
+    if not isinstance(source_content, dict):
+        return None
+    serper = source_content.get("serper_response")
+    if not isinstance(serper, dict):
+        return None
+    spec = TOOL_REGISTRY.get(tool_name)
+    if spec is None:
+        return None
+    try:
+        module = importlib.import_module(spec.module)
+        formatter = module.format_sources_data
+        max_sources = getattr(module, "MAX_SOURCES", 5)
+    except (ImportError, AttributeError):
+        # No formatter to reproduce the tool's own rendering: dropping the row
+        # is the only honest option -- replaying it would silently benchmark
+        # the candidate on different evidence than the baseline saw.
+        log.warning(
+            "no format_sources_data for %r; tournament rows cannot be "
+            "rendered faithfully and will be dropped",
+            tool_name,
+        )
+        return None
+    rendered = formatter(
+        serper.get("organic", [])[:max_sources], serper.get("peopleAlsoAsk", [])
+    )
+    return rendered or None
+
+
 def _load_tournament_rows(
     tool_filter: str,
     platform_filter: Optional[str],
@@ -659,6 +720,7 @@ def _load_tournament_rows(
 
     rows: list[dict[str, Any]] = []
     seen: set[str] = set()
+    unrenderable = 0
     with open(scored_path, encoding="utf-8") as handle:
         for line in handle:
             line = line.strip()
@@ -684,9 +746,16 @@ def _load_tournament_rows(
             row_id = row.get("row_id")
             if not row_id or row_id in seen:
                 continue
-            content = evidence.get(row_id)
-            if not content:
+            raw_content = evidence.get(row_id)
+            if not raw_content:
                 continue  # no captured evidence -> nothing to replay against
+            content = _render_tournament_evidence(tool_filter, raw_content)
+            if not content:
+                # Unrenderable evidence is dropped rather than replayed: a
+                # dict repr in the prompt would score, silently, as if it
+                # were the sources the baseline saw.
+                unrenderable += 1
+                continue
             seen.add(row_id)
             rows.append(
                 {
@@ -699,8 +768,20 @@ def _load_tournament_rows(
                     "tool_name": row.get("tool_name") or row.get("tool"),
                     "extracted_user_prompt": row.get("question_text", ""),
                     "extracted_additional_information": content,
+                    # The superforcaster template has a literal `Today's
+                    # date: {today}`; without this it renders empty while the
+                    # tournament baseline had a real date. Prediction markets
+                    # are time-sensitive, so an empty date is not cosmetic.
+                    "extracted_today": _tournament_today(row),
                 }
             )
+    if unrenderable:
+        log.warning(
+            "Tournament fallback: dropped %d row(s) whose captured evidence "
+            "could not be rendered the way %s renders it",
+            unrenderable,
+            tool_filter,
+        )
     log.info(
         "Tournament fallback: %d replay rows for %s (evidence available for "
         "%d predictions)",
@@ -1716,6 +1797,35 @@ def _parse_vllm_candidate(
     }
 
 
+def _assert_prompt_is_replayable(
+    template: str, supplied: set[str], tool_name: str
+) -> None:
+    """Fail before the loop if the template needs data replay cannot supply.
+
+    Replay fills a fixed set of placeholders per family. A template that
+    asks for anything else raises ``KeyError`` inside the per-row loop --
+    after the earlier rows have already been paid for, with a message that
+    names only the missing key. ``factual_research_v2``'s ``ESTIMATE_USER``
+    wants ``resolution_rules``, which comes from market metadata the enriched
+    row does not carry, so it cannot be reconstructed at replay time at all.
+
+    :param template: the prompt template about to be replayed.
+    :param supplied: placeholder names replay will provide.
+    :param tool_name: candidate tool, for the message.
+    :raises ValueError: when the template needs an unsupplied placeholder.
+    """
+    required = {name for _, name, _, _ in string.Formatter().parse(template) if name}
+    missing = required - supplied
+    if missing:
+        raise ValueError(
+            f"cannot replay {tool_name!r}: its prompt template needs "
+            f"{sorted(missing)}, which the enriched rows do not carry "
+            f"(replay supplies {sorted(supplied)}). Thread the field through "
+            f"enrich before benchmarking this tool, rather than replaying it "
+            f"against a partial prompt."
+        )
+
+
 def replay(  # pylint: disable=too-many-statements,too-many-locals
     dataset: Path,
     output_dir: Path,
@@ -1835,6 +1945,9 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
         # use cached evidence. ESTIMATE_USER takes (question, today, briefing).
         PREDICTION_PROMPT = candidate_module.ESTIMATE_USER
         system_prompt = candidate_module.ESTIMATE_SYSTEM
+        _assert_prompt_is_replayable(
+            PREDICTION_PROMPT, {"question", "today", "briefing"}, candidate_tool_name
+        )
     else:
         PREDICTION_PROMPT = candidate_module.PREDICTION_PROMPT
         system_prompt = _default_family_system_prompt(candidate_module)

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -594,6 +594,102 @@ def _prepare_output_dir(output_dir: Path) -> None:
         (output_dir / stale).unlink(missing_ok=True)
 
 
+DEFAULT_TOURNAMENT_SCORED = (
+    Path(__file__).parent / "results" / "tournament_scored.jsonl"
+)
+DEFAULT_TOURNAMENT_PREDICTIONS = (
+    Path(__file__).parent / "results" / "tournament_predictions.jsonl"
+)
+
+
+def _load_tournament_rows(
+    tool_filter: str,
+    platform_filter: Optional[str],
+    scored_path: Path = DEFAULT_TOURNAMENT_SCORED,
+    predictions_path: Path = DEFAULT_TOURNAMENT_PREDICTIONS,
+) -> list[dict[str, Any]]:
+    """Build replay-ready rows for a tool from the tournament arm.
+
+    A tournament-only tool has no production deliveries, so the usual
+    deliver_id -> marketplace -> IPFS enrichment cannot run (mech-predict
+    #416: five identical ``0 rows for baseline`` failures). The tournament
+    arm already stores what that enrichment would recover: the question and
+    the ``source_content`` the tool was fed. ``tournament_scored.jsonl``
+    carries the resolved outcomes but drops ``source_content``, while
+    ``tournament_predictions.jsonl`` keeps it -- so the two are joined by
+    ``row_id`` and emitted in the same shape ``_fetch_and_extract_prompts``
+    produces.
+
+    :param tool_filter: tool name to keep.
+    :param platform_filter: platform to keep, or ``None`` for all.
+    :param scored_path: path to ``tournament_scored.jsonl``.
+    :param predictions_path: path to ``tournament_predictions.jsonl``.
+    :return: enriched rows (empty when either file is missing or nothing matches).
+    """
+    if not scored_path.is_file() or not predictions_path.is_file():
+        log.warning(
+            "tournament fallback unavailable: %s / %s",
+            scored_path,
+            predictions_path,
+        )
+        return []
+
+    evidence: dict[str, str] = {}
+    with open(predictions_path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            row_id = row.get("row_id")
+            content = row.get("source_content")
+            if row_id and content:
+                evidence[row_id] = content
+
+    rows: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    with open(scored_path, encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except ValueError:
+                continue
+            if row.get("tool") != tool_filter and row.get("tool_name") != tool_filter:
+                continue
+            if platform_filter and row.get("platform") != platform_filter:
+                continue
+            if row.get("final_outcome") is None or row.get("p_yes") is None:
+                continue
+            row_id = row.get("row_id")
+            if not row_id or row_id in seen:
+                continue
+            content = evidence.get(row_id)
+            if not content:
+                continue  # no captured evidence -> nothing to replay against
+            seen.add(row_id)
+            rows.append(
+                {
+                    **row,
+                    "extracted_user_prompt": row.get("question_text", ""),
+                    "extracted_additional_information": content,
+                }
+            )
+    log.info(
+        "Tournament fallback: %d replay rows for %s (evidence available for "
+        "%d predictions)",
+        len(rows),
+        tool_filter,
+        len(evidence),
+    )
+    return rows
+
+
 def enrich(
     production_log: Path,
     tool_filter: str,
@@ -615,6 +711,8 @@ def enrich(
     :param sample_per_platform: stratified sample N per platform before IPFS fetch.
     :param seed: random seed for sampling.
     :param platform_filter: only include rows from this platform (default: all).
+    :raises SystemExit: when neither production nor the tournament arm yields
+        any replayable row for ``tool_filter``.
     """
     rows, rejected, no_row_id = _load_and_filter_rows(
         production_log, tool_filter, last_days, platform_filter
@@ -652,8 +750,32 @@ def enrich(
     log.info("Wrote filter stats: %s", stats_path)
 
     if not rows:
+        # No production deliveries for this tool: it may be tournament-only.
+        # The tournament arm carries the same question + captured evidence,
+        # so replay from there rather than failing (mech-predict#416).
         scope = f" [platform={platform_filter}]" if platform_filter else ""
-        raise SystemExit(f"0 rows for baseline {tool_filter!r}{scope} across the pool")
+        log.warning(
+            "0 production rows for %r%s; trying the tournament arm",
+            tool_filter,
+            scope,
+        )
+        tournament_rows = _load_tournament_rows(tool_filter, platform_filter)
+        if not tournament_rows:
+            raise SystemExit(
+                f"0 rows for baseline {tool_filter!r}{scope} in production or "
+                "the tournament arm"
+            )
+        if sample_per_platform is not None:
+            tournament_rows = stratified_sample(
+                tournament_rows, sample_per_platform, seed
+            )
+        _log_platform_breakdown(tournament_rows)
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with open(output, "w", encoding="utf-8") as handle:
+            for row in tournament_rows:
+                handle.write(json.dumps(row) + "\n")
+        log.info("Written %d tournament rows to %s", len(tournament_rows), output)
+        return
 
     # Stratified sample BEFORE IPFS fetch to avoid unnecessary downloads.
     if sample_per_platform is not None:

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -605,8 +605,8 @@ DEFAULT_TOURNAMENT_PREDICTIONS = (
 def _load_tournament_rows(
     tool_filter: str,
     platform_filter: Optional[str],
-    scored_path: Path = DEFAULT_TOURNAMENT_SCORED,
-    predictions_path: Path = DEFAULT_TOURNAMENT_PREDICTIONS,
+    scored_path: Optional[Path] = None,
+    predictions_path: Optional[Path] = None,
 ) -> list[dict[str, Any]]:
     """Build replay-ready rows for a tool from the tournament arm.
 
@@ -622,10 +622,18 @@ def _load_tournament_rows(
 
     :param tool_filter: tool name to keep.
     :param platform_filter: platform to keep, or ``None`` for all.
-    :param scored_path: path to ``tournament_scored.jsonl``.
-    :param predictions_path: path to ``tournament_predictions.jsonl``.
+    :param scored_path: path to ``tournament_scored.jsonl``; the module
+        default is read at CALL time (not bound at import) so a caller --
+        or the workflow, pointing at the downloaded artifact -- can
+        override it.
+    :param predictions_path: path to ``tournament_predictions.jsonl``,
+        same resolution rule.
     :return: enriched rows (empty when either file is missing or nothing matches).
     """
+    scored_path = DEFAULT_TOURNAMENT_SCORED if scored_path is None else scored_path
+    predictions_path = (
+        DEFAULT_TOURNAMENT_PREDICTIONS if predictions_path is None else predictions_path
+    )
     if not scored_path.is_file() or not predictions_path.is_file():
         log.warning(
             "tournament fallback unavailable: %s / %s",
@@ -664,7 +672,14 @@ def _load_tournament_rows(
                 continue
             if platform_filter and row.get("platform") != platform_filter:
                 continue
-            if row.get("final_outcome") is None or row.get("p_yes") is None:
+            # p_no as well as p_yes: replay's baseline arm copies both
+            # verbatim, so a row missing either KeyErrors mid-run -- after
+            # the earlier rows have already been paid for.
+            if (
+                row.get("final_outcome") is None
+                or row.get("p_yes") is None
+                or row.get("p_no") is None
+            ):
                 continue
             row_id = row.get("row_id")
             if not row_id or row_id in seen:
@@ -676,6 +691,12 @@ def _load_tournament_rows(
             rows.append(
                 {
                     **row,
+                    # replay() and the scorers key on ``tool_name``; tournament
+                    # rows written before that spelling settled use ``tool``.
+                    # Normalize here so the fallback's output honours the same
+                    # contract as the production path -- an un-normalized row
+                    # KeyErrors in replay() at ``sampled[0]["tool_name"]``.
+                    "tool_name": row.get("tool_name") or row.get("tool"),
                     "extracted_user_prompt": row.get("question_text", ""),
                     "extracted_additional_information": content,
                 }
@@ -698,6 +719,8 @@ def enrich(
     sample_per_platform: Optional[int] = None,
     seed: int = 42,
     platform_filter: Optional[Literal["omen", "polymarket"]] = None,
+    tournament_scored: Optional[Path] = None,
+    tournament_predictions: Optional[Path] = None,
 ) -> None:
     """Fetch IPFS prompts and extract components for replay.
 
@@ -711,6 +734,10 @@ def enrich(
     :param sample_per_platform: stratified sample N per platform before IPFS fetch.
     :param seed: random seed for sampling.
     :param platform_filter: only include rows from this platform (default: all).
+    :param tournament_scored: override for ``tournament_scored.jsonl`` (the
+        tournament fallback source).
+    :param tournament_predictions: override for
+        ``tournament_predictions.jsonl`` (carries the captured evidence).
     :raises SystemExit: when neither production nor the tournament arm yields
         any replayable row for ``tool_filter``.
     """
@@ -742,40 +769,75 @@ def enrich(
     stats_path.parent.mkdir(parents=True, exist_ok=True)
     stats_path.write_text(
         json.dumps(
-            {"accepted": len(rows), "rejected": rejected, "no_row_id": no_row_id},
+            {
+                "source": "production",
+                "accepted": len(rows),
+                "rejected": rejected,
+                "no_row_id": no_row_id,
+            },
             indent=2,
         ),
         encoding="utf-8",
     )
     log.info("Wrote filter stats: %s", stats_path)
 
-    if not rows:
-        # No production deliveries for this tool: it may be tournament-only.
-        # The tournament arm carries the same question + captured evidence,
-        # so replay from there rather than failing (mech-predict#416).
-        scope = f" [platform={platform_filter}]" if platform_filter else ""
-        log.warning(
-            "0 production rows for %r%s; trying the tournament arm",
-            tool_filter,
-            scope,
+    scope = f" [platform={platform_filter}]" if platform_filter else ""
+
+    def _tournament_fallback(why: str) -> bool:
+        """Write tournament-sourced rows to ``output``; True when it produced any.
+
+        :param why: what made the production path unusable (for the log).
+        :return: whether replayable rows were written.
+        """
+        log.warning("%s for %r%s; trying the tournament arm", why, tool_filter, scope)
+        fallback_rows = _load_tournament_rows(
+            tool_filter, platform_filter, tournament_scored, tournament_predictions
         )
-        tournament_rows = _load_tournament_rows(tool_filter, platform_filter)
-        if not tournament_rows:
-            raise SystemExit(
-                f"0 rows for baseline {tool_filter!r}{scope} in production or "
-                "the tournament arm"
-            )
+        if not fallback_rows:
+            return False
         if sample_per_platform is not None:
-            tournament_rows = stratified_sample(
-                tournament_rows, sample_per_platform, seed
-            )
-        _log_platform_breakdown(tournament_rows)
+            fallback_rows = stratified_sample(fallback_rows, sample_per_platform, seed)
+        _log_platform_breakdown(fallback_rows)
         output.parent.mkdir(parents=True, exist_ok=True)
         with open(output, "w", encoding="utf-8") as handle:
-            for row in tournament_rows:
+            for row in fallback_rows:
                 handle.write(json.dumps(row) + "\n")
-        log.info("Written %d tournament rows to %s", len(tournament_rows), output)
-        return
+        # Rewrite the sidecar: it was written from the PRODUCTION pool above,
+        # but the dataset now holds tournament rows. Leaving it would caption
+        # the human-facing verdict with rejection counts for a population that
+        # was not benchmarked. The production counts are kept under
+        # `production_attempt` so the reason for the fallback stays diagnosable.
+        stats_path.write_text(
+            json.dumps(
+                {
+                    "source": "tournament",
+                    "accepted": len(fallback_rows),
+                    "rejected": {},
+                    "no_row_id": 0,
+                    "production_attempt": {
+                        "accepted": len(rows),
+                        "rejected": rejected,
+                        "no_row_id": no_row_id,
+                    },
+                    "fallback_reason": why,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        log.info("Written %d tournament rows to %s", len(fallback_rows), output)
+        return True
+
+    if not rows:
+        # No production deliveries for this tool: it may be tournament-only
+        # (mech-predict#416). The tournament arm carries the same question
+        # and captured evidence, so replay from there.
+        if _tournament_fallback("0 production rows"):
+            return
+        raise SystemExit(
+            f"0 rows for baseline {tool_filter!r}{scope} in production or "
+            "the tournament arm"
+        )
 
     # Stratified sample BEFORE IPFS fetch to avoid unnecessary downloads.
     if sample_per_platform is not None:
@@ -811,6 +873,20 @@ def enrich(
     log.info("%d/%d deliveries have IPFS hashes", has_hash, len(ipfs_hashes))
 
     enriched = _fetch_and_extract_prompts(rows, ipfs_hashes, tool_name=tool_filter)
+    if not enriched:
+        # Production rows existed but none survived IPFS enrichment (no
+        # delivery hash, unfetchable prompt, unparseable components). Writing
+        # an empty file here would hand the replay stage a silently zero-row
+        # benchmark -- worse than #416's loud failure. Try the tournament arm.
+        if _tournament_fallback(
+            f"{len(rows)} production rows but 0 survived IPFS enrichment"
+        ):
+            return
+        raise SystemExit(
+            f"0 replayable rows for baseline {tool_filter!r}{scope}: "
+            f"{len(rows)} production rows yielded no usable prompt and the "
+            "tournament arm has none either"
+        )
     _log_platform_breakdown(enriched)
 
     # Write
@@ -1326,6 +1402,17 @@ def _log_replay_summary(
     log.info("    Parse delta: %+.1f%% — %s", parse_delta_pct, parse_verdict)
 
     if filter_stats is not None:
+        if filter_stats.get("source") == "tournament":
+            # Say so loudly: these rows are tournament predictions replayed
+            # from captured evidence, not production deliveries. A reader who
+            # assumes production would over-read the verdict.
+            attempt = filter_stats.get("production_attempt") or {}
+            log.info("  Row source: TOURNAMENT ARM (no replayable production rows)")
+            log.info(
+                "    Reason: %s   (production pool accepted %d)",
+                filter_stats.get("fallback_reason", "unknown"),
+                attempt.get("accepted", 0),
+            )
         r = filter_stats.get("rejected", {})
         total_rej = sum(r.values()) if r else 0
         # Scoping buckets + not_valid_parse make up the full rejected total;

--- a/benchmark/served_tools.py
+++ b/benchmark/served_tools.py
@@ -111,11 +111,12 @@ def tournament_tools() -> Optional[Set[str]]:
     """Tool names on the tournament roster, normalized; ``None`` if unknown.
 
     Thin delegate to :func:`benchmark.tournament_tools.roster_names` so this
-    module is not a fourth, subtly-different parse of the same file. In
-    particular the names come back in the UNDERSCORE namespace, which is what
-    makes membership tests against package names correct -- comparing raw
-    roster keys (dash spelling) to package names (underscore spelling) can
-    never match for a versioned tool.
+    module is not a fourth, subtly-different parse of the same file. The names
+    come back in the DASH namespace -- that is the direction
+    ``normalize_tool_name`` folds -- which makes membership tests correct as
+    long as BOTH sides are folded the same way. Comparing raw roster keys to
+    raw package names can never match for a versioned tool
+    (``factual_research-v2`` vs ``factual_research_v2``).
 
     :return: roster names folded into this module's single comparison
         namespace (``normalize_tool_name``), or ``None`` when unknown.
@@ -285,13 +286,19 @@ def main() -> int:
             print(f"  * {tool}{tag}")
 
     print("\nNOT ACTIONABLE")
-    if repo is None:
-        # Every line in this section is a claim about what this repo ships, so
-        # with an unreadable ledger they would all be confident negatives read
-        # off a file we could not open -- "ships no package here" for tools
-        # that plainly do. That is the same misreading the roster's UNKNOWN
-        # state exists to prevent, one layer up.
-        print("  UNKNOWN -- packages.json unreadable; shipped set is unknown")
+    if repo is None or served is None:
+        # Every line in this section is a claim about what this repo ships or
+        # what production serves. With EITHER side unknown they are confident
+        # negatives read off data we could not obtain -- with discovery down
+        # this section asserted that every shipped tool is un-selectable, two
+        # lines after correctly printing UNKNOWN. The ledger side got this
+        # guard first; the discovery side is the same bug mirrored.
+        reason = (
+            "packages.json unreadable; shipped set is unknown"
+            if repo is None
+            else "discovery did not resolve; selectable set is unknown"
+        )
+        print(f"  UNKNOWN -- {reason}")
         return 0 if resolved else 1
     for tool in sorted(repo - (actionable or set())):
         in_roster = _roster_has(tool)

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -11,6 +11,7 @@ from benchmark.ci_replay import (
     _compute_parse_reliability,
     _format_reliability_block,
     _load_filter_stats,
+    _metrics_table,
     compute_metrics,
     format_report,
 )
@@ -71,6 +72,7 @@ class TestParseReliability:
 
 def _stats(
     *,
+    source: str = "production",
     accepted: int = 100,
     not_valid_parse: int = 0,
     duplicate: int = 0,
@@ -81,6 +83,7 @@ def _stats(
     older_than_cutoff: int = 0,
 ) -> dict:
     return {
+        "source": source,
         "accepted": accepted,
         "rejected": {
             "duplicate": duplicate,
@@ -436,3 +439,47 @@ class TestFormatReportFooter:
         footer = report.splitlines()[-1]
         assert footer.index("deliveries") < footer.index("seed 1337")
         assert footer.index("seed 1337") < footer.index("LOCKhart07")
+
+
+class TestTournamentSourcedComment:
+    """The PR comment must not present tournament rows as production data.
+
+    The sidecar already records which arm the rows came from; before this,
+    ci_replay never read it, so a fallback run rendered "Baseline (prod)" and
+    a "Production parse rate" computed entirely from tournament rows -- the
+    one artifact a reviewer actually acts on.
+    """
+
+    def _metrics(self, rows: list[dict]) -> dict:
+        """Metrics for a row list.
+
+        :param rows: replay rows.
+        :return: computed metrics.
+        """
+        return compute_metrics(rows)
+
+    def test_tournament_run_is_labelled_not_prod(self) -> None:
+        """The metrics table header must say tournament, not prod."""
+        m = self._metrics([_row("valid")] * 5)
+        assert "Baseline (prod)" in _metrics_table(m, m, "production")
+        assert "Baseline (tourn)" in _metrics_table(m, m, "tournament")
+
+    def test_tournament_run_reports_no_production_parse_rate(self) -> None:
+        """A production parse rate off tournament rows is meaningless."""
+        candidate = self._metrics([_row("valid")] * 5)
+        stats = _stats(source="tournament", accepted=5)
+        stats["production_attempt"] = {"accepted": 0, "rejected": {}}
+        stats["fallback_reason"] = "0 production rows"
+        text = "\n".join(_format_reliability_block(candidate, [], stats))
+        assert (
+            "Production parse rate" not in text
+        ), "captioned tournament rows as a production parse rate"
+        assert "tournament arm" in text
+        assert "not a production delivery" in text
+
+    def test_production_run_is_unchanged(self) -> None:
+        """The production path must keep its existing rendering."""
+        candidate = self._metrics([_row("valid")] * 5)
+        text = "\n".join(_format_reliability_block(candidate, [], _stats(accepted=5)))
+        assert "Production parse rate: 5/5 (100.0%)" in text
+        assert "tournament arm" not in text

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -1221,7 +1221,7 @@ class TestTournamentFallback:
                 {"row_id": "r2", "source_content": "evidence two"},
             ],
         )
-        rows = _load_tournament_rows("t", "polymarket", scored, preds)
+        rows, _dropped = _load_tournament_rows("t", "polymarket", scored, preds)
         assert len(rows) == 1
         assert rows[0]["extracted_user_prompt"] == "Q1?"
         assert rows[0]["extracted_additional_information"] == "evidence one"
@@ -1245,7 +1245,7 @@ class TestTournamentFallback:
             ],
         )
         self._write(preds, [{"row_id": "r1", "source_content": None}])
-        assert not _load_tournament_rows("t", "polymarket", scored, preds)
+        assert not _load_tournament_rows("t", "polymarket", scored, preds)[0]
 
     def test_platform_and_tool_filters(self, tmp_path):  # type: ignore[no-untyped-def]
         """Only the requested tool and platform are kept."""
@@ -1281,8 +1281,8 @@ class TestTournamentFallback:
                 {"row_id": "b", "source_content": "y"},
             ],
         )
-        assert not _load_tournament_rows("t", "polymarket", scored, preds)
-        assert len(_load_tournament_rows("t", "omen", scored, preds)) == 1
+        assert not _load_tournament_rows("t", "polymarket", scored, preds)[0]
+        assert len(_load_tournament_rows("t", "omen", scored, preds)[0]) == 1
 
     def test_emitted_rows_always_carry_tool_name(self, tmp_path):  # type: ignore[no-untyped-def]
         """Legacy ``tool``-keyed rows are normalized to ``tool_name``.
@@ -1326,7 +1326,7 @@ class TestTournamentFallback:
                 {"row_id": "current", "source_content": "e2"},
             ],
         )
-        rows = _load_tournament_rows("t", "polymarket", scored, preds)
+        rows, _dropped = _load_tournament_rows("t", "polymarket", scored, preds)
         assert len(rows) == 2
         assert all(row["tool_name"] == "t" for row in rows)
 
@@ -1370,7 +1370,7 @@ class TestTournamentFallback:
                 {"row_id": "no_p_no", "source_content": "e2"},
             ],
         )
-        rows = _load_tournament_rows("t", "polymarket", scored, preds)
+        rows, _dropped = _load_tournament_rows("t", "polymarket", scored, preds)
         assert [row["row_id"] for row in rows] == ["ok"]
 
     def test_enrich_falls_back_when_production_rows_yield_nothing(  # type: ignore[no-untyped-def]
@@ -1651,7 +1651,7 @@ class TestTournamentFallback:
                 }
             ],
         )
-        rows = _load_tournament_rows(tool, "polymarket", scored, preds)
+        rows, _dropped = _load_tournament_rows(tool, "polymarket", scored, preds)
         assert len(rows) == 1
         info = rows[0]["extracted_additional_information"]
         assert isinstance(info, str), "a dict reached the prompt"
@@ -1689,7 +1689,7 @@ class TestTournamentFallback:
         )
         # A shape with no serper_response -- nothing to render from.
         self._write(preds, [{"row_id": "bad", "source_content": {"mode": "cleaned"}}])
-        assert not _load_tournament_rows(tool, "polymarket", scored, preds)
+        assert not _load_tournament_rows(tool, "polymarket", scored, preds)[0]
 
     def test_prompt_needing_unsupplied_fields_fails_before_the_loop(self):  # type: ignore[no-untyped-def]
         """A template replay cannot fill must raise up front, not mid-run."""
@@ -1711,4 +1711,4 @@ class TestTournamentFallback:
         """Absent tournament files degrade to empty, not an exception."""
         assert not _load_tournament_rows(
             "t", "polymarket", tmp_path / "no.jsonl", tmp_path / "no2.jsonl"
-        )
+        )[0]

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -12,6 +12,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 import pytest
+from benchmark import prompt_replay as pr
 from benchmark.prompt_replay import (
     DEFAULT_REPLAY_SYSTEM_PROMPT,
     _baseline_family,
@@ -19,6 +20,7 @@ from benchmark.prompt_replay import (
     _extract_factual_research_prompt_components,
     _get_structured_output_schema,
     _load_and_filter_rows,
+    _load_tournament_rows,
     _log_replay_summary,
     _parse_vllm_candidate,
     _prepare_output_dir,
@@ -1186,8 +1188,6 @@ class TestTournamentFallback:
 
     def test_joins_scored_outcomes_with_captured_evidence(self, tmp_path):  # type: ignore[no-untyped-def]
         """Rows come from scored (outcome) joined to predictions (evidence)."""
-        from benchmark.prompt_replay import _load_tournament_rows
-
         scored = tmp_path / "tournament_scored.jsonl"
         preds = tmp_path / "tournament_predictions.jsonl"
         self._write(
@@ -1199,6 +1199,7 @@ class TestTournamentFallback:
                     "platform": "polymarket",
                     "question_text": "Q1?",
                     "p_yes": 0.7,
+                    "p_no": 0.3,
                     "final_outcome": True,
                 },
                 {
@@ -1207,6 +1208,7 @@ class TestTournamentFallback:
                     "platform": "polymarket",
                     "question_text": "Q2?",
                     "p_yes": 0.2,
+                    "p_no": 0.8,
                     "final_outcome": None,  # unresolved -> excluded
                 },
             ],
@@ -1225,8 +1227,6 @@ class TestTournamentFallback:
 
     def test_rows_without_evidence_are_dropped(self, tmp_path):  # type: ignore[no-untyped-def]
         """A scored row whose prediction captured no evidence is unusable."""
-        from benchmark.prompt_replay import _load_tournament_rows
-
         scored = tmp_path / "s.jsonl"
         preds = tmp_path / "p.jsonl"
         self._write(
@@ -1238,17 +1238,16 @@ class TestTournamentFallback:
                     "platform": "polymarket",
                     "question_text": "Q?",
                     "p_yes": 0.7,
+                    "p_no": 0.3,
                     "final_outcome": True,
                 }
             ],
         )
         self._write(preds, [{"row_id": "r1", "source_content": None}])
-        assert _load_tournament_rows("t", "polymarket", scored, preds) == []
+        assert not _load_tournament_rows("t", "polymarket", scored, preds)
 
     def test_platform_and_tool_filters(self, tmp_path):  # type: ignore[no-untyped-def]
         """Only the requested tool and platform are kept."""
-        from benchmark.prompt_replay import _load_tournament_rows
-
         scored = tmp_path / "s.jsonl"
         preds = tmp_path / "p.jsonl"
         self._write(
@@ -1260,6 +1259,7 @@ class TestTournamentFallback:
                     "platform": "omen",
                     "question_text": "Q?",
                     "p_yes": 0.5,
+                    "p_no": 0.5,
                     "final_outcome": True,
                 },
                 {
@@ -1268,6 +1268,7 @@ class TestTournamentFallback:
                     "platform": "polymarket",
                     "question_text": "Q?",
                     "p_yes": 0.5,
+                    "p_no": 0.5,
                     "final_outcome": True,
                 },
             ],
@@ -1279,16 +1280,322 @@ class TestTournamentFallback:
                 {"row_id": "b", "source_content": "y"},
             ],
         )
-        assert _load_tournament_rows("t", "polymarket", scored, preds) == []
+        assert not _load_tournament_rows("t", "polymarket", scored, preds)
         assert len(_load_tournament_rows("t", "omen", scored, preds)) == 1
+
+    def test_emitted_rows_always_carry_tool_name(self, tmp_path):  # type: ignore[no-untyped-def]
+        """Legacy ``tool``-keyed rows are normalized to ``tool_name``.
+
+        The loader accepts either spelling on input, but ``replay`` reads
+        ``sampled[0]["tool_name"]`` and copies ``row["tool_name"]`` per row --
+        an un-normalized row KeyErrors there, so the fallback would emit a
+        dataset that cannot be replayed.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": "legacy",
+                    "tool": "t",  # legacy spelling
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": True,
+                },
+                {
+                    "row_id": "current",
+                    "tool_name": "t",  # current spelling
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": False,
+                },
+            ],
+        )
+        self._write(
+            preds,
+            [
+                {"row_id": "legacy", "source_content": "e1"},
+                {"row_id": "current", "source_content": "e2"},
+            ],
+        )
+        rows = _load_tournament_rows("t", "polymarket", scored, preds)
+        assert len(rows) == 2
+        assert all(row["tool_name"] == "t" for row in rows)
+
+    def test_rows_missing_p_no_are_dropped(self, tmp_path):  # type: ignore[no-untyped-def]
+        """A row without ``p_no`` is unusable: replay's baseline arm needs it.
+
+        ``replay`` copies ``row["p_no"]`` verbatim into the baseline arm, so a
+        row missing it raises KeyError partway through the run -- after the
+        earlier rows have already been paid for.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": "ok",
+                    "tool_name": "t",
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": True,
+                },
+                {
+                    "row_id": "no_p_no",
+                    "tool_name": "t",
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "final_outcome": True,
+                },
+            ],
+        )
+        self._write(
+            preds,
+            [
+                {"row_id": "ok", "source_content": "e1"},
+                {"row_id": "no_p_no", "source_content": "e2"},
+            ],
+        )
+        rows = _load_tournament_rows("t", "polymarket", scored, preds)
+        assert [row["row_id"] for row in rows] == ["ok"]
+
+    def test_enrich_falls_back_when_production_rows_yield_nothing(  # type: ignore[no-untyped-def]
+        self, tmp_path, monkeypatch
+    ):
+        """Production rows that all fail enrichment must not write an empty file.
+
+        The fallback used to be gated on "zero production rows", so a tool with
+        a handful of production deliveries that yield no usable prompt (no
+        delivery hash, unfetchable, unparseable) produced an EMPTY enriched
+        file and exited 0 -- handing the replay stage a silently zero-row
+        benchmark. It must fall back to the tournament arm instead.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row(), _row(), _row()])
+
+        scored = tmp_path / "tournament_scored.jsonl"
+        preds = tmp_path / "tournament_predictions.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": "t1",
+                    "tool_name": "superforcaster",
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": True,
+                }
+            ],
+        )
+        self._write(preds, [{"row_id": "t1", "source_content": "captured evidence"}])
+
+        # Every production row fails enrichment (no reachable delivery).
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        monkeypatch.setattr(pr, "_fetch_and_extract_prompts", lambda *a, **k: [])
+
+        output = tmp_path / "out" / "dataset.jsonl"
+        pr.enrich(
+            log_path,
+            "superforcaster",
+            output,
+            tournament_scored=scored,
+            tournament_predictions=preds,
+        )
+        written = [
+            json.loads(line)
+            for line in output.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+        assert len(written) == 1
+        assert written[0]["extracted_additional_information"] == "captured evidence"
+        assert written[0]["tool_name"] == "superforcaster"
+
+    def test_enrich_exits_when_neither_arm_has_rows(self, tmp_path, monkeypatch):  # type: ignore[no-untyped-def]
+        """Nothing in production AND nothing in the tournament -> loud exit.
+
+        Guards the other side of the widened fallback: it must not turn a
+        genuinely empty run into a silent success.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row(), _row()])
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        monkeypatch.setattr(pr, "_fetch_and_extract_prompts", lambda *a, **k: [])
+
+        output = tmp_path / "out" / "dataset.jsonl"
+        with pytest.raises(SystemExit) as exc:
+            pr.enrich(
+                log_path,
+                "superforcaster",
+                output,
+                tournament_scored=tmp_path / "absent.jsonl",
+                tournament_predictions=tmp_path / "absent2.jsonl",
+            )
+        assert "superforcaster" in str(exc.value)
+        assert not output.exists()
+
+    def test_fallback_rewrites_the_filter_stats_sidecar(self, tmp_path, monkeypatch):  # type: ignore[no-untyped-def]
+        """After a fallback the sidecar must describe the TOURNAMENT rows.
+
+        The sidecar is written from the production pool before the fallback
+        runs, and replay feeds it into the human-facing verdict summary. Left
+        as-is it would caption the report with rejection counts for a
+        population that was never benchmarked.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row(), _row(), _row()])
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": "t1",
+                    "tool_name": "superforcaster",
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": True,
+                }
+            ],
+        )
+        self._write(preds, [{"row_id": "t1", "source_content": "evidence"}])
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        monkeypatch.setattr(pr, "_fetch_and_extract_prompts", lambda *a, **k: [])
+
+        output = tmp_path / "out" / "dataset.jsonl"
+        pr.enrich(
+            log_path,
+            "superforcaster",
+            output,
+            tournament_scored=scored,
+            tournament_predictions=preds,
+        )
+        stats = json.loads(
+            output.with_name(output.name + ".filter_stats.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert stats["source"] == "tournament"
+        assert stats["accepted"] == 1, "sidecar must count the rows actually written"
+        assert (
+            stats["production_attempt"]["accepted"] == 3
+        ), "the production attempt must stay diagnosable"
+        assert "fallback_reason" in stats
+
+    def test_production_sidecar_is_tagged_as_production(self, tmp_path, monkeypatch):  # type: ignore[no-untyped-def]
+        """The normal path must label its sidecar too, or 'source' means nothing.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row()])
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        monkeypatch.setattr(
+            pr,
+            "_fetch_and_extract_prompts",
+            lambda rows, *a, **k: [
+                {
+                    **r,
+                    "extracted_user_prompt": "q",
+                    "extracted_additional_information": "e",
+                }
+                for r in rows
+            ],
+        )
+        output = tmp_path / "out" / "dataset.jsonl"
+        pr.enrich(log_path, "superforcaster", output)
+        stats = json.loads(
+            output.with_name(output.name + ".filter_stats.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert stats["source"] == "production"
+
+    def test_fallback_respects_the_sample_budget(self, tmp_path, monkeypatch):  # type: ignore[no-untyped-def]
+        """``--sample N`` must bound the tournament arm too, not just production.
+
+        Otherwise a fallback silently replays the entire tournament history for
+        that tool -- an unbounded LLM bill on a path that exists precisely
+        because the operator asked for a small sample.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        # Production sampling runs before the fallback, and stratified_sample
+        # needs p_yes/platform -- real production rows always carry both.
+        _write_jsonl(
+            log_path,
+            [{**_row(platform="polymarket", row_id="prod-1"), "p_yes": 0.5}],
+        )
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": f"t{i}",
+                    "tool_name": "superforcaster",
+                    "platform": "polymarket",
+                    "question_text": f"Q{i}?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": bool(i % 2),
+                }
+                for i in range(50)
+            ],
+        )
+        self._write(
+            preds,
+            [{"row_id": f"t{i}", "source_content": "evidence"} for i in range(50)],
+        )
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        monkeypatch.setattr(pr, "_fetch_and_extract_prompts", lambda *a, **k: [])
+
+        output = tmp_path / "out" / "dataset.jsonl"
+        pr.enrich(
+            log_path,
+            "superforcaster",
+            output,
+            sample_per_platform=10,
+            tournament_scored=scored,
+            tournament_predictions=preds,
+        )
+        written = [
+            line for line in output.read_text(encoding="utf-8").splitlines() if line
+        ]
+        assert (
+            len(written) == 10
+        ), f"sample budget ignored on the fallback path: wrote {len(written)}/50"
 
     def test_missing_files_return_empty(self, tmp_path):  # type: ignore[no-untyped-def]
         """Absent tournament files degrade to empty, not an exception."""
-        from benchmark.prompt_replay import _load_tournament_rows
-
-        assert (
-            _load_tournament_rows(
-                "t", "polymarket", tmp_path / "no.jsonl", tmp_path / "no2.jsonl"
-            )
-            == []
+        assert not _load_tournament_rows(
+            "t", "polymarket", tmp_path / "no.jsonl", tmp_path / "no2.jsonl"
         )

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -15,6 +15,7 @@ import pytest
 from benchmark import prompt_replay as pr
 from benchmark.prompt_replay import (
     DEFAULT_REPLAY_SYSTEM_PROMPT,
+    _assert_prompt_is_replayable,
     _baseline_family,
     _default_family_system_prompt,
     _extract_factual_research_prompt_components,
@@ -1593,6 +1594,118 @@ class TestTournamentFallback:
         assert (
             len(written) == 10
         ), f"sample budget ignored on the fallback path: wrote {len(written)}/50"
+
+    def test_evidence_is_rendered_as_the_tool_rendered_it(self, tmp_path):  # type: ignore[no-untyped-def]
+        """The fallback must reproduce `format_sources_data`, byte for byte.
+
+        The tournament arm stores `used_params["source_content"]`, which every
+        capturing tool writes as `{"mode":..., "serper_response": <raw Serper
+        JSON>}` -- the payload BEFORE formatting. The production path stores
+        the already-rendered `<background>` text. Passing the dict through put
+        a Python dict repr in the prompt while the baseline p_yes came from
+        clean sources, so the Brier delta measured evidence-format drift.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        tool = "superforcaster-polymarket-v4"
+        mod = importlib.import_module(
+            "packages.valory.customs.superforcaster_polymarket_v4"
+            ".superforcaster_polymarket_v4"
+        )
+        serper: dict = {
+            "organic": [
+                {
+                    "title": f"T{i}",
+                    "link": f"http://s{i}",
+                    "snippet": f"S{i}",
+                    "position": i,
+                }
+                for i in range(1, 8)
+            ],
+            "peopleAlsoAsk": [{"question": "q?", "snippet": "paa"}],
+            "credits": 1,
+        }
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": "r1",
+                    "tool_name": tool,
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": True,
+                    "predicted_at": "2026-06-01T12:00:00Z",
+                }
+            ],
+        )
+        self._write(
+            preds,
+            [
+                {
+                    "row_id": "r1",
+                    "source_content": {"mode": "cleaned", "serper_response": serper},
+                }
+            ],
+        )
+        rows = _load_tournament_rows(tool, "polymarket", scored, preds)
+        assert len(rows) == 1
+        info = rows[0]["extracted_additional_information"]
+        assert isinstance(info, str), "a dict reached the prompt"
+        expected = mod.format_sources_data(
+            serper["organic"][: mod.MAX_SOURCES], serper["peopleAlsoAsk"]
+        )
+        assert info == expected, "evidence differs from what the tool rendered"
+        assert "credits" not in info, "raw Serper noise leaked into the prompt"
+        assert (
+            rows[0]["extracted_today"] == "2026-06-01"
+        ), "empty date -- the superforcaster template renders `Today's date: `"
+
+    def test_unrenderable_evidence_is_dropped_not_replayed(self, tmp_path):  # type: ignore[no-untyped-def]
+        """A row we cannot render faithfully must not be replayed as-is.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        tool = "superforcaster-polymarket-v4"
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": "bad",
+                    "tool_name": tool,
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": True,
+                    "predicted_at": "2026-06-01T00:00:00Z",
+                }
+            ],
+        )
+        # A shape with no serper_response -- nothing to render from.
+        self._write(preds, [{"row_id": "bad", "source_content": {"mode": "cleaned"}}])
+        assert not _load_tournament_rows(tool, "polymarket", scored, preds)
+
+    def test_prompt_needing_unsupplied_fields_fails_before_the_loop(self):  # type: ignore[no-untyped-def]
+        """A template replay cannot fill must raise up front, not mid-run."""
+        with pytest.raises(ValueError) as exc:
+            _assert_prompt_is_replayable(
+                "Q: {question} on {today} given {briefing} under {resolution_rules}",
+                {"question", "today", "briefing"},
+                "factual_research-v2",
+            )
+        assert "resolution_rules" in str(exc.value)
+        # and a template we CAN fill must not raise
+        _assert_prompt_is_replayable(
+            "Q: {question} on {today} given {briefing}",
+            {"question", "today", "briefing"},
+            "factual_research-v2",
+        )
 
     def test_missing_files_return_empty(self, tmp_path):  # type: ignore[no-untyped-def]
         """Absent tournament files degrade to empty, not an exception."""

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -1174,3 +1174,121 @@ class TestStructuredSchemaResolution:
         schema = captured.get("response_format")
         assert schema is not None, "_call_openai_structured was not invoked"
         assert schema.__module__.endswith("superforcaster_polymarket_v4")
+
+
+class TestTournamentFallback:
+    """enrich() falls back to the tournament arm for tournament-only tools."""
+
+    @staticmethod
+    def _write(path, rows):  # type: ignore[no-untyped-def]
+        """Write JSONL rows to path."""
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+    def test_joins_scored_outcomes_with_captured_evidence(self, tmp_path):  # type: ignore[no-untyped-def]
+        """Rows come from scored (outcome) joined to predictions (evidence)."""
+        from benchmark.prompt_replay import _load_tournament_rows
+
+        scored = tmp_path / "tournament_scored.jsonl"
+        preds = tmp_path / "tournament_predictions.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": "r1",
+                    "tool": "t",
+                    "platform": "polymarket",
+                    "question_text": "Q1?",
+                    "p_yes": 0.7,
+                    "final_outcome": True,
+                },
+                {
+                    "row_id": "r2",
+                    "tool": "t",
+                    "platform": "polymarket",
+                    "question_text": "Q2?",
+                    "p_yes": 0.2,
+                    "final_outcome": None,  # unresolved -> excluded
+                },
+            ],
+        )
+        self._write(
+            preds,
+            [
+                {"row_id": "r1", "source_content": "evidence one"},
+                {"row_id": "r2", "source_content": "evidence two"},
+            ],
+        )
+        rows = _load_tournament_rows("t", "polymarket", scored, preds)
+        assert len(rows) == 1
+        assert rows[0]["extracted_user_prompt"] == "Q1?"
+        assert rows[0]["extracted_additional_information"] == "evidence one"
+
+    def test_rows_without_evidence_are_dropped(self, tmp_path):  # type: ignore[no-untyped-def]
+        """A scored row whose prediction captured no evidence is unusable."""
+        from benchmark.prompt_replay import _load_tournament_rows
+
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": "r1",
+                    "tool": "t",
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.7,
+                    "final_outcome": True,
+                }
+            ],
+        )
+        self._write(preds, [{"row_id": "r1", "source_content": None}])
+        assert _load_tournament_rows("t", "polymarket", scored, preds) == []
+
+    def test_platform_and_tool_filters(self, tmp_path):  # type: ignore[no-untyped-def]
+        """Only the requested tool and platform are kept."""
+        from benchmark.prompt_replay import _load_tournament_rows
+
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": "a",
+                    "tool": "t",
+                    "platform": "omen",
+                    "question_text": "Q?",
+                    "p_yes": 0.5,
+                    "final_outcome": True,
+                },
+                {
+                    "row_id": "b",
+                    "tool": "other",
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.5,
+                    "final_outcome": True,
+                },
+            ],
+        )
+        self._write(
+            preds,
+            [
+                {"row_id": "a", "source_content": "x"},
+                {"row_id": "b", "source_content": "y"},
+            ],
+        )
+        assert _load_tournament_rows("t", "polymarket", scored, preds) == []
+        assert len(_load_tournament_rows("t", "omen", scored, preds)) == 1
+
+    def test_missing_files_return_empty(self, tmp_path):  # type: ignore[no-untyped-def]
+        """Absent tournament files degrade to empty, not an exception."""
+        from benchmark.prompt_replay import _load_tournament_rows
+
+        assert (
+            _load_tournament_rows(
+                "t", "polymarket", tmp_path / "no.jsonl", tmp_path / "no2.jsonl"
+            )
+            == []
+        )

--- a/benchmark/tests/test_served_tools.py
+++ b/benchmark/tests/test_served_tools.py
@@ -670,3 +670,75 @@ class TestTriageActionableFilter:
             f"an empty actionable set was converted to {captured['actionable']!r} "
             "-- that turns 'nothing is actionable' into 'assess everything'"
         )
+
+    def test_dash_spelled_production_tool_is_not_silenced(self) -> None:
+        """The two sides of the gate live in different namespaces.
+
+        `actionable_tools()` returns packages.json PACKAGE names (underscores);
+        the scored data is keyed on the on-chain advertised name (dashes). A
+        raw membership test matches only tools whose spellings coincide -- on
+        polymarket exactly one -- so the gate silenced the entire production
+        superforcaster line while stopping nothing it was meant to stop.
+        """
+        stats = {
+            "n": 200,
+            "valid_n": 200,
+            "brier": 0.42,
+            "log_loss": 1.3,
+            "reliability": 0.98,
+        }
+        prev = {**stats, "brier": 0.20, "log_loss": 0.6}
+        decisions = triage(
+            {"by_tool": {"superforcaster-polymarket-v4": stats}},
+            {"by_tool": {"superforcaster-polymarket-v4": prev}},
+            {},
+            actionable={"superforcaster_polymarket_v4"},
+        )
+        assert decisions[0]["decision"] == "open_issue", (
+            "a served, shipped production tool was silenced by a spelling "
+            "mismatch between packages.json and the scored data"
+        )
+
+    def test_genuinely_unserved_tool_is_still_gated(self) -> None:
+        """Normalizing must not weaken the gate itself."""
+        stats = {
+            "n": 200,
+            "valid_n": 200,
+            "brier": 0.42,
+            "log_loss": 1.3,
+            "reliability": 0.98,
+        }
+        prev = {**stats, "brier": 0.20, "log_loss": 0.6}
+        decisions = triage(
+            {"by_tool": {"predict-fine-tuned-calibrated": stats}},
+            {"by_tool": {"predict-fine-tuned-calibrated": prev}},
+            {},
+            actionable={"superforcaster_polymarket_v4"},
+        )
+        assert decisions[0]["decision"] == "silent"
+        assert decisions[0]["reason"] == "not_actionable"
+
+    def test_gate_does_not_suppress_non_fix_decisions(self) -> None:
+        """Only the agent-routed fix issue is gated.
+
+        As a top-of-loop `continue` the gate also silenced widen-sample and
+        deployment-review notes, which carry PROMOTION_LABEL, never tag the
+        coding agent, and exist precisely to ask a human about starved or
+        tournament-only tools -- the population the gate identifies.
+        """
+        thin = {
+            "n": 3,
+            "valid_n": 3,
+            "brier": 0.42,
+            "log_loss": 1.3,
+            "reliability": 0.98,
+        }
+        decisions = triage(
+            {"by_tool": {"unserved-thin": thin}},
+            {"by_tool": {"unserved-thin": thin}},
+            {},
+            actionable={"superforcaster_polymarket_v4"},
+        )
+        assert (
+            decisions[0]["reason"] != "not_actionable"
+        ), "a non-fix decision was overwritten by the actionable gate"

--- a/benchmark/tests/test_served_tools.py
+++ b/benchmark/tests/test_served_tools.py
@@ -742,3 +742,55 @@ class TestTriageActionableFilter:
         assert (
             decisions[0]["reason"] != "not_actionable"
         ), "a non-fix decision was overwritten by the actionable gate"
+
+    def test_discovery_raising_falls_back_to_assess_everything(
+        self, monkeypatch: Any
+    ) -> None:
+        """A raise inside discovery must hand triage None, not a stale value.
+
+        Every existing double returns None directly, so the `except` whose job
+        is to PRODUCE None was never entered -- only its downstream consumer
+        was pinned. This is the one path where a regression silently
+        reintroduces the stall #406 fixed: if a future edit left `actionable`
+        holding a partial value here, nothing would fail.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        captured: Dict[str, Any] = {}
+
+        def fake_triage(*args: Any, **kwargs: Any) -> list:
+            """Capture what main() hands over.
+
+            :param args: positional args.
+            :param kwargs: keyword args.
+            :return: no decisions.
+            """
+            captured["actionable"] = kwargs.get("actionable")
+            return []
+
+        def boom(platform: str) -> set:
+            """Simulate a subgraph/IPFS outage.
+
+            :param platform: platform being resolved.
+            :raises RuntimeError: always.
+            """
+            raise RuntimeError("subgraph unreachable")
+
+        monkeypatch.setattr(tit, "actionable_tools", boom)
+        monkeypatch.setattr(tit, "triage", fake_triage)
+        monkeypatch.setattr(tit, "_load_json", lambda *a, **k: {})
+        monkeypatch.setattr(tit, "_open_issue_tools", lambda *a, **k: {})
+        monkeypatch.setattr(tit, "_closed_issue_pairs", lambda *a, **k: [])
+        monkeypatch.setattr(tit, "_load_count_rows", lambda *a, **k: ({}, {}))
+        monkeypatch.setattr(
+            tit, "_load_tournament_count_rows", lambda *a, **k: ({}, {})
+        )
+        monkeypatch.setattr(sys, "argv", ["triage", "--dry-run"])
+        try:
+            tit.main()
+        except SystemExit:
+            pass
+        assert "actionable" in captured, "main() never reached triage()"
+        assert (
+            captured["actionable"] is None
+        ), "a discovery outage must assess everything, not silence tools"

--- a/benchmark/tests/test_served_tools.py
+++ b/benchmark/tests/test_served_tools.py
@@ -26,6 +26,8 @@ from typing import Any, Dict, List, Optional
 
 import pytest
 from benchmark import served_tools
+from benchmark import tool_improvement_triage as tit
+from benchmark.tool_improvement_triage import triage
 
 
 class TestRepoTools:
@@ -494,6 +496,34 @@ class TestMainCli:
         assert "UNKNOWN -- packages.json unreadable" in out
         assert code == 1
 
+    def test_unknown_discovery_never_asserts_selectable_negatives(
+        self, monkeypatch: Any, capsys: Any, tmp_path: Any
+    ) -> None:
+        """Discovery down + healthy ledger must not claim tools are unserved.
+
+        The mirror of the unreadable-ledger case: with `served` unknown,
+        `repo - (actionable or set())` is the WHOLE ledger, so the section
+        asserted every shipped tool is un-selectable -- two lines after
+        correctly printing UNKNOWN, and false for every tool that is served.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        code, out = self._run(
+            monkeypatch,
+            capsys,
+            tmp_path,
+            [],
+            {"omenstrat Pearl": None, "polystrat Pearl": None},
+            ledger={"dev": {"custom/valory/superforcaster/0.1.0": "bafy"}},
+        )
+        assert (
+            "not selectable in production" not in out
+        ), "asserted a selectable-negative off an unresolved discovery"
+        assert "UNKNOWN -- discovery did not resolve; selectable set" in out
+        assert code == 1
+
     def test_exit_code_covers_an_unknown_ledger(
         self, monkeypatch: Any, capsys: Any, tmp_path: Any
     ) -> None:
@@ -594,3 +624,49 @@ class TestTriageActionableFilter:
             actionable=None,
         )
         assert decisions[0]["decision"] == "open_issue"
+
+    def test_main_passes_an_empty_actionable_through_unchanged(
+        self, monkeypatch: Any
+    ) -> None:
+        """A resolved-but-EMPTY actionable set must reach triage() as-is.
+
+        This pins the behavioural half of the tri-state migration. The old
+        code did `if actionable: ... else: actionable = None`, converting a
+        genuine "nothing here is actionable" into "assess everything" -- the
+        opposite decision. Asserting on triage() alone cannot catch that: the
+        conversion happens in main(), so this captures what main() actually
+        hands over.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        captured: Dict[str, Any] = {}
+
+        def fake_triage(*args: Any, **kwargs: Any) -> list:
+            """Capture the actionable argument and stop the pass.
+
+            :param args: positional args from main().
+            :param kwargs: keyword args from main().
+            :return: no decisions.
+            """
+            captured["actionable"] = kwargs.get("actionable")
+            return []
+
+        monkeypatch.setattr(tit, "actionable_tools", lambda platform: set())
+        monkeypatch.setattr(tit, "triage", fake_triage)
+        monkeypatch.setattr(tit, "_load_json", lambda *a, **k: {})
+        monkeypatch.setattr(tit, "_open_issue_tools", lambda *a, **k: {})
+        monkeypatch.setattr(tit, "_closed_issue_pairs", lambda *a, **k: [])
+        monkeypatch.setattr(tit, "_load_count_rows", lambda *a, **k: ({}, {}))
+        monkeypatch.setattr(
+            tit, "_load_tournament_count_rows", lambda *a, **k: ({}, {})
+        )
+        monkeypatch.setattr(sys, "argv", ["triage", "--dry-run"])
+        try:
+            tit.main()
+        except SystemExit:
+            pass
+        assert "actionable" in captured, "main() never reached triage()"
+        assert captured["actionable"] == set(), (
+            f"an empty actionable set was converted to {captured['actionable']!r} "
+            "-- that turns 'nothing is actionable' into 'assess everything'"
+        )

--- a/benchmark/tests/test_served_tools.py
+++ b/benchmark/tests/test_served_tools.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional
 
 from benchmark import served_tools
+from benchmark.tool_improvement_triage import triage
 
 
 class TestRepoTools:
@@ -123,3 +124,59 @@ class TestTournamentRoster:
             served_tools, "TOURNAMENT_TOOLS_PATH", tmp_path / "nope.json"
         )
         assert served_tools.tournament_tools() == set()
+
+
+class TestTriageActionableFilter:
+    """triage() honours the actionable set."""
+
+    def test_non_actionable_tool_is_silent(self) -> None:
+        """A tool outside the actionable set never reaches the triggers."""
+        stats = {
+            "n": 200,
+            "valid_n": 200,
+            "brier": 0.40,
+            "log_loss": 1.2,
+            "reliability": 0.98,
+        }
+        decisions = triage(
+            {"by_tool": {"tournament-only-tool": stats}},
+            {"by_tool": {"tournament-only-tool": {**stats, "brier": 0.20}}},
+            {},
+            actionable={"some-other-tool"},
+        )
+        assert decisions[0]["decision"] == "silent"
+        assert decisions[0]["reason"] == "not_actionable"
+
+    def test_actionable_tool_is_assessed(self) -> None:
+        """A tool inside the set is evaluated normally (fires here)."""
+        stats = {
+            "n": 200,
+            "valid_n": 200,
+            "brier": 0.40,
+            "log_loss": 1.2,
+            "reliability": 0.98,
+        }
+        decisions = triage(
+            {"by_tool": {"served-tool": stats}},
+            {"by_tool": {"served-tool": {**stats, "brier": 0.20, "log_loss": 0.6}}},
+            {},
+            actionable={"served-tool"},
+        )
+        assert decisions[0]["decision"] == "open_issue"
+
+    def test_none_means_assess_everything(self) -> None:
+        """actionable=None (discovery failed) preserves the legacy behaviour."""
+        stats = {
+            "n": 200,
+            "valid_n": 200,
+            "brier": 0.40,
+            "log_loss": 1.2,
+            "reliability": 0.98,
+        }
+        decisions = triage(
+            {"by_tool": {"anything": stats}},
+            {"by_tool": {"anything": {**stats, "brier": 0.20, "log_loss": 0.6}}},
+            {},
+            actionable=None,
+        )
+        assert decisions[0]["decision"] == "open_issue"

--- a/benchmark/tests/test_tool_improvement_triage.py
+++ b/benchmark/tests/test_tool_improvement_triage.py
@@ -1412,6 +1412,12 @@ class TestMainExitCode:
         monkeypatch.setattr(
             "benchmark.tool_improvement_triage.RESULTS_DIR", results_dir
         )
+        # Discovery is network-bound and these fixtures use synthetic tool
+        # names; None = "assess everything" (the fail-open path).
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.actionable_tools",
+            lambda *a, **k: None,
+        )
 
         # gh issue list succeeds with no open issues; gh issue create fails.
         call_count = {"n": 0}
@@ -1454,6 +1460,12 @@ class TestMainExitCode:
         (results_dir / "scores_polymarket.json").write_text(json.dumps(empty))
         monkeypatch.setattr(
             "benchmark.tool_improvement_triage.RESULTS_DIR", results_dir
+        )
+        # Discovery is network-bound and these fixtures use synthetic tool
+        # names; None = "assess everything" (the fail-open path).
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.actionable_tools",
+            lambda *a, **k: None,
         )
         # Pre-existing state should NOT be overwritten.
         state_path = tmp_path / "state.json"
@@ -1845,6 +1857,12 @@ class TestMainPromotionDispatch:
         self._write_firing_scores(results_dir)
         monkeypatch.setattr(
             "benchmark.tool_improvement_triage.RESULTS_DIR", results_dir
+        )
+        # Discovery is network-bound and these fixtures use synthetic tool
+        # names; None = "assess everything" (the fail-open path).
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.actionable_tools",
+            lambda *a, **k: None,
         )
         monkeypatch.setattr(
             "benchmark.tool_improvement_triage._load_lineage_children",
@@ -2693,6 +2711,12 @@ class TestMainWidenSampleDispatch:
         monkeypatch.setattr(
             "benchmark.tool_improvement_triage.RESULTS_DIR", results_dir
         )
+        # Discovery is network-bound and these fixtures use synthetic tool
+        # names; None = "assess everything" (the fail-open path).
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.actionable_tools",
+            lambda *a, **k: None,
+        )
         monkeypatch.setattr(
             "benchmark.tool_improvement_triage.TOURNAMENT_TOOLS_PATH",
             tmp_path / "tournament_tools.json",
@@ -2765,6 +2789,12 @@ class TestMainWidenSampleDispatch:
         )
         monkeypatch.setattr(
             "benchmark.tool_improvement_triage.RESULTS_DIR", results_dir
+        )
+        # Discovery is network-bound and these fixtures use synthetic tool
+        # names; None = "assess everything" (the fail-open path).
+        monkeypatch.setattr(
+            "benchmark.tool_improvement_triage.actionable_tools",
+            lambda *a, **k: None,
         )
         monkeypatch.setattr(
             "benchmark.tool_improvement_triage.TOURNAMENT_TOOLS_PATH",

--- a/benchmark/tool_improvement_triage.py
+++ b/benchmark/tool_improvement_triage.py
@@ -115,6 +115,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from benchmark.served_tools import actionable_tools
+
 ENABLED_PLATFORMS = ["polymarket"]
 BRIER_REGRESSION_THRESHOLD = 0.040
 BRIER_LEVEL_THRESHOLD = 0.25
@@ -820,6 +822,7 @@ def triage(
     count_windows: Optional[Dict[str, Dict[str, Any]]] = None,
     tournament_windows: Optional[Dict[str, Dict[str, Any]]] = None,
     tournament_roster: Optional[set] = None,
+    actionable: Optional[set] = None,
 ) -> List[Dict[str, Any]]:
     """Apply the gate cascade to ``cur`` vs ``prev`` and return one decision dict per tool."""
     # ``count_windows`` (per-tool output of ``_count_window_stats``) feeds
@@ -890,6 +893,20 @@ def triage(
     ):
         c = cur_by_tool.get(tool) or {}
         p = (prev.get("by_tool") or {}).get(tool, {})
+        if actionable is not None and tool not in actionable:
+            # Not selectable on this platform's mechs, or not shipped by this
+            # repo: a fix issue would have no validation path and no
+            # deployment consequence (mech-predict#416). Stay silent.
+            decisions.append(
+                {
+                    "tool": tool,
+                    "platform": platform,
+                    "decision": "silent",
+                    "reason": "not_actionable",
+                    "issue_open": False,
+                }
+            )
+            continue
         d: Dict[str, Any] = {
             "tool": tool,
             "platform": platform,
@@ -1794,6 +1811,33 @@ def main() -> int:
                 len(tournament_windows),
                 platform,
             )
+        # Restrict fix issues to tools that are BOTH selectable on this
+        # platform's mechs and shipped by this repo. Fail-OPEN: if discovery
+        # cannot resolve (subgraph/GitHub/IPFS outage), assess everything
+        # rather than silently stalling the whole triage -- the pre-existing
+        # behavior, logged loudly.
+        actionable: Optional[set] = None
+        try:
+            actionable = actionable_tools(platform)
+            if actionable:
+                log.info(
+                    "actionable on %s (selectable AND shipped here): %s",
+                    platform,
+                    sorted(actionable),
+                )
+            else:
+                log.warning(
+                    "actionable set for %s resolved EMPTY; assessing all tools "
+                    "this pass (discovery may be degraded).",
+                    platform,
+                )
+                actionable = None
+        except Exception as exc:  # noqa: BLE001 - never block triage on discovery
+            log.warning(
+                "served-tool discovery failed for %s (%s); assessing all tools.",
+                platform,
+                exc,
+            )
         roster = _tournament_roster()
         tournament_scores = _load_json(
             RESULTS_DIR / f"scores_tournament_{platform}.json"
@@ -1811,6 +1855,7 @@ def main() -> int:
             count_windows=count_windows,
             tournament_windows=tournament_windows,
             tournament_roster=roster,
+            actionable=actionable,
         )
         all_decisions.extend(decisions)
 

--- a/benchmark/tool_improvement_triage.py
+++ b/benchmark/tool_improvement_triage.py
@@ -113,7 +113,7 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from benchmark.served_tools import actionable_tools
 from benchmark.tool_usage import normalize_tool_name
@@ -823,7 +823,7 @@ def triage(
     count_windows: Optional[Dict[str, Dict[str, Any]]] = None,
     tournament_windows: Optional[Dict[str, Dict[str, Any]]] = None,
     tournament_roster: Optional[set] = None,
-    actionable: Optional[set] = None,
+    actionable: Optional[Set[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Apply the gate cascade to ``cur`` vs ``prev`` and return one decision dict per tool."""
     # ``count_windows`` (per-tool output of ``_count_window_stats``) feeds
@@ -1832,7 +1832,7 @@ def main() -> int:
         # cannot resolve (subgraph/GitHub/IPFS outage), assess everything
         # rather than silently stalling the whole triage -- the pre-existing
         # behavior, logged loudly.
-        actionable: Optional[set] = None
+        actionable: Optional[Set[str]] = None
         try:
             actionable = actionable_tools(platform)
             if actionable is None:
@@ -1862,6 +1862,9 @@ def main() -> int:
                 "served-tool discovery failed for %s (%s); assessing all tools.",
                 platform,
                 exc,
+                # A transient subgraph/IPFS outage and a bug in the caller look
+                # identical without the traceback.
+                exc_info=True,
             )
         roster = _tournament_roster()
         tournament_scores = _load_json(

--- a/benchmark/tool_improvement_triage.py
+++ b/benchmark/tool_improvement_triage.py
@@ -116,6 +116,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from benchmark.served_tools import actionable_tools
+from benchmark.tool_usage import normalize_tool_name
 
 ENABLED_PLATFORMS = ["polymarket"]
 BRIER_REGRESSION_THRESHOLD = 0.040
@@ -888,25 +889,22 @@ def triage(
     # calendar stats (n_cur=0) and flows into the count fallback /
     # widen-sample routing below.
     cur_by_tool = cur.get("by_tool") or {}
+    # The two sides of the actionable test live in DIFFERENT namespaces:
+    # `actionable` holds packages.json package names (underscores,
+    # `superforcaster_polymarket_v4`) while the scored data is keyed on the
+    # on-chain advertised tool name (dashes, `superforcaster-polymarket-v4`).
+    # Comparing them raw matches only tools whose two spellings coincide --
+    # which on polymarket is exactly one, so the gate silenced the entire
+    # production superforcaster line while letting nothing through it was
+    # meant to stop. Fold once, here.
+    actionable_norm = (
+        None if actionable is None else {normalize_tool_name(a) for a in actionable}
+    )
     for tool in sorted(
         set(cur_by_tool) | set(count_windows or {}) | set(tournament_windows or {})
     ):
         c = cur_by_tool.get(tool) or {}
         p = (prev.get("by_tool") or {}).get(tool, {})
-        if actionable is not None and tool not in actionable:
-            # Not selectable on this platform's mechs, or not shipped by this
-            # repo: a fix issue would have no validation path and no
-            # deployment consequence (mech-predict#416). Stay silent.
-            decisions.append(
-                {
-                    "tool": tool,
-                    "platform": platform,
-                    "decision": "silent",
-                    "reason": "not_actionable",
-                    "issue_open": False,
-                }
-            )
-            continue
         d: Dict[str, Any] = {
             "tool": tool,
             "platform": platform,
@@ -1129,6 +1127,24 @@ def triage(
                 issue_open=True,
             )
         decisions.append(d)
+    # Gate ONLY the agent-routed fix issue. The rationale -- a fix issue on a
+    # tool nobody serves has no validation path and no deployment consequence
+    # (mech-predict#416) -- covers `open_issue` and nothing else. As a
+    # top-of-loop `continue` it also suppressed `insufficient_data` /
+    # widen_sample and `descendant_exists` / deployment-review notes, which
+    # carry PROMOTION_LABEL, never tag the coding agent, and exist precisely
+    # to ask a human about starved or tournament-only tools -- the population
+    # the gate identifies. Silencing those was the opposite of the intent.
+    if actionable_norm is not None:
+        for decision in decisions:
+            if decision.get("decision") != "open_issue":
+                continue
+            if normalize_tool_name(decision["tool"]) in actionable_norm:
+                continue
+            decision["decision"] = "silent"
+            decision["reason"] = "not_actionable"
+            decision["issue_open"] = False
+
     return decisions
 
 

--- a/benchmark/tool_improvement_triage.py
+++ b/benchmark/tool_improvement_triage.py
@@ -1819,19 +1819,28 @@ def main() -> int:
         actionable: Optional[set] = None
         try:
             actionable = actionable_tools(platform)
-            if actionable:
+            if actionable is None:
+                # UNKNOWN, not empty. `actionable_tools` now says which it is,
+                # so the old `if actionable:` emptiness test is obsolete -- it
+                # collapsed a genuine "nothing here is actionable" into
+                # "assess everything", which is the opposite decision.
+                log.warning(
+                    "actionable set for %s is UNKNOWN (discovery or ledger "
+                    "unavailable); assessing all tools this pass.",
+                    platform,
+                )
+            elif not actionable:
+                log.warning(
+                    "actionable set for %s resolved EMPTY: nothing selectable "
+                    "here is shipped by this repo, so every tool stays silent.",
+                    platform,
+                )
+            else:
                 log.info(
                     "actionable on %s (selectable AND shipped here): %s",
                     platform,
                     sorted(actionable),
                 )
-            else:
-                log.warning(
-                    "actionable set for %s resolved EMPTY; assessing all tools "
-                    "this pass (discovery may be degraded).",
-                    platform,
-                )
-                actionable = None
         except Exception as exc:  # noqa: BLE001 - never block triage on discovery
             log.warning(
                 "served-tool discovery failed for %s (%s); assessing all tools.",


### PR DESCRIPTION
> Stacked on **#418** (served-tool discovery). Review/merge that first — this PR is the consumer of it.

## What

**1. The triage only fires on actionable tools.** `triage()` takes an `actionable` set and stays silent (`reason=not_actionable`) on anything outside it. `main()` resolves it **per platform** via `served_tools.actionable_tools(platform)` — selectable on *that platform's* mechs **and** shipped by this repo.

Platform scoping is not cosmetic; the sets are disjoint today:

| Platform | Actionable |
|---|---|
| omen | `factual_research`, `propose_question`, `superforcaster`, `superforcaster_calibrated_full_search` |
| polymarket | `superforcaster_full_search`, `superforcaster_polymarket_v1`, `_v2`, `_v4` |

**Fail-open on a discovery *exception*** — the pass assesses everything, logged loudly, because a discovery outage must not silence the whole triage (that would recreate the stall #406 fixed).

**A resolved-but-EMPTY set fails CLOSED** — every tool stays silent. That is the correct call and is what the code does; an earlier draft of this description said otherwise. `test_main_passes_an_empty_actionable_through_unchanged` pins it.

**2. The benchmark falls back to the tournament arm.** `enrich()` no longer dies with `0 rows for baseline` when a tool has no replayable production deliveries. `tournament_scored.jsonl` carries the resolved outcomes but drops `source_content`, so it is joined by `row_id` with `tournament_predictions.jsonl`, which keeps it. Rows are emitted in the shape `_fetch_and_extract_prompts` produces, skipping the `deliver_id` → marketplace → IPFS path a tournament-only tool has no data for.

## Why

Both come from the same incident. [#416](https://github.com/valory-xyz/mech-predict/pull/416) was a fix PR for `predict-fine-tuned-calibrated` — a tournament-only tool — and its benchmark failed five times identically (`0 rows for baseline`, `wrong_tool=370554`). After this PR: no fix issue would open for that tool at all, and if one ever did, its benchmark would resolve against tournament rows instead of dying.

## What end-to-end testing changed

The first version of this PR passed its unit tests and **still did not work**. Running it end to end in a sandbox — a tool with 40 tournament rows and 3 production rows, LLM mocked, zero spend — found four defects. All were in the seam *between* stages, which is why per-function tests missed them: they asserted on the fields `_load_tournament_rows` adds and never fed its output into `replay()`.

| # | Defect | Effect if shipped |
|---|---|---|
| 1 | Fallback fired only on **zero** production rows | A tool with a few deliveries that all failed enrichment wrote an **empty enriched file and exited 0** — a silently zero-row benchmark, worse than the loud failure this PR set out to fix |
| 2 | Emitted rows not normalized to `tool_name` | `replay()` KeyErrors at `sampled[0]["tool_name"]`. The loader accepted `tool` *or* `tool_name` on input but emitted the row verbatim — accepting a wider shape than we normalize to was manufacturing invalid output |
| 3 | Rows missing `p_no` | KeyError **mid-replay**, after earlier rows were already paid for |
| 4 | **The fallback could never fire in CI** | `benchmark/results/` is gitignored and `benchmark_replay.yaml` downloaded only the production-log artifact, so the tournament files were always absent — the feature was inert in the one place it exists for |

Fixed by widening the fallback condition, normalizing `tool_name` at load, dropping rows without `p_no`, and adding a **non-fatal** download of the `tournament-predictions` artifact (which carries both files).

**Provenance, so the verdict cannot be misread.** The `filter_stats` sidecar is written from the production pool *before* the fallback runs, so after a fallback it captioned the human-facing summary with rejection counts for a population that was never benchmarked. It now carries `source`, is rewritten on fallback (production counts kept under `production_attempt`, plus `fallback_reason`), and the replay summary prints `Row source: TOURNAMENT ARM` outright.

## Tests

**107** in `test_prompt_replay.py`; **1378** across the suite. Every fix is mutation-tested — reverting it fails the test that covers it — including the sample-budget guard, which bounds the fallback's LLM spend (`--sample N` previously bounded only the production path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)