### PR TITLE
ci: unblock linter_checks (safety import crash) + fix a clock-dependent test

### DIFF
--- a/.github/workflows/common_checks.yaml
+++ b/.github/workflows/common_checks.yaml
@@ -88,6 +88,16 @@ jobs:
       - name: Install dependencies
         run: pip install 'tomte[tox,cli] @ git+https://github.com/valory-xyz/tomte.git@v0.7.0' tox-uv
       - name: Security checks
+        env:
+          # nltk 3.10.1 (pulled in transitively by `safety`) installs an import
+          # hook that refuses any nltk-initiated import resolving INSIDE the
+          # current working directory. tox puts its venvs in `.tox/` at the
+          # repo root, so `regex` -- a normal site-packages dependency -- counts
+          # as "in the CWD" and `safety` dies on import before it can check
+          # anything. The hook's own suggestion (PYTHONSAFEPATH) does not help:
+          # it blocks on the module's resolved ORIGIN, not on sys.path. Moving
+          # the venvs out of the repo is what actually satisfies it.
+          TOX_WORK_DIR: ${{ runner.temp }}/tox
         run: tomte tox -p -e safety -e bandit
       - name: Check packages
         run: tomte tox -e check-packages

--- a/benchmark/tests/test_analyze.py
+++ b/benchmark/tests/test_analyze.py
@@ -3259,7 +3259,7 @@ class TestStartOfCurrentMonthUtc:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """Anchors to the 1st of the current UTC month at 00:00:00."""
-        from benchmark import analyze
+        from benchmark import analyze, scoring_primitives
 
         # Wrap ``datetime`` in a small shim so the helper sees a fixed
         # ``now()`` while other datetime ops go through the real class.
@@ -3274,7 +3274,13 @@ class TestStartOfCurrentMonthUtc:
                 """Return the fixed test datetime for any tz."""
                 return fixed_now if tz is None else fixed_now.astimezone(tz)
 
-        monkeypatch.setattr(analyze, "datetime", _DatetimeShim)
+        # Patch ``scoring_primitives``, not ``analyze``: the helper is a thin
+        # delegate to ``scoring_primitives.start_of_current_month_utc``, so the
+        # name it reads at call time lives in THAT module. Patching `analyze`
+        # left the real clock in play and the assertion below passed only while
+        # the wall clock happened to be in the hardcoded month -- it began
+        # failing on the 1st of the next one.
+        monkeypatch.setattr(scoring_primitives, "datetime", _DatetimeShim)
         result = analyze._start_of_current_month_utc()
         assert result == _datetime(2026, 7, 1, 0, 0, 0, tzinfo=_timezone.utc)
 


### PR DESCRIPTION
## Why

CI in this repo is currently red on `main` and on every open PR, for two independent reasons. Neither is related to any feature branch.

### 1. `safety` crashes on import, taking the whole job with it

`nltk 3.10.1` — pulled in transitively by `safety`'s typosquatting module — installs an import hook that refuses **any nltk-initiated import that resolves inside the current working directory**. tox puts its venvs in `.tox/` at the repo root, so `regex`, an ordinary site-packages dependency, resolves "inside the CWD" and the import dies:

```
ImportError: Blocked import of regex from current working directory for security reasons.
```

`safety` never gets to check anything — this is a crash, not a reported vulnerability.

The blast radius is larger than it looks, because `Security checks` is the **first** step in `linter_checks`:

| | |
|---|---|
| `Security checks` | ❌ fails |
| `Check packages` / `Check hash` / `Code checks` / `AbciApp consistency checks` | ⏭️ skipped — never run |
| `test`, `integration_tests` (`needs: linter_checks`) | ⏭️ skipped — **no tests run on any PR** |

So today the lint gates and the entire test suite are silently not executing.

**Fix:** move tox's venvs out of the working directory. The hook's own error message suggests `PYTHONSAFEPATH`, which does **not** work — it blocks on the module's resolved *origin*, not on `sys.path`. Verified both ways locally:

| Attempt | Result |
|---|---|
| `PYTHONSAFEPATH=1` | ❌ still `ImportError` |
| `TOX_WORK_DIR` outside the repo | 🟢 `No known security vulnerabilities reported` |

This is a workaround for an upstream interaction (nltk's hook vs. tox's default venv location); worth raising against tomte so the pin/config lives there, but this unblocks the repo now.

### 2. `TestStartOfCurrentMonthUtc` is clock-dependent, and was false-green

The test monkeypatches `analyze.datetime`, but `_start_of_current_month_utc()` is a thin delegate to `scoring_primitives.start_of_current_month_utc()`, which reads `scoring_primitives.datetime`. The shim patched a name the code under test never consults, so the helper **always read the real clock** — the test passed only while the wall clock happened to agree with the hardcoded `2026, 7, 1`. It began failing on 1 August.

**Fix:** patch the module the function actually reads.

## Verification

- `1404 passed`, zero failures (previously 1 failure).
- The corrected test now **follows the shim**: pointing `fixed_now` at an unrelated month (`2025-03`) makes the assertion track it, confirming it is genuinely clock-independent rather than merely re-pinned to today.
- Reverting the one-line patch target reproduces the failure, so the fix is load-bearing.
- `safety` reproduced locally before the change and passes after it; `black`, `isort`, `flake8`, `darglint` all green.
- Workflow change is one `env:` key on a single step; every other step is untouched.

Suggested merge order: this first, then #420 — which cannot get a meaningful green run until `linter_checks` stops short-circuiting.
