### PR TITLE
fix(F5): stop the benchmark verdict comparing two different measurements

### DIFF
--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -67,6 +67,48 @@ def _compute_parse_reliability(rows: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def pair_arms(
+    baseline_rows: list[dict[str, Any]],
+    candidate_rows: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Restrict both arms to the markets where BOTH produced a usable prediction.
+
+    The baseline arm is valid by construction -- ``replay()`` copies the
+    production p_yes and stamps ``prediction_parse_status: "valid"`` before the
+    candidate LLM is even called -- while the candidate can fail to parse.
+    Scoring each file independently therefore compares an average over every
+    sampled market against an average over whichever subset the candidate
+    managed to answer, and a candidate that fails on the markets the baseline
+    handled worst improves its own score by dropping them.
+
+    Pairing is positional: ``replay()`` writes exactly one baseline and one
+    candidate row per sampled market, in a single loop, with no path that emits
+    one without the other. ``row_id`` looks like the natural join key but
+    cannot be used -- it is salted with the arm name AND with each arm's own
+    ``model`` (production's for the baseline, the replay model for the
+    candidate), so the two arms never share one.
+
+    :param baseline_rows: rows from ``baseline.jsonl``.
+    :param candidate_rows: rows from ``candidate.jsonl``.
+    :return: ``(baseline subset, candidate subset)``, index-aligned and
+        restricted to markets scored by both.
+    :raises SystemExit: when the two arms disagree on the market at some
+        position. Comparing metrics computed over different markets is a worse
+        failure than not reporting, so this refuses rather than degrades.
+    """
+    paired: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    for base, cand in zip(baseline_rows, candidate_rows):
+        if base.get("question_text") != cand.get("question_text"):
+            raise SystemExit(
+                "baseline and candidate rows are misaligned: position holds "
+                f"{base.get('question_text')!r} vs {cand.get('question_text')!r}. "
+                "Refusing to compare metrics computed over different markets."
+            )
+        if base.get("p_yes") is not None and cand.get("p_yes") is not None:
+            paired.append((base, cand))
+    return [b for b, _ in paired], [c for _, c in paired]
+
+
 def compute_metrics(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Compute Brier score, accuracy, and overconfident-wrong count.
 
@@ -305,7 +347,7 @@ def _format_reliability_block(
         # or the counters exist without a reader, and a pool that lost most of
         # its rows still reads as clean.
         t_rejected = {
-            k: v for k, v in (filter_stats.get("rejected") or {}).items() if v
+            k: v for k, v in (filter_stats.get("rejected", {}) or {}).items() if v
         }
         if t_rejected:
             lines.append(
@@ -316,25 +358,29 @@ def _format_reliability_block(
         r = filter_stats.get("rejected", {}) or {}
         accepted = filter_stats.get("accepted", 0)
         not_valid = r.get("not_valid_parse", 0)
-        # Production parse rate: of the in-scope production deliveries, how many
-        # parsed. enrich drops the non-parseable ones (that is what keeps the
-        # scored baseline 100% valid), so they are the only rejections that
-        # belong in this ratio. The scoping rejections (wrong_tool,
-        # wrong_platform, ...) are just rows for other tools/platforms and carry
-        # no reliability signal, so they are not reported.
+        # Only not_valid_parse counts toward the sample count: enrich drops
+        # non-parseable rows (that is what keeps the scored baseline 100%
+        # valid). The scoping rejections (wrong_tool, wrong_platform, ...) are
+        # rows for other tools/platforms and carry no reliability signal.
         denom = accepted + not_valid
         if denom > 0:
-            # Provenance, NOT a tool metric: this is how much of the pool was
-            # discarded, and it is measured in production (real mech, on-chain
-            # delivery) while the candidate figure above comes from a direct
-            # API call in CI. Printing the two as rates side by side invited
-            # exactly one false reading -- "candidate 100% vs production 96.7%
-            # proves the fix works" -- when the discarded rows are precisely
-            # the ones the candidate is never given.
+            # Provenance, not a tool metric: the production figure is measured
+            # in production (real mech, on-chain delivery) and is not
+            # comparable to the candidate figure above, which comes from a
+            # direct API call in CI.
             lines.append("")
             lines.append("**Sample**")
             lines.append("")
             lines.append(f"- Drawn from {accepted} usable production deliveries.")
+            # Written by enrich only when the IPFS fetch lost rows. Without it
+            # the pool size and the scored count cannot be reconciled, and the
+            # gap has no other bucket to attribute it to.
+            lost = filter_stats.get("enrichment_failed", 0)
+            if lost:
+                lines.append(
+                    f"- {lost} sampled row(s) dropped during IPFS enrichment "
+                    "(no delivery hash, or the prompt could not be fetched)."
+                )
             if not_valid:
                 lines.append(
                     f"- {not_valid} of {denom} production deliveries were left "
@@ -419,7 +465,7 @@ def format_report(
         "",
         _metrics_table(baseline, candidate, _src),
         "",
-        f"*Computed on {candidate.get('n', 0)} markets where both arms "
+        f"*Computed on {candidate['n']} markets where both arms "
         "produced a usable prediction.*",
         "",
     ]
@@ -567,6 +613,15 @@ def main() -> None:
         print("ERROR: No baseline rows found", file=sys.stderr)
         sys.exit(1)
 
+    # An empty candidate file is reachable: the replay step can die after
+    # opening candidate.jsonl but before flushing a row, while baseline.jsonl
+    # is already complete. Without this it renders a clean green verdict --
+    # "no usable prediction on 0 of 0 markets" with a tick -- which reads as a
+    # healthy candidate when in fact nothing was measured.
+    if not candidate_rows:
+        print("ERROR: No candidate rows found", file=sys.stderr)
+        sys.exit(1)
+
     # prompt_replay writes candidate_failures.jsonl next to candidate.jsonl
     # whenever any candidate failed to parse. Missing file = zero failures.
     failures_path = args.candidate.parent / "candidate_failures.jsonl"
@@ -576,8 +631,18 @@ def main() -> None:
     # was present at enrich time. Missing file = no stats (older pipelines).
     filter_stats = _load_filter_stats(args.candidate)
 
-    baseline_metrics = compute_metrics(baseline_rows)
-    candidate_metrics = compute_metrics(candidate_rows)
+    # Score both arms over the SAME markets, or the headline delta rewards the
+    # candidate for failing: see :func:`pair_arms`.
+    paired_baseline, paired_candidate = pair_arms(baseline_rows, candidate_rows)
+    baseline_metrics = compute_metrics(paired_baseline)
+    candidate_metrics = compute_metrics(paired_candidate)
+    # Parse reliability describes the WHOLE candidate arm -- it is the count of
+    # markets the candidate could not answer, which is exactly what pairing
+    # removes. Computed on the paired subset it would report "0 of N" forever,
+    # deleting the signal the health block exists to carry.
+    candidate_metrics["parse_reliability"] = compute_metrics(candidate_rows)[
+        "parse_reliability"
+    ]
 
     # Infer tool from data
     tool = baseline_rows[0].get("tool_name", "unknown")

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -84,18 +84,30 @@ def pair_arms(
     Pairing is positional: ``replay()`` writes exactly one baseline and one
     candidate row per sampled market, in a single loop, with no path that emits
     one without the other. ``row_id`` looks like the natural join key but
-    cannot be used -- it is salted with the arm name AND with each arm's own
-    ``model`` (production's for the baseline, the replay model for the
-    candidate), so the two arms never share one.
+    cannot be used -- both arms hash the same payload and differ only in the
+    ``"baseline"`` / ``"candidate"`` prefix, so they never share a row_id and
+    joining on it would silently match nothing.
 
     :param baseline_rows: rows from ``baseline.jsonl``.
     :param candidate_rows: rows from ``candidate.jsonl``.
     :return: ``(baseline subset, candidate subset)``, index-aligned and
         restricted to markets scored by both.
-    :raises SystemExit: when the two arms disagree on the market at some
-        position. Comparing metrics computed over different markets is a worse
-        failure than not reporting, so this refuses rather than degrades.
+    :raises SystemExit: when the arms have different lengths, or disagree on
+        the market at some position. Comparing metrics computed over different
+        markets is a worse failure than not reporting, so this refuses rather
+        than degrades.
     """
+    # `zip` stops at the shorter arm, which would silently drop the baseline
+    # tail and score a truncated run as if it were complete. That is reachable
+    # by the same crash the empty-candidate guard in main() exists for: a
+    # replay dying mid-run flushes SOME candidate rows, not none, and a
+    # partial run must not render a plausible verdict.
+    if len(baseline_rows) != len(candidate_rows):
+        raise SystemExit(
+            f"baseline and candidate arms have different lengths "
+            f"({len(baseline_rows)} vs {len(candidate_rows)}); one arm was "
+            "truncated mid-run. Refusing to compare."
+        )
     paired: list[tuple[dict[str, Any], dict[str, Any]]] = []
     for base, cand in zip(baseline_rows, candidate_rows):
         if base.get("question_text") != cand.get("question_text"):
@@ -640,9 +652,7 @@ def main() -> None:
     # markets the candidate could not answer, which is exactly what pairing
     # removes. Computed on the paired subset it would report "0 of N" forever,
     # deleting the signal the health block exists to carry.
-    candidate_metrics["parse_reliability"] = compute_metrics(candidate_rows)[
-        "parse_reliability"
-    ]
+    candidate_metrics["parse_reliability"] = _compute_parse_reliability(candidate_rows)
 
     # Infer tool from data
     tool = baseline_rows[0].get("tool_name", "unknown")

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -301,6 +301,17 @@ def _format_reliability_block(
             "  Baseline p_yes is the tournament model's prediction, not a "
             "production delivery."
         )
+        # The tournament loader counts why it dropped rows; surface them here
+        # or the counters exist without a reader, and a pool that lost most of
+        # its rows still reads as clean.
+        t_rejected = {
+            k: v for k, v in (filter_stats.get("rejected") or {}).items() if v
+        }
+        if t_rejected:
+            lines.append(
+                "- Tournament rows discarded: "
+                + ", ".join(f"{k}={v}" for k, v in sorted(t_rejected.items()))
+            )
     elif filter_stats is not None:
         r = filter_stats.get("rejected", {}) or {}
         accepted = filter_stats.get("accepted", 0)

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -261,14 +261,15 @@ def _format_reliability_block(
     c_rel = candidate["parse_reliability"]
     c_total = c_rel["total"]
     c_valid = c_rel["valid"]
-    c_rate = c_rel["parse_rate"] or 0.0
     c_marker = "✅" if c_valid == c_total else "⚠️"
 
+    c_bad = c_total - c_valid
     lines: list[str] = [
-        "**Reliability**",
+        "**Candidate health**",
         "",
-        f"- Candidate parse rate: {c_valid}/{c_total} "
-        f"({c_rate * 100:.1f}%) {c_marker}",
+        f"- Candidate returned no usable prediction on {c_bad} of {c_total} "
+        f"markets {c_marker}"
+        + (" (excluded from the metrics above)." if c_bad else "."),
     ]
 
     # Breakdown only surfaces when candidate drifted — keeps the happy-path
@@ -304,10 +305,24 @@ def _format_reliability_block(
         # no reliability signal, so they are not reported.
         denom = accepted + not_valid
         if denom > 0:
-            lines.append(
-                f"- Production parse rate: {accepted}/{denom} "
-                f"({accepted / denom * 100:.1f}%)"
-            )
+            # Provenance, NOT a tool metric: this is how much of the pool was
+            # discarded, and it is measured in production (real mech, on-chain
+            # delivery) while the candidate figure above comes from a direct
+            # API call in CI. Printing the two as rates side by side invited
+            # exactly one false reading -- "candidate 100% vs production 96.7%
+            # proves the fix works" -- when the discarded rows are precisely
+            # the ones the candidate is never given.
+            lines.append("")
+            lines.append("**Sample**")
+            lines.append("")
+            lines.append(f"- Drawn from {accepted} usable production deliveries.")
+            if not_valid:
+                lines.append(
+                    f"- {not_valid} of {denom} production deliveries were left "
+                    "out of the pool: the production run itself returned no "
+                    "usable number, so there is nothing for a candidate to be "
+                    "scored against on those markets."
+                )
         # no_row_id is a kept-row diagnostic (always 0 in healthy production);
         # surface it only when nonzero so a flywheel row_id regression is loud.
         no_row_id = filter_stats.get("no_row_id", 0)
@@ -385,6 +400,9 @@ def format_report(
         "",
         _metrics_table(baseline, candidate, _src),
         "",
+        f"*Computed on {candidate.get('n', 0)} markets where both arms "
+        "produced a usable prediction.*",
+        "",
     ]
     parts.extend(_format_reliability_block(candidate, failure_rows or [], filter_stats))
 
@@ -422,10 +440,11 @@ def format_report(
         parts.append("")
 
     # Footer
-    footer_parts = [
-        f"{baseline['n']} "
-        + ("deliveries" if _src == "production" else "tournament rows")
-    ]
+    # "N deliveries" was the sampled count -- exactly what made "301
+    # deliveries" for `--sample 300` confusing. Report what was SCORED: the
+    # denominator the metrics above actually use.
+    _unit = "scored" if _src == "production" else "tournament rows scored"
+    footer_parts = [f"{candidate['n']} {_unit}"]
     if meta.get("seed"):
         footer_parts.append(f"seed {meta['seed']}")
     if meta.get("phase"):

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -707,9 +707,6 @@ def _drop_reason_detail(dropped: dict[str, int]) -> str:
     )
     if not hit:
         return ""
-    # Every reason is listed, not the top few: each `k=v` is a handful of
-    # characters, and a truncated list beside a total summed over ALL of them
-    # reads as an arithmetic error ("17 dropped: a=10, b=5, c=1").
     shown = ", ".join(f"{k}={v}" for k, v in hit)
     return f" ({sum(v for _, v in hit)} tournament row(s) dropped: {shown})"
 
@@ -937,18 +934,15 @@ def enrich(
     # an invisible assumption.
     stats_path = output.with_name(output.name + ".filter_stats.json")
     stats_path.parent.mkdir(parents=True, exist_ok=True)
-    stats_path.write_text(
-        json.dumps(
-            {
-                "source": "production",
-                "accepted": len(rows),
-                "rejected": rejected,
-                "no_row_id": no_row_id,
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
+    # Kept in memory so the post-enrichment update below can rewrite the file
+    # from this dict rather than reading its own output back.
+    production_stats: dict[str, Any] = {
+        "source": "production",
+        "accepted": len(rows),
+        "rejected": rejected,
+        "no_row_id": no_row_id,
+    }
+    stats_path.write_text(json.dumps(production_stats, indent=2), encoding="utf-8")
     log.info("Wrote filter stats: %s", stats_path)
 
     scope = f" [platform={platform_filter}]" if platform_filter else ""
@@ -1078,9 +1072,11 @@ def enrich(
     # the fetch ran, so record the loss now rather than leaving it only in a
     # log line the PR comment never sees.
     if len(enriched) < len(rows):
-        stats = json.loads(stats_path.read_text(encoding="utf-8"))
-        stats["enrichment_failed"] = len(rows) - len(enriched)
-        stats_path.write_text(json.dumps(stats, indent=2), encoding="utf-8")
+        # Rebuilt from the in-memory dict, not read back from disk: a deleted
+        # or truncated sidecar would otherwise raise here and throw away rows
+        # that were already fetched and enriched.
+        production_stats["enrichment_failed"] = len(rows) - len(enriched)
+        stats_path.write_text(json.dumps(production_stats, indent=2), encoding="utf-8")
         log.info(
             "%d row(s) lost during IPFS enrichment; recorded in %s",
             len(rows) - len(enriched),

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -696,16 +696,21 @@ def _drop_reason_detail(dropped: dict[str, int]) -> str:
     turns that into a next step.
 
     :param dropped: per-reason drop counts from :func:`_load_tournament_rows`.
-    :return: a parenthesised detail clause, or "" when nothing was dropped
-        (i.e. the arm held no candidate rows at all, which the caller's own
-        wording already covers).
+    :return: a parenthesised detail clause, or "" when ``dropped`` is empty
+        because the tournament files were absent -- the caller's own text
+        already conveys that state. (An all-zero ``dropped`` cannot reach a
+        caller: :func:`_load_tournament_rows` returns a bare ``{}`` for the
+        missing-files case and otherwise only omits counts it never saw.)
     """
     hit = sorted(
         ((k, v) for k, v in dropped.items() if v), key=lambda kv: (-kv[1], kv[0])
     )
     if not hit:
         return ""
-    shown = ", ".join(f"{k}={v}" for k, v in hit[:3])
+    # Every reason is listed, not the top few: each `k=v` is a handful of
+    # characters, and a truncated list beside a total summed over ALL of them
+    # reads as an arithmetic error ("17 dropped: a=10, b=5, c=1").
+    shown = ", ".join(f"{k}={v}" for k, v in hit)
     return f" ({sum(v for _, v in hit)} tournament row(s) dropped: {shown})"
 
 
@@ -979,15 +984,11 @@ def enrich(
                     "source": "tournament",
                     "accepted": len(fallback_rows),
                     "rejected": {k: v for k, v in fallback_dropped.items() if v},
-                    # Top-level `no_row_id` means "rows we KEPT that lacked a
-                    # row_id" (production semantics — they bypass dedup, so
-                    # they are a warning about kept data). The tournament arm
-                    # DROPS such rows instead, so its count is a drop reason
-                    # and already sits in `rejected` above; this diagnostic is
-                    # 0 by construction. Echoing the drop count here made one
-                    # set of rows readable as both kept-and-suspect and
-                    # dropped, and double-counted them for anything summing
-                    # the two.
+                    # The tournament arm DROPS rows that lack a row_id, so that
+                    # count belongs in `rejected` above. This top-level key
+                    # means "rows we KEPT despite having no row_id" (production
+                    # semantics -- they bypass dedup), which is 0 by
+                    # construction here.
                     "no_row_id": 0,
                     "production_attempt": {
                         "accepted": production_accepted,
@@ -1069,6 +1070,22 @@ def enrich(
             f"tournament arm has none either{_drop_reason_detail(fallback_dropped)}"
         )
     _log_platform_breakdown(enriched)
+
+    # Rows lost between the sample and here (no delivery hash, unfetchable
+    # prompt, unparseable components) leave on bare `continue`s with no bucket,
+    # so they are the one shortfall a reader cannot attribute when reconciling
+    # the pool size against the scored count. The sidecar was written before
+    # the fetch ran, so record the loss now rather than leaving it only in a
+    # log line the PR comment never sees.
+    if len(enriched) < len(rows):
+        stats = json.loads(stats_path.read_text(encoding="utf-8"))
+        stats["enrichment_failed"] = len(rows) - len(enriched)
+        stats_path.write_text(json.dumps(stats, indent=2), encoding="utf-8")
+        log.info(
+            "%d row(s) lost during IPFS enrichment; recorded in %s",
+            len(rows) - len(enriched),
+            stats_path,
+        )
 
     # Write
     _write_replay_rows(output, enriched)
@@ -1979,10 +1996,13 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
         ``benchmark.tools.TOOL_REGISTRY``; ``--candidate-tool`` names a tool
         that is not either; a vLLM candidate is paired with a non-superforcaster
         baseline (it renders its prompt from that family's extracted sources);
-        or the candidate is a two-stage reasoning tool while the rows carry no
-        ``extracted_reasoning`` (tournament-sourced rows never do). Raised
-        rather than returned so a mis-specified benchmark fails the job instead
-        of publishing a verdict computed from nothing.
+        the candidate is a two-stage reasoning tool while the rows carry no
+        ``extracted_reasoning`` (tournament-sourced rows never do); or the
+        candidate's template asks for a placeholder the enriched rows do not
+        carry (via :func:`_assert_prompt_is_replayable`, which names the
+        missing field -- the most useful of the five when a schema regression
+        is the cause). Raised rather than returned so a mis-specified benchmark
+        fails the job instead of publishing a verdict computed from nothing.
     """
     # Load enriched dataset first to detect tool
     sampled: list[dict[str, Any]] = load_jsonl(dataset)

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -663,6 +663,7 @@ def _render_tournament_evidence(tool_name: str, source_content: Any) -> Optional
             "cannot render tournament evidence for %r the way the tool does; "
             "row dropped",
             tool_name,
+            exc_info=True,
         )
         return None
     return rendered or None
@@ -683,6 +684,29 @@ def _write_replay_rows(output: Path, rows: list[dict[str, Any]]) -> None:
     with open(output, "w", encoding="utf-8") as handle:
         for row in rows:
             handle.write(json.dumps(row) + "\n")
+
+
+def _drop_reason_detail(dropped: dict[str, int]) -> str:
+    """Explain a tournament shortfall from its per-reason drop counts.
+
+    The failure message is the only artifact a human sees when both arms come
+    up empty, and "the tournament arm has none either" gives them nowhere to
+    start: a roster/name mismatch (every row ``wrong_tool``) and a genuinely
+    absent tool (no rows at all) read identically. Naming the dominant reasons
+    turns that into a next step.
+
+    :param dropped: per-reason drop counts from :func:`_load_tournament_rows`.
+    :return: a parenthesised detail clause, or "" when nothing was dropped
+        (i.e. the arm held no candidate rows at all, which the caller's own
+        wording already covers).
+    """
+    hit = sorted(
+        ((k, v) for k, v in dropped.items() if v), key=lambda kv: (-kv[1], kv[0])
+    )
+    if not hit:
+        return ""
+    shown = ", ".join(f"{k}={v}" for k, v in hit[:3])
+    return f" ({sum(v for _, v in hit)} tournament row(s) dropped: {shown})"
 
 
 def _load_tournament_rows(
@@ -923,6 +947,9 @@ def enrich(
     log.info("Wrote filter stats: %s", stats_path)
 
     scope = f" [platform={platform_filter}]" if platform_filter else ""
+    # Captured out of the closure so the failure paths below can say WHY the
+    # tournament arm produced nothing, rather than only that it did.
+    fallback_dropped: dict[str, int] = {}
 
     def _tournament_fallback(why: str) -> bool:
         """Write tournament-sourced rows to ``output``; True when it produced any.
@@ -930,6 +957,7 @@ def enrich(
         :param why: what made the production path unusable (for the log).
         :return: whether replayable rows were written.
         """
+        nonlocal fallback_dropped
         log.warning("%s for %r%s; trying the tournament arm", why, tool_filter, scope)
         fallback_rows, fallback_dropped = _load_tournament_rows(
             tool_filter, platform_filter, tournament_scored, tournament_predictions
@@ -951,7 +979,16 @@ def enrich(
                     "source": "tournament",
                     "accepted": len(fallback_rows),
                     "rejected": {k: v for k, v in fallback_dropped.items() if v},
-                    "no_row_id": fallback_dropped.get("no_row_id", 0),
+                    # Top-level `no_row_id` means "rows we KEPT that lacked a
+                    # row_id" (production semantics — they bypass dedup, so
+                    # they are a warning about kept data). The tournament arm
+                    # DROPS such rows instead, so its count is a drop reason
+                    # and already sits in `rejected` above; this diagnostic is
+                    # 0 by construction. Echoing the drop count here made one
+                    # set of rows readable as both kept-and-suspect and
+                    # dropped, and double-counted them for anything summing
+                    # the two.
+                    "no_row_id": 0,
                     "production_attempt": {
                         "accepted": production_accepted,
                         "rejected": rejected,
@@ -974,7 +1011,7 @@ def enrich(
             return
         raise SystemExit(
             f"0 rows for baseline {tool_filter!r}{scope} in production or "
-            "the tournament arm"
+            f"the tournament arm{_drop_reason_detail(fallback_dropped)}"
         )
 
     # Stratified sample BEFORE IPFS fetch to avoid unnecessary downloads.
@@ -1016,23 +1053,25 @@ def enrich(
         # delivery hash, unfetchable prompt, unparseable components). Writing
         # an empty file here would hand the replay stage a silently zero-row
         # benchmark -- worse than #416's loud failure. Try the tournament arm.
+        # `len(rows)`, not `production_accepted`: the sample above already
+        # narrowed the pool, so only these rows were ever handed to IPFS.
+        # Reporting the pre-sample count read as "500 rows all failed" when 50
+        # were attempted -- and this string is surfaced verbatim in the PR
+        # comment via the sidecar's `fallback_reason`. The pre-sample total
+        # stays available under `production_attempt.accepted`.
         if _tournament_fallback(
-            f"{production_accepted} production rows but 0 survived IPFS " "enrichment"
+            f"{len(rows)} production rows but 0 survived IPFS enrichment"
         ):
             return
         raise SystemExit(
             f"0 replayable rows for baseline {tool_filter!r}{scope}: "
             f"{len(rows)} production rows yielded no usable prompt and the "
-            "tournament arm has none either"
+            f"tournament arm has none either{_drop_reason_detail(fallback_dropped)}"
         )
     _log_platform_breakdown(enriched)
 
     # Write
-    output.parent.mkdir(parents=True, exist_ok=True)
-    with open(output, "w", encoding="utf-8") as f:
-        for row in enriched:
-            f.write(json.dumps(row) + "\n")
-
+    _write_replay_rows(output, enriched)
     log.info("Written to %s", output)
 
 
@@ -1572,16 +1611,26 @@ def _log_replay_summary(
             )
         r = filter_stats.get("rejected", {})
         total_rej = sum(r.values()) if r else 0
-        # Scoping buckets + not_valid_parse make up the full rejected total;
-        # iterate SCOPING_BUCKETS so this can't drift out of sync.
-        breakdown = ", ".join(f"{k}={r.get(k, 0)}" for k in SCOPING_BUCKETS)
+        if filter_stats.get("source") == "tournament":
+            # The tournament arm drops rows for its OWN reasons (bad_json,
+            # no_question, no_evidence, unrenderable, ...), none of which are
+            # scoping buckets. Enumerating SCOPING_BUCKETS here printed six
+            # production buckets at zero beside a non-zero total -- a line
+            # that contradicted itself. Render the counts actually recorded.
+            breakdown = ", ".join(f"{k}={v}" for k, v in sorted(r.items()) if v)
+        else:
+            # Production: scoping buckets + not_valid_parse account for the
+            # whole total, so enumerate them even at zero (a bucket that stops
+            # appearing is itself the signal) rather than printing only what
+            # happens to be non-zero.
+            breakdown = ", ".join(f"{k}={r.get(k, 0)}" for k in SCOPING_BUCKETS)
+            breakdown += f", not_valid_parse={r.get('not_valid_parse', 0)}"
         log.info("  Pre-filter (from enrich):")
         log.info(
-            "    Accepted: %d   Rejected: %d (%s, not_valid_parse=%d)  no_row_id=%d",
+            "    Accepted: %d   Rejected: %d (%s)  no_row_id=%d",
             filter_stats.get("accepted", 0),
             total_rej,
-            breakdown,
-            r.get("not_valid_parse", 0),
+            breakdown or "none",
             filter_stats.get("no_row_id", 0),
         )
 
@@ -1925,6 +1974,15 @@ def replay(  # pylint: disable=too-many-statements,too-many-locals
         W-2 rows. The candidate must share the baseline's prompt-attribute
         schema (PREDICTION_PROMPT / ESTIMATE_USER / etc.) and be registered in
         benchmark.tools.TOOL_REGISTRY.
+    :raises ValueError: when the pairing cannot be replayed — the baseline
+        tool named by the enriched rows is not in
+        ``benchmark.tools.TOOL_REGISTRY``; ``--candidate-tool`` names a tool
+        that is not either; a vLLM candidate is paired with a non-superforcaster
+        baseline (it renders its prompt from that family's extracted sources);
+        or the candidate is a two-stage reasoning tool while the rows carry no
+        ``extracted_reasoning`` (tournament-sourced rows never do). Raised
+        rather than returned so a mis-specified benchmark fails the job instead
+        of publishing a verdict computed from nothing.
     """
     # Load enriched dataset first to detect tool
     sampled: list[dict[str, Any]] = load_jsonl(dataset)

--- a/benchmark/prompt_replay.py
+++ b/benchmark/prompt_replay.py
@@ -1066,7 +1066,6 @@ def stratified_sample(
             for key in non_empty:
                 allocations[key] = min(allocations[key], len(non_empty[key]))
 
-            # Ensure total matches budget (distribute remainder largest-first)
             allocated = sum(allocations.values())
             deficit = budget - allocated
             if deficit > 0:
@@ -1078,6 +1077,26 @@ def stratified_sample(
                     deficit -= add
                     if deficit == 0:
                         break
+
+        # Ensure total matches budget. The round() above can push the total
+        # OVER, which is why `--sample 300` returned 301 and `--sample 10`
+        # returned 12; only the deficit direction was corrected.
+        allocated = sum(allocations.values())
+        surplus = allocated - budget
+        if surplus > 0:
+            # Trim largest-first, NEVER below one row per stratum. When there
+            # are more non-empty strata than budget the floor is allowed to
+            # win -- covering every (outcome, brier-bucket) stratum matters
+            # more than the exact count there, because dropping strata biases
+            # the sample. That is the only case permitted to exceed N;
+            # rounding is not.
+            for key in sorted(non_empty, key=lambda k: allocations[k], reverse=True):
+                if surplus <= 0:
+                    break
+                take = min(surplus, allocations[key] - 1)
+                if take > 0:
+                    allocations[key] -= take
+                    surplus -= take
 
         # Sample from each stratum
         platform_sampled = 0

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -4,8 +4,11 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
+import pytest
+from benchmark import ci_replay
 from benchmark.ci_replay import (
     PARSE_STATUS_BUCKETS,
     _compute_parse_reliability,
@@ -14,6 +17,7 @@ from benchmark.ci_replay import (
     _metrics_table,
     compute_metrics,
     format_report,
+    pair_arms,
 )
 
 
@@ -130,8 +134,8 @@ class TestReliabilityBlock:
 
         They land in the *rejected* bucket because the filter correctly
         excluded them — that is what keeps the scored baseline 100% valid — so
-        a non-zero count must not raise a warning. It only lowers the reported
-        production parse rate.
+        a non-zero count must not raise a warning. It only shrinks the pool
+        the sample was drawn from.
         """
         candidate = self._metrics([_row("valid")] * 5)
         lines = _format_reliability_block(
@@ -139,7 +143,6 @@ class TestReliabilityBlock:
         )
         text = "\n".join(lines)
         assert "⚠️" not in text
-        # 5 / (5 + 2) = 71.4%
         assert "2 of 7 production deliveries were left out" in text
 
     def test_scoping_rejections_are_not_reported(self) -> None:
@@ -167,14 +170,14 @@ class TestReliabilityBlock:
         ):
             assert bucket not in text
         assert "⚠️" not in text
-        # Scoping rejections do not affect the production parse rate either.
+        # Scoping rejections do not shrink the reported pool either.
         assert "Drawn from 5 usable production deliveries." in text
 
-    def test_production_parse_rate_rendered_with_rejections(self) -> None:
-        """Render ``accepted/(accepted+not_valid_parse)`` as a percentage.
+    def test_left_out_count_rendered_with_rejections(self) -> None:
+        """Report how many deliveries were left out, and out of how many.
 
         The scored baseline is 100% valid by construction (enrich drops the
-        non-parseable rows). The pre-drop ratio is what tells reviewers how
+        non-parseable rows). The pre-drop count is what tells reviewers how
         noisy production actually was.
         """
         candidate = self._metrics([_row("valid")] * 100)
@@ -184,8 +187,8 @@ class TestReliabilityBlock:
         text = "\n".join(lines)
         assert "35 of 135 production deliveries were left out" in text
 
-    def test_production_parse_rate_at_100_when_no_parse_rejections(self) -> None:
-        """Zero not_valid_parse rejections: rate is 100%, but still rendered.
+    def test_pool_size_rendered_when_no_parse_rejections(self) -> None:
+        """Zero not_valid_parse rejections: the pool size still renders.
 
         Keeping it on the happy path means a later regression (non-zero
         ``not_valid_parse``) isn't a surprise line appearing out of nowhere.
@@ -199,14 +202,14 @@ class TestReliabilityBlock:
         text = "\n".join(lines)
         assert "Drawn from 50 usable production deliveries." in text
 
-    def test_production_parse_rate_omitted_when_no_sidecar(self) -> None:
-        """Older pipelines (no filter_stats) don't render the production rate line."""
+    def test_sample_block_omitted_when_no_sidecar(self) -> None:
+        """Older pipelines (no filter_stats) render no Sample block at all."""
         candidate = self._metrics([_row("valid")] * 5)
         text = "\n".join(_format_reliability_block(candidate, [], None))
         assert "**Sample**" not in text
 
     def test_prefilter_omitted_when_stats_none(self) -> None:
-        """Older pipelines (no sidecar) render without the production parse line."""
+        """Older pipelines (no sidecar) render without the Sample block."""
         candidate = self._metrics([_row("valid")] * 3)
         text = "\n".join(_format_reliability_block(candidate, [], None))
         assert "**Sample**" not in text
@@ -310,8 +313,8 @@ class TestFormatReportEndToEnd:
         assert "Boom." in report
         assert "⚠️" in report
 
-    def test_report_renders_production_parse_rate_when_stats_provided(self) -> None:
-        """A filter_stats dict adds the Production parse rate to the reliability block."""
+    def test_report_renders_sample_block_when_stats_provided(self) -> None:
+        """A filter_stats dict adds the Sample provenance block to the report."""
         baseline = compute_metrics([_row("valid")] * 3)
         candidate = compute_metrics([_row("valid")] * 3)
         report = format_report(
@@ -320,12 +323,12 @@ class TestFormatReportEndToEnd:
             {"tool": "superforcaster"},
             filter_stats=_stats(accepted=3, wrong_tool=10, no_outcome=2),
         )
-        # Scoping rejections don't enter the ratio or raise a warning.
+        # Scoping rejections don't shrink the pool or raise a warning.
         assert "Drawn from 3 usable production deliveries." in report
         assert "⚠️" not in report
 
     def test_not_valid_parse_lowers_rate_without_warning_in_full_report(self) -> None:
-        """not_valid_parse rows lower the production rate but never raise ⚠️."""
+        """not_valid_parse rows shrink the pool but never raise ⚠️."""
         baseline = compute_metrics([_row("valid")] * 3)
         candidate = compute_metrics([_row("valid")] * 3)
         report = format_report(
@@ -483,3 +486,340 @@ class TestTournamentSourcedComment:
         text = "\n".join(_format_reliability_block(candidate, [], _stats(accepted=5)))
         assert "Drawn from 5 usable production deliveries." in text
         assert "tournament arm" not in text
+
+
+def _arm_pair(n: int, candidate_fails_on: set[int]) -> tuple[list[dict], list[dict]]:
+    """Build index-aligned baseline/candidate arms.
+
+    The baseline is always usable (replay stamps it valid before the
+    candidate LLM runs); the candidate returns nothing on the given
+    indices, and is deliberately WORSE elsewhere so a drop-driven "win"
+    is unambiguous.
+
+    :param n: number of markets.
+    :param candidate_fails_on: indices the candidate cannot answer.
+    :return: (baseline rows, candidate rows).
+    """
+    base, cand = [], []
+    for i in range(n):
+        # The markets the candidate drops are the ones the baseline got
+        # WORST (p_yes 0.0 against a True outcome).
+        worst = i in candidate_fails_on
+        base.append(
+            {
+                "platform": "omen",
+                "tool_name": "t",
+                "question_text": f"Q{i}?",
+                "p_yes": 0.0 if worst else 0.6,
+                "p_no": 1.0 if worst else 0.4,
+                "prediction_parse_status": "valid",
+                "final_outcome": True,
+            }
+        )
+        cand.append(
+            {
+                "platform": "omen",
+                "tool_name": "t",
+                "question_text": f"Q{i}?",
+                "p_yes": None if worst else 0.59,
+                "p_no": None if worst else 0.41,
+                "prediction_parse_status": "malformed" if worst else "valid",
+                "final_outcome": True,
+            }
+        )
+    return base, cand
+
+
+class TestArmPairing:
+    """Both arms must be scored over the SAME markets."""
+
+    def test_baseline_is_not_scored_on_markets_the_candidate_dropped(self) -> None:
+        """The dropped markets must leave the BASELINE average too.
+
+        Otherwise the candidate wins by failing: it is scored on its own
+        subset while the baseline carries the markets it could not answer.
+        """
+        base, cand = _arm_pair(100, candidate_fails_on={0, 1, 2})
+        pb, pc = pair_arms(base, cand)
+        assert len(pb) == len(pc) == 97
+        # Every surviving baseline row is one the candidate also answered.
+        assert all(r["p_yes"] == 0.6 for r in pb), "a dropped market survived"
+        assert compute_metrics(pb)["n"] == compute_metrics(pc)["n"] == 97
+
+    def test_dropping_the_hardest_markets_no_longer_buys_a_win(self) -> None:
+        """The reported delta must not flip sign purely from candidate drops.
+
+        Unpaired, the baseline carries three 0.0-vs-True markets the candidate
+        never answered, so the candidate "improves" Brier. Paired, the
+        candidate is strictly worse on identical markets and must show it.
+        """
+        base, cand = _arm_pair(100, candidate_fails_on={0, 1, 2})
+        unpaired_delta = compute_metrics(cand)["brier"] - compute_metrics(base)["brier"]
+        pb, pc = pair_arms(base, cand)
+        paired_delta = compute_metrics(pc)["brier"] - compute_metrics(pb)["brier"]
+        assert unpaired_delta < 0, "fixture no longer reproduces the false win"
+        assert paired_delta > 0, "pairing must expose the candidate as worse"
+
+    def test_caption_and_footer_report_the_paired_count(self) -> None:
+        """`Computed on N` and the footer must both mean markets scored by both."""
+        base, cand = _arm_pair(100, candidate_fails_on={0, 1, 2})
+        pb, pc = pair_arms(base, cand)
+        cand_metrics = compute_metrics(pc)
+        cand_metrics["parse_reliability"] = compute_metrics(cand)["parse_reliability"]
+        report = format_report(
+            compute_metrics(pb),
+            cand_metrics,
+            {"tool": "t", "seed": "42", "triggered_by": "bot"},
+            failure_rows=[],
+            filter_stats=None,
+        )
+        assert "Computed on 97 markets" in report
+        assert report.splitlines()[-1].strip("*").startswith("97 scored")
+        # Health still reports against the FULL arm, not the paired subset.
+        assert "no usable prediction on 3 of 100 markets" in report
+
+    def test_misaligned_arms_refuse_to_render(self) -> None:
+        """Different markets at the same position must fail loudly, not silently."""
+        base, cand = _arm_pair(3, candidate_fails_on=set())
+        cand[1]["question_text"] = "a completely different market"
+        with pytest.raises(SystemExit) as exc:
+            pair_arms(base, cand)
+        assert "misaligned" in str(exc.value)
+
+
+class TestSampleBlockNegativeCases:
+    """Lines that must NOT render on a clean run."""
+
+    def test_left_out_line_absent_when_nothing_was_left_out(self) -> None:
+        """A clean pool must not render `0 of N ... left out`.
+
+        The line is conditional; dropping the guard would print it on every
+        healthy run, and every existing test passes a non-zero count.
+        """
+        candidate = compute_metrics([_row("valid")] * 5)
+        text = "\n".join(_format_reliability_block(candidate, [], _stats(accepted=5)))
+        assert "Drawn from 5 usable production deliveries." in text
+        assert "left out" not in text
+
+    def test_enrichment_losses_reach_the_reader(self) -> None:
+        """Rows lost during IPFS enrichment must be attributable in the comment."""
+        candidate = compute_metrics([_row("valid")] * 5)
+        stats = _stats(accepted=50)
+        stats["enrichment_failed"] = 7
+        text = "\n".join(_format_reliability_block(candidate, [], stats))
+        assert "7 sampled row(s) dropped during IPFS enrichment" in text
+
+    def test_enrichment_line_absent_when_nothing_was_lost(self) -> None:
+        """No enrichment loss, no line."""
+        candidate = compute_metrics([_row("valid")] * 5)
+        text = "\n".join(_format_reliability_block(candidate, [], _stats(accepted=50)))
+        assert "IPFS enrichment" not in text
+
+
+class TestTournamentRenderingCoverage:
+    """Tournament-specific strings that previously had no test."""
+
+    @staticmethod
+    def _tstats(**rejected: int) -> dict:
+        """Tournament sidecar with the given non-zero drop reasons.
+
+        :param rejected: per-reason drop counts.
+        :return: sidecar dict.
+        """
+        return {
+            "source": "tournament",
+            "accepted": 5,
+            "rejected": dict(rejected),
+            "no_row_id": 0,
+            "production_attempt": {"accepted": 500, "rejected": {}},
+            "fallback_reason": "0 production rows",
+        }
+
+    def test_discarded_line_renders_with_real_drop_counts(self) -> None:
+        """`Tournament rows discarded` must render, sorted, when drops exist.
+
+        Every prior tournament fixture defaulted each bucket to 0, so this
+        branch was never entered under test.
+        """
+        candidate = compute_metrics([_row("valid")] * 5)
+        text = "\n".join(
+            _format_reliability_block(
+                candidate,
+                [],
+                self._tstats(no_evidence=950, unrenderable=3, no_row_id=2),
+            )
+        )
+        assert (
+            "- Tournament rows discarded: no_evidence=950, no_row_id=2, "
+            "unrenderable=3" in text
+        )
+
+    def test_discarded_line_absent_when_nothing_was_discarded(self) -> None:
+        """No drops, no line."""
+        candidate = compute_metrics([_row("valid")] * 5)
+        text = "\n".join(_format_reliability_block(candidate, [], self._tstats()))
+        assert "Tournament rows discarded" not in text
+
+    def test_footer_unit_says_tournament_rows_scored(self) -> None:
+        """The tournament footer unit had no test at all.
+
+        `grep "tournament rows scored" benchmark/tests/` was empty, so the
+        production/tournament split in the footer was unpinned.
+        """
+        rows = [
+            {**_row("valid"), "question_text": f"Q{i}?", "platform": "polymarket"}
+            for i in range(4)
+        ]
+        report = format_report(
+            compute_metrics(rows),
+            compute_metrics(rows),
+            {"tool": "t", "seed": "42", "triggered_by": "bot"},
+            failure_rows=[],
+            filter_stats=self._tstats(),
+        )
+        assert report.splitlines()[-1].strip("*").startswith("4 tournament rows scored")
+
+    def test_footer_count_is_the_candidate_denominator(self) -> None:
+        """Footer must track the candidate's N, not the baseline's.
+
+        With equal-sized arms in every prior fixture, reverting this to
+        `baseline['n']` passed the whole suite.
+        """
+        base = [{**_row("valid"), "question_text": f"Q{i}?"} for i in range(9)]
+        cand = [
+            {
+                **_row("valid" if i < 4 else "malformed", 0.6 if i < 4 else None),
+                "question_text": f"Q{i}?",
+            }
+            for i in range(9)
+        ]
+        report = format_report(
+            compute_metrics(base),
+            compute_metrics(cand),
+            {"tool": "t", "seed": "42", "triggered_by": "bot"},
+            failure_rows=[],
+            filter_stats=None,
+        )
+        assert (
+            report.splitlines()[-1].strip("*").startswith("4 scored")
+        ), "footer used the baseline denominator"
+
+
+class TestMainRowGuards:
+    """`main()` must refuse to render a verdict from a missing arm."""
+
+    @staticmethod
+    def _write(path: Path, rows: list[dict]) -> None:
+        """Write JSONL rows.
+
+        :param path: destination.
+        :param rows: rows to serialise.
+        """
+        path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
+
+    def _run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cand: list[dict]
+    ) -> int:
+        """Run ``main()`` with a full baseline and the given candidate rows.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param cand: candidate rows to write.
+        :return: the SystemExit code (0 when it ran to completion).
+        """
+
+        base_p, cand_p = tmp_path / "baseline.jsonl", tmp_path / "candidate.jsonl"
+        self._write(
+            base_p,
+            [{**_row("valid"), "question_text": f"Q{i}?"} for i in range(3)],
+        )
+        self._write(cand_p, cand)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["ci_replay", "--baseline", str(base_p), "--candidate", str(cand_p)],
+        )
+        try:
+            ci_replay.main()
+        except SystemExit as exc:
+            return int(exc.code or 0)
+        return 0
+
+    def test_empty_candidate_file_is_an_error_not_a_green_verdict(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A candidate that flushed no rows must fail, not render a tick.
+
+        Reachable when replay dies after opening candidate.jsonl but before
+        writing to it. Previously this rendered "no usable prediction on 0 of
+        0 markets ✅" -- a clean pass over nothing.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        code = self._run(tmp_path, monkeypatch, [])
+        assert code == 1
+        assert "No candidate rows" in capsys.readouterr().err
+
+    def test_populated_candidate_renders(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The guard must not reject a healthy run.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        code = self._run(
+            tmp_path,
+            monkeypatch,
+            [{**_row("valid"), "question_text": f"Q{i}?"} for i in range(3)],
+        )
+        assert code == 0
+        assert "Computed on 3 markets" in capsys.readouterr().out
+
+    def test_main_scores_both_arms_over_the_paired_markets(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """`main()` must actually USE the pairing, not merely have it available.
+
+        Driven end-to-end rather than by calling ``pair_arms`` directly: a
+        test that exercises the helper alone still passes when ``main()``
+        scores each file independently, which is the bug.
+
+        The fixture is the false win itself -- the candidate cannot answer the
+        3 markets the baseline got worst, and is marginally worse everywhere
+        else. Unpaired it reports an improvement; paired it must report a
+        regression, over 97 markets rather than 100.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        base, cand = _arm_pair(100, candidate_fails_on={0, 1, 2})
+        base_p, cand_p = tmp_path / "baseline.jsonl", tmp_path / "candidate.jsonl"
+        self._write(base_p, base)
+        self._write(cand_p, cand)
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["ci_replay", "--baseline", str(base_p), "--candidate", str(cand_p)],
+        )
+        ci_replay.main()
+        out = capsys.readouterr().out
+        assert "Computed on 97 markets" in out, "main() scored the arms unpaired"
+        # Brier row: candidate must be the WORSE number once paired.
+        brier_row = next(line for line in out.splitlines() if "Brier score" in line)
+        b_val, c_val = (float(x) for x in brier_row.split("|")[2:4])
+        assert c_val > b_val, f"paired candidate must be worse, got {brier_row}"

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -21,6 +21,18 @@ from benchmark.ci_replay import (
 )
 
 
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    """Write rows as JSONL. Same construction as the sibling test module.
+
+    :param path: destination.
+    :param rows: rows to serialise.
+    """
+    path.write_text(
+        "\n".join(json.dumps(r) for r in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
 def _row(status: str = "valid", p_yes: float | None = 0.6) -> dict:
     return {
         "platform": "omen",
@@ -433,7 +445,7 @@ class TestFormatReportFooter:
         assert "[@LOCKhart07]" not in footer
 
     def test_footer_order_deliveries_seed_triggered_by(self) -> None:
-        """Footer parts stay in the existing order: deliveries → seed → triggered-by."""
+        """Footer parts stay in the existing order: scored → seed → triggered-by."""
         report = self._report(
             seed="1337",
             triggered_by="LOCKhart07",
@@ -578,13 +590,33 @@ class TestArmPairing:
         # Health still reports against the FULL arm, not the paired subset.
         assert "no usable prediction on 3 of 100 markets" in report
 
+    def test_truncated_arm_refuses_to_render(self) -> None:
+        """A partial candidate flush must fail, not score a truncated pair.
+
+        `zip` stops at the shorter arm, so without this a replay that died
+        after writing some — but not all — candidate rows would silently drop
+        the baseline tail and publish a plausible verdict over whatever
+        happened to be flushed. The empty-candidate guard in `main()` only
+        catches the zero case; this is the 1..n-1 case.
+        """
+        base, cand = _arm_pair(10, candidate_fails_on=set())
+        with pytest.raises(SystemExit) as exc:
+            pair_arms(base, cand[:4])
+        msg = str(exc.value)
+        assert "different lengths" in msg
+        assert "10 vs 4" in msg
+        assert "Refusing to compare" in msg
+
     def test_misaligned_arms_refuse_to_render(self) -> None:
         """Different markets at the same position must fail loudly, not silently."""
         base, cand = _arm_pair(3, candidate_fails_on=set())
         cand[1]["question_text"] = "a completely different market"
         with pytest.raises(SystemExit) as exc:
             pair_arms(base, cand)
-        assert "misaligned" in str(exc.value)
+        msg = str(exc.value)
+        assert "misaligned" in msg
+        assert "Refusing to compare" in msg
+        assert "a completely different market" in msg, "name the conflict"
 
 
 class TestSampleBlockNegativeCases:
@@ -708,15 +740,6 @@ class TestTournamentRenderingCoverage:
 class TestMainRowGuards:
     """`main()` must refuse to render a verdict from a missing arm."""
 
-    @staticmethod
-    def _write(path: Path, rows: list[dict]) -> None:
-        """Write JSONL rows.
-
-        :param path: destination.
-        :param rows: rows to serialise.
-        """
-        path.write_text("".join(json.dumps(r) + "\n" for r in rows), encoding="utf-8")
-
     def _run(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cand: list[dict]
     ) -> int:
@@ -729,11 +752,11 @@ class TestMainRowGuards:
         """
 
         base_p, cand_p = tmp_path / "baseline.jsonl", tmp_path / "candidate.jsonl"
-        self._write(
+        _write_jsonl(
             base_p,
             [{**_row("valid"), "question_text": f"Q{i}?"} for i in range(3)],
         )
-        self._write(cand_p, cand)
+        _write_jsonl(cand_p, cand)
         monkeypatch.setattr(
             sys,
             "argv",
@@ -808,8 +831,8 @@ class TestMainRowGuards:
         """
         base, cand = _arm_pair(100, candidate_fails_on={0, 1, 2})
         base_p, cand_p = tmp_path / "baseline.jsonl", tmp_path / "candidate.jsonl"
-        self._write(base_p, base)
-        self._write(cand_p, cand)
+        _write_jsonl(base_p, base)
+        _write_jsonl(cand_p, cand)
 
         monkeypatch.setattr(
             sys,
@@ -819,7 +842,21 @@ class TestMainRowGuards:
         ci_replay.main()
         out = capsys.readouterr().out
         assert "Computed on 97 markets" in out, "main() scored the arms unpaired"
-        # Brier row: candidate must be the WORSE number once paired.
-        brier_row = next(line for line in out.splitlines() if "Brier score" in line)
-        b_val, c_val = (float(x) for x in brier_row.split("|")[2:4])
+        # Health must still describe the FULL arm. Sourcing it from the
+        # paired subset would read "0 of 97" and delete the signal.
+        assert "no usable prediction on 3 of 100 markets" in out
+        # Locate the Brier columns via the table HEADER rather than fixed
+        # offsets: hardcoding them makes an added column raise ValueError
+        # (a table-formatting error) instead of failing as a regression.
+        lines = out.splitlines()
+        header = next(line for line in lines if "| Metric" in line)
+        cols = [c.strip() for c in header.split("|")]
+        # Match by PREFIX: the baseline label carries the row source
+        # ("Baseline (prod)" / "Baseline (tourn)") and the candidate is
+        # "Candidate (PR)".
+        b_i = next(i for i, c in enumerate(cols) if c.startswith("Baseline"))
+        c_i = next(i for i, c in enumerate(cols) if c.startswith("Candidate"))
+        brier_row = next(line for line in lines if "Brier score" in line)
+        cells = [c.strip() for c in brier_row.split("|")]
+        b_val, c_val = float(cells[b_i]), float(cells[c_i])
         assert c_val > b_val, f"paired candidate must be worse, got {brier_row}"

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -108,8 +108,8 @@ class TestReliabilityBlock:
         candidate = self._metrics([_row("valid")] * 5)
         lines = _format_reliability_block(candidate, [], _stats(accepted=5))
         text = "\n".join(lines)
-        assert "Candidate parse rate: 5/5 (100.0%) ✅" in text
-        assert "Production parse rate: 5/5 (100.0%)" in text
+        assert "Candidate returned no usable prediction on 0 of 5 markets ✅" in text
+        assert "Drawn from 5 usable production deliveries." in text
         # Breakdown is hidden when candidate is at 100%.
         assert "Breakdown:" not in text
         # Scoping rejections are expected noise and never reported.
@@ -122,7 +122,7 @@ class TestReliabilityBlock:
         candidate = self._metrics([_row("valid")] * 7 + [_row("malformed", None)] * 3)
         lines = _format_reliability_block(candidate, [], _stats(accepted=10))
         text = "\n".join(lines)
-        assert "Candidate parse rate: 7/10 (70.0%) ⚠️" in text
+        assert "Candidate returned no usable prediction on 3 of 10 markets ⚠️" in text
         assert "malformed=3" in text
 
     def test_not_valid_parse_is_not_a_warning(self) -> None:
@@ -140,7 +140,7 @@ class TestReliabilityBlock:
         text = "\n".join(lines)
         assert "⚠️" not in text
         # 5 / (5 + 2) = 71.4%
-        assert "Production parse rate: 5/7 (71.4%)" in text
+        assert "2 of 7 production deliveries were left out" in text
 
     def test_scoping_rejections_are_not_reported(self) -> None:
         """Scoping buckets (wrong_tool etc.) are rows for other tools — pure noise."""
@@ -168,7 +168,7 @@ class TestReliabilityBlock:
             assert bucket not in text
         assert "⚠️" not in text
         # Scoping rejections do not affect the production parse rate either.
-        assert "Production parse rate: 5/5 (100.0%)" in text
+        assert "Drawn from 5 usable production deliveries." in text
 
     def test_production_parse_rate_rendered_with_rejections(self) -> None:
         """Render ``accepted/(accepted+not_valid_parse)`` as a percentage.
@@ -182,7 +182,7 @@ class TestReliabilityBlock:
             candidate, [], _stats(accepted=100, not_valid_parse=35)
         )
         text = "\n".join(lines)
-        assert "Production parse rate: 100/135 (74.1%)" in text
+        assert "35 of 135 production deliveries were left out" in text
 
     def test_production_parse_rate_at_100_when_no_parse_rejections(self) -> None:
         """Zero not_valid_parse rejections: rate is 100%, but still rendered.
@@ -197,20 +197,20 @@ class TestReliabilityBlock:
             _stats(accepted=50, wrong_tool=3, no_outcome=1),
         )
         text = "\n".join(lines)
-        assert "Production parse rate: 50/50 (100.0%)" in text
+        assert "Drawn from 50 usable production deliveries." in text
 
     def test_production_parse_rate_omitted_when_no_sidecar(self) -> None:
         """Older pipelines (no filter_stats) don't render the production rate line."""
         candidate = self._metrics([_row("valid")] * 5)
         text = "\n".join(_format_reliability_block(candidate, [], None))
-        assert "Production parse rate" not in text
+        assert "**Sample**" not in text
 
     def test_prefilter_omitted_when_stats_none(self) -> None:
         """Older pipelines (no sidecar) render without the production parse line."""
         candidate = self._metrics([_row("valid")] * 3)
         text = "\n".join(_format_reliability_block(candidate, [], None))
-        assert "Production parse rate" not in text
-        assert "Candidate parse rate" in text
+        assert "**Sample**" not in text
+        assert "Candidate returned no usable prediction" in text
 
     def test_failure_bodies_rendered_in_collapsed_details(self) -> None:
         """Failure bodies inline under a <details> so the PR comment stays tidy."""
@@ -276,16 +276,16 @@ class TestFormatReportEndToEnd:
         baseline = compute_metrics([_row("valid")] * 3)
         candidate = compute_metrics([_row("valid")] * 3)
         report = format_report(baseline, candidate, {"tool": "superforcaster"})
-        assert "**Reliability**" in report
+        assert "**Candidate health**" in report
         assert "| Metric |" in report
-        assert report.index("| Metric |") < report.index("**Reliability**")
+        assert report.index("| Metric |") < report.index("**Candidate health**")
 
     def test_report_renders_without_failures_or_filter_stats(self) -> None:
         """format_report works on its minimal arg set (older pipelines)."""
         baseline = compute_metrics([_row("valid")] * 3)
         candidate = compute_metrics([_row("valid")] * 3)
         report = format_report(baseline, candidate, {"tool": "superforcaster"})
-        assert "Candidate parse rate: 3/3 (100.0%) ✅" in report
+        assert "Candidate returned no usable prediction on 0 of 3 markets ✅" in report
         assert "Pre-filter" not in report
         assert "<details><summary>Candidate parse failures" not in report
 
@@ -321,7 +321,7 @@ class TestFormatReportEndToEnd:
             filter_stats=_stats(accepted=3, wrong_tool=10, no_outcome=2),
         )
         # Scoping rejections don't enter the ratio or raise a warning.
-        assert "Production parse rate: 3/3 (100.0%)" in report
+        assert "Drawn from 3 usable production deliveries." in report
         assert "⚠️" not in report
 
     def test_not_valid_parse_lowers_rate_without_warning_in_full_report(self) -> None:
@@ -334,7 +334,7 @@ class TestFormatReportEndToEnd:
             {"tool": "superforcaster"},
             filter_stats=_stats(accepted=3, not_valid_parse=1),
         )
-        assert "Production parse rate: 3/4 (75.0%)" in report
+        assert "1 of 4 production deliveries were left out" in report
         assert "⚠️" not in report
 
 
@@ -437,7 +437,7 @@ class TestFormatReportFooter:
             trigger_comment_url="https://example.com/c",
         )
         footer = report.splitlines()[-1]
-        assert footer.index("deliveries") < footer.index("seed 1337")
+        assert footer.index("scored") < footer.index("seed 1337")
         assert footer.index("seed 1337") < footer.index("LOCKhart07")
 
 
@@ -481,5 +481,5 @@ class TestTournamentSourcedComment:
         """The production path must keep its existing rendering."""
         candidate = self._metrics([_row("valid")] * 5)
         text = "\n".join(_format_reliability_block(candidate, [], _stats(accepted=5)))
-        assert "Production parse rate: 5/5 (100.0%)" in text
+        assert "Drawn from 5 usable production deliveries." in text
         assert "tournament arm" not in text

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -19,6 +19,7 @@ from benchmark.prompt_replay import (
     _assert_prompt_is_replayable,
     _baseline_family,
     _default_family_system_prompt,
+    _drop_reason_detail,
     _extract_factual_research_prompt_components,
     _get_structured_output_schema,
     _load_and_filter_rows,
@@ -295,13 +296,17 @@ class TestStratifiedSampleBudget:
     """`--sample N` must return exactly N rows."""
 
     @staticmethod
-    def _pool(n: int) -> list:
+    def _pool(n: int, pool_seed: int = 1) -> list:
         """A pool spanning every (outcome, brier-bucket) stratum.
 
         :param n: how many rows.
+        :param pool_seed: seed for the pool SHAPE (stratum sizes), which is
+            what decides whether the proportional pass rounds up. Varying it
+            is what makes the budget assertion bite above the smallest
+            budgets -- one fixed shape only overshoots at budget=10.
         :return: rows.
         """
-        rng = random.Random(1)
+        rng = random.Random(pool_seed)
         return [
             {
                 "platform": "polymarket",
@@ -313,7 +318,8 @@ class TestStratifiedSampleBudget:
         ]
 
     @pytest.mark.parametrize("budget", [10, 50, 100, 300, 500])
-    def test_returns_exactly_the_budget(self, budget: int) -> None:
+    @pytest.mark.parametrize("pool_seed", range(8))
+    def test_returns_exactly_the_budget(self, budget: int, pool_seed: int) -> None:
         """Neither the per-stratum floor nor round() may overshoot.
 
         Both could: the floor gives every non-empty stratum a row (so a budget
@@ -322,9 +328,17 @@ class TestStratifiedSampleBudget:
         301 and `--sample 10` returned 12. Budgets BELOW the stratum count are
         excluded here: that overshoot is deliberate and pinned separately.
 
+        The pool SHAPE, not the budget, decides whether rounding overshoots --
+        against a single fixed pool only `budget=10` regressed, so the other
+        four budgets passed with the fix removed and the parametrisation
+        promised coverage it did not deliver. Varying the pool seed pins the
+        fix at every budget.
+
         :param budget: requested sample size.
+        :param pool_seed: seed for the pool shape.
         """
-        assert len(stratified_sample(self._pool(2000), budget, seed=42)) == budget
+        pool = self._pool(2000, pool_seed)
+        assert len(stratified_sample(pool, budget, seed=42)) == budget
 
     def test_budget_above_pool_returns_the_pool(self) -> None:
         """Asking for more than exists yields everything, not an error."""
@@ -2105,3 +2119,100 @@ class TestPrefilterBreakdownVocabulary:
         assert "duplicate=0" in text
         assert "wrong_tool=7" in text
         assert "not_valid_parse=2" in text
+
+
+class TestEnrichmentLossRecorded:
+    """Rows lost to IPFS enrichment must be attributable, not silent."""
+
+    def test_sidecar_records_the_enrichment_shortfall(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """Rows dropped between the sample and the write land in the sidecar.
+
+        They leave on bare ``continue``s with no bucket, so without this the
+        pool size and the scored count cannot be reconciled by a reader.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row(deliver_id=f"0x{i}") for i in range(5)])
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        # 5 rows in, only 2 survive enrichment.
+        monkeypatch.setattr(
+            pr,
+            "_fetch_and_extract_prompts",
+            lambda rows, *a, **k: [
+                {
+                    **r,
+                    "extracted_user_prompt": "q",
+                    "extracted_additional_information": "e",
+                }
+                for r in rows[:2]
+            ],
+        )
+        output = tmp_path / "out" / "dataset.jsonl"
+        pr.enrich(log_path, "superforcaster", output)
+        stats = json.loads(
+            output.with_name(output.name + ".filter_stats.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert stats["enrichment_failed"] == 3
+        assert stats["accepted"] == 5, "the pool count must stay as-is"
+
+    def test_no_key_when_nothing_was_lost(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """A clean enrichment writes no shortfall key.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row(deliver_id=f"0x{i}") for i in range(3)])
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        monkeypatch.setattr(
+            pr,
+            "_fetch_and_extract_prompts",
+            lambda rows, *a, **k: [
+                {
+                    **r,
+                    "extracted_user_prompt": "q",
+                    "extracted_additional_information": "e",
+                }
+                for r in rows
+            ],
+        )
+        output = tmp_path / "out" / "dataset.jsonl"
+        pr.enrich(log_path, "superforcaster", output)
+        stats = json.loads(
+            output.with_name(output.name + ".filter_stats.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert "enrichment_failed" not in stats
+
+
+class TestDropReasonDetail:
+    """The failure clause must be arithmetically self-consistent."""
+
+    def test_all_drop_reasons_listed(self) -> None:
+        """Every reason is shown, so the total always sums to the visible list.
+
+        Showing only the top 3 beside a total summed over ALL reasons reads as
+        an arithmetic error to anyone who adds them up.
+        """
+        detail = _drop_reason_detail(
+            {"no_evidence": 10, "bad_json": 5, "wrong_tool": 1, "duplicate": 1}
+        )
+        assert detail.startswith(" (17 tournament row(s) dropped: ")
+        for reason in ("no_evidence=10", "bad_json=5", "wrong_tool=1", "duplicate=1"):
+            assert reason in detail, f"{reason} missing"
+        # The listed counts must reconcile to the stated total.
+        shown = detail.split(": ", 1)[1].rstrip(")")
+        assert sum(int(p.split("=")[1]) for p in shown.split(", ")) == 17
+
+    def test_empty_when_files_were_absent(self) -> None:
+        """An empty dict means the tournament files were absent."""
+        assert _drop_reason_detail({}) == ""

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import random
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -286,6 +287,57 @@ class TestEnrichZeroRows:
         assert "platform=polymarket" in str(exc.value)
         assert not output.exists()
         assert (tmp_path / "out" / "dataset.jsonl.filter_stats.json").exists()
+
+
+class TestStratifiedSampleBudget:
+    """`--sample N` must return exactly N rows."""
+
+    @staticmethod
+    def _pool(n: int) -> list:
+        """A pool spanning every (outcome, brier-bucket) stratum.
+
+        :param n: how many rows.
+        :return: rows.
+        """
+        rng = random.Random(1)
+        return [
+            {
+                "platform": "polymarket",
+                "final_outcome": rng.random() < 0.5,
+                "p_yes": round(rng.random(), 3),
+                "row_id": f"r{i}",
+            }
+            for i in range(n)
+        ]
+
+    @pytest.mark.parametrize("budget", [10, 50, 100, 300, 500])
+    def test_returns_exactly_the_budget(self, budget: int) -> None:
+        """Neither the per-stratum floor nor round() may overshoot.
+
+        Both could: the floor gives every non-empty stratum a row (so a budget
+        below the stratum count overshot), and the proportional pass rounds.
+        Only the deficit direction was corrected, so `--sample 300` returned
+        301 and `--sample 10` returned 12. Budgets BELOW the stratum count are
+        excluded here: that overshoot is deliberate and pinned separately.
+
+        :param budget: requested sample size.
+        """
+        assert len(stratified_sample(self._pool(2000), budget, seed=42)) == budget
+
+    def test_budget_above_pool_returns_the_pool(self) -> None:
+        """Asking for more than exists yields everything, not an error."""
+        assert len(stratified_sample(self._pool(120), 500, seed=42)) == 120
+
+    def test_budget_below_stratum_count_keeps_every_stratum(self) -> None:
+        """Fewer budget than strata is the ONE case allowed to exceed N.
+
+        Covering every (outcome, brier-bucket) stratum matters more than the
+        exact count there -- dropping strata biases the sample. Pinned by
+        ``TestStratifiedSampleSinglePlatform.test_per_stratum_floor_can_exceed_budget``;
+        this test exists so the budget fix is not later mistaken for licence
+        to break that trade.
+        """
+        assert len(stratified_sample(self._pool(600), 5, seed=42)) > 5
 
 
 class TestStratifiedSampleSinglePlatform:

--- a/benchmark/tests/test_prompt_replay.py
+++ b/benchmark/tests/test_prompt_replay.py
@@ -26,7 +26,9 @@ from benchmark.prompt_replay import (
     _log_replay_summary,
     _parse_vllm_candidate,
     _prepare_output_dir,
+    _render_tournament_evidence,
     _replay_vllm_candidate,
+    _write_replay_rows,
     enrich,
     extract_prompt_components,
     main,
@@ -1764,3 +1766,342 @@ class TestTournamentFallback:
         assert not _load_tournament_rows(
             "t", "polymarket", tmp_path / "no.jsonl", tmp_path / "no2.jsonl"
         )[0]
+
+
+class TestTournamentArmReportingFixes:
+    """Provenance/diagnostic behaviours of the tournament arm.
+
+    Every assertion here pins a fix whose visible effect is a string in a log
+    line, a key in the sidecar, or which writer got called -- none of which
+    the rest of the suite constrains. Without them each fix reverts silently
+    with the suite still green.
+    """
+
+    @staticmethod
+    def _write(path: Path, rows: list[dict]) -> None:
+        """Write JSONL rows to path.
+
+        :param path: destination.
+        :param rows: rows to serialise.
+        """
+        path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+    def _tournament_pair(self, tmp_path: Path, n: int = 1) -> tuple[Path, Path]:
+        """Build a minimal scored/predictions pair the fallback can consume.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param n: how many replayable rows to emit.
+        :return: (scored path, predictions path).
+        """
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": f"t{i}",
+                    "tool_name": "superforcaster",
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": True,
+                }
+                for i in range(n)
+            ],
+        )
+        self._write(
+            preds, [{"row_id": f"t{i}", "source_content": "evidence"} for i in range(n)]
+        )
+        return scored, preds
+
+    def test_fallback_reason_counts_sampled_rows_not_the_whole_pool(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """``fallback_reason`` must name the rows actually handed to IPFS.
+
+        Sampling happens before enrichment, so a 6-row pool cut to 2 attempts
+        exactly 2 fetches. Reporting the pre-sample 6 reads as "all 6 failed"
+        -- and this string reaches the PR comment verbatim.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(
+            log_path,
+            [
+                {
+                    **_row(deliver_id=f"0x{i}", platform="polymarket"),
+                    "p_yes": 0.6,
+                }
+                for i in range(6)
+            ],
+        )
+        scored, preds = self._tournament_pair(tmp_path)
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        monkeypatch.setattr(pr, "_fetch_and_extract_prompts", lambda *a, **k: [])
+
+        output = tmp_path / "out" / "dataset.jsonl"
+        pr.enrich(
+            log_path,
+            "superforcaster",
+            output,
+            sample_per_platform=2,
+            tournament_scored=scored,
+            tournament_predictions=preds,
+        )
+        stats = json.loads(
+            output.with_name(output.name + ".filter_stats.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert stats["fallback_reason"].startswith(
+            "2 production rows"
+        ), f"must report the sampled count, got {stats['fallback_reason']!r}"
+        assert (
+            stats["production_attempt"]["accepted"] == 6
+        ), "the full pool size must stay available under production_attempt"
+
+    def test_tournament_sidecar_does_not_double_write_no_row_id(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """A dropped-for-no-row_id row is a rejection, not a kept-row warning.
+
+        Top-level ``no_row_id`` means "rows we KEPT that lacked one". The
+        tournament arm drops them, so the count belongs in ``rejected`` only;
+        emitting it in both places double-counts the same rows.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row()])
+        scored, preds = self._tournament_pair(tmp_path)
+        with open(scored, "a", encoding="utf-8") as handle:
+            for _ in range(2):
+                handle.write(
+                    json.dumps(
+                        {
+                            "tool_name": "superforcaster",
+                            "platform": "polymarket",
+                            "question_text": "Q?",
+                            "p_yes": 0.6,
+                            "p_no": 0.4,
+                            "final_outcome": True,
+                        }
+                    )
+                    + "\n"
+                )
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        monkeypatch.setattr(pr, "_fetch_and_extract_prompts", lambda *a, **k: [])
+
+        output = tmp_path / "out" / "dataset.jsonl"
+        pr.enrich(
+            log_path,
+            "superforcaster",
+            output,
+            tournament_scored=scored,
+            tournament_predictions=preds,
+        )
+        stats = json.loads(
+            output.with_name(output.name + ".filter_stats.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert stats["rejected"]["no_row_id"] == 2, "the drop must be recorded once"
+        assert (
+            stats["no_row_id"] == 0
+        ), "the kept-row diagnostic is 0 by construction on the tournament arm"
+
+    def test_exit_message_names_the_dominant_drop_reason(self, tmp_path: Path) -> None:
+        """Both arms empty must say WHY, not just that they were.
+
+        A roster/name mismatch (every row ``wrong_tool``) and a genuinely
+        absent tool are indistinguishable without it.
+
+        :param tmp_path: pytest tmp_path fixture.
+        """
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row(tool="something-else")])
+        scored = tmp_path / "s.jsonl"
+        preds = tmp_path / "p.jsonl"
+        self._write(
+            scored,
+            [
+                {
+                    "row_id": f"t{i}",
+                    "tool_name": "a-different-tool",
+                    "platform": "polymarket",
+                    "question_text": "Q?",
+                    "p_yes": 0.6,
+                    "p_no": 0.4,
+                    "final_outcome": True,
+                }
+                for i in range(3)
+            ],
+        )
+        self._write(preds, [{"row_id": "t0", "source_content": "e"}])
+
+        with pytest.raises(SystemExit) as exc:
+            pr.enrich(
+                log_path,
+                "superforcaster",
+                tmp_path / "out" / "dataset.jsonl",
+                tournament_scored=scored,
+                tournament_predictions=preds,
+            )
+        assert "wrong_tool=3" in str(
+            exc.value
+        ), f"must name the dominant drop reason, got {exc.value!r}"
+
+    def test_production_write_goes_through_the_shared_writer(
+        self, tmp_path: Path, monkeypatch: Any
+    ) -> None:
+        """The production path must use ``_write_replay_rows`` like the fallback.
+
+        A second inline writer is how the two paths' on-disk bytes drift apart
+        (``ensure_ascii``, trailing newline) without any test noticing.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        calls: list[int] = []
+        real = _write_replay_rows
+
+        def _spy(output: Path, rows: list) -> None:
+            """Record the call, then delegate.
+
+            :param output: destination path.
+            :param rows: rows to write.
+            """
+            calls.append(len(rows))
+            real(output, rows)
+
+        monkeypatch.setattr(pr, "_write_replay_rows", _spy)
+        log_path = tmp_path / "log.jsonl"
+        _write_jsonl(log_path, [_row()])
+        monkeypatch.setattr(pr, "_fetch_ipfs_hashes_for_deliver_ids", lambda *a: {})
+        monkeypatch.setattr(
+            pr,
+            "_fetch_and_extract_prompts",
+            lambda rows, *a, **k: [
+                {
+                    **r,
+                    "extracted_user_prompt": "q",
+                    "extracted_additional_information": "e",
+                }
+                for r in rows
+            ],
+        )
+        output = tmp_path / "out" / "dataset.jsonl"
+        pr.enrich(log_path, "superforcaster", output)
+        assert calls == [1], "production must write via the shared writer"
+
+    def test_unrenderable_evidence_logs_the_exception(self, caplog: Any) -> None:
+        """The drop warning must carry the traceback that caused it.
+
+        The except clause spans five exception types; without ``exc_info`` a
+        whole enrich run can drop every row and leave no way to tell which of
+        the five fired, or where.
+
+        :param caplog: pytest caplog fixture.
+        """
+        with caplog.at_level("WARNING"):
+            result = _render_tournament_evidence(
+                "superforcaster",
+                # A list of strings breaks `item.get(...)` inside the formatter.
+                {"mode": "x", "serper_response": {"organic": ["not-a-dict"]}},
+            )
+        assert result is None
+        drops = [r for r in caplog.records if "cannot render" in r.getMessage()]
+        assert drops, "the drop must be logged"
+        assert drops[0].exc_info is not None, "the warning must carry the traceback"
+
+
+class TestPrefilterBreakdownVocabulary:
+    """The Pre-filter breakdown must use the vocabulary of its own source."""
+
+    def _summary(self, tmp_path: Path, caplog: Any, stats: dict) -> str:
+        """Run ``_log_replay_summary`` with ``stats`` and return the log text.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param caplog: pytest caplog fixture.
+        :param stats: the sidecar dict to render.
+        :return: captured log text.
+        """
+        candidate = tmp_path / "candidate.jsonl"
+        _write_jsonl(candidate, [{"p_yes": 0.8, "p_no": 0.2, "final_outcome": True}])
+        with caplog.at_level("INFO"):
+            _log_replay_summary(
+                sampled=[
+                    {"p_yes": 0.7, "p_no": 0.3, "final_outcome": True, "tool_name": "x"}
+                ],
+                candidate_path=candidate,
+                baseline_brier_sum=0.1,
+                candidate_brier_sum=0.2,
+                total=1,
+                n_scored=1,
+                baseline_path=candidate,
+                status_counts={
+                    "valid": 1,
+                    "missing_fields": 0,
+                    "malformed": 0,
+                    "error": 0,
+                },
+                filter_stats=stats,
+            )
+        return caplog.text
+
+    def test_tournament_breakdown_uses_tournament_reasons(
+        self, tmp_path: Path, caplog: Any
+    ) -> None:
+        """Tournament drops must render as themselves, not as zeroed scoping buckets.
+
+        Enumerating SCOPING_BUCKETS on a tournament sidecar printed six
+        production buckets at zero beside a non-zero total -- a line that
+        contradicts itself.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param caplog: pytest caplog fixture.
+        """
+        text = self._summary(
+            tmp_path,
+            caplog,
+            {
+                "source": "tournament",
+                "accepted": 1,
+                "rejected": {"no_evidence": 950, "unrenderable": 3},
+                "no_row_id": 0,
+                "production_attempt": {"accepted": 0},
+                "fallback_reason": "0 production rows",
+            },
+        )
+        assert "Rejected: 953" in text
+        assert "no_evidence=950" in text
+        assert "unrenderable=3" in text
+        assert (
+            "duplicate=0" not in text
+        ), "production buckets must not be printed for a tournament sidecar"
+
+    def test_production_breakdown_still_enumerates_every_bucket(
+        self, tmp_path: Path, caplog: Any
+    ) -> None:
+        """Production keeps enumerating zero buckets: a vanished bucket is a signal.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param caplog: pytest caplog fixture.
+        """
+        text = self._summary(
+            tmp_path,
+            caplog,
+            {
+                "source": "production",
+                "accepted": 1,
+                "rejected": {"duplicate": 0, "wrong_tool": 7, "not_valid_parse": 2},
+                "no_row_id": 0,
+            },
+        )
+        assert "duplicate=0" in text
+        assert "wrong_tool=7" in text
+        assert "not_valid_parse=2" in text


### PR DESCRIPTION
> Stacked on **#419** — review/merge that first.

## The problem

The verdict comment printed two parse rates side by side:

```
Candidate parse rate:  301/301 (100.0%) ✅
Production parse rate: 555/574  (96.7%)
```

They are not comparable, for three independent reasons:

1. **Different machinery.** The production status was recorded by the real mech — on-chain delivery, production timeouts. The candidate's comes from a direct API call in CI.
2. **Different populations.** `enrich` drops rows whose *production* output was unparseable (no baseline number to score against), so the candidate is only ever tested on markets production already handled. The rows that actually broke production are removed before it runs.
3. **The production figure isn't the baseline's rate on the sample at all** — it's `accepted / (accepted + not_valid_parse)` over the whole pool. A provenance statistic wearing a tool-metric label.

**This already produced a false conclusion.** On [#417](https://github.com/valory-xyz/mech-predict/pull/417#issuecomment-5127937960) the agent read that pair and wrote:

> *"Parse rate: 100% candidate vs 96.7% production — **output-contract fix confirmed working**"*

The one evidence that could have supported it — the 19 markets that broke production — is exactly what the comparison excludes.

## After

```
*Computed on 297 markets where both arms produced a usable prediction.*

**Candidate health**
- Candidate returned no usable prediction on 3 of 300 markets ⚠️ (excluded from the metrics above).

**Sample**
- Drawn from 555 usable production deliveries.
- 19 of 574 production deliveries were left out of the pool: the production run itself
  returned no usable number, so there is nothing for a candidate to be scored against
  on those markets.

*297 scored | seed 42 | triggered by …*
```

The candidate's failure count still does real work — it flags a broken candidate and shrinks the comparison set — it just stops being framed as a duel. The metrics table now states its denominator, which was previously invisible.

## Also: `--sample N` returned N+1

`round()` in the proportional pass could overshoot and only the *deficit* direction was corrected. Measured on realistic pools:

| Budget | Before | After |
|---|---|---|
| 300 | **301** in 11 of 40 pools | 300 in 40 of 40 |
| 10 | **12** | 10 |
| 3 (fewer than the 6 strata) | 6 | **6 — unchanged, deliberately** |

The last row is left alone: when there are more non-empty strata than budget, covering every stratum matters more than the exact count, because dropping strata biases the sample. That trade is already pinned by `test_per_stratum_floor_can_exceed_budget`, and I nearly broke it — the narrower fix corrects rounding only.

## Tests

1410 pass. Mutation-tested: removing the surplus correction fails the budget test; the report changes are pinned by the retargeted `ci_replay` assertions.

### For a new-version PR (baseline ≠ candidate) the header names both sides

```
## Benchmark: superforcaster-polymarket-v2 → superforcaster-polymarket-v5 — Polymarket

| Metric | Baseline v2 (production) | Candidate v5 (this PR) | Delta |
|--------|--------------------------|------------------------|-------|
| Brier score | 0.3188 | 0.3147 | −1.3% |

*Computed on 301 markets where both arms produced a usable prediction.*

**Candidate health**
- Candidate returned no usable prediction on 0 of 301 markets ✅.
```

For an in-place edit both sides carry the same tool name, so the header says so explicitly — `v4 vs v4` in a table is otherwise baffling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)