### PR TITLE
feat(scripts): parity verifier gets coverage check + K8s-Job artifact output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Only used by Dockerfile.verify today. If more Dockerfiles land, tighten
+# this per-image with named contexts rather than making it broader.
+
+# Test fixtures and captured logs — never needed inside the image.
+benchmark/tests/
+benchmark/datasets/logs/
+benchmark/datasets/logs_fresh/
+tests/
+
+# Build artifacts and caches.
+.venv/
+.tox/
+.mypy_cache/
+.pytest_cache/
+.coverage
+__pycache__/
+*.pyc
+
+# Local scratch.
+state/
+results/
+production_log*.jsonl
+*.docx

--- a/.github/workflows/publish-verify-image.yaml
+++ b/.github/workflows/publish-verify-image.yaml
@@ -4,15 +4,30 @@ name: Publish verify image
 # a K8s Job for the mech-analytics parity verification (Dockerfile.verify,
 # entry point is scripts/verify_migration_swap.py).
 #
-# Publishes on release only. Tag stripped of the leading v to match the
-# existing release.yaml convention (v0.5.4 → valory/mech-predict-verify:0.5.4).
+# * On release: builds AND pushes tagged image to Docker Hub.
+# * On PR touching Dockerfile.verify, the verify script, the workflow,
+#   or the deps that end up in the image: builds only (no push, no
+#   credentials needed) and runs ``--help`` against the built image so
+#   the entry point wiring is exercised end-to-end. Prevents shipping a
+#   broken Dockerfile (chown ordering, PYTHONPATH, deps drift) whose
+#   only signal today is "infra tries to run it and it crashes".
 
 on:
   release:
     types: [prereleased, released]
+  pull_request:
+    paths:
+      - "Dockerfile.verify"
+      - ".dockerignore"
+      - "scripts/verify_migration_swap.py"
+      - "benchmark/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/publish-verify-image.yaml"
 
 jobs:
   publish:
+    if: github.event_name == 'release'
     runs-on: ubuntu-22.04
     env:
       IMAGE: valory/mech-predict-verify
@@ -47,3 +62,33 @@ jobs:
           # revision without needing git inside the runtime image.
           build-args: |
             GIT_SHA=${{ github.sha }}
+
+  build-only:
+    # PR-triggered smoke build — no registry push, no secrets required,
+    # so it runs safely on fork PRs. Load the image into the local
+    # Docker daemon and invoke ``--help`` to catch any regression in
+    # Dockerfile layer ordering, PYTHONPATH, or entrypoint that would
+    # otherwise only surface when infra tries to run the released tag.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
+    env:
+      IMAGE: valory/mech-predict-verify:pr-${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.verify
+          push: false
+          load: true
+          tags: ${{ env.IMAGE }}
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+
+      - name: Smoke-test entrypoint
+        run: docker run --rm ${{ env.IMAGE }} --help

--- a/.github/workflows/publish-verify-image.yaml
+++ b/.github/workflows/publish-verify-image.yaml
@@ -42,3 +42,8 @@ jobs:
           file: Dockerfile.verify
           push: true
           tags: ${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
+          # Bake the source commit into the image so the verify script's
+          # metadata header can attribute each artifact to a specific
+          # revision without needing git inside the runtime image.
+          build-args: |
+            GIT_SHA=${{ github.sha }}

--- a/.github/workflows/publish-verify-image.yaml
+++ b/.github/workflows/publish-verify-image.yaml
@@ -4,78 +4,41 @@ name: Publish verify image
 # a K8s Job for the mech-analytics parity verification (Dockerfile.verify,
 # entry point is scripts/verify_migration_swap.py).
 #
-# Triggers:
-#   * release (prerelease or released) → tags the image with the release
-#     name (v-prefix stripped so ``v0.5.3`` → ``valory/mech-predict-verify:0.5.3``)
-#     to match the existing convention in release.yaml.
-#   * workflow_dispatch → tags the image ``dev-<short_sha>`` so infra
-#     can smoke-test the K8s Job spec off a feature branch without
-#     cutting a full release.
-#   * pull_request touching Dockerfile.verify, the script, or its
-#     imports → build only (no push, no secrets required). Keeps the
-#     Dockerfile honest: a rename or a missing dep won't ship broken
-#     because it wasn't built until release day.
+# Publishes on release only. Tag stripped of the leading v to match the
+# existing release.yaml convention (v0.5.4 → valory/mech-predict-verify:0.5.4).
 
 on:
   release:
     types: [prereleased, released]
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: "Git ref to build (branch or SHA)."
-        default: "main"
-  pull_request:
-    paths:
-      - "Dockerfile.verify"
-      - "scripts/verify_migration_swap.py"
-      - "benchmark/datasets/fetch_production.py"
-      - "benchmark/mech_analytics_client.py"
-      - "pyproject.toml"
-      - "uv.lock"
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-22.04
     env:
       IMAGE: valory/mech-predict-verify
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.ref || github.ref }}
 
       - name: Compute image tag
         id: tag
         run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            # Strip the leading "v" to match release.yaml's oar-<agent> convention.
-            tag="${GITHUB_REF_NAME#v}"
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            tag="dev-$(git rev-parse --short HEAD)"
-          else
-            # pull_request: don't push, tag is only used locally for the build step.
-            tag="pr-$(git rev-parse --short HEAD)"
-          fi
+          tag="${GITHUB_REF_NAME#v}"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "Computed tag: $tag"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # Login only when we're going to push. Pull-request runs skip the
-      # secret entirely so a fork PR can still build.
       - name: Log in to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build (and push on release / dispatch)
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: Dockerfile.verify
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-verify-image.yaml
+++ b/.github/workflows/publish-verify-image.yaml
@@ -1,0 +1,81 @@
+name: Publish verify image
+
+# Builds and pushes valory/mech-predict-verify — the image infra runs as
+# a K8s Job for the mech-analytics parity verification (Dockerfile.verify,
+# entry point is scripts/verify_migration_swap.py).
+#
+# Triggers:
+#   * release (prerelease or released) → tags the image with the release
+#     name (v-prefix stripped so ``v0.5.3`` → ``valory/mech-predict-verify:0.5.3``)
+#     to match the existing convention in release.yaml.
+#   * workflow_dispatch → tags the image ``dev-<short_sha>`` so infra
+#     can smoke-test the K8s Job spec off a feature branch without
+#     cutting a full release.
+#   * pull_request touching Dockerfile.verify, the script, or its
+#     imports → build only (no push, no secrets required). Keeps the
+#     Dockerfile honest: a rename or a missing dep won't ship broken
+#     because it wasn't built until release day.
+
+on:
+  release:
+    types: [prereleased, released]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build (branch or SHA)."
+        default: "main"
+  pull_request:
+    paths:
+      - "Dockerfile.verify"
+      - "scripts/verify_migration_swap.py"
+      - "benchmark/datasets/fetch_production.py"
+      - "benchmark/mech_analytics_client.py"
+      - "pyproject.toml"
+      - "uv.lock"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    env:
+      IMAGE: valory/mech-predict-verify
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            # Strip the leading "v" to match release.yaml's oar-<agent> convention.
+            tag="${GITHUB_REF_NAME#v}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="dev-$(git rev-parse --short HEAD)"
+          else
+            # pull_request: don't push, tag is only used locally for the build step.
+            tag="pr-$(git rev-parse --short HEAD)"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Computed tag: $tag"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Login only when we're going to push. Pull-request runs skip the
+      # secret entirely so a fork PR can still build.
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build (and push on release / dispatch)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.verify
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-verify-image.yaml
+++ b/.github/workflows/publish-verify-image.yaml
@@ -91,4 +91,14 @@ jobs:
             GIT_SHA=${{ github.sha }}
 
       - name: Smoke-test entrypoint
-        run: docker run --rm ${{ env.IMAGE }} --help
+        # ``--help`` proves the ENTRYPOINT + argparse layer wire up,
+        # but the script's ``from benchmark.datasets import ...``
+        # calls are function-local, so ``--help`` returns before
+        # touching PYTHONPATH. A second call under the same
+        # ``uv run`` interpreter that actually imports benchmark
+        # catches a broken PYTHONPATH / WORKDIR / COPY layout
+        # regression at PR time instead of at deploy time.
+        run: |
+          docker run --rm ${{ env.IMAGE }} --help
+          docker run --rm --entrypoint uv ${{ env.IMAGE }} \
+            run --no-sync python -c "from benchmark.datasets import fetch_production"

--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -42,9 +42,18 @@ WORKDIR /app
 # the entrypoint runs and puts /app/scripts on sys.path[0].
 ENV PYTHONPATH=/app
 
+# Non-root runtime — image writes to /reports which infra mounts,
+# never to /app. Create the user BEFORE ``uv sync`` so the virtualenv
+# and every file layered on top are owned by ``verifier`` at build
+# time, avoiding a redundant recursive chown of the (large) .venv tree
+# at the end of the build.
+RUN useradd --system --create-home --uid 1001 verifier \
+    && chown verifier:verifier /app
+USER verifier
+
 # Layer dep install ahead of source copy so a script edit doesn't
 # invalidate the (slow) dependency layer.
-COPY pyproject.toml uv.lock ./
+COPY --chown=verifier:verifier pyproject.toml uv.lock ./
 
 # --no-dev: the verifier doesn't need pytest, black, mypy, etc.
 # --no-install-project: the ``benchmark`` package is copied in below
@@ -54,14 +63,10 @@ RUN uv sync --frozen --no-dev --no-install-project
 
 # Copy only what the script imports. benchmark/ is the transitive
 # dep footprint; scripts/verify_migration_swap.py is the entry point.
-COPY benchmark/ ./benchmark/
-COPY scripts/verify_migration_swap.py ./scripts/verify_migration_swap.py
-
-# Non-root runtime — image writes to /reports which infra mounts,
-# never to /app.
-RUN useradd --system --create-home --uid 1001 verifier \
-    && chown -R verifier:verifier /app
-USER verifier
+COPY --chown=verifier:verifier benchmark/ ./benchmark/
+COPY --chown=verifier:verifier \
+    scripts/verify_migration_swap.py \
+    ./scripts/verify_migration_swap.py
 
 # uv.venv sits at /app/.venv; using `uv run` keeps env + interpreter
 # discovery consistent with local invocations.

--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -28,9 +28,12 @@ FROM python:3.13-slim AS base
 ARG GIT_SHA=unknown
 ENV GIT_SHA=$GIT_SHA
 
-# uv comes from its official static-linked distroless image; matches
-# the version mech-predict CI already uses (uv sync + uv.lock).
-COPY --from=ghcr.io/astral-sh/uv:0.5.14 /uv /uvx /usr/local/bin/
+# uv comes from its official static-linked distroless image. Must be
+# >= 0.6 because pyproject.toml uses the ``default-groups = "all"``
+# string shorthand (the older list form landed in uv 0.4; the string
+# shorthand only in 0.6). 0.5.14 fails at ``uv sync`` parse time with
+# "invalid type: string \"all\", expected a sequence".
+COPY --from=ghcr.io/astral-sh/uv:0.12.1 /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 

--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -9,10 +9,10 @@
 # Published on tag as valory/mech-predict-verify:<version> via
 # .github/workflows/publish-verify-image.yaml.
 #
-# The image is deliberately narrow: only benchmark/ (the subgraph +
-# lake client modules the script imports) and scripts/verify_migration_swap.py
-# ship. Runtime deps come from uv.lock so the image is reproducible
-# from any commit.
+# Runtime deps come from uv.lock so the image is reproducible from any
+# commit. The image ships benchmark/ (the module the script imports
+# transitively) and scripts/verify_migration_swap.py; ``benchmark/tests``
+# is excluded via .dockerignore so pytest fixtures don't ride along.
 #
 # Runtime contract:
 #   * env: MECH_ANALYTICS_URL, plus subgraph URLs (see script docstring)
@@ -21,24 +21,39 @@
 
 FROM python:3.13-slim AS base
 
+# Bake the source commit into the image at build time. The verify script
+# reads GIT_SHA from the env; without this the ``git rev-parse`` fallback
+# fires and every artifact attributes the run to ``unknown`` since the
+# image ships without a git binary and without a .git directory.
+ARG GIT_SHA=unknown
+ENV GIT_SHA=$GIT_SHA
+
 # uv comes from its official static-linked distroless image; matches
 # the version mech-predict CI already uses (uv sync + uv.lock).
 COPY --from=ghcr.io/astral-sh/uv:0.5.14 /uv /uvx /usr/local/bin/
 
 WORKDIR /app
 
+# The verify script imports ``from benchmark.datasets import ...``, so
+# the repo root must be on sys.path. ``--no-install-project`` below
+# means the ``benchmark`` package is copied in but not installed as a
+# wheel, so nothing else adds /app to sys.path. Setting PYTHONPATH
+# here fixes ``ModuleNotFoundError: No module named 'benchmark'`` when
+# the entrypoint runs and puts /app/scripts on sys.path[0].
+ENV PYTHONPATH=/app
+
 # Layer dep install ahead of source copy so a script edit doesn't
 # invalidate the (slow) dependency layer.
 COPY pyproject.toml uv.lock ./
 
 # --no-dev: the verifier doesn't need pytest, black, mypy, etc.
-# --no-install-project: mech-predict itself isn't imported as an
-# installed package here; we just need the third-party wheels.
+# --no-install-project: the ``benchmark`` package is copied in below
+# rather than installed as a wheel (mech-predict's pyproject only
+# packages ``packages/`` anyway, so a full install wouldn't help).
 RUN uv sync --frozen --no-dev --no-install-project
 
 # Copy only what the script imports. benchmark/ is the transitive
-# dep footprint of scripts/verify_migration_swap.py; scripts/ holds
-# the entry point.
+# dep footprint; scripts/verify_migration_swap.py is the entry point.
 COPY benchmark/ ./benchmark/
 COPY scripts/verify_migration_swap.py ./scripts/verify_migration_swap.py
 

--- a/Dockerfile.verify
+++ b/Dockerfile.verify
@@ -1,0 +1,53 @@
+# syntax=docker/dockerfile:1
+#
+# Image for the mech-predict / mech-analytics parity verification script
+# (scripts/verify_migration_swap.py). Used by infra as a K8s Job during
+# consumer-migration rollouts to prove the mech-analytics lake covers
+# every on-chain request the marketplace subgraph knows about and the
+# per-tool numbers agree.
+#
+# Published on tag as valory/mech-predict-verify:<version> via
+# .github/workflows/publish-verify-image.yaml.
+#
+# The image is deliberately narrow: only benchmark/ (the subgraph +
+# lake client modules the script imports) and scripts/verify_migration_swap.py
+# ship. Runtime deps come from uv.lock so the image is reproducible
+# from any commit.
+#
+# Runtime contract:
+#   * env: MECH_ANALYTICS_URL, plus subgraph URLs (see script docstring)
+#   * mount: /reports for --output-dir report artifacts
+#   * exit codes: 0 pass, 2 min-row, 3 parity divergence, 4 coverage gap
+
+FROM python:3.13-slim AS base
+
+# uv comes from its official static-linked distroless image; matches
+# the version mech-predict CI already uses (uv sync + uv.lock).
+COPY --from=ghcr.io/astral-sh/uv:0.5.14 /uv /uvx /usr/local/bin/
+
+WORKDIR /app
+
+# Layer dep install ahead of source copy so a script edit doesn't
+# invalidate the (slow) dependency layer.
+COPY pyproject.toml uv.lock ./
+
+# --no-dev: the verifier doesn't need pytest, black, mypy, etc.
+# --no-install-project: mech-predict itself isn't imported as an
+# installed package here; we just need the third-party wheels.
+RUN uv sync --frozen --no-dev --no-install-project
+
+# Copy only what the script imports. benchmark/ is the transitive
+# dep footprint of scripts/verify_migration_swap.py; scripts/ holds
+# the entry point.
+COPY benchmark/ ./benchmark/
+COPY scripts/verify_migration_swap.py ./scripts/verify_migration_swap.py
+
+# Non-root runtime — image writes to /reports which infra mounts,
+# never to /app.
+RUN useradd --system --create-home --uid 1001 verifier \
+    && chown -R verifier:verifier /app
+USER verifier
+
+# uv.venv sits at /app/.venv; using `uv run` keeps env + interpreter
+# discovery consistent with local invocations.
+ENTRYPOINT ["uv", "run", "--no-sync", "python", "scripts/verify_migration_swap.py"]

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -1245,10 +1245,9 @@ DELIVER_REQUEST_IDS_QUERY = """
 {
   delivers(
     first: %(first)s
-    skip: %(skip)s
     orderBy: blockTimestamp
     orderDirection: desc
-    where: { blockTimestamp_gt: %(timestamp_gt)s }
+    where: { blockTimestamp_gt: %(timestamp_gt)s, blockTimestamp_lt: %(timestamp_lt)s }
   ) {
     id
     blockTimestamp
@@ -1273,8 +1272,9 @@ def fetch_all_delivery_request_ids(
     marketplace_url: str,
     request_ts_gt: int,
     request_ts_lt: int,
+    batch_size: int = DEFAULT_BATCH_SIZE,
 ) -> tuple[set[str], int]:
-    """Return every on-chain request_id whose *request time* is in the window.
+    """Return every request_id delivered in the window, per the marketplace subgraph.
 
     The coverage check compares this set against the mech-analytics
     lake's set for the same window. Both sides must be bounded on the
@@ -1308,8 +1308,12 @@ def fetch_all_delivery_request_ids(
     a null ``parsedRequest`` — the point of the coverage check is to
     prove every delivered request is in the lake, including ones
     mech-predict currently discards because their IPFS payload didn't
-    parse. Coverage is a claim about ingest completeness, not about
-    what today's business logic happens to consume.
+    parse. The set is the "delivered in the window" universe. A
+    ``Request`` that was never answered (or answered more than
+    ``_DELIVERY_LAG_ENVELOPE_S`` after the window closed) is not in
+    the denominator; consumers that need request-level completeness
+    would need a separate ``requests`` sweep, deliberately out of
+    scope for the migration cutover gate.
 
     The second return value is the count of deliveries that came back
     without a resolvable ``request.id`` (or without a
@@ -1319,76 +1323,113 @@ def fetch_all_delivery_request_ids(
     — every dropped row is a request that could genuinely be absent
     from the lake but that we can never report as absent.
 
-    Includes a completeness assertion at end-of-sweep: the oldest
-    delivery returned must have ``blockTimestamp`` at or below
-    ``request_ts_gt``, because the query is sorted
-    ``orderDirection: desc`` and a truncated paginator (silent
-    ``len(page) < first`` truncation, the same shape as the
-    ``fetch_open`` bug fixed in #392) would otherwise bias coverage
-    toward PASS by shrinking the denominator.
+    Pagination uses a descending timestamp cursor rather than
+    ``skip``: each page rolls ``blockTimestamp_lt`` down to the
+    oldest ``blockTimestamp`` returned in that page (exclusive), and
+    the loop terminates when the subgraph returns an empty page. This
+    side-steps two failure modes of the skip-based
+    ``len(page) < first → EOF`` pattern that the previous
+    implementation used:
+
+    * A graph-node ``first`` clamp (returning fewer rows than
+      requested even when more exist) is silently treated as EOF and
+      shrinks the coverage denominator. With the cursor approach a
+      clamp just means more iterations — no lost rows.
+    * ``skip`` has a deep-scan cap on graph-node, which the 7-day
+      envelope routinely crosses.
+
+    Edge case: because the cursor advance is exclusive, a single
+    second holding more than ``batch_size`` deliveries would have
+    the "extra" rows skipped on the next page. In practice mech
+    deliveries are seconds-scale so this doesn't happen, but the
+    function emits a warning when a page's rows all share one
+    ``blockTimestamp`` so the operator can bump ``batch_size``
+    rather than silently ship a shrunken denominator.
 
     :param marketplace_url: GraphQL endpoint for the marketplace subgraph.
     :param request_ts_gt: unix seconds, exclusive lower bound on
         request time (matches the lake's ``since``).
     :param request_ts_lt: unix seconds, exclusive upper bound on
         request time (matches the lake's ``until``).
+    :param batch_size: page size sent as ``first``. graph-node may
+        clamp; the cursor loop handles that transparently. Default
+        matches the module-wide ``DEFAULT_BATCH_SIZE``.
     :return: tuple of (request_ids set, dropped_no_rid_count).
-    :raises RuntimeError: if the paginator returned a truncated sweep
-        (oldest delivery blockTimestamp did not reach ``request_ts_gt``).
     """
     delivery_ts_lt = request_ts_lt + _DELIVERY_LAG_ENVELOPE_S
-    query = _inject_timestamp_lt(
-        DELIVER_REQUEST_IDS_QUERY, delivery_ts_lt, "DELIVER_REQUEST_IDS_QUERY"
-    )
-    raw = _paginated_fetch(
-        marketplace_url,
-        query,
-        "delivers",
-        {"timestamp_gt": request_ts_gt},
-    )
 
     request_ids: set[str] = set()
     dropped_no_rid = 0
-    oldest_delivery_ts: Optional[int] = None
-    for d in raw:
-        try:
-            delivery_ts = int(d["blockTimestamp"])
-        except (KeyError, TypeError, ValueError):
-            dropped_no_rid += 1
-            continue
-        if oldest_delivery_ts is None or delivery_ts < oldest_delivery_ts:
-            oldest_delivery_ts = delivery_ts
+    cursor_ts_lt = delivery_ts_lt
 
-        request = d.get("request") or {}
-        rid = request.get("id")
-        req_ts_raw = request.get("blockTimestamp")
-        if not rid or req_ts_raw is None:
-            dropped_no_rid += 1
-            continue
-        try:
-            req_ts = int(req_ts_raw)
-        except (TypeError, ValueError):
-            dropped_no_rid += 1
-            continue
-        if request_ts_gt < req_ts < request_ts_lt:
-            request_ids.add(rid)
+    while True:
+        query = DELIVER_REQUEST_IDS_QUERY % {
+            "first": batch_size,
+            "timestamp_gt": request_ts_gt,
+            "timestamp_lt": cursor_ts_lt,
+        }
+        data = _post_graphql(marketplace_url, {"query": query})
+        page = data.get("delivers", [])
+        if not page:
+            break
 
-    # Completeness check: if the paginator stopped early on a
-    # graph-node-clamped short page, the oldest delivery in our set
-    # will still be well above ``request_ts_gt``. A complete
-    # descending-order sweep must have reached the lower bound.
-    # ``oldest_delivery_ts is None`` means the query returned zero
-    # rows, which is a legitimate empty window and not truncation —
-    # the caller's ``--min-marketplace-rows`` floor is the right gate
-    # for that condition.
-    if oldest_delivery_ts is not None and oldest_delivery_ts > request_ts_gt:
-        raise RuntimeError(
-            f"fetch_all_delivery_request_ids: truncated sweep — oldest "
-            f"delivery blockTimestamp={oldest_delivery_ts} > "
-            f"request_ts_gt={request_ts_gt}. The paginator likely hit a "
-            f"short-page-as-EOF exit inside a graph-node ``first`` clamp; "
-            f"coverage denominator is incomplete and cannot be trusted."
+        page_oldest_ts: Optional[int] = None
+        page_newest_ts: Optional[int] = None
+        for d in page:
+            try:
+                delivery_ts = int(d["blockTimestamp"])
+            except (KeyError, TypeError, ValueError):
+                dropped_no_rid += 1
+                continue
+            if page_oldest_ts is None or delivery_ts < page_oldest_ts:
+                page_oldest_ts = delivery_ts
+            if page_newest_ts is None or delivery_ts > page_newest_ts:
+                page_newest_ts = delivery_ts
+            request = d.get("request") or {}
+            rid = request.get("id")
+            req_ts_raw = request.get("blockTimestamp")
+            if not rid or req_ts_raw is None:
+                dropped_no_rid += 1
+                continue
+            try:
+                req_ts = int(req_ts_raw)
+            except (TypeError, ValueError):
+                dropped_no_rid += 1
+                continue
+            if request_ts_gt < req_ts < request_ts_lt:
+                request_ids.add(rid)
+
+        log.info(
+            "  fetched %d delivers (running set size %d)", len(page), len(request_ids)
         )
+
+        if page_oldest_ts is None:
+            # No usable blockTimestamps in the page → no way to advance
+            # the cursor. Refuse to loop and let the caller see the
+            # drop count as evidence of a schema drift or a broken page.
+            log.warning(
+                "fetch_all_delivery_request_ids: page of %d rows had no "
+                "usable blockTimestamp; halting to avoid an infinite loop.",
+                len(page),
+            )
+            break
+
+        # Cursor advance is exclusive: the next page's
+        # ``blockTimestamp_lt`` skips rows AT ``page_oldest_ts``. That's
+        # only lossy if a single second held more than ``batch_size``
+        # deliveries; the paginator surfaces that as a warning so an
+        # operator can bump ``--batch-size`` rather than silently ship
+        # an under-counted denominator.
+        if page_newest_ts == page_oldest_ts and len(page) >= batch_size:
+            log.warning(
+                "fetch_all_delivery_request_ids: page of %d rows all share "
+                "blockTimestamp=%d; the next page's exclusive cursor advance "
+                "may skip further deliveries at this timestamp. Rerun with "
+                "a larger batch_size if the coverage denominator looks low.",
+                len(page),
+                page_oldest_ts,
+            )
+        cursor_ts_lt = page_oldest_ts
 
     if dropped_no_rid:
         log.warning(

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -19,20 +19,19 @@ from __future__ import annotations
 
 import argparse
 import base64
-from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 import logging
 import os
-from pathlib import Path
 import re
 import shutil
 import sys
 import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Optional
 
 import requests
-
 from benchmark.categories import PLATFORM_ALLOWED_CATEGORIES
 from benchmark.datasets.subgraph import post_graphql
 from benchmark.io import append_jsonl
@@ -1141,11 +1140,16 @@ def fetch_deliveries(
         DELIVERS_QUERY if schema == DELIVERS_SCHEMA_PARSED else DELIVERS_QUERY_LEGACY
     )
     if timestamp_lt is not None:
-        query_template = query_template.replace(
-            "where: { blockTimestamp_gt: %(timestamp_gt)s }",
-            f"where: {{ blockTimestamp_gt: %(timestamp_gt)s, "
-            f"blockTimestamp_lt: {int(timestamp_lt)} }}",
+        # Both DELIVERS_QUERY and DELIVERS_QUERY_LEGACY carry the same
+        # ``where: { blockTimestamp_gt: %(timestamp_gt)s }`` literal, so
+        # reformatting one but not the other would silently strip the
+        # upper bound only for that schema variant.
+        variant = (
+            "DELIVERS_QUERY"
+            if schema == DELIVERS_SCHEMA_PARSED
+            else "DELIVERS_QUERY_LEGACY"
         )
+        query_template = _inject_timestamp_lt(query_template, timestamp_lt, variant)
     raw = _paginated_fetch(
         marketplace_url,
         query_template,
@@ -1254,7 +1258,7 @@ def fetch_all_delivery_request_ids(
     marketplace_url: str,
     timestamp_gt: int,
     timestamp_lt: Optional[int] = None,
-) -> set[str]:
+) -> tuple[set[str], int]:
     """Return the full set of on-chain request_ids delivered in the window.
 
     Unlike :func:`fetch_deliveries`, this does not skip deliveries with
@@ -1264,18 +1268,21 @@ def fetch_all_delivery_request_ids(
     parse. Coverage is a claim about ingest completeness, not about
     what today's business logic happens to consume.
 
+    The second return value is the count of deliveries that came back
+    without a resolvable ``request.id`` and were therefore dropped from
+    the coverage denominator. Callers surface this so a non-zero drop
+    can't be hidden inside a "no missing IDs" PASS verdict — every
+    dropped row is a request that could genuinely be absent from the
+    lake but that we can never report as absent.
+
     :param marketplace_url: GraphQL endpoint for the marketplace subgraph.
     :param timestamp_gt: unix seconds, exclusive lower bound.
     :param timestamp_lt: optional unix seconds, exclusive upper bound.
-    :return: set of on-chain request_ids (Request.id) delivered in the window.
+    :return: tuple of (request_ids set, dropped_no_rid_count).
     """
     query = DELIVER_REQUEST_IDS_QUERY
     if timestamp_lt is not None:
-        query = query.replace(
-            "where: { blockTimestamp_gt: %(timestamp_gt)s }",
-            f"where: {{ blockTimestamp_gt: %(timestamp_gt)s, "
-            f"blockTimestamp_lt: {int(timestamp_lt)} }}",
-        )
+        query = _inject_timestamp_lt(query, timestamp_lt, "DELIVER_REQUEST_IDS_QUERY")
     raw = _paginated_fetch(
         marketplace_url,
         query,
@@ -1283,12 +1290,51 @@ def fetch_all_delivery_request_ids(
         {"timestamp_gt": timestamp_gt},
     )
     request_ids: set[str] = set()
+    dropped_no_rid = 0
     for d in raw:
         request = d.get("request") or {}
         rid = request.get("id")
         if rid:
             request_ids.add(rid)
-    return request_ids
+        else:
+            dropped_no_rid += 1
+    if dropped_no_rid:
+        log.warning(
+            "fetch_all_delivery_request_ids: dropped %d delivery/deliveries "
+            "with missing request.id from coverage denominator",
+            dropped_no_rid,
+        )
+    return request_ids, dropped_no_rid
+
+
+def _inject_timestamp_lt(query: str, timestamp_lt: int, query_name: str) -> str:
+    """Insert a ``blockTimestamp_lt`` bound into a delivers query.
+
+    ``str.replace`` returns the source unchanged when the target isn't
+    found — a silent no-op that would revert the query back to the
+    unbounded ``since → now`` shape and hide it behind a successful
+    pagination. Asserting the substitution actually landed catches
+    a future reformat of the query literal at run time instead of at
+    review time.
+
+    :param query: the raw GraphQL query text with a
+        ``where: { blockTimestamp_gt: %(timestamp_gt)s }`` clause.
+    :param timestamp_lt: the exclusive upper bound to insert.
+    :param query_name: source name for the assertion message.
+    :return: the query with both ``blockTimestamp_gt`` and
+        ``blockTimestamp_lt`` in the ``where`` clause.
+    """
+    target = "where: { blockTimestamp_gt: %(timestamp_gt)s }"
+    replacement = (
+        f"where: {{ blockTimestamp_gt: %(timestamp_gt)s, "
+        f"blockTimestamp_lt: {int(timestamp_lt)} }}"
+    )
+    new_query = query.replace(target, replacement)
+    assert new_query != query, (
+        f"_inject_timestamp_lt: bound did not apply to {query_name} — "
+        f"literal drifted from expected substring {target!r}"
+    )
+    return new_query
 
 
 # ---------------------------------------------------------------------------
@@ -1425,11 +1471,17 @@ def fetch_omen_resolved(
     """
     query = OMEN_BETS_QUERY
     if resolved_before is not None:
-        query = query.replace(
-            "currentAnswerTimestamp_gt: %(resolved_after)s",
+        target = "currentAnswerTimestamp_gt: %(resolved_after)s"
+        replacement = (
             f"currentAnswerTimestamp_gt: %(resolved_after)s\n"
-            f"        currentAnswerTimestamp_lt: {int(resolved_before)}",
+            f"        currentAnswerTimestamp_lt: {int(resolved_before)}"
         )
+        new_query = query.replace(target, replacement)
+        assert new_query != query, (
+            "fetch_omen_resolved: resolved_before bound did not apply — "
+            f"OMEN_BETS_QUERY literal drifted from {target!r}"
+        )
+        query = new_query
     raw = _paginated_fetch(
         PREDICT_OMEN_SUBGRAPH_URL,
         query,
@@ -1486,11 +1538,17 @@ def fetch_polymarket_resolved(
     """
     query = POLYMARKET_RESOLVED_QUESTIONS_QUERY
     if resolved_before is not None:
-        query = query.replace(
-            "resolution_: { blockTimestamp_gt: %(resolved_after)s }",
+        target = "resolution_: { blockTimestamp_gt: %(resolved_after)s }"
+        replacement = (
             f"resolution_: {{ blockTimestamp_gt: %(resolved_after)s, "
-            f"blockTimestamp_lt: {int(resolved_before)} }}",
+            f"blockTimestamp_lt: {int(resolved_before)} }}"
         )
+        new_query = query.replace(target, replacement)
+        assert new_query != query, (
+            "fetch_polymarket_resolved: resolved_before bound did not apply — "
+            f"POLYMARKET_RESOLVED_QUESTIONS_QUERY literal drifted from {target!r}"
+        )
+        query = new_query
     raw = _paginated_fetch(
         PREDICT_POLYMARKET_SUBGRAPH_URL,
         query,

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -1237,7 +1237,10 @@ def fetch_deliveries(
 # in a window is present in the lake, regardless of whether mech-predict
 # would currently use it. Selecting a smaller field set keeps
 # marketplace-subgraph load lower during coverage sweeps than the full
-# DELIVERS_QUERY would.
+# DELIVERS_QUERY would. Selects ``request.blockTimestamp`` because the
+# parity verifier needs to filter on REQUEST time (matches the lake side's
+# ``requested_at`` semantics), not delivery time — see the comment on
+# ``fetch_all_delivery_request_ids``.
 DELIVER_REQUEST_IDS_QUERY = """
 {
   delivers(
@@ -1248,18 +1251,58 @@ DELIVER_REQUEST_IDS_QUERY = """
     where: { blockTimestamp_gt: %(timestamp_gt)s }
   ) {
     id
-    request { id }
+    blockTimestamp
+    request { id blockTimestamp }
   }
 }
 """
 
+# Envelope around the request window on the delivery-time bound sent to
+# the subgraph. A request submitted just before ``request_ts_until`` may
+# be delivered after it, so the delivery-time upper bound has to be
+# widened by an assumed maximum request→delivery lag; a request
+# submitted just after ``request_ts_gt`` cannot be delivered before it,
+# so the lower bound uses the raw request window boundary. 7 days is a
+# generous upper bound relative to normal mech latency (seconds to
+# minutes) and catches operator-side stalls without inflating the sweep
+# more than 1-2× on a typical 3-day parity window.
+_DELIVERY_LAG_ENVELOPE_S = 7 * 24 * 60 * 60
+
 
 def fetch_all_delivery_request_ids(
     marketplace_url: str,
-    timestamp_gt: int,
-    timestamp_lt: Optional[int] = None,
+    request_ts_gt: int,
+    request_ts_lt: int,
 ) -> tuple[set[str], int]:
-    """Return the full set of on-chain request_ids delivered in the window.
+    """Return every on-chain request_id whose *request time* is in the window.
+
+    The coverage check compares this set against the mech-analytics
+    lake's set for the same window. Both sides must be bounded on the
+    same clock or the diff produces false alarms:
+
+    * The lake's ``/v1/data/scored-rows`` endpoint filters on
+      ``requested_at`` (verified in mech-analytics
+      ``etl/api/routes/data.py``).
+    * The marketplace subgraph's ``Deliver`` entity carries a
+      ``blockTimestamp`` (delivery time) and a nested
+      ``request { blockTimestamp }`` (request time).
+
+    Bounding the marketplace sweep on delivery time and comparing to a
+    lake set bounded on request time creates two systematic errors:
+    leading-edge requests (submitted just before ``since``, delivered
+    inside the window) show up as "missing from lake" false alarms, and
+    trailing-edge requests (submitted just before ``until``, delivered
+    after it) are permanently invisible to any window's check. Both
+    happen without any real coverage gap and both are the wrong signal
+    at a cutover gate.
+
+    Fix: enumerate deliveries within a widened delivery-time envelope
+    ``(request_ts_gt, request_ts_lt + _DELIVERY_LAG_ENVELOPE_S)`` — which
+    catches every delivery whose request could fall inside the window
+    — then filter client-side to
+    ``request.blockTimestamp in (request_ts_gt, request_ts_lt)``.
+    Bounds are exclusive on both sides to mirror the marketplace
+    subgraph's ``blockTimestamp_gt`` / ``blockTimestamp_lt`` semantics.
 
     Unlike :func:`fetch_deliveries`, this does not skip deliveries with
     a null ``parsedRequest`` — the point of the coverage check is to
@@ -1269,39 +1312,89 @@ def fetch_all_delivery_request_ids(
     what today's business logic happens to consume.
 
     The second return value is the count of deliveries that came back
-    without a resolvable ``request.id`` and were therefore dropped from
-    the coverage denominator. Callers surface this so a non-zero drop
-    can't be hidden inside a "no missing IDs" PASS verdict — every
-    dropped row is a request that could genuinely be absent from the
-    lake but that we can never report as absent.
+    without a resolvable ``request.id`` (or without a
+    ``request.blockTimestamp`` we could bucket on) and were therefore
+    dropped from the coverage denominator. Callers surface this so a
+    non-zero drop can't be hidden inside a "no missing IDs" PASS verdict
+    — every dropped row is a request that could genuinely be absent
+    from the lake but that we can never report as absent.
+
+    Includes a completeness assertion at end-of-sweep: the oldest
+    delivery returned must have ``blockTimestamp`` at or below
+    ``request_ts_gt``, because the query is sorted
+    ``orderDirection: desc`` and a truncated paginator (silent
+    ``len(page) < first`` truncation, the same shape as the
+    ``fetch_open`` bug fixed in #392) would otherwise bias coverage
+    toward PASS by shrinking the denominator.
 
     :param marketplace_url: GraphQL endpoint for the marketplace subgraph.
-    :param timestamp_gt: unix seconds, exclusive lower bound.
-    :param timestamp_lt: optional unix seconds, exclusive upper bound.
+    :param request_ts_gt: unix seconds, exclusive lower bound on
+        request time (matches the lake's ``since``).
+    :param request_ts_lt: unix seconds, exclusive upper bound on
+        request time (matches the lake's ``until``).
     :return: tuple of (request_ids set, dropped_no_rid_count).
+    :raises RuntimeError: if the paginator returned a truncated sweep
+        (oldest delivery blockTimestamp did not reach ``request_ts_gt``).
     """
-    query = DELIVER_REQUEST_IDS_QUERY
-    if timestamp_lt is not None:
-        query = _inject_timestamp_lt(query, timestamp_lt, "DELIVER_REQUEST_IDS_QUERY")
+    delivery_ts_lt = request_ts_lt + _DELIVERY_LAG_ENVELOPE_S
+    query = _inject_timestamp_lt(
+        DELIVER_REQUEST_IDS_QUERY, delivery_ts_lt, "DELIVER_REQUEST_IDS_QUERY"
+    )
     raw = _paginated_fetch(
         marketplace_url,
         query,
         "delivers",
-        {"timestamp_gt": timestamp_gt},
+        {"timestamp_gt": request_ts_gt},
     )
+
     request_ids: set[str] = set()
     dropped_no_rid = 0
+    oldest_delivery_ts: Optional[int] = None
     for d in raw:
+        try:
+            delivery_ts = int(d["blockTimestamp"])
+        except (KeyError, TypeError, ValueError):
+            dropped_no_rid += 1
+            continue
+        if oldest_delivery_ts is None or delivery_ts < oldest_delivery_ts:
+            oldest_delivery_ts = delivery_ts
+
         request = d.get("request") or {}
         rid = request.get("id")
-        if rid:
-            request_ids.add(rid)
-        else:
+        req_ts_raw = request.get("blockTimestamp")
+        if not rid or req_ts_raw is None:
             dropped_no_rid += 1
+            continue
+        try:
+            req_ts = int(req_ts_raw)
+        except (TypeError, ValueError):
+            dropped_no_rid += 1
+            continue
+        if request_ts_gt < req_ts < request_ts_lt:
+            request_ids.add(rid)
+
+    # Completeness check: if the paginator stopped early on a
+    # graph-node-clamped short page, the oldest delivery in our set
+    # will still be well above ``request_ts_gt``. A complete
+    # descending-order sweep must have reached the lower bound.
+    # ``oldest_delivery_ts is None`` means the query returned zero
+    # rows, which is a legitimate empty window and not truncation —
+    # the caller's ``--min-marketplace-rows`` floor is the right gate
+    # for that condition.
+    if oldest_delivery_ts is not None and oldest_delivery_ts > request_ts_gt:
+        raise RuntimeError(
+            f"fetch_all_delivery_request_ids: truncated sweep — oldest "
+            f"delivery blockTimestamp={oldest_delivery_ts} > "
+            f"request_ts_gt={request_ts_gt}. The paginator likely hit a "
+            f"short-page-as-EOF exit inside a graph-node ``first`` clamp; "
+            f"coverage denominator is incomplete and cannot be trusted."
+        )
+
     if dropped_no_rid:
         log.warning(
             "fetch_all_delivery_request_ids: dropped %d delivery/deliveries "
-            "with missing request.id from coverage denominator",
+            "with missing/unparseable request.id or blockTimestamp from "
+            "coverage denominator",
             dropped_no_rid,
         )
     return request_ids, dropped_no_rid
@@ -1313,16 +1406,21 @@ def _inject_timestamp_lt(query: str, timestamp_lt: int, query_name: str) -> str:
     ``str.replace`` returns the source unchanged when the target isn't
     found — a silent no-op that would revert the query back to the
     unbounded ``since → now`` shape and hide it behind a successful
-    pagination. Asserting the substitution actually landed catches
-    a future reformat of the query literal at run time instead of at
-    review time.
+    pagination. Raising when the substitution didn't land catches a
+    future reformat of the query literal at run time instead of at
+    review time. ``raise`` (rather than ``assert``) is deliberate: this
+    guard has to survive ``python -O`` / ``PYTHONOPTIMIZE=1``, which
+    strip ``assert`` statements and would silently disable the check
+    exactly when the image is slim-optimised for deployment.
 
     :param query: the raw GraphQL query text with a
         ``where: { blockTimestamp_gt: %(timestamp_gt)s }`` clause.
     :param timestamp_lt: the exclusive upper bound to insert.
-    :param query_name: source name for the assertion message.
+    :param query_name: source name for the error message.
     :return: the query with both ``blockTimestamp_gt`` and
         ``blockTimestamp_lt`` in the ``where`` clause.
+    :raises ValueError: if the target substring is not present in the
+        query (literal drifted between reformat and this call).
     """
     target = "where: { blockTimestamp_gt: %(timestamp_gt)s }"
     replacement = (
@@ -1330,10 +1428,11 @@ def _inject_timestamp_lt(query: str, timestamp_lt: int, query_name: str) -> str:
         f"blockTimestamp_lt: {int(timestamp_lt)} }}"
     )
     new_query = query.replace(target, replacement)
-    assert new_query != query, (
-        f"_inject_timestamp_lt: bound did not apply to {query_name} — "
-        f"literal drifted from expected substring {target!r}"
-    )
+    if new_query == query:
+        raise ValueError(
+            f"_inject_timestamp_lt: bound did not apply to {query_name} — "
+            f"literal drifted from expected substring {target!r}"
+        )
     return new_query
 
 
@@ -1455,36 +1554,18 @@ class ResolvedMarkets:
         return len(self._seen) > 0
 
 
-def fetch_omen_resolved(
-    resolved_after: int, resolved_before: Optional[int] = None
-) -> ResolvedMarkets:
+def fetch_omen_resolved(resolved_after: int) -> ResolvedMarkets:
     """Bulk fetch Omen markets that resolved after the given timestamp.
 
     Filters by resolution time (currentAnswerTimestamp), not bet placement time.
     Indexes by both market ID (fpmm address) and question title.
 
     :param resolved_after: UNIX timestamp; only include markets resolved after this.
-    :param resolved_before: optional UNIX timestamp; when set, cap resolution
-        time strictly below this value. Used by the parity script to bound
-        the enumeration to a specific window instead of "since X to now".
     :return: ResolvedMarkets indexed by ID and title.
     """
-    query = OMEN_BETS_QUERY
-    if resolved_before is not None:
-        target = "currentAnswerTimestamp_gt: %(resolved_after)s"
-        replacement = (
-            f"currentAnswerTimestamp_gt: %(resolved_after)s\n"
-            f"        currentAnswerTimestamp_lt: {int(resolved_before)}"
-        )
-        new_query = query.replace(target, replacement)
-        assert new_query != query, (
-            "fetch_omen_resolved: resolved_before bound did not apply — "
-            f"OMEN_BETS_QUERY literal drifted from {target!r}"
-        )
-        query = new_query
     raw = _paginated_fetch(
         PREDICT_OMEN_SUBGRAPH_URL,
-        query,
+        OMEN_BETS_QUERY,
         "bets",
         {"resolved_after": resolved_after},
     )
@@ -1521,9 +1602,7 @@ def fetch_omen_resolved(
     return markets
 
 
-def fetch_polymarket_resolved(
-    resolved_after: int, resolved_before: Optional[int] = None
-) -> ResolvedMarkets:
+def fetch_polymarket_resolved(resolved_after: int) -> ResolvedMarkets:
     """Bulk fetch Polymarket markets that resolved after the given timestamp.
 
     Discovers resolved markets directly from the ``questions`` entity using
@@ -1532,26 +1611,11 @@ def fetch_polymarket_resolved(
     bets fell outside a candidate window.
 
     :param resolved_after: UNIX timestamp; only include markets resolved after this.
-    :param resolved_before: optional UNIX timestamp; when set, cap resolution
-        time strictly below this value.
     :return: ResolvedMarkets indexed by ID and title.
     """
-    query = POLYMARKET_RESOLVED_QUESTIONS_QUERY
-    if resolved_before is not None:
-        target = "resolution_: { blockTimestamp_gt: %(resolved_after)s }"
-        replacement = (
-            f"resolution_: {{ blockTimestamp_gt: %(resolved_after)s, "
-            f"blockTimestamp_lt: {int(resolved_before)} }}"
-        )
-        new_query = query.replace(target, replacement)
-        assert new_query != query, (
-            "fetch_polymarket_resolved: resolved_before bound did not apply — "
-            f"POLYMARKET_RESOLVED_QUESTIONS_QUERY literal drifted from {target!r}"
-        )
-        query = new_query
     raw = _paginated_fetch(
         PREDICT_POLYMARKET_SUBGRAPH_URL,
-        query,
+        POLYMARKET_RESOLVED_QUESTIONS_QUERY,
         "questions",
         {"resolved_after": resolved_after},
     )

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import requests
+
 from benchmark.categories import PLATFORM_ALLOWED_CATEGORIES
 from benchmark.datasets.subgraph import post_graphql
 from benchmark.io import append_jsonl
@@ -1110,6 +1111,7 @@ def _parse_request_context(content_str: str) -> dict[str, Any]:
 def fetch_deliveries(
     marketplace_url: str,
     timestamp_gt: int,
+    timestamp_lt: Optional[int] = None,
 ) -> tuple[list[dict[str, Any]], Optional[int]]:
     """Bulk fetch all recent deliveries with prediction data.
 
@@ -1134,6 +1136,12 @@ def fetch_deliveries(
     query_template = (
         DELIVERS_QUERY if schema == DELIVERS_SCHEMA_PARSED else DELIVERS_QUERY_LEGACY
     )
+    if timestamp_lt is not None:
+        query_template = query_template.replace(
+            "where: { blockTimestamp_gt: %(timestamp_gt)s }",
+            f"where: {{ blockTimestamp_gt: %(timestamp_gt)s, "
+            f"blockTimestamp_lt: {int(timestamp_lt)} }}",
+        )
     raw = _paginated_fetch(
         marketplace_url,
         query_template,
@@ -1214,6 +1222,69 @@ def fetch_deliveries(
         log.info("  %d/%d deliveries have market_id", has_market_id, len(deliveries))
 
     return deliveries, unparsed_request_cap
+
+
+# Coverage-check query: only the request.id, no parsedRequest gate. Used
+# by the mech-analytics parity verifier to prove every on-chain request
+# in a window is present in the lake, regardless of whether mech-predict
+# would currently use it. Selecting a smaller field set keeps
+# marketplace-subgraph load lower during coverage sweeps than the full
+# DELIVERS_QUERY would.
+DELIVER_REQUEST_IDS_QUERY = """
+{
+  delivers(
+    first: %(first)s
+    skip: %(skip)s
+    orderBy: blockTimestamp
+    orderDirection: desc
+    where: { blockTimestamp_gt: %(timestamp_gt)s }
+  ) {
+    id
+    request { id }
+  }
+}
+"""
+
+
+def fetch_all_delivery_request_ids(
+    marketplace_url: str,
+    timestamp_gt: int,
+    timestamp_lt: Optional[int] = None,
+) -> set[str]:
+    """Return the full set of on-chain request_ids delivered in the window.
+
+    Unlike :func:`fetch_deliveries`, this does not skip deliveries with
+    a null ``parsedRequest`` — the point of the coverage check is to
+    prove every delivered request is in the lake, including ones
+    mech-predict currently discards because their IPFS payload didn't
+    parse. Coverage is a claim about ingest completeness, not about
+    what today's business logic happens to consume.
+
+    :param marketplace_url: GraphQL endpoint for the marketplace subgraph.
+    :param timestamp_gt: unix seconds, exclusive lower bound.
+    :param timestamp_lt: optional unix seconds, exclusive upper bound.
+    :return: set of on-chain request_ids (Request.id) delivered in the window.
+    """
+    query = DELIVER_REQUEST_IDS_QUERY
+    if timestamp_lt is not None:
+        query = query.replace(
+            "where: { blockTimestamp_gt: %(timestamp_gt)s }",
+            f"where: {{ blockTimestamp_gt: %(timestamp_gt)s, "
+            f"blockTimestamp_lt: {int(timestamp_lt)} }}",
+        )
+    raw = _paginated_fetch(
+        marketplace_url,
+        query,
+        "delivers",
+        {"timestamp_gt": timestamp_gt},
+    )
+    request_ids: set[str] = set()
+    for d in raw:
+        request = d.get("request") or {}
+        rid = request.get("id")
+        if rid:
+            request_ids.add(rid)
+    return request_ids
 
 
 # ---------------------------------------------------------------------------
@@ -1334,18 +1405,30 @@ class ResolvedMarkets:
         return len(self._seen) > 0
 
 
-def fetch_omen_resolved(resolved_after: int) -> ResolvedMarkets:
+def fetch_omen_resolved(
+    resolved_after: int, resolved_before: Optional[int] = None
+) -> ResolvedMarkets:
     """Bulk fetch Omen markets that resolved after the given timestamp.
 
     Filters by resolution time (currentAnswerTimestamp), not bet placement time.
     Indexes by both market ID (fpmm address) and question title.
 
     :param resolved_after: UNIX timestamp; only include markets resolved after this.
+    :param resolved_before: optional UNIX timestamp; when set, cap resolution
+        time strictly below this value. Used by the parity script to bound
+        the enumeration to a specific window instead of "since X to now".
     :return: ResolvedMarkets indexed by ID and title.
     """
+    query = OMEN_BETS_QUERY
+    if resolved_before is not None:
+        query = query.replace(
+            "currentAnswerTimestamp_gt: %(resolved_after)s",
+            f"currentAnswerTimestamp_gt: %(resolved_after)s\n"
+            f"        currentAnswerTimestamp_lt: {int(resolved_before)}",
+        )
     raw = _paginated_fetch(
         PREDICT_OMEN_SUBGRAPH_URL,
-        OMEN_BETS_QUERY,
+        query,
         "bets",
         {"resolved_after": resolved_after},
     )
@@ -1382,7 +1465,9 @@ def fetch_omen_resolved(resolved_after: int) -> ResolvedMarkets:
     return markets
 
 
-def fetch_polymarket_resolved(resolved_after: int) -> ResolvedMarkets:
+def fetch_polymarket_resolved(
+    resolved_after: int, resolved_before: Optional[int] = None
+) -> ResolvedMarkets:
     """Bulk fetch Polymarket markets that resolved after the given timestamp.
 
     Discovers resolved markets directly from the ``questions`` entity using
@@ -1391,11 +1476,20 @@ def fetch_polymarket_resolved(resolved_after: int) -> ResolvedMarkets:
     bets fell outside a candidate window.
 
     :param resolved_after: UNIX timestamp; only include markets resolved after this.
+    :param resolved_before: optional UNIX timestamp; when set, cap resolution
+        time strictly below this value.
     :return: ResolvedMarkets indexed by ID and title.
     """
+    query = POLYMARKET_RESOLVED_QUESTIONS_QUERY
+    if resolved_before is not None:
+        query = query.replace(
+            "resolution_: { blockTimestamp_gt: %(resolved_after)s }",
+            f"resolution_: {{ blockTimestamp_gt: %(resolved_after)s, "
+            f"blockTimestamp_lt: {int(resolved_before)} }}",
+        )
     raw = _paginated_fetch(
         PREDICT_POLYMARKET_SUBGRAPH_URL,
-        POLYMARKET_RESOLVED_QUESTIONS_QUERY,
+        query,
         "questions",
         {"resolved_after": resolved_after},
     )
@@ -2280,6 +2374,7 @@ def process_platform(
     delivery_ts_gt: int,
     existing_ids: set[str],
     pending_deliveries: list[dict[str, Any]],
+    delivery_ts_lt: Optional[int] = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], int, int]:
     """Process one platform: fetch deliveries, match to resolved markets, build rows.
 
@@ -2326,7 +2421,7 @@ def process_platform(
     # 2. Fetch and process new deliveries
     log.info("%s: fetching deliveries...", platform)
     new_deliveries, unparsed_request_cap = fetch_deliveries(
-        marketplace_url, delivery_ts_gt
+        marketplace_url, delivery_ts_gt, timestamp_lt=delivery_ts_lt
     )
     log.info(
         "%s: %d new deliveries, %d resolved markets, %d pending from before",

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -19,16 +19,16 @@ from __future__ import annotations
 
 import argparse
 import base64
+from datetime import datetime, timedelta, timezone
 import hashlib
 import json
 import logging
 import os
+from pathlib import Path
 import re
 import shutil
 import sys
 import time
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Any, Optional
 
 import requests
@@ -1130,6 +1130,10 @@ def fetch_deliveries(
 
     :param marketplace_url: GraphQL endpoint for the marketplace subgraph.
     :param timestamp_gt: only fetch deliveries after this UNIX timestamp.
+    :param timestamp_lt: optional UNIX timestamp; when set, cap the
+        fetch strictly below this value. Used by the parity verifier
+        to bound enumeration to a specific window instead of
+        ``since → now``.
     :return: tuple of (delivery dicts, delivery-cursor cap or None).
     """
     schema = detect_delivers_schema(marketplace_url)
@@ -2388,6 +2392,10 @@ def process_platform(
     :param delivery_ts_gt: only fetch deliveries after this UNIX timestamp.
     :param existing_ids: row IDs already written, for deduplication.
     :param pending_deliveries: unmatched deliveries from previous runs.
+    :param delivery_ts_lt: optional UNIX timestamp forwarded to
+        ``fetch_deliveries`` as ``timestamp_lt``. When set, deliveries
+        are capped strictly below this value. Used by the parity
+        verifier to bound the window.
     :return: tuple of (rows, still_pending, max_delivery_timestamp,
         max_resolved_timestamp).
     """

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -22,7 +22,7 @@ import json
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 import requests
@@ -2201,3 +2201,274 @@ class TestEnrichmentSkipsPrefilled:
             rows, "http://gnosis"
         )
         assert rows[0]["tool_version"] == "bafyexact"
+
+
+class TestInjectTimestampLt:
+    """_inject_timestamp_lt splices an upper bound into a delivers query."""
+
+    def test_inserts_upper_bound_alongside_lower(self) -> None:
+        """Both bounds land in the same ``where`` clause."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        result = fp._inject_timestamp_lt(  # pylint: disable=protected-access
+            fp.DELIVER_REQUEST_IDS_QUERY, 1700000000, "DELIVER_REQUEST_IDS_QUERY"
+        )
+        assert (
+            "where: { blockTimestamp_gt: %(timestamp_gt)s, "
+            "blockTimestamp_lt: 1700000000 }"
+        ) in result
+
+    def test_raises_valueerror_when_target_absent(self) -> None:
+        """Silent-no-op protection: a drifted literal raises, not returns."""
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        # ``str.replace`` on a missing target returns the source unchanged.
+        # The guard has to raise so a future reformat of the query literal
+        # is caught at run time and can't silently revert the delivery-time
+        # bound to ``since → now`` (which would break coverage on any
+        # window not ending at "now").
+        drifted = "{ delivers( where: { blockTimestamp_gte: 0 } ) { id } }"
+        with pytest.raises(ValueError, match="literal drifted"):
+            fp._inject_timestamp_lt(  # pylint: disable=protected-access
+                drifted, 1700000000, "custom_test_query"
+            )
+
+
+class TestFetchAllDeliveryRequestIds:
+    """Coverage-side enumeration + request-time filter + truncation guard."""
+
+    @staticmethod
+    def _deliver(
+        deliver_id: str,
+        delivery_ts: int,
+        request_id: Optional[str],
+        request_ts: Optional[int],
+    ) -> dict[str, Any]:
+        """Build one raw delivers-row shape as the subgraph returns it."""
+        request: dict[str, Any] = {}
+        if request_id is not None:
+            request["id"] = request_id
+        if request_ts is not None:
+            request["blockTimestamp"] = str(request_ts)
+        return {
+            "id": deliver_id,
+            "blockTimestamp": str(delivery_ts),
+            "request": request,
+        }
+
+    def test_filters_client_side_on_request_time(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Deliveries whose request time falls inside the window survive.
+
+        The delivery-time envelope has to be widened (subgraph filter),
+        then the client-side filter narrows to request time. Verifies:
+        (a) only requests inside ``(request_ts_gt, request_ts_lt)`` are
+        returned, (b) the subgraph is asked for the widened delivery
+        upper bound.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        request_ts_gt = 1_700_000_000
+        request_ts_lt = 1_700_100_000
+        captured: dict[str, Any] = {}
+
+        def fake_paginated(
+            _url: str,
+            query: str,
+            _entity: str,
+            template_vars: dict[str, Any],
+            **_kwargs: Any,
+        ) -> list[dict[str, Any]]:
+            captured["query"] = query
+            captured["template_vars"] = template_vars
+            # inside window, both bounds
+            in_window = self._deliver(
+                "0xd1",
+                delivery_ts=request_ts_gt + 500,
+                request_id="0xreq_in",
+                request_ts=request_ts_gt + 100,
+            )
+            # request predates window (crosses the exclusive lower bound)
+            below = self._deliver(
+                "0xd2",
+                delivery_ts=request_ts_gt + 200,
+                request_id="0xreq_below",
+                request_ts=request_ts_gt,
+            )
+            # request past window upper bound
+            above = self._deliver(
+                "0xd3",
+                delivery_ts=request_ts_lt + 3600,
+                request_id="0xreq_above",
+                request_ts=request_ts_lt,
+            )
+            # oldest delivery reaches the lower bound so the truncation
+            # guard is satisfied
+            floor = self._deliver(
+                "0xd4",
+                delivery_ts=request_ts_gt - 10,
+                request_id="0xreq_floor",
+                request_ts=request_ts_gt - 100,
+            )
+            return [in_window, below, above, floor]
+
+        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
+        ids, dropped = fp.fetch_all_delivery_request_ids(
+            "http://marketplace",
+            request_ts_gt=request_ts_gt,
+            request_ts_lt=request_ts_lt,
+        )
+        # Only the request whose time is strictly inside the window survives.
+        assert ids == {"0xreq_in"}
+        assert dropped == 0
+        # Widened delivery-time upper bound goes to the subgraph.
+        # pylint: disable-next=protected-access
+        delivery_upper = request_ts_lt + fp._DELIVERY_LAG_ENVELOPE_S
+        assert f"blockTimestamp_lt: {delivery_upper}" in captured["query"]
+        # The subgraph lower bound is the raw request lower bound.
+        assert captured["template_vars"] == {"timestamp_gt": request_ts_gt}
+
+    def test_drops_rows_missing_request_id_or_ts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rows without a resolvable ``request.id`` or ``blockTimestamp`` drop.
+
+        Each dropped row is counted so the caller can gate PASS on a
+        zero drop count (any drop is a coverage denominator gap).
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        request_ts_gt = 1_700_000_000
+        request_ts_lt = 1_700_100_000
+
+        def fake_paginated(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+            return [
+                # valid — kept in the set
+                self._deliver(
+                    "0xok",
+                    delivery_ts=request_ts_gt + 100,
+                    request_id="0xreq_ok",
+                    request_ts=request_ts_gt + 50,
+                ),
+                # missing request.id — dropped
+                self._deliver(
+                    "0xno_id",
+                    delivery_ts=request_ts_gt + 200,
+                    request_id=None,
+                    request_ts=request_ts_gt + 60,
+                ),
+                # missing request.blockTimestamp — dropped
+                self._deliver(
+                    "0xno_ts",
+                    delivery_ts=request_ts_gt + 300,
+                    request_id="0xreq_no_ts",
+                    request_ts=None,
+                ),
+                # unparseable blockTimestamp — dropped
+                {
+                    "id": "0xbad_ts",
+                    "blockTimestamp": str(request_ts_gt + 400),
+                    "request": {
+                        "id": "0xreq_bad_ts",
+                        "blockTimestamp": "not-an-int",
+                    },
+                },
+                # missing delivery blockTimestamp — dropped
+                {
+                    "id": "0xno_dt",
+                    "request": {
+                        "id": "0xreq_no_dt",
+                        "blockTimestamp": str(request_ts_gt + 50),
+                    },
+                },
+                # floor row so the truncation guard passes
+                self._deliver(
+                    "0xfloor",
+                    delivery_ts=request_ts_gt - 10,
+                    request_id="0xreq_floor",
+                    request_ts=request_ts_gt - 100,
+                ),
+            ]
+
+        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
+        ids, dropped = fp.fetch_all_delivery_request_ids(
+            "http://marketplace",
+            request_ts_gt=request_ts_gt,
+            request_ts_lt=request_ts_lt,
+        )
+        assert ids == {"0xreq_ok"}
+        # Four rows are unresolvable (no id, no ts, bad ts, no delivery ts).
+        assert dropped == 4
+
+    def test_raises_on_truncated_sweep(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Oldest returned delivery > lower bound means paginator truncated.
+
+        A silent short-page-as-EOF exit inside a graph-node ``first``
+        clamp would leave the oldest delivery well above
+        ``request_ts_gt`` and bias coverage toward PASS by shrinking the
+        denominator. Must raise, not silently pass.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        request_ts_gt = 1_700_000_000
+        request_ts_lt = 1_700_100_000
+
+        def fake_paginated(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
+            # Oldest delivery blockTimestamp is well above request_ts_gt
+            # (paginator gave up before reaching the lower bound).
+            return [
+                self._deliver(
+                    "0xa",
+                    delivery_ts=request_ts_gt + 90_000,
+                    request_id="0xreq_a",
+                    request_ts=request_ts_gt + 10,
+                ),
+                self._deliver(
+                    "0xb",
+                    delivery_ts=request_ts_gt + 80_000,
+                    request_id="0xreq_b",
+                    request_ts=request_ts_gt + 20,
+                ),
+            ]
+
+        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
+        with pytest.raises(RuntimeError, match="truncated sweep"):
+            fp.fetch_all_delivery_request_ids(
+                "http://marketplace",
+                request_ts_gt=request_ts_gt,
+                request_ts_lt=request_ts_lt,
+            )
+
+    def test_empty_sweep_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Zero deliveries returned is a legitimate empty window, not truncation.
+
+        ``oldest_delivery_ts is None`` on an empty sweep — the completeness
+        guard must skip the raise for this case. The caller's
+        ``--min-marketplace-rows`` floor is the right gate for empty
+        windows.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        monkeypatch.setattr(fp, "_paginated_fetch", lambda *a, **kw: [])
+        ids, dropped = fp.fetch_all_delivery_request_ids(
+            "http://marketplace",
+            request_ts_gt=1_700_000_000,
+            request_ts_lt=1_700_100_000,
+        )
+        assert ids == set()
+        assert dropped == 0

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -19,6 +19,7 @@
 """Tests for benchmark/datasets/fetch_production.py"""
 
 import json
+import re
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -2204,7 +2205,14 @@ class TestEnrichmentSkipsPrefilled:
 
 
 class TestInjectTimestampLt:
-    """_inject_timestamp_lt splices an upper bound into a delivers query."""
+    """_inject_timestamp_lt splices an upper bound into a delivers query.
+
+    Still used by :func:`fetch_deliveries` on the ``DELIVERS_QUERY`` /
+    ``DELIVERS_QUERY_LEGACY`` templates (the ParsedDelivery ingest
+    path).  :func:`fetch_all_delivery_request_ids` now parameterises
+    ``blockTimestamp_lt`` directly in ``DELIVER_REQUEST_IDS_QUERY``
+    and does not go through this helper.
+    """
 
     def test_inserts_upper_bound_alongside_lower(self) -> None:
         """Both bounds land in the same ``where`` clause."""
@@ -2212,7 +2220,7 @@ class TestInjectTimestampLt:
         from benchmark.datasets import fetch_production as fp
 
         result = fp._inject_timestamp_lt(  # pylint: disable=protected-access
-            fp.DELIVER_REQUEST_IDS_QUERY, 1700000000, "DELIVER_REQUEST_IDS_QUERY"
+            fp.DELIVERS_QUERY, 1700000000, "DELIVERS_QUERY"
         )
         assert (
             "where: { blockTimestamp_gt: %(timestamp_gt)s, "
@@ -2236,8 +2244,60 @@ class TestInjectTimestampLt:
             )
 
 
+class _FakeMarketplaceSubgraph:
+    """Fake ``_post_graphql`` that honours the where-clause bounds.
+
+    Parses ``blockTimestamp_gt``, ``blockTimestamp_lt`` and ``first``
+    out of the query the caller sends and returns only the matching
+    rows, ordered ``blockTimestamp`` descending. Optionally clamps
+    ``first`` below the requested value to model graph-node's
+    server-side page cap — the whole point of the cursor pagination
+    fix is that this doesn't lose rows.
+    """
+
+    _TS_GT_RE = re.compile(r"blockTimestamp_gt:\s*(\d+)")
+    _TS_LT_RE = re.compile(r"blockTimestamp_lt:\s*(\d+)")
+    _FIRST_RE = re.compile(r"first:\s*(\d+)")
+
+    def __init__(
+        self,
+        rows: list[dict[str, Any]],
+        first_clamp: Optional[int] = None,
+    ) -> None:
+        self.rows = rows
+        self.first_clamp = first_clamp
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, _url: str, payload: dict[str, Any]) -> dict[str, Any]:
+        query = payload["query"]
+        ts_gt = int(self._TS_GT_RE.search(query).group(1))  # type: ignore[union-attr]
+        ts_lt = int(self._TS_LT_RE.search(query).group(1))  # type: ignore[union-attr]
+        first = int(self._FIRST_RE.search(query).group(1))  # type: ignore[union-attr]
+        if self.first_clamp is not None:
+            first = min(first, self.first_clamp)
+        matching = [r for r in self.rows if ts_gt < int(r["blockTimestamp"]) < ts_lt]
+        matching.sort(key=lambda r: -int(r["blockTimestamp"]))
+        page = matching[:first]
+        self.calls.append(
+            {
+                "ts_gt": ts_gt,
+                "ts_lt": ts_lt,
+                "first": first,
+                "returned": len(page),
+            }
+        )
+        return {"delivers": page}
+
+
 class TestFetchAllDeliveryRequestIds:
-    """Coverage-side enumeration + request-time filter + truncation guard."""
+    """Coverage-side enumeration with cursor pagination.
+
+    Every test drives the real ``fetch_all_delivery_request_ids`` end
+    to end through the real query template, the real cursor advance
+    loop, and the real request-time filter — only ``_post_graphql`` is
+    stubbed at the HTTP boundary. The previous suite stubbed
+    ``_paginated_fetch``, which was exactly the seam under test.
+    """
 
     @staticmethod
     def _deliver(
@@ -2258,217 +2318,269 @@ class TestFetchAllDeliveryRequestIds:
             "request": request,
         }
 
-    def test_filters_client_side_on_request_time(
+    def test_single_page_sweep_filters_client_side_on_request_time(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Deliveries whose request time falls inside the window survive.
-
-        The delivery-time envelope has to be widened (subgraph filter),
-        then the client-side filter narrows to request time. Verifies:
-        (a) only requests inside ``(request_ts_gt, request_ts_lt)`` are
-        returned, (b) the subgraph is asked for the widened delivery
-        upper bound.
-
-        :param monkeypatch: pytest monkeypatch fixture.
-        """
+        """Client-side request-time filter narrows the widened envelope."""
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
         request_ts_gt = 1_700_000_000
         request_ts_lt = 1_700_100_000
-        captured: dict[str, Any] = {}
-
-        def fake_paginated(
-            _url: str,
-            query: str,
-            _entity: str,
-            template_vars: dict[str, Any],
-            **_kwargs: Any,
-        ) -> list[dict[str, Any]]:
-            captured["query"] = query
-            captured["template_vars"] = template_vars
-            # inside window, both bounds
-            in_window = self._deliver(
+        rows = [
+            # in-window (request time strictly inside the parity window)
+            self._deliver(
                 "0xd1",
                 delivery_ts=request_ts_gt + 500,
                 request_id="0xreq_in",
                 request_ts=request_ts_gt + 100,
-            )
-            # request predates window (crosses the exclusive lower bound)
-            below = self._deliver(
+            ),
+            # delivery inside envelope but request AT the exclusive lower
+            # bound — must be filtered client-side
+            self._deliver(
                 "0xd2",
                 delivery_ts=request_ts_gt + 200,
                 request_id="0xreq_below",
                 request_ts=request_ts_gt,
-            )
-            # request past window upper bound
-            above = self._deliver(
+            ),
+            # request past window upper bound (delivered inside envelope
+            # because envelope is widened by _DELIVERY_LAG_ENVELOPE_S)
+            self._deliver(
                 "0xd3",
                 delivery_ts=request_ts_lt + 3600,
                 request_id="0xreq_above",
                 request_ts=request_ts_lt,
-            )
-            # oldest delivery reaches the lower bound so the truncation
-            # guard is satisfied
-            floor = self._deliver(
-                "0xd4",
-                delivery_ts=request_ts_gt - 10,
-                request_id="0xreq_floor",
-                request_ts=request_ts_gt - 100,
-            )
-            return [in_window, below, above, floor]
+            ),
+        ]
+        fake = _FakeMarketplaceSubgraph(rows)
+        monkeypatch.setattr(fp, "_post_graphql", fake)
 
-        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
         ids, dropped = fp.fetch_all_delivery_request_ids(
             "http://marketplace",
             request_ts_gt=request_ts_gt,
             request_ts_lt=request_ts_lt,
         )
-        # Only the request whose time is strictly inside the window survives.
+
         assert ids == {"0xreq_in"}
         assert dropped == 0
-        # Widened delivery-time upper bound goes to the subgraph.
+        # The subgraph was asked for the widened envelope, not the raw
+        # parity window — the whole point of the widening.
         # pylint: disable-next=protected-access
-        delivery_upper = request_ts_lt + fp._DELIVERY_LAG_ENVELOPE_S
-        assert f"blockTimestamp_lt: {delivery_upper}" in captured["query"]
-        # The subgraph lower bound is the raw request lower bound.
-        assert captured["template_vars"] == {"timestamp_gt": request_ts_gt}
+        expected_upper = request_ts_lt + fp._DELIVERY_LAG_ENVELOPE_S
+        assert fake.calls[0]["ts_gt"] == request_ts_gt
+        assert fake.calls[0]["ts_lt"] == expected_upper
+
+    def test_multi_page_cursor_walks_down_to_lower_bound(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Batch size smaller than dataset must not lose rows.
+
+        Fifteen deliveries all inside the window, ``batch_size=5`` — the
+        cursor must issue three pages plus a final empty one and return
+        every request_id.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        request_ts_gt = 1_700_000_000
+        request_ts_lt = 1_700_100_000
+        rows = [
+            self._deliver(
+                f"0xd{i}",
+                delivery_ts=request_ts_gt + i * 100,
+                request_id=f"0xreq_{i}",
+                request_ts=request_ts_gt + i * 100 - 1,
+            )
+            for i in range(1, 16)
+        ]
+        fake = _FakeMarketplaceSubgraph(rows)
+        monkeypatch.setattr(fp, "_post_graphql", fake)
+
+        ids, dropped = fp.fetch_all_delivery_request_ids(
+            "http://marketplace",
+            request_ts_gt=request_ts_gt,
+            request_ts_lt=request_ts_lt,
+            batch_size=5,
+        )
+
+        assert ids == {f"0xreq_{i}" for i in range(1, 16)}
+        assert dropped == 0
+        # ceil(15/5) = 3 full pages + one empty terminator.
+        assert len(fake.calls) == 4
+        assert fake.calls[-1]["returned"] == 0
+
+    def test_clamped_batch_size_still_covers_all_rows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """graph-node clamping ``first`` below the request must not lose rows.
+
+        This is the failure mode the previous truncation guard was meant
+        to catch, and the reason the guard shipped as unconditionally
+        true: with skip-based ``len(page) < first → EOF`` a clamp is
+        silently treated as EOF and shrinks the coverage denominator.
+        With the cursor loop, a clamp just means more iterations. A
+        regression that reintroduces the ``< first`` short-page break
+        would fail this test.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        request_ts_gt = 1_700_000_000
+        request_ts_lt = 1_700_100_000
+        rows = [
+            self._deliver(
+                f"0xd{i}",
+                delivery_ts=request_ts_gt + i * 10,
+                request_id=f"0xreq_{i}",
+                request_ts=request_ts_gt + i * 10 - 1,
+            )
+            for i in range(1, 21)
+        ]
+        # batch_size requests 100, subgraph returns at most 3 per page.
+        fake = _FakeMarketplaceSubgraph(rows, first_clamp=3)
+        monkeypatch.setattr(fp, "_post_graphql", fake)
+
+        ids, dropped = fp.fetch_all_delivery_request_ids(
+            "http://marketplace",
+            request_ts_gt=request_ts_gt,
+            request_ts_lt=request_ts_lt,
+            batch_size=100,
+        )
+
+        assert ids == {f"0xreq_{i}" for i in range(1, 21)}
+        assert dropped == 0
+        # ceil(20/3) = 7 full pages + one empty terminator.
+        assert len(fake.calls) == 8
+        assert all(c["returned"] <= 3 for c in fake.calls[:-1])
+
+    def test_same_timestamp_page_at_batch_size_logs_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Exclusive cursor advance skips ties past batch_size — must warn.
+
+        Because ``cursor_ts_lt = page_oldest_ts`` is exclusive, if a
+        single blockTimestamp holds more than ``batch_size``
+        deliveries, the next page's ``blockTimestamp_lt`` filter
+        excludes rows AT that timestamp and any not yet seen are
+        silently lost. This is deliberate — the fallback would be
+        to implement a composite (blockTimestamp, id) cursor, which
+        is a lot of code for a case that basically doesn't occur
+        with seconds-scale deliveries. What the function DOES do is
+        surface the case as a warning so an operator can bump
+        ``batch_size`` and rerun rather than trust a shrunken
+        coverage denominator.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param caplog: pytest log-capture fixture.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        request_ts_gt = 1_700_000_000
+        request_ts_lt = 1_700_100_000
+        # Four deliveries at the SAME blockTimestamp, batch_size=3.
+        # First page returns three of them, the warning fires, and the
+        # fourth is silently skipped by the exclusive cursor.
+        rows = [
+            self._deliver(
+                f"0xd_{i}",
+                delivery_ts=request_ts_gt + 500,
+                request_id=f"0xreq_{i}",
+                request_ts=request_ts_gt + 100,
+            )
+            for i in range(1, 5)
+        ]
+        fake = _FakeMarketplaceSubgraph(rows)
+        monkeypatch.setattr(fp, "_post_graphql", fake)
+
+        with caplog.at_level("WARNING", logger="benchmark.datasets.fetch_production"):
+            ids, _dropped = fp.fetch_all_delivery_request_ids(
+                "http://marketplace",
+                request_ts_gt=request_ts_gt,
+                request_ts_lt=request_ts_lt,
+                batch_size=3,
+            )
+
+        assert any(
+            "all share blockTimestamp" in rec.message for rec in caplog.records
+        ), "the operator-facing warning must fire when a page is entirely at one ts"
+        # Three of the four survive; the batch_size < ties case is
+        # exactly what the warning is telling the operator to escalate.
+        assert len(ids) == 3
 
     def test_drops_rows_missing_request_id_or_ts(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Rows without a resolvable ``request.id`` or ``blockTimestamp`` drop.
-
-        Each dropped row is counted so the caller can gate PASS on a
-        zero drop count (any drop is a coverage denominator gap).
-
-        :param monkeypatch: pytest monkeypatch fixture.
-        """
+        """Rows without a resolvable ``request.id`` or ``blockTimestamp`` drop."""
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
         request_ts_gt = 1_700_000_000
         request_ts_lt = 1_700_100_000
-
-        def fake_paginated(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
-            return [
-                # valid — kept in the set
-                self._deliver(
-                    "0xok",
-                    delivery_ts=request_ts_gt + 100,
-                    request_id="0xreq_ok",
-                    request_ts=request_ts_gt + 50,
-                ),
-                # missing request.id — dropped
-                self._deliver(
-                    "0xno_id",
-                    delivery_ts=request_ts_gt + 200,
-                    request_id=None,
-                    request_ts=request_ts_gt + 60,
-                ),
-                # missing request.blockTimestamp — dropped
-                self._deliver(
-                    "0xno_ts",
-                    delivery_ts=request_ts_gt + 300,
-                    request_id="0xreq_no_ts",
-                    request_ts=None,
-                ),
-                # unparseable blockTimestamp — dropped
-                {
-                    "id": "0xbad_ts",
-                    "blockTimestamp": str(request_ts_gt + 400),
-                    "request": {
-                        "id": "0xreq_bad_ts",
-                        "blockTimestamp": "not-an-int",
-                    },
+        rows: list[dict[str, Any]] = [
+            self._deliver(
+                "0xok",
+                delivery_ts=request_ts_gt + 100,
+                request_id="0xreq_ok",
+                request_ts=request_ts_gt + 50,
+            ),
+            self._deliver(
+                "0xno_id",
+                delivery_ts=request_ts_gt + 200,
+                request_id=None,
+                request_ts=request_ts_gt + 60,
+            ),
+            self._deliver(
+                "0xno_ts",
+                delivery_ts=request_ts_gt + 300,
+                request_id="0xreq_no_ts",
+                request_ts=None,
+            ),
+            {
+                "id": "0xbad_ts",
+                "blockTimestamp": str(request_ts_gt + 400),
+                "request": {
+                    "id": "0xreq_bad_ts",
+                    "blockTimestamp": "not-an-int",
                 },
-                # missing delivery blockTimestamp — dropped
-                {
-                    "id": "0xno_dt",
-                    "request": {
-                        "id": "0xreq_no_dt",
-                        "blockTimestamp": str(request_ts_gt + 50),
-                    },
-                },
-                # floor row so the truncation guard passes
-                self._deliver(
-                    "0xfloor",
-                    delivery_ts=request_ts_gt - 10,
-                    request_id="0xreq_floor",
-                    request_ts=request_ts_gt - 100,
-                ),
-            ]
+            },
+        ]
+        fake = _FakeMarketplaceSubgraph(rows)
+        monkeypatch.setattr(fp, "_post_graphql", fake)
 
-        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
         ids, dropped = fp.fetch_all_delivery_request_ids(
             "http://marketplace",
             request_ts_gt=request_ts_gt,
             request_ts_lt=request_ts_lt,
         )
+
         assert ids == {"0xreq_ok"}
-        # Four rows are unresolvable (no id, no ts, bad ts, no delivery ts).
-        assert dropped == 4
+        # Three unresolvable rows: no id, no ts, bad ts.
+        assert dropped == 3
 
-    def test_raises_on_truncated_sweep(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Oldest returned delivery > lower bound means paginator truncated.
-
-        A silent short-page-as-EOF exit inside a graph-node ``first``
-        clamp would leave the oldest delivery well above
-        ``request_ts_gt`` and bias coverage toward PASS by shrinking the
-        denominator. Must raise, not silently pass.
-
-        :param monkeypatch: pytest monkeypatch fixture.
-        """
+    def test_empty_sweep_returns_empty_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Zero deliveries returned exits cleanly (no exception)."""
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp
 
-        request_ts_gt = 1_700_000_000
-        request_ts_lt = 1_700_100_000
+        fake = _FakeMarketplaceSubgraph(rows=[])
+        monkeypatch.setattr(fp, "_post_graphql", fake)
 
-        def fake_paginated(*_args: Any, **_kwargs: Any) -> list[dict[str, Any]]:
-            # Oldest delivery blockTimestamp is well above request_ts_gt
-            # (paginator gave up before reaching the lower bound).
-            return [
-                self._deliver(
-                    "0xa",
-                    delivery_ts=request_ts_gt + 90_000,
-                    request_id="0xreq_a",
-                    request_ts=request_ts_gt + 10,
-                ),
-                self._deliver(
-                    "0xb",
-                    delivery_ts=request_ts_gt + 80_000,
-                    request_id="0xreq_b",
-                    request_ts=request_ts_gt + 20,
-                ),
-            ]
-
-        monkeypatch.setattr(fp, "_paginated_fetch", fake_paginated)
-        with pytest.raises(RuntimeError, match="truncated sweep"):
-            fp.fetch_all_delivery_request_ids(
-                "http://marketplace",
-                request_ts_gt=request_ts_gt,
-                request_ts_lt=request_ts_lt,
-            )
-
-    def test_empty_sweep_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Zero deliveries returned is a legitimate empty window, not truncation.
-
-        ``oldest_delivery_ts is None`` on an empty sweep — the completeness
-        guard must skip the raise for this case. The caller's
-        ``--min-marketplace-rows`` floor is the right gate for empty
-        windows.
-
-        :param monkeypatch: pytest monkeypatch fixture.
-        """
-        # pylint: disable-next=import-outside-toplevel
-        from benchmark.datasets import fetch_production as fp
-
-        monkeypatch.setattr(fp, "_paginated_fetch", lambda *a, **kw: [])
         ids, dropped = fp.fetch_all_delivery_request_ids(
             "http://marketplace",
             request_ts_gt=1_700_000_000,
             request_ts_lt=1_700_100_000,
         )
+
         assert ids == set()
         assert dropped == 0
+        # One call — the initial page came back empty and terminated.
+        assert len(fake.calls) == 1

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -2110,7 +2110,9 @@ class TestUnparsedRequestCursorCap:
         )
         lagging_cap = now - 600
         monkeypatch.setattr(
-            fp, "fetch_deliveries", lambda url, ts: ([matched], lagging_cap)
+            fp,
+            "fetch_deliveries",
+            lambda url, ts, **_kwargs: ([matched], lagging_cap),
         )
         monkeypatch.setattr(
             fp, "_enrich_rows_with_ipfs_metadata", lambda rows, url: None
@@ -2162,7 +2164,9 @@ class TestPendingSurvivesQuietRun:
             "parsed_missing": False,
         }
         monkeypatch.setattr(
-            fp, "fetch_deliveries", lambda url, ts: ([new_delivery], None)
+            fp,
+            "fetch_deliveries",
+            lambda url, ts, **_kwargs: ([new_delivery], None),
         )
 
         rows, all_pending, _, _ = fp.process_platform(

--- a/benchmark/tests/test_verify_migration_swap.py
+++ b/benchmark/tests/test_verify_migration_swap.py
@@ -21,12 +21,15 @@
 The gate is the actual go/no-go for the migration. An earlier edit
 could invert one threshold comparison, swap a numerator/denominator,
 or leave a stray early ``return 0`` and the script would print "PASS"
-on materially divergent data. These tests pin exit codes 0/2/3.
+on materially divergent data. These tests pin exit codes 0/2/3/4 and
+the artifact contract.
 """
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -72,14 +75,43 @@ def _patch_pulls(
     mp_rows: list[dict[str, Any]],
     lake_rows: list[dict[str, Any]],
     deliver_to_request: dict[str, dict[str, str]] | None = None,
+    marketplace_ids_by_platform: dict[str, set[str]] | None = None,
+    lake_ids_unfiltered: set[str] | None = None,
 ) -> None:
-    """Replace both pull entry points so main() runs with synthetic data."""
+    """Replace every pull entry point so main() runs with synthetic data.
+
+    ``main()`` calls four pull functions now — the two original ones
+    (``_pull_mech_predict_rows``, ``_pull_lake_rows``) plus the two
+    coverage-check helpers (``_pull_marketplace_request_ids``,
+    ``_pull_lake_request_ids_unfiltered``). Stubbing only two makes the
+    tests attempt real outbound HTTP for the other two, which fails on
+    ``MechAnalyticsError: MECH_ANALYTICS_URL is not set``.
+
+    Defaults derive the coverage-side ids from ``mp_rows`` / ``lake_rows``
+    so tests that only care about parity don't have to spell them out.
+    ``marketplace_ids_by_platform`` and ``lake_ids_unfiltered`` are
+    explicit knobs for the coverage-focused tests.
+    """
     dtr = (
         deliver_to_request
         if deliver_to_request is not None
         else {
             "omen": {r["deliver_id"]: r["request_id"] for r in mp_rows},
         }
+    )
+    mp_ids = {r["request_id"] for r in mp_rows if r.get("request_id")}
+    lake_ids = {r["request_id"] for r in lake_rows if r.get("request_id")}
+    marketplace = (
+        marketplace_ids_by_platform
+        if marketplace_ids_by_platform is not None
+        else {"omen": mp_ids, "polymarket": set()}
+    )
+    # Default: lake has at least everything mech-predict has (no coverage
+    # gap) so pre-existing parity tests aren't secondarily blocked by the
+    # coverage-gap exit code (4). Tests that specifically want to
+    # exercise coverage-gap semantics pass their own set.
+    lake_unfiltered = (
+        lake_ids_unfiltered if lake_ids_unfiltered is not None else lake_ids | mp_ids
     )
 
     def _mp(_since_ts: int, _until_ts: int) -> tuple[list[dict[str, Any]], dict]:
@@ -88,16 +120,45 @@ def _patch_pulls(
     def _lake(_since: datetime, _until: datetime) -> list[dict[str, Any]]:
         return lake_rows
 
+    def _marketplace_ids(
+        _since_ts: int, _until_ts: int
+    ) -> tuple[dict[str, set[str]], dict[str, int]]:
+        # Second element = per-platform ``dropped_no_request_id``. Zero
+        # here for the parity-focused tests that use the default; the
+        # coverage-focused tests spell it out via monkeypatch.
+        return marketplace, {p: 0 for p in marketplace}
+
+    def _lake_ids(_since: datetime, _until: datetime) -> set[str]:
+        return lake_unfiltered
+
     monkeypatch.setattr(vms, "_pull_mech_predict_rows", _mp)
     monkeypatch.setattr(vms, "_pull_lake_rows", _lake)
+    monkeypatch.setattr(vms, "_pull_marketplace_request_ids", _marketplace_ids)
+    monkeypatch.setattr(vms, "_pull_lake_request_ids_unfiltered", _lake_ids)
 
 
 def _base_argv() -> list[str]:
-    """Argv covering a 24h window so _compute_window doesn't reject."""
+    """Argv covering a 24h window so _compute_window doesn't reject.
+
+    ``--min-marketplace-rows 1`` overrides the production default
+    (10) — test fixtures have single-digit row counts on purpose
+    and the coverage-side floor exists to catch a subgraph outage in
+    production, not to constrain fixtures. Tests that specifically
+    exercise the min-marketplace-rows gate pass their own value.
+    """
     now = datetime.now(timezone.utc)
     since = (now - timedelta(days=2)).isoformat().replace("+00:00", "Z")
     until = (now - timedelta(days=1)).isoformat().replace("+00:00", "Z")
-    return ["--since", since, "--until", until, "--min-rows", "5"]
+    return [
+        "--since",
+        since,
+        "--until",
+        until,
+        "--min-rows",
+        "5",
+        "--min-marketplace-rows",
+        "1",
+    ]
 
 
 class TestDivergenceGate:
@@ -184,3 +245,153 @@ class TestDivergenceGate:
         _patch_pulls(monkeypatch, rows, lake, deliver_to_request=dtr)
         argv = _base_argv() + ["--min-rows", "5", "--min-overlap-fraction", "0.9"]
         assert vms.main(argv) == 0
+
+
+class TestCoverageGate:
+    """Exit code 4 covers three coverage failure modes, each blocking PASS.
+
+    The coverage check runs before the parity min-row guard on purpose:
+    a coverage gap and a thin parity window are correlated (a lake
+    missing rows *is* a lake with fewer rows), so a coverage failure
+    would get miscategorised as "window too thin" if parity ran first.
+    Each of the three failure modes here must return 4, not 2.
+    """
+
+    def test_marketplace_id_missing_from_lake_returns_four(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A single request_id in the marketplace but not the lake trips exit 4."""
+        rows = [_mp_row(f"r{i}") for i in range(10)]
+        lake = [_lake_row(f"r{i}") for i in range(10)]
+        marketplace_ids = {r["request_id"] for r in rows} | {"only-marketplace"}
+        # Lake unfiltered lacks ``only-marketplace``.
+        _patch_pulls(
+            monkeypatch,
+            rows,
+            lake,
+            marketplace_ids_by_platform={"omen": marketplace_ids, "polymarket": set()},
+            lake_ids_unfiltered={r["request_id"] for r in lake},
+        )
+        assert vms.main(_base_argv()) == 4
+
+    def test_dropped_no_request_id_returns_four(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A marketplace delivery dropped for missing request.id blocks PASS.
+
+        Even with a perfect set-diff (every returned id is in the lake),
+        a non-zero drop means one or more requests could be silently
+        absent from the lake without the check being able to name them.
+        The gate must fail.
+        """
+        rows = [_mp_row(f"r{i}") for i in range(10)]
+        lake = [_lake_row(f"r{i}") for i in range(10)]
+        marketplace_ids = {r["request_id"] for r in rows}
+
+        def _marketplace_ids(
+            _since_ts: int, _until_ts: int
+        ) -> tuple[dict[str, set[str]], dict[str, int]]:
+            # One row dropped on the omen side, nothing missing from the
+            # lake for what we DID resolve.
+            return {"omen": marketplace_ids, "polymarket": set()}, {
+                "omen": 1,
+                "polymarket": 0,
+            }
+
+        def _lake_ids(_since: datetime, _until: datetime) -> set[str]:
+            return marketplace_ids
+
+        _patch_pulls(monkeypatch, rows, lake)
+        monkeypatch.setattr(vms, "_pull_marketplace_request_ids", _marketplace_ids)
+        monkeypatch.setattr(vms, "_pull_lake_request_ids_unfiltered", _lake_ids)
+        assert vms.main(_base_argv()) == 4
+
+    def test_vacuous_marketplace_side_returns_four(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Both marketplace platforms returning zero rows must not PASS.
+
+        ``marketplace_ids - lake_ids`` is trivially empty when the
+        marketplace side is empty. Without the ``--min-marketplace-rows``
+        floor a subgraph outage would silently PASS as "no missing IDs".
+        """
+        rows = [_mp_row(f"r{i}") for i in range(10)]
+        lake = [_lake_row(f"r{i}") for i in range(10)]
+        _patch_pulls(
+            monkeypatch,
+            rows,
+            lake,
+            marketplace_ids_by_platform={"omen": set(), "polymarket": set()},
+            lake_ids_unfiltered={r["request_id"] for r in lake},
+        )
+        # Base argv uses --min-marketplace-rows 1, override upward so a
+        # zero-row total actually trips the floor.
+        argv = [
+            "--since",
+            (datetime.now(timezone.utc) - timedelta(days=2))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "--until",
+            (datetime.now(timezone.utc) - timedelta(days=1))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "--min-rows",
+            "5",
+            "--min-marketplace-rows",
+            "1",
+        ]
+        assert vms.main(argv) == 4
+
+
+class TestArtifact:
+    """--output-dir artifact contract: PASS runs write PASS + exit_code 0;
+    exception in flight writes ERROR + non-zero exit_code (never a false PASS).
+    """
+
+    def test_pass_run_writes_pass_verdict_and_zero_exit(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        rows = [_mp_row(f"r{i}") for i in range(10)]
+        lake = [_lake_row(f"r{i}") for i in range(10)]
+        _patch_pulls(monkeypatch, rows, lake)
+        argv = _base_argv() + ["--output-dir", str(tmp_path)]
+
+        assert vms.main(argv) == 0
+
+        artifacts = sorted(tmp_path.glob("*.json"))
+        assert len(artifacts) == 1
+        data = json.loads(artifacts[0].read_text())
+        assert data["verdict"] == "PASS"
+        assert data["exit_code"] == 0
+        assert data["coverage"]["total_missing"] == 0
+
+    def test_exception_in_flight_writes_error_not_false_pass(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A raised exception must not leave the artifact certifying PASS.
+
+        Before the fix, ``exit_code`` initialised to 0 and only flipped
+        on the explicit return paths, so any exception in the try body
+        landed a JSON artifact with ``verdict: PASS`` on the mounted
+        PVC. The K8s Job runner's non-zero exit told the truth, the
+        report on the volume did not.
+        """
+        rows = [_mp_row(f"r{i}") for i in range(10)]
+        lake = [_lake_row(f"r{i}") for i in range(10)]
+        _patch_pulls(monkeypatch, rows, lake)
+
+        def _boom(*_a: Any, **_kw: Any) -> Any:
+            raise RuntimeError("simulated subgraph outage")
+
+        # Blow up on the first coverage-side pull after metadata is emitted.
+        monkeypatch.setattr(vms, "_pull_marketplace_request_ids", _boom)
+        argv = _base_argv() + ["--output-dir", str(tmp_path)]
+
+        with pytest.raises(RuntimeError, match="simulated subgraph outage"):
+            vms.main(argv)
+
+        artifacts = sorted(tmp_path.glob("*.json"))
+        assert len(artifacts) == 1
+        data = json.loads(artifacts[0].read_text())
+        assert data["verdict"] == "ERROR"
+        assert data["exit_code"] != 0

--- a/benchmark/tests/test_verify_migration_swap.py
+++ b/benchmark/tests/test_verify_migration_swap.py
@@ -101,7 +101,9 @@ def _patch_pulls(
         ``mp_rows``.
     :param marketplace_ids_by_platform: explicit override for the
         marketplace-side coverage IDs. Defaults to ``mp_rows`` request
-        ids on the omen platform and empty on polymarket.
+        ids on the omen platform only — polymarket is omitted so the
+        per-platform vacuous-sweep floor doesn't secondarily block
+        parity-focused tests whose fixtures are single-platform.
     :param lake_ids_unfiltered: explicit override for the lake-side
         coverage IDs. Defaults to a union of ``lake_rows`` and
         ``mp_rows`` so parity tests don't secondarily fail the
@@ -119,7 +121,7 @@ def _patch_pulls(
     marketplace = (
         marketplace_ids_by_platform
         if marketplace_ids_by_platform is not None
-        else {"omen": mp_ids, "polymarket": set()}
+        else {"omen": mp_ids}
     )
     # Default: lake has at least everything mech-predict has (no coverage
     # gap) so pre-existing parity tests aren't secondarily blocked by the
@@ -362,6 +364,54 @@ class TestCoverageGate:
             "5",
             "--min-marketplace-rows",
             "1",
+        ]
+        assert vms.main(argv) == 4
+
+    def test_single_platform_vacuous_returns_four(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One populated platform can't mask an outage on the other.
+
+        The floor is enforced per platform, not on the aggregate. If
+        omen returns 12 IDs (above the floor of 10) but polymarket
+        returns zero (well below), aggregate = 12 would silently PASS
+        an aggregate check while polymarket's coverage is fully
+        vacuous. This test would fail if the guard were ever collapsed
+        back to a sum-across-platforms check.
+
+        :param monkeypatch: pytest fixture used to stub the pulls with
+            one populated and one empty platform.
+        """
+        rows = [_mp_row(f"r{i}") for i in range(12)]
+        lake = [_lake_row(f"r{i}") for i in range(12)]
+        omen_ids = {r["request_id"] for r in rows}
+        _patch_pulls(
+            monkeypatch,
+            rows,
+            lake,
+            # omen well above the floor, polymarket empty.
+            marketplace_ids_by_platform={
+                "omen": omen_ids,
+                "polymarket": set(),
+            },
+            # Lake covers every marketplace ID so ``missing_from_lake`` is
+            # zero — this test isolates the per-platform floor from the
+            # set-diff failure mode.
+            lake_ids_unfiltered=omen_ids,
+        )
+        argv = [
+            "--since",
+            (datetime.now(timezone.utc) - timedelta(days=2))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "--until",
+            (datetime.now(timezone.utc) - timedelta(days=1))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "--min-rows",
+            "5",
+            "--min-marketplace-rows",
+            "10",
         ]
         assert vms.main(argv) == 4
 

--- a/benchmark/tests/test_verify_migration_swap.py
+++ b/benchmark/tests/test_verify_migration_swap.py
@@ -279,17 +279,36 @@ class TestCoverageGate:
     def test_marketplace_id_missing_from_lake_returns_four(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A single request_id in the marketplace but not the lake trips exit 4."""
+        """A single request_id in the marketplace but not the lake trips exit 4.
+
+        Both platforms are populated above the vacuous floor so the ONLY
+        reason to return 4 is the missing_from_lake predicate. A previous
+        version of this test seeded ``polymarket: set()`` which tripped the
+        per-platform vacuous floor before the missing-from-lake check ever
+        fired — the test asserted exit 4 for the wrong reason. Mutating
+        ``if coverage.total_missing > 0: → if False:`` would silently keep
+        the old test green while completely deleting the feature this PR
+        adds. This test is written so that mutation now fails.
+
+        :param monkeypatch: pytest fixture used to swap the four pull
+            entry points.
+        """
         rows = [_mp_row(f"r{i}") for i in range(10)]
         lake = [_lake_row(f"r{i}") for i in range(10)]
-        marketplace_ids = {r["request_id"] for r in rows} | {"only-marketplace"}
-        # Lake unfiltered lacks ``only-marketplace``.
+        omen_ids = {r["request_id"] for r in rows} | {"only-marketplace"}
+        # Populate polymarket too, all present in the lake, so only the
+        # missing "only-marketplace" ID is the reason for a coverage gap.
+        polymarket_ids = {f"poly{i}" for i in range(5)}
+        lake_unfiltered = {r["request_id"] for r in lake} | polymarket_ids
         _patch_pulls(
             monkeypatch,
             rows,
             lake,
-            marketplace_ids_by_platform={"omen": marketplace_ids, "polymarket": set()},
-            lake_ids_unfiltered={r["request_id"] for r in lake},
+            marketplace_ids_by_platform={
+                "omen": omen_ids,
+                "polymarket": polymarket_ids,
+            },
+            lake_ids_unfiltered=lake_unfiltered,
         )
         assert vms.main(_base_argv()) == 4
 
@@ -303,29 +322,111 @@ class TestCoverageGate:
         absent from the lake without the check being able to name them.
         The gate must fail.
 
+        Both platforms populated above the vacuous floor here for the same
+        reason as the sibling test above — the drop counter is what has to
+        trip, not the floor. Mutating ``if coverage.total_dropped_no_rid >
+        0: → if False:`` must fail this test.
+
         :param monkeypatch: pytest fixture used to override the
             marketplace pull stub with a non-zero drop count.
         """
         rows = [_mp_row(f"r{i}") for i in range(10)]
         lake = [_lake_row(f"r{i}") for i in range(10)]
-        marketplace_ids = {r["request_id"] for r in rows}
+        omen_ids = {r["request_id"] for r in rows}
+        polymarket_ids = {f"poly{i}" for i in range(5)}
 
         def _marketplace_ids(
             _since_ts: int, _until_ts: int
         ) -> tuple[dict[str, set[str]], dict[str, int]]:
-            # One row dropped on the omen side, nothing missing from the
-            # lake for what we DID resolve.
-            return {"omen": marketplace_ids, "polymarket": set()}, {
+            # One row dropped on the omen side; nothing missing from the
+            # lake for anything the sweep did resolve.
+            return {"omen": omen_ids, "polymarket": polymarket_ids}, {
                 "omen": 1,
                 "polymarket": 0,
             }
 
         def _lake_ids(_since: datetime, _until: datetime) -> set[str]:
-            return marketplace_ids
+            return omen_ids | polymarket_ids
 
         _patch_pulls(monkeypatch, rows, lake)
         monkeypatch.setattr(vms, "_pull_marketplace_request_ids", _marketplace_ids)
         monkeypatch.setattr(vms, "_pull_lake_request_ids_unfiltered", _lake_ids)
+        assert vms.main(_base_argv()) == 4
+
+    def test_min_marketplace_rows_zero_still_traps_empty_platform(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An operator setting the flag to 0 must not turn off the zero-backstop.
+
+        ``--min-marketplace-rows 0`` used to let a total marketplace
+        outage on one platform PASS: the enforcement was strict
+        ``count < min``, and ``count < 0`` never held. That would let
+        an operator opt out of the check entirely with one env var,
+        turning a subgraph outage into a green artifact. The floor is
+        now ``max(1, min_marketplace_rows)`` so zero is always
+        vacuous, regardless of the flag.
+
+        :param monkeypatch: pytest fixture used to swap the four pull
+            entry points.
+        """
+        rows = [_mp_row(f"r{i}") for i in range(10)]
+        lake = [_lake_row(f"r{i}") for i in range(10)]
+        _patch_pulls(
+            monkeypatch,
+            rows,
+            lake,
+            marketplace_ids_by_platform={"omen": set(), "polymarket": set()},
+            lake_ids_unfiltered={r["request_id"] for r in lake},
+        )
+        argv = [
+            "--since",
+            (datetime.now(timezone.utc) - timedelta(days=2))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "--until",
+            (datetime.now(timezone.utc) - timedelta(days=1))
+            .isoformat()
+            .replace("+00:00", "Z"),
+            "--min-rows",
+            "5",
+            "--min-marketplace-rows",
+            "0",
+        ]
+        assert vms.main(argv) == 4
+
+    def test_coverage_gap_precedence_over_min_row_guard(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When both min-rows (2) and coverage-gap (4) could fire, coverage wins.
+
+        Sets up a state where the parity pull is thin enough to trip the
+        min-row guard AND the marketplace side has a missing-from-lake
+        request. If the order in ``main()`` is ever swapped (or the
+        coverage check moved after the parity min-row check), this
+        assertion flips to 2. That would produce artifacts labelled as
+        "window too thin" for actual coverage gaps — misleading exactly
+        the operator this gate exists for.
+
+        :param monkeypatch: pytest fixture used to swap the four pull
+            entry points.
+        """
+        # Two rows on each side (below --min-rows 5 in _base_argv). Both
+        # platforms above the vacuous floor.
+        rows = [_mp_row(f"r{i}") for i in range(2)]
+        lake = [_lake_row(f"r{i}") for i in range(2)]
+        omen_ids = {r["request_id"] for r in rows} | {"only-marketplace"}
+        polymarket_ids = {f"poly{i}" for i in range(5)}
+        _patch_pulls(
+            monkeypatch,
+            rows,
+            lake,
+            marketplace_ids_by_platform={
+                "omen": omen_ids,
+                "polymarket": polymarket_ids,
+            },
+            # Lake missing "only-marketplace" → coverage-gap condition met.
+            lake_ids_unfiltered={r["request_id"] for r in lake} | polymarket_ids,
+        )
         assert vms.main(_base_argv()) == 4
 
     def test_vacuous_marketplace_side_returns_four(

--- a/benchmark/tests/test_verify_migration_swap.py
+++ b/benchmark/tests/test_verify_migration_swap.py
@@ -91,6 +91,21 @@ def _patch_pulls(
     so tests that only care about parity don't have to spell them out.
     ``marketplace_ids_by_platform`` and ``lake_ids_unfiltered`` are
     explicit knobs for the coverage-focused tests.
+
+    :param monkeypatch: pytest fixture used to swap the four pull
+        entry points on ``vms``.
+    :param mp_rows: synthetic mech-predict rows.
+    :param lake_rows: synthetic lake rows for the resolved parity pull.
+    :param deliver_to_request: per-platform ``{deliver_id: request_id}``.
+        Defaults to a 1:1 map on the omen platform derived from
+        ``mp_rows``.
+    :param marketplace_ids_by_platform: explicit override for the
+        marketplace-side coverage IDs. Defaults to ``mp_rows`` request
+        ids on the omen platform and empty on polymarket.
+    :param lake_ids_unfiltered: explicit override for the lake-side
+        coverage IDs. Defaults to a union of ``lake_rows`` and
+        ``mp_rows`` so parity tests don't secondarily fail the
+        coverage gate.
     """
     dtr = (
         deliver_to_request
@@ -145,6 +160,8 @@ def _base_argv() -> list[str]:
     and the coverage-side floor exists to catch a subgraph outage in
     production, not to constrain fixtures. Tests that specifically
     exercise the min-marketplace-rows gate pass their own value.
+
+    :return: argv list suitable for feeding to ``vms.main``.
     """
     now = datetime.now(timezone.utc)
     since = (now - timedelta(days=2)).isoformat().replace("+00:00", "Z")
@@ -283,6 +300,9 @@ class TestCoverageGate:
         a non-zero drop means one or more requests could be silently
         absent from the lake without the check being able to name them.
         The gate must fail.
+
+        :param monkeypatch: pytest fixture used to override the
+            marketplace pull stub with a non-zero drop count.
         """
         rows = [_mp_row(f"r{i}") for i in range(10)]
         lake = [_lake_row(f"r{i}") for i in range(10)]
@@ -314,6 +334,9 @@ class TestCoverageGate:
         ``marketplace_ids - lake_ids`` is trivially empty when the
         marketplace side is empty. Without the ``--min-marketplace-rows``
         floor a subgraph outage would silently PASS as "no missing IDs".
+
+        :param monkeypatch: pytest fixture used to stub the pulls with
+            empty marketplace-side sets.
         """
         rows = [_mp_row(f"r{i}") for i in range(10)]
         lake = [_lake_row(f"r{i}") for i in range(10)]
@@ -344,13 +367,21 @@ class TestCoverageGate:
 
 
 class TestArtifact:
-    """--output-dir artifact contract: PASS runs write PASS + exit_code 0;
-    exception in flight writes ERROR + non-zero exit_code (never a false PASS).
+    """--output-dir artifact contract.
+
+    PASS runs write ``verdict=PASS + exit_code=0``; an exception in
+    flight writes ``verdict=ERROR + non-zero exit_code`` — never a
+    false PASS on the mounted volume regardless of what killed the run.
     """
 
     def test_pass_run_writes_pass_verdict_and_zero_exit(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
+        """A clean parity+coverage PASS lands the expected artifact.
+
+        :param monkeypatch: pytest fixture used to swap the pull entries.
+        :param tmp_path: pytest fixture giving a per-test writable dir.
+        """
         rows = [_mp_row(f"r{i}") for i in range(10)]
         lake = [_lake_row(f"r{i}") for i in range(10)]
         _patch_pulls(monkeypatch, rows, lake)
@@ -375,6 +406,10 @@ class TestArtifact:
         landed a JSON artifact with ``verdict: PASS`` on the mounted
         PVC. The K8s Job runner's non-zero exit told the truth, the
         report on the volume did not.
+
+        :param monkeypatch: pytest fixture used to inject a raising
+            stub into the first coverage pull.
+        :param tmp_path: pytest fixture giving a per-test writable dir.
         """
         rows = [_mp_row(f"r{i}") for i in range(10)]
         lake = [_lake_row(f"r{i}") for i in range(10)]

--- a/scripts/verify_migration_swap.py
+++ b/scripts/verify_migration_swap.py
@@ -69,17 +69,18 @@ Required env vars:
 from __future__ import annotations
 
 import argparse
-from collections import Counter, defaultdict
-from datetime import datetime, timedelta, timezone
 import io
 import json
 import logging
 import os
-from pathlib import Path
 import statistics
 import subprocess
 import sys
 import time
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Sequence
 
 log = logging.getLogger("verify_migration_swap")
@@ -89,8 +90,14 @@ log = logging.getLogger("verify_migration_swap")
 # Guards / knobs                                                              #
 # --------------------------------------------------------------------------- #
 
-# Below this row count on either side the comparison is vacuous.
+# Below this row count on either side the parity comparison is vacuous.
 MINIMUM_ROWS_PER_SIDE = 100
+
+# Below this total across all platforms the coverage sweep is vacuous —
+# an empty marketplace side makes ``marketplace_ids - lake_ids`` trivially
+# empty regardless of whether the lake actually has anything. The floor
+# distinguishes "healthy sweep, no gap" from "sweep returned nothing".
+MINIMUM_MARKETPLACE_ROWS = 10
 
 # Comparing floats coming from independent code paths — allow small drift.
 FLOAT_TOL = 1e-6
@@ -127,10 +134,18 @@ def _pull_mech_predict_rows(
     ]
     for platform, marketplace_url, fetch_resolved in platforms:
         log.info("pulling mech-predict rows: platform=%s", platform)
-        # Bound both queries to the window so enumeration doesn't fan out from
-        # `since` to `now` for old windows (the source of hours-long runs
-        # against 6-month-old windows).
-        resolved = fetch_resolved(resolved_after=since_ts, resolved_before=until_ts)
+        # Delivery time IS bounded to the window here (parity's row set is
+        # keyed on delivery, which both sides agree on). Resolution time is
+        # NOT bounded: the lake's ``/v1/data/scored-rows`` endpoint only
+        # supports filtering on ``requested_at``, not on resolution time.
+        # Narrowing the mech-predict side on resolution time while the
+        # lake side has no equivalent bound would deflate the overlap
+        # near the trailing edge — markets that resolve shortly after
+        # ``until`` would stay in the lake but disappear from
+        # mech-predict, showing up as ``only_lake`` for reasons unrelated
+        # to real migration divergence. Pay the enumeration cost for
+        # correctness.
+        resolved = fetch_resolved(resolved_after=since_ts)
         rows, _still_pending, _max_delivery_ts, _max_resolved_ts = fp.process_platform(
             platform=platform,
             marketplace_url=marketplace_url,
@@ -219,7 +234,9 @@ def _pull_lake_rows(since: datetime, until: datetime) -> list[dict[str, Any]]:
     return list(iter_scored_rows(since=since, until=until, resolved=True))
 
 
-def _pull_marketplace_request_ids(since_ts: int, until_ts: int) -> dict[str, set[str]]:
+def _pull_marketplace_request_ids(
+    since_ts: int, until_ts: int
+) -> tuple[dict[str, set[str]], dict[str, int]]:
     """Fetch every on-chain request_id delivered in the window, per platform.
 
     Coverage-check input: the ground truth of on-chain mech traffic
@@ -228,9 +245,15 @@ def _pull_marketplace_request_ids(since_ts: int, until_ts: int) -> dict[str, set
     ID set below to prove no on-chain request is missing from the
     lake.
 
+    Also threads the per-platform "delivery had no request.id" drop
+    count out of ``fetch_all_delivery_request_ids``. A non-zero drop
+    means the coverage denominator shrank silently — those requests
+    could be genuinely absent from the lake but the check has no way
+    to name them. The caller blocks PASS on any non-zero drop.
+
     :param since_ts: unix seconds, inclusive lower bound.
     :param until_ts: unix seconds, exclusive upper bound.
-    :return: platform name → set of on-chain request_ids for that platform.
+    :return: tuple of (platform → request_ids set, platform → dropped_no_rid).
     """
     # pylint: disable=import-outside-toplevel
     from benchmark.datasets import fetch_production as fp
@@ -240,6 +263,7 @@ def _pull_marketplace_request_ids(since_ts: int, until_ts: int) -> dict[str, set
         ("polymarket", fp.MECH_MARKETPLACE_POLYGON_URL),
     ]
     ids_by_platform: dict[str, set[str]] = {}
+    dropped_by_platform: dict[str, int] = {}
     for platform, marketplace_url in platforms:
         log.info(
             "pulling marketplace request_ids: platform=%s window=[%s, %s)",
@@ -247,10 +271,12 @@ def _pull_marketplace_request_ids(since_ts: int, until_ts: int) -> dict[str, set
             since_ts,
             until_ts,
         )
-        ids_by_platform[platform] = fp.fetch_all_delivery_request_ids(
+        ids, dropped = fp.fetch_all_delivery_request_ids(
             marketplace_url, since_ts, timestamp_lt=until_ts
         )
-    return ids_by_platform
+        ids_by_platform[platform] = ids
+        dropped_by_platform[platform] = dropped
+    return ids_by_platform, dropped_by_platform
 
 
 def _pull_lake_request_ids_unfiltered(since: datetime, until: datetime) -> set[str]:
@@ -651,39 +677,86 @@ def _section(title: str) -> None:
 # --------------------------------------------------------------------------- #
 
 
+@dataclass(frozen=True)
+class _CoverageResult:
+    """Structured outcome of the coverage check.
+
+    Groups every fact the verdict decision needs plus everything the
+    JSON artifact needs to persist, so ``main`` doesn't juggle five
+    parallel dicts and the caller can't accidentally rely on stale
+    fields.
+    """
+
+    total_missing: int
+    missing_by_platform: dict[str, list[str]]
+    total_dropped_no_rid: int
+    dropped_by_platform: dict[str, int]
+    marketplace_counts: dict[str, int]
+    total_marketplace: int
+
+
 def _report_coverage_check(
     marketplace_ids_by_platform: dict[str, set[str]],
+    dropped_by_platform: dict[str, int],
     lake_ids: set[str],
-) -> tuple[int, dict[str, list[str]]]:
+) -> _CoverageResult:
     """Coverage check: prove every on-chain request is in the lake.
 
     For each platform, computes the set of request_ids the marketplace
     subgraph knows about but the lake does not. Prints a per-platform
-    breakdown and returns the total gap size plus the per-platform ID
-    lists so the caller can put the full lists in the JSON artifact
-    and act on the gate.
+    breakdown and returns a :class:`_CoverageResult` with every fact
+    the caller needs to compute the verdict and populate the artifact.
+
+    Coverage failure modes the caller must gate on:
+
+    * ``total_missing > 0`` — genuine gap, on-chain requests absent
+      from the lake.
+    * ``total_dropped_no_rid > 0`` — the marketplace pull returned
+      deliveries whose ``request.id`` was missing, so those requests
+      never entered the coverage denominator and could be silently
+      absent from the lake without being reported.
+    * ``total_marketplace < min_marketplace_rows`` (checked by caller) —
+      an empty or near-empty coverage sweep is indistinguishable from
+      complete coverage on the set-diff alone; the caller enforces a
+      floor to distinguish "healthy sweep, no gap" from "sweep
+      returned nothing, so of course there's no diff".
 
     :param marketplace_ids_by_platform: output of
-        :func:`_pull_marketplace_request_ids`.
+        :func:`_pull_marketplace_request_ids` (first tuple element).
+    :param dropped_by_platform: output of
+        :func:`_pull_marketplace_request_ids` (second tuple element) —
+        per-platform count of deliveries dropped because their
+        ``request.id`` was missing.
     :param lake_ids: output of :func:`_pull_lake_request_ids_unfiltered`.
-    :return: tuple of (total_missing_count, per-platform missing lists).
+    :return: :class:`_CoverageResult` with per-platform and aggregate stats.
     """
     _section("Coverage check (marketplace subgraph → mech-analytics lake)")
     missing_by_platform: dict[str, list[str]] = {}
+    marketplace_counts: dict[str, int] = {}
     total_missing = 0
+    total_marketplace = 0
     for platform, marketplace_ids in marketplace_ids_by_platform.items():
         missing = sorted(marketplace_ids - lake_ids)
         missing_by_platform[platform] = missing
+        marketplace_counts[platform] = len(marketplace_ids)
         total_missing += len(missing)
-        marker = "✓" if not missing else "✗"
+        total_marketplace += len(marketplace_ids)
+        dropped = dropped_by_platform.get(platform, 0)
+        marker = "✓" if not missing and dropped == 0 else "✗"
         print(
             f"  {platform}: marketplace={len(marketplace_ids):>7}  "
-            f"missing_from_lake={len(missing):>5}  {marker}"
+            f"missing_from_lake={len(missing):>5}  "
+            f"dropped_no_request_id={dropped:>4}  {marker}"
         )
+    total_dropped = sum(dropped_by_platform.values())
     print(f"  lake (all chains, incl. off-chain): {len(lake_ids):>7}")
     print(
         f"  total missing from lake:            {total_missing:>7}  "
         f"{'✓' if total_missing == 0 else '✗'}"
+    )
+    print(
+        f"  total dropped_no_request_id:        {total_dropped:>7}  "
+        f"{'✓' if total_dropped == 0 else '✗'}"
     )
     if total_missing:
         print()
@@ -699,7 +772,23 @@ def _report_coverage_check(
             for rid in missing[:20]:
                 print(f"    {rid}")
             print("    (full list in the .json artifact)")
-    return total_missing, missing_by_platform
+    if total_dropped:
+        print()
+        print(
+            f"  {total_dropped} marketplace delivery/deliveries had a missing "
+            f"``request.id`` and were dropped from the coverage denominator. "
+            f"Each dropped row is a request that could genuinely be absent "
+            f"from the lake but that the check cannot name. Investigate "
+            f"the marketplace subgraph schema."
+        )
+    return _CoverageResult(
+        total_missing=total_missing,
+        missing_by_platform=missing_by_platform,
+        total_dropped_no_rid=total_dropped,
+        dropped_by_platform=dropped_by_platform,
+        marketplace_counts=marketplace_counts,
+        total_marketplace=total_marketplace,
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -710,15 +799,21 @@ def _report_coverage_check(
 def _git_sha() -> str:
     """Return the current git commit SHA, or ``unknown`` on failure.
 
-    ``git`` is resolved via PATH deliberately: hardcoding an absolute
-    path would be brittle across environments (Linux/macOS/CI/Docker
-    all put git in different locations) and the argv is a fixed literal
-    that never accepts user input. ``unknown`` is returned when the
-    tool isn't installed (stripped-down container) or the working
-    directory isn't a git repo.
+    Reads from the ``GIT_SHA`` env var first, then falls back to
+    invoking ``git rev-parse``. The env-var branch is what the shipped
+    K8s image uses: the Dockerfile has no ``git`` binary and no
+    ``.git`` directory, so the ``git`` branch would always fail there
+    and every artifact would attribute the run to ``unknown``. The
+    publish workflow bakes ``GITHUB_SHA`` into the image at build
+    time via ``--build-arg GIT_SHA=...`` so the artifact can point
+    at the exact commit that produced it. Local dev runs use the
+    ``git`` branch.
 
     :return: 40-char SHA hex string, or the literal ``unknown``.
     """
+    from_env = os.environ.get("GIT_SHA", "").strip()
+    if from_env:
+        return from_env
     try:
         return (
             subprocess.check_output(  # nosec B603 B607
@@ -730,6 +825,10 @@ def _git_sha() -> str:
             .strip()
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
+        log.warning(
+            "_git_sha: neither GIT_SHA env var nor git binary available; "
+            "run provenance will be attributed to 'unknown'"
+        )
         return "unknown"
 
 
@@ -813,6 +912,17 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=int,
         default=MINIMUM_ROWS_PER_SIDE,
         help=f"min rows per side to accept comparison (default {MINIMUM_ROWS_PER_SIDE})",
+    )
+    p.add_argument(
+        "--min-marketplace-rows",
+        type=int,
+        default=MINIMUM_MARKETPLACE_ROWS,
+        help=(
+            "min total marketplace deliveries across platforms for the "
+            "coverage check to be non-vacuous. An empty coverage sweep "
+            "makes an empty set-diff, which would otherwise report PASS. "
+            f"Default {MINIMUM_MARKETPLACE_ROWS}."
+        ),
     )
     p.add_argument(
         "--min-overlap-fraction",
@@ -905,9 +1015,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     :param argv: optional CLI argument override; defaults to ``sys.argv``.
     :return: exit code — 0 pass; 2 min-row guard trip; 3 parity
         divergence above thresholds; 4 coverage gap
-        (on-chain requests missing from the lake).
+        (on-chain requests missing from the lake, or drops in the
+        marketplace pull, or vacuous coverage sweep).
     """
-    # pylint: disable=too-many-locals,too-many-statements
+    # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     args = _parse_args(argv)
     logging.basicConfig(
         level=logging.INFO if args.verbose else logging.WARNING,
@@ -920,7 +1031,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     report_buffer = io.StringIO()
     sys.stdout = _Tee(report_buffer)  # type: ignore[assignment]
     started_at = time.monotonic()
-    exit_code = 0
+    # Sentinel: any non-zero exit + non-PASS verdict. Only the explicit
+    # success path flips these to 0 / "PASS". If the try body raises
+    # before reaching the verdict block, the ``finally`` writes the
+    # artifact certifying "ERROR" — matches what the pod's non-zero
+    # exit already tells the K8s Job runner, but now the persisted
+    # report on the PVC agrees instead of falsely certifying PASS.
+    exit_code = 1
+    verdict = "ERROR"
     metadata: dict[str, Any] = {}
     coverage_summary: dict[str, Any] = {}
     parity_summary: dict[str, Any] = {}
@@ -932,20 +1050,38 @@ def main(argv: Sequence[str] | None = None) -> int:
         until_ts = int(until.timestamp())
 
         # --- Coverage check (fast-fail: if the lake is missing on-chain
-        # requests, parity on the overlap doesn't rescue that).
-        marketplace_ids_by_platform = _pull_marketplace_request_ids(since_ts, until_ts)
+        # requests, parity on the overlap doesn't rescue that. Return
+        # exit 4 *before* the parity pull so a coverage gap can't be
+        # miscategorised by the min-row guard.).
+        marketplace_ids_by_platform, dropped_by_platform = (
+            _pull_marketplace_request_ids(since_ts, until_ts)
+        )
         lake_ids_unfiltered = _pull_lake_request_ids_unfiltered(since, until)
-        total_missing, missing_by_platform = _report_coverage_check(
-            marketplace_ids_by_platform, lake_ids_unfiltered
+        coverage = _report_coverage_check(
+            marketplace_ids_by_platform, dropped_by_platform, lake_ids_unfiltered
         )
         coverage_summary = {
-            "marketplace_ids_by_platform_count": {
-                p: len(v) for p, v in marketplace_ids_by_platform.items()
-            },
+            "marketplace_ids_by_platform_count": coverage.marketplace_counts,
+            "total_marketplace": coverage.total_marketplace,
             "lake_ids_unfiltered_count": len(lake_ids_unfiltered),
-            "missing_from_lake_by_platform": missing_by_platform,
-            "total_missing": total_missing,
+            "missing_from_lake_by_platform": coverage.missing_by_platform,
+            "total_missing": coverage.total_missing,
+            "dropped_no_request_id_by_platform": coverage.dropped_by_platform,
+            "total_dropped_no_request_id": coverage.total_dropped_no_rid,
         }
+
+        # Gate on the coverage side BEFORE hitting parity: a coverage
+        # gap or a vacuous sweep or a schema-drift drop is worth its
+        # own dedicated exit code, and the min-row guard on the parity
+        # pull below would otherwise swallow the same situation as a
+        # generic "window too thin".
+        coverage_failure = _coverage_failure_reason(coverage, args.min_marketplace_rows)
+        if coverage_failure is not None:
+            print()
+            print(f"FAIL (coverage): {coverage_failure}")
+            exit_code = 4
+            verdict = "FAIL"
+            return exit_code
 
         # --- Parity check on the resolved intersection.
         mp_rows, deliver_to_request_by_platform = _pull_mech_predict_rows(
@@ -965,6 +1101,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "Extend the window, check the endpoints, or lower --min-rows."
             )
             exit_code = 2
+            verdict = "FAIL"
             return exit_code
 
         print(f"mech-predict rows: {len(mp_rows)}   lake rows: {len(lake_rows)}")
@@ -985,7 +1122,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         overlap_denom = min(mp_ids_size, lake_ids_size)
         overlap_fraction = len(intersection) / overlap_denom if overlap_denom else 0.0
         mismatch_fraction = outcome_mismatch / resolved_both if resolved_both else 0.0
-        print(f"  coverage: missing_from_lake={total_missing} " f"(threshold == 0)")
+        print(
+            f"  coverage: missing_from_lake={coverage.total_missing} "
+            f"dropped_no_request_id={coverage.total_dropped_no_rid} "
+            f"total_marketplace={coverage.total_marketplace} (thresholds "
+            f"missing==0, dropped==0, marketplace>={args.min_marketplace_rows})"
+        )
         print(
             f"  overlap:  {len(intersection)} / {overlap_denom} = "
             f"{overlap_fraction:.4f}  (threshold >= {args.min_overlap_fraction})"
@@ -1006,18 +1148,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             "mismatch_fraction": mismatch_fraction,
         }
 
-        # Coverage failure takes precedence — an incomplete lake means
-        # even a perfect parity number is describing an incomplete
-        # picture. Reviewer needs to know the gap first.
-        if total_missing > 0:
-            print()
-            print(
-                f"FAIL (coverage): {total_missing} on-chain request_ids "
-                f"are missing from the lake."
-            )
-            exit_code = 4
-            return exit_code
-
         failures: list[str] = []
         if overlap_fraction < args.min_overlap_fraction:
             failures.append(
@@ -1035,13 +1165,18 @@ def main(argv: Sequence[str] | None = None) -> int:
             for reason in failures:
                 print(f"  - {reason}")
             exit_code = 3
+            verdict = "FAIL"
             return exit_code
         print()
         print("PASS: coverage complete, parity within thresholds")
+        exit_code = 0
+        verdict = "PASS"
         return exit_code
     finally:
         elapsed_s = time.monotonic() - started_at
-        print(f"\nwall time: {elapsed_s:.1f}s")
+        print(
+            f"\nwall time: {elapsed_s:.1f}s  verdict: {verdict}  exit_code: {exit_code}"
+        )
         sys.stdout = sys.__stdout__  # type: ignore[assignment]
         if args.output_dir:
             window_slug = f"{since.date().isoformat()}_to_{until.date().isoformat()}"
@@ -1049,7 +1184,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "metadata": {**metadata, "wall_time_s": round(elapsed_s, 1)},
                 "coverage": coverage_summary,
                 "parity": parity_summary,
-                "verdict": "PASS" if exit_code == 0 else "FAIL",
+                "verdict": verdict,
                 "exit_code": exit_code,
             }
             _write_report_files(
@@ -1058,6 +1193,51 @@ def main(argv: Sequence[str] | None = None) -> int:
                 report_buffer.getvalue(),
                 json_data,
             )
+
+
+def _coverage_failure_reason(
+    coverage: "_CoverageResult", min_marketplace_rows: int
+) -> str | None:
+    """Return a human-readable failure reason for the coverage check, or None.
+
+    Three ways coverage can fail, in priority order:
+
+    1. ``total_marketplace < min_marketplace_rows`` — the marketplace
+       sweep is vacuous. ``marketplace_ids - lake_ids`` is trivially
+       empty when the marketplace side is empty, so without this floor
+       any subgraph outage would silently PASS as "no missing IDs".
+    2. ``total_dropped_no_rid > 0`` — deliveries came back without a
+       resolvable ``request.id`` and were dropped from the coverage
+       denominator. Each dropped row is a request that could be absent
+       from the lake but that we can never name, so a "no missing IDs"
+       PASS would be misleading.
+    3. ``total_missing > 0`` — a genuine coverage gap.
+
+    :param coverage: the result of :func:`_report_coverage_check`.
+    :param min_marketplace_rows: floor from ``--min-marketplace-rows``.
+    :return: human-readable failure reason, or ``None`` on success.
+    """
+    if coverage.total_marketplace < min_marketplace_rows:
+        return (
+            f"vacuous coverage sweep — total marketplace deliveries "
+            f"{coverage.total_marketplace} < min_marketplace_rows "
+            f"{min_marketplace_rows}. An empty coverage side makes "
+            f"``marketplace_ids - lake_ids`` trivially empty and would "
+            f"otherwise report PASS. Check the marketplace subgraph."
+        )
+    if coverage.total_dropped_no_rid > 0:
+        return (
+            f"{coverage.total_dropped_no_rid} marketplace delivery/"
+            f"deliveries dropped from the coverage denominator because "
+            f"``request.id`` was missing. Each dropped row is a request "
+            f"the check can't name — cannot confirm coverage."
+        )
+    if coverage.total_missing > 0:
+        return (
+            f"{coverage.total_missing} on-chain request_ids are "
+            f"missing from the lake."
+        )
+    return None
 
 
 if __name__ == "__main__":

--- a/scripts/verify_migration_swap.py
+++ b/scripts/verify_migration_swap.py
@@ -69,17 +69,17 @@ Required env vars:
 from __future__ import annotations
 
 import argparse
+from collections import Counter, defaultdict
+from datetime import datetime, timedelta, timezone
 import io
 import json
 import logging
 import os
+from pathlib import Path
 import statistics
 import subprocess
 import sys
 import time
-from collections import Counter, defaultdict
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from typing import Any, Sequence
 
 log = logging.getLogger("verify_migration_swap")
@@ -708,13 +708,16 @@ def _report_coverage_check(
 
 
 def _git_sha() -> str:
-    """Return the current git commit SHA, or ``unknown`` if git isn't
-    available (e.g. running inside a stripped-down container).
+    """Return the current git commit SHA, or ``unknown`` on failure.
 
     ``git`` is resolved via PATH deliberately: hardcoding an absolute
     path would be brittle across environments (Linux/macOS/CI/Docker
     all put git in different locations) and the argv is a fixed literal
-    that never accepts user input.
+    that never accepts user input. ``unknown`` is returned when the
+    tool isn't installed (stripped-down container) or the working
+    directory isn't a git repo.
+
+    :return: 40-char SHA hex string, or the literal ``unknown``.
     """
     try:
         return (
@@ -733,13 +736,19 @@ def _git_sha() -> str:
 def _print_metadata(
     since: datetime, until: datetime, mech_analytics_url: str
 ) -> dict[str, Any]:
-    """Print the run's provenance header and return the same fields as a
-    dict for the JSON artifact.
+    """Print the run's provenance header and return the same as a dict.
 
     Every artifact this script writes needs to be dated and attributable
     so a reviewer months later can tell whether a report is still
     current — which mech-analytics version it verified, which script
     commit produced it, when it ran.
+
+    :param since: window lower bound (inclusive, timezone-aware).
+    :param until: window upper bound (exclusive, timezone-aware).
+    :param mech_analytics_url: the ``MECH_ANALYTICS_URL`` this run hit
+        (or ``<unset>`` when the env var was missing).
+    :return: the same metadata as a dict, for embedding in the
+        ``.json`` artifact.
     """
     metadata = {
         "run_at_utc": datetime.now(timezone.utc).isoformat(),
@@ -772,6 +781,11 @@ def _write_report_files(
     A K8s Job mounts a PVC or emptyDir at ``output_dir``; a reviewer or
     a follow-up step can then read the ``.md`` for the human summary
     and the ``.json`` for full ID lists and machine consumption.
+
+    :param output_dir: directory to write into; created if missing.
+    :param window_slug: filename stem, typically ``<since>_to_<until>``.
+    :param human_report: full stdout capture from the run.
+    :param json_data: structured summary (metadata + coverage + parity).
     """
     output_dir.mkdir(parents=True, exist_ok=True)
     md_path = output_dir / f"{window_slug}.md"
@@ -853,20 +867,39 @@ class _Tee:
     """
 
     def __init__(self, buffer: io.StringIO) -> None:
+        """Store the buffer and snapshot the original stdout stream.
+
+        :param buffer: in-memory buffer that receives every write.
+        """
         self._buffer = buffer
+        # ``sys.__stdout__`` is typed ``Optional[TextIO]`` (it's None when
+        # the interpreter runs with stdout detached, e.g. under some
+        # embedded contexts). This script only runs as an ordinary CLI so
+        # the field is always populated; assert to encode that invariant
+        # for mypy so the write/flush calls below don't need a runtime
+        # None check on every emit.
+        assert sys.__stdout__ is not None, "sys.__stdout__ unavailable"
         self._stdout = sys.__stdout__
 
     def write(self, s: str) -> int:
+        """Write ``s`` to both the original stdout and the capture buffer.
+
+        :param s: the text ``print`` handed us.
+        :return: number of characters the buffer accepted (satisfies the
+            file-like contract ``print`` relies on).
+        """
         self._stdout.write(s)
         return self._buffer.write(s)
 
     def flush(self) -> None:
+        """Flush the underlying stdout so line-buffered pods see output.
+
+        The buffer is in-memory so it has no flush semantics.
+        """
         self._stdout.flush()
 
 
-def main(
-    argv: Sequence[str] | None = None,
-) -> int:  # pylint: disable=too-many-locals,too-many-statements
+def main(argv: Sequence[str] | None = None) -> int:
     """Run coverage + parity checks and emit a report to stdout (+ file).
 
     :param argv: optional CLI argument override; defaults to ``sys.argv``.
@@ -874,6 +907,7 @@ def main(
         divergence above thresholds; 4 coverage gap
         (on-chain requests missing from the lake).
     """
+    # pylint: disable=too-many-locals,too-many-statements
     args = _parse_args(argv)
     logging.basicConfig(
         level=logging.INFO if args.verbose else logging.WARNING,

--- a/scripts/verify_migration_swap.py
+++ b/scripts/verify_migration_swap.py
@@ -889,8 +889,13 @@ def _write_report_files(
     output_dir.mkdir(parents=True, exist_ok=True)
     md_path = output_dir / f"{window_slug}.md"
     json_path = output_dir / f"{window_slug}.json"
-    md_path.write_text(human_report)
-    json_path.write_text(json.dumps(json_data, indent=2, default=str))
+    # Encoding is pinned to UTF-8: the report body contains the Unicode
+    # arrow (``→``) in the coverage-check section header, which the
+    # Windows default codec (cp1252) can't encode. K8s images run
+    # Linux so this only shows up in the CI matrix's Windows job, but
+    # the fix is portable and doesn't cost anything on Linux/macOS.
+    md_path.write_text(human_report, encoding="utf-8")
+    json_path.write_text(json.dumps(json_data, indent=2, default=str), encoding="utf-8")
     print(f"\nwrote {md_path}")
     print(f"wrote {json_path}")
 

--- a/scripts/verify_migration_swap.py
+++ b/scripts/verify_migration_swap.py
@@ -1254,12 +1254,17 @@ def _coverage_failure_reason(
 
     Three ways coverage can fail, in priority order:
 
-    1. Any single platform has ``marketplace_count < min_marketplace_rows``
-       — that platform's sweep is vacuous. ``marketplace_ids - lake_ids``
-       is trivially empty when a platform's marketplace side is empty,
-       so without this per-platform floor a subgraph outage on ONE
-       platform would silently PASS as "no missing IDs" (the healthy
-       platform's rows would carry the aggregate above the floor).
+    1. Any single platform has ``marketplace_count <
+       max(1, min_marketplace_rows)`` — that platform's sweep is
+       vacuous. ``marketplace_ids - lake_ids`` is trivially empty when
+       a platform's marketplace side is empty, so without this
+       per-platform floor a subgraph outage on ONE platform would
+       silently PASS as "no missing IDs" (the healthy platform's rows
+       would carry the aggregate above the floor). The ``max(1, ...)``
+       is an unconditional zero-backstop: an operator lowering
+       ``--min-marketplace-rows`` to ``0`` is opting into a weaker
+       check, not out of the check — a total outage on a platform
+       must still fail closed.
     2. ``total_dropped_no_rid > 0`` — deliveries came back without a
        resolvable ``request.id`` and were dropped from the coverage
        denominator. Each dropped row is a request that could be absent
@@ -1269,13 +1274,15 @@ def _coverage_failure_reason(
 
     :param coverage: the result of :func:`_report_coverage_check`.
     :param min_marketplace_rows: floor from ``--min-marketplace-rows``,
-        enforced per platform (not on the aggregate).
+        enforced per platform (not on the aggregate). Effective floor
+        is ``max(1, min_marketplace_rows)`` — see item 1.
     :return: human-readable failure reason, or ``None`` on success.
     """
+    effective_floor = max(1, min_marketplace_rows)
     vacuous_platforms = sorted(
         (platform, count)
         for platform, count in coverage.marketplace_counts.items()
-        if count < min_marketplace_rows
+        if count < effective_floor
     )
     if vacuous_platforms:
         details = ", ".join(
@@ -1283,10 +1290,12 @@ def _coverage_failure_reason(
         )
         return (
             f"vacuous coverage sweep on {len(vacuous_platforms)} platform(s) "
-            f"({details}) — each below min_marketplace_rows "
-            f"{min_marketplace_rows}. An empty coverage side for even one "
-            f"platform makes ``marketplace_ids - lake_ids`` trivially empty "
-            f"for that platform and would otherwise report PASS. Check the "
+            f"({details}) — each below effective floor {effective_floor} "
+            f"(from --min-marketplace-rows={min_marketplace_rows}, promoted "
+            f"to at least 1 so a total outage always fails closed). An "
+            f"empty coverage side for even one platform makes "
+            f"``marketplace_ids - lake_ids`` trivially empty for that "
+            f"platform and would otherwise report PASS. Check the "
             f"marketplace subgraph for the affected platform(s)."
         )
     if coverage.total_dropped_no_rid > 0:
@@ -1298,7 +1307,7 @@ def _coverage_failure_reason(
         )
     if coverage.total_missing > 0:
         return (
-            f"{coverage.total_missing} on-chain request_ids are "
+            f"{coverage.total_missing} delivered request_ids are "
             f"missing from the lake."
         )
     return None

--- a/scripts/verify_migration_swap.py
+++ b/scripts/verify_migration_swap.py
@@ -272,7 +272,9 @@ def _pull_marketplace_request_ids(
             until_ts,
         )
         ids, dropped = fp.fetch_all_delivery_request_ids(
-            marketplace_url, since_ts, timestamp_lt=until_ts
+            marketplace_url,
+            request_ts_gt=since_ts,
+            request_ts_lt=until_ts,
         )
         ids_by_platform[platform] = ids
         dropped_by_platform[platform] = dropped
@@ -699,6 +701,7 @@ def _report_coverage_check(
     marketplace_ids_by_platform: dict[str, set[str]],
     dropped_by_platform: dict[str, int],
     lake_ids: set[str],
+    min_marketplace_rows: int,
 ) -> _CoverageResult:
     """Coverage check: prove every on-chain request is in the lake.
 
@@ -715,11 +718,12 @@ def _report_coverage_check(
       deliveries whose ``request.id`` was missing, so those requests
       never entered the coverage denominator and could be silently
       absent from the lake without being reported.
-    * ``total_marketplace < min_marketplace_rows`` (checked by caller) —
-      an empty or near-empty coverage sweep is indistinguishable from
-      complete coverage on the set-diff alone; the caller enforces a
-      floor to distinguish "healthy sweep, no gap" from "sweep
-      returned nothing, so of course there's no diff".
+    * per-platform ``marketplace_count < min_marketplace_rows`` (checked
+      by caller) — an empty or near-empty coverage sweep on any single
+      platform is indistinguishable from complete coverage on the
+      set-diff alone; the caller enforces the floor per platform so a
+      subgraph outage on one platform can't be masked by a healthy pull
+      on the other.
 
     :param marketplace_ids_by_platform: output of
         :func:`_pull_marketplace_request_ids` (first tuple element).
@@ -728,6 +732,12 @@ def _report_coverage_check(
         per-platform count of deliveries dropped because their
         ``request.id`` was missing.
     :param lake_ids: output of :func:`_pull_lake_request_ids_unfiltered`.
+    :param min_marketplace_rows: floor from ``--min-marketplace-rows``,
+        used here purely for the per-platform ``✗`` marker so an
+        under-populated platform is called out in the report body even
+        though the verdict itself is decided in the caller. Keeping the
+        floor in one place (the failure-reason helper) is what
+        determines PASS/FAIL; this is a display hint only.
     :return: :class:`_CoverageResult` with per-platform and aggregate stats.
     """
     _section("Coverage check (marketplace subgraph → mech-analytics lake)")
@@ -742,9 +752,12 @@ def _report_coverage_check(
         total_missing += len(missing)
         total_marketplace += len(marketplace_ids)
         dropped = dropped_by_platform.get(platform, 0)
-        marker = "✓" if not missing and dropped == 0 else "✗"
+        vacuous = len(marketplace_ids) < min_marketplace_rows
+        marker = "✓" if not missing and dropped == 0 and not vacuous else "✗"
+        vacuous_note = f" (below floor {min_marketplace_rows})" if vacuous else ""
         print(
-            f"  {platform}: marketplace={len(marketplace_ids):>7}  "
+            f"  {platform}: marketplace={len(marketplace_ids):>7}"
+            f"{vacuous_note}  "
             f"missing_from_lake={len(missing):>5}  "
             f"dropped_no_request_id={dropped:>4}  {marker}"
         )
@@ -990,10 +1003,13 @@ class _Tee:
         # ``sys.__stdout__`` is typed ``Optional[TextIO]`` (it's None when
         # the interpreter runs with stdout detached, e.g. under some
         # embedded contexts). This script only runs as an ordinary CLI so
-        # the field is always populated; assert to encode that invariant
-        # for mypy so the write/flush calls below don't need a runtime
-        # None check on every emit.
-        assert sys.__stdout__ is not None, "sys.__stdout__ unavailable"
+        # the field is always populated. Raise (not assert) so ``-O`` /
+        # ``PYTHONOPTIMIZE`` cannot strip the guard and cause a downstream
+        # ``AttributeError`` on the first write.
+        if sys.__stdout__ is None:
+            raise RuntimeError(
+                "sys.__stdout__ unavailable; _Tee requires an attached stdout stream"
+            )
         self._stdout = sys.__stdout__
 
     def write(self, s: str) -> int:
@@ -1063,7 +1079,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         )
         lake_ids_unfiltered = _pull_lake_request_ids_unfiltered(since, until)
         coverage = _report_coverage_check(
-            marketplace_ids_by_platform, dropped_by_platform, lake_ids_unfiltered
+            marketplace_ids_by_platform,
+            dropped_by_platform,
+            lake_ids_unfiltered,
+            args.min_marketplace_rows,
         )
         coverage_summary = {
             "marketplace_ids_by_platform_count": coverage.marketplace_counts,
@@ -1207,10 +1226,12 @@ def _coverage_failure_reason(
 
     Three ways coverage can fail, in priority order:
 
-    1. ``total_marketplace < min_marketplace_rows`` — the marketplace
-       sweep is vacuous. ``marketplace_ids - lake_ids`` is trivially
-       empty when the marketplace side is empty, so without this floor
-       any subgraph outage would silently PASS as "no missing IDs".
+    1. Any single platform has ``marketplace_count < min_marketplace_rows``
+       — that platform's sweep is vacuous. ``marketplace_ids - lake_ids``
+       is trivially empty when a platform's marketplace side is empty,
+       so without this per-platform floor a subgraph outage on ONE
+       platform would silently PASS as "no missing IDs" (the healthy
+       platform's rows would carry the aggregate above the floor).
     2. ``total_dropped_no_rid > 0`` — deliveries came back without a
        resolvable ``request.id`` and were dropped from the coverage
        denominator. Each dropped row is a request that could be absent
@@ -1219,16 +1240,26 @@ def _coverage_failure_reason(
     3. ``total_missing > 0`` — a genuine coverage gap.
 
     :param coverage: the result of :func:`_report_coverage_check`.
-    :param min_marketplace_rows: floor from ``--min-marketplace-rows``.
+    :param min_marketplace_rows: floor from ``--min-marketplace-rows``,
+        enforced per platform (not on the aggregate).
     :return: human-readable failure reason, or ``None`` on success.
     """
-    if coverage.total_marketplace < min_marketplace_rows:
+    vacuous_platforms = sorted(
+        (platform, count)
+        for platform, count in coverage.marketplace_counts.items()
+        if count < min_marketplace_rows
+    )
+    if vacuous_platforms:
+        details = ", ".join(
+            f"{platform}={count}" for platform, count in vacuous_platforms
+        )
         return (
-            f"vacuous coverage sweep — total marketplace deliveries "
-            f"{coverage.total_marketplace} < min_marketplace_rows "
-            f"{min_marketplace_rows}. An empty coverage side makes "
-            f"``marketplace_ids - lake_ids`` trivially empty and would "
-            f"otherwise report PASS. Check the marketplace subgraph."
+            f"vacuous coverage sweep on {len(vacuous_platforms)} platform(s) "
+            f"({details}) — each below min_marketplace_rows "
+            f"{min_marketplace_rows}. An empty coverage side for even one "
+            f"platform makes ``marketplace_ids - lake_ids`` trivially empty "
+            f"for that platform and would otherwise report PASS. Check the "
+            f"marketplace subgraph for the affected platform(s)."
         )
     if coverage.total_dropped_no_rid > 0:
         return (

--- a/scripts/verify_migration_swap.py
+++ b/scripts/verify_migration_swap.py
@@ -21,11 +21,17 @@ r"""Reconcile mech-predict's row universe against mech-analytics.
 
 Two checks per window:
 
-* **Coverage** — every on-chain request_id the marketplace subgraph
-  knows about must be present in the mech-analytics lake. This proves
-  ingest completeness ahead of the mech-predict cutover: switching to
-  the lake cannot silently drop rows that today's production path can
-  see. Fails with exit code 4 if any on-chain request is missing.
+* **Coverage** — every request delivered in the window (per the
+  marketplace subgraph's ``delivers`` collection) must be present in
+  the mech-analytics lake. This proves ingest completeness ahead of
+  the mech-predict cutover: switching to the lake cannot silently
+  drop rows that today's production path can see. Note this is a
+  delivery-derived denominator: a ``Request`` never answered (or
+  answered more than the delivery-lag envelope after the window
+  closed) is outside the set. That matches what today's mech-predict
+  path consumes; it is not a claim about request-level completeness.
+  Fails with exit code 4 if any delivered request is missing from
+  the lake.
 * **Parity** — on the resolved intersection, ``final_outcome``,
   ``market_id`` binding, and per-tool ``brier`` / ``directional_accuracy``
   must agree between the two sides. Fails with exit code 3 if the
@@ -58,7 +64,7 @@ Exit codes:
     0 — coverage complete, parity within thresholds
     2 — min-row guard tripped (window too thin to conclude anything)
     3 — parity divergence exceeds thresholds
-    4 — coverage gap (at least one on-chain request missing from lake)
+    4 — coverage gap (at least one delivered request missing from lake)
 
 Required env vars:
     MECH_ANALYTICS_URL             (lake-side endpoint)
@@ -93,10 +99,14 @@ log = logging.getLogger("verify_migration_swap")
 # Below this row count on either side the parity comparison is vacuous.
 MINIMUM_ROWS_PER_SIDE = 100
 
-# Below this total across all platforms the coverage sweep is vacuous —
-# an empty marketplace side makes ``marketplace_ids - lake_ids`` trivially
-# empty regardless of whether the lake actually has anything. The floor
-# distinguishes "healthy sweep, no gap" from "sweep returned nothing".
+# Applied per platform: any single platform with fewer than
+# ``MINIMUM_MARKETPLACE_ROWS`` delivered requests in the window fails
+# the coverage gate. An empty coverage side on one platform makes
+# ``marketplace_ids - lake_ids`` trivially empty regardless of whether
+# the lake actually has anything, so a healthy pull on the other
+# platform must not mask a subgraph outage on this one. The floor
+# distinguishes "healthy sweep, no gap" from "sweep returned nothing"
+# on a per-platform basis.
 MINIMUM_MARKETPLACE_ROWS = 10
 
 # Comparing floats coming from independent code paths — allow small drift.
@@ -237,13 +247,18 @@ def _pull_lake_rows(since: datetime, until: datetime) -> list[dict[str, Any]]:
 def _pull_marketplace_request_ids(
     since_ts: int, until_ts: int
 ) -> tuple[dict[str, set[str]], dict[str, int]]:
-    """Fetch every on-chain request_id delivered in the window, per platform.
+    """Fetch every request delivered in the window, per platform.
 
-    Coverage-check input: the ground truth of on-chain mech traffic
-    for the window, straight from the marketplace subgraph without any
-    parsedRequest / tool filter. Compared against the unfiltered lake
-    ID set below to prove no on-chain request is missing from the
-    lake.
+    Coverage-check input: the ground truth of delivered mech traffic
+    for the window, straight from the marketplace subgraph's
+    ``delivers`` collection without any parsedRequest / tool filter.
+    Compared against the unfiltered lake ID set below to prove no
+    delivered request is missing from the lake. Requests that were
+    never delivered — or delivered more than
+    ``fp._DELIVERY_LAG_ENVELOPE_S`` after ``until_ts`` — are outside
+    this set by construction; the coverage claim is about ingest
+    completeness for the mech-predict path, which itself consumes
+    deliveries.
 
     Also threads the per-platform "delivery had no request.id" drop
     count out of ``fetch_all_delivery_request_ids``. A non-zero drop
@@ -286,7 +301,7 @@ def _pull_lake_request_ids_unfiltered(since: datetime, until: datetime) -> set[s
 
     Coverage-check counterpart to :func:`_pull_marketplace_request_ids`.
     Includes pending rows and off-chain rows, because the coverage
-    question is "is this on-chain request in the lake at all?", not
+    question is "is this delivered request in the lake at all?", not
     "did mech-analytics finish scoring it?".
 
     :param since: timezone-aware datetime, inclusive lower bound.
@@ -703,16 +718,20 @@ def _report_coverage_check(
     lake_ids: set[str],
     min_marketplace_rows: int,
 ) -> _CoverageResult:
-    """Coverage check: prove every on-chain request is in the lake.
+    """Coverage check: prove every delivered request is in the lake.
 
     For each platform, computes the set of request_ids the marketplace
-    subgraph knows about but the lake does not. Prints a per-platform
-    breakdown and returns a :class:`_CoverageResult` with every fact
-    the caller needs to compute the verdict and populate the artifact.
+    subgraph has a ``Deliver`` for in the window but the lake does
+    not. Prints a per-platform breakdown and returns a
+    :class:`_CoverageResult` with every fact the caller needs to
+    compute the verdict and populate the artifact. Requests that were
+    never answered — or answered after the widened delivery envelope
+    — are not in the marketplace set by construction, so they cannot
+    be reported missing here.
 
     Coverage failure modes the caller must gate on:
 
-    * ``total_missing > 0`` — genuine gap, on-chain requests absent
+    * ``total_missing > 0`` — genuine gap, delivered requests absent
       from the lake.
     * ``total_dropped_no_rid > 0`` — the marketplace pull returned
       deliveries whose ``request.id`` was missing, so those requests
@@ -773,7 +792,7 @@ def _report_coverage_check(
     )
     if total_missing:
         print()
-        print("  These on-chain request_ids are not in the mech-analytics lake.")
+        print("  These delivered request_ids are not in the mech-analytics lake.")
         print("  Check ``mech_migration_failures`` on the predict-api DB for each")
         print("  ID to see if it's a known-loss backfill failure")
         print("  (parsed_request_null, unhandled_type_prompt, etc.).")
@@ -936,10 +955,12 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=int,
         default=MINIMUM_MARKETPLACE_ROWS,
         help=(
-            "min total marketplace deliveries across platforms for the "
-            "coverage check to be non-vacuous. An empty coverage sweep "
-            "makes an empty set-diff, which would otherwise report PASS. "
-            f"Default {MINIMUM_MARKETPLACE_ROWS}."
+            "min marketplace deliveries per platform for the coverage "
+            "check to be non-vacuous. Applied to each platform "
+            "independently — an empty coverage sweep on one platform "
+            "makes an empty set-diff and would otherwise let a subgraph "
+            "outage on that platform hide behind a healthy pull on the "
+            f"other. Default {MINIMUM_MARKETPLACE_ROWS}."
         ),
     )
     p.add_argument(
@@ -1036,8 +1057,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     :param argv: optional CLI argument override; defaults to ``sys.argv``.
     :return: exit code — 0 pass; 2 min-row guard trip; 3 parity
         divergence above thresholds; 4 coverage gap
-        (on-chain requests missing from the lake, or drops in the
-        marketplace pull, or vacuous coverage sweep).
+        (delivered requests missing from the lake, or drops in the
+        marketplace pull, or a below-floor coverage sweep on any
+        single platform).
     """
     # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     args = _parse_args(argv)
@@ -1146,11 +1168,17 @@ def main(argv: Sequence[str] | None = None) -> int:
         overlap_denom = min(mp_ids_size, lake_ids_size)
         overlap_fraction = len(intersection) / overlap_denom if overlap_denom else 0.0
         mismatch_fraction = outcome_mismatch / resolved_both if resolved_both else 0.0
+        per_platform_counts = ", ".join(
+            f"{platform}={count}"
+            for platform, count in sorted(coverage.marketplace_counts.items())
+        )
         print(
             f"  coverage: missing_from_lake={coverage.total_missing} "
             f"dropped_no_request_id={coverage.total_dropped_no_rid} "
+            f"marketplace_per_platform=[{per_platform_counts}] "
             f"total_marketplace={coverage.total_marketplace} (thresholds "
-            f"missing==0, dropped==0, marketplace>={args.min_marketplace_rows})"
+            f"missing==0, dropped==0, "
+            f"per-platform marketplace>={args.min_marketplace_rows})"
         )
         print(
             f"  overlap:  {len(intersection)} / {overlap_denom} = "

--- a/scripts/verify_migration_swap.py
+++ b/scripts/verify_migration_swap.py
@@ -19,36 +19,46 @@
 # ------------------------------------------------------------------------------
 r"""Reconcile mech-predict's row universe against mech-analytics.
 
-Runs the four divergence-class checks documented in
-``mech-analytics/docs/testing_mech_predict.md`` for a chosen window,
-plus a per-tool aggregate parity comparison on the reconciled row set.
+Two checks per window:
 
-Left side: the actual production path in mech-predict — marketplace
-subgraph + IPFS via ``benchmark.datasets.fetch_production``. Both
-platforms (Omen on Gnosis, Polymarket on Polygon), multi-day, comparing
-field values not id membership.
+* **Coverage** — every on-chain request_id the marketplace subgraph
+  knows about must be present in the mech-analytics lake. This proves
+  ingest completeness ahead of the mech-predict cutover: switching to
+  the lake cannot silently drop rows that today's production path can
+  see. Fails with exit code 4 if any on-chain request is missing.
+* **Parity** — on the resolved intersection, ``final_outcome``,
+  ``market_id`` binding, and per-tool ``brier`` / ``directional_accuracy``
+  must agree between the two sides. Fails with exit code 3 if the
+  overlap fraction is under ``--min-overlap-fraction`` or the outcome
+  mismatch rate exceeds ``--max-outcome-mismatch-fraction``.
 
-Right side: mech-analytics's ``/v1/data/scored-rows`` endpoint via
-``benchmark.mech_analytics_client``.
+Left side (both checks): the actual production path in mech-predict —
+marketplace subgraph + IPFS via ``benchmark.datasets.fetch_production``.
+Both platforms (Omen on Gnosis, Polymarket on Polygon).
 
-Reports:
-    1. Row-set overlap on ``request_id``: intersection, mech-predict
-       only, lake only.
-    2. ``final_outcome`` diff on rows resolved on both sides.
-    3. ``market_id`` diff on rows present in both sets.
-    4. Multi-deliver-per-request rate on mech-predict + NULL rate
-       for ``market_prob_at_prediction`` / ``market_liquidity_usd`` /
-       ``market_spread_at_prediction`` on the lake side.
-    5. Per-tool aggregate on the overlap (brier, log_loss,
-       directional_accuracy).
+Right side (both checks): mech-analytics's ``/v1/data/scored-rows``
+endpoint via ``benchmark.mech_analytics_client``. Coverage uses the
+unfiltered call; parity uses ``resolved=true`` to match production's
+scorer path.
 
-Fails loud if either side returns under ``MINIMUM_ROWS_PER_SIDE`` so a
-vacuous match on empty data doesn't get reported as parity.
+Fails loud with exit code 2 if either side returns under
+``MINIMUM_ROWS_PER_SIDE`` so a vacuous match on empty data doesn't get
+reported as parity.
 
 Usage:
+    # local, prints to stdout
     scripts/verify_migration_swap.py --days 7
+
+    # K8s Job style — also writes <window>.md and <window>.json
     scripts/verify_migration_swap.py --since 2026-07-01T00:00:00Z \\
-                                     --until 2026-07-08T00:00:00Z
+                                     --until 2026-07-08T00:00:00Z \\
+                                     --output-dir /reports
+
+Exit codes:
+    0 — coverage complete, parity within thresholds
+    2 — min-row guard tripped (window too thin to conclude anything)
+    3 — parity divergence exceeds thresholds
+    4 — coverage gap (at least one on-chain request missing from lake)
 
 Required env vars:
     MECH_ANALYTICS_URL             (lake-side endpoint)
@@ -59,11 +69,17 @@ Required env vars:
 from __future__ import annotations
 
 import argparse
+import io
+import json
 import logging
+import os
 import statistics
+import subprocess
 import sys
+import time
 from collections import Counter, defaultdict
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, Sequence
 
 log = logging.getLogger("verify_migration_swap")
@@ -111,7 +127,10 @@ def _pull_mech_predict_rows(
     ]
     for platform, marketplace_url, fetch_resolved in platforms:
         log.info("pulling mech-predict rows: platform=%s", platform)
-        resolved = fetch_resolved(resolved_after=since_ts)
+        # Bound both queries to the window so enumeration doesn't fan out from
+        # `since` to `now` for old windows (the source of hours-long runs
+        # against 6-month-old windows).
+        resolved = fetch_resolved(resolved_after=since_ts, resolved_before=until_ts)
         rows, _still_pending, _max_delivery_ts, _max_resolved_ts = fp.process_platform(
             platform=platform,
             marketplace_url=marketplace_url,
@@ -119,6 +138,7 @@ def _pull_mech_predict_rows(
             delivery_ts_gt=since_ts,
             existing_ids=set(),
             pending_deliveries=[],
+            delivery_ts_lt=until_ts,
         )
         rows = [
             r
@@ -197,6 +217,67 @@ def _pull_lake_rows(since: datetime, until: datetime) -> list[dict[str, Any]]:
         "pulling lake rows since=%s until=%s", since.isoformat(), until.isoformat()
     )
     return list(iter_scored_rows(since=since, until=until, resolved=True))
+
+
+def _pull_marketplace_request_ids(since_ts: int, until_ts: int) -> dict[str, set[str]]:
+    """Fetch every on-chain request_id delivered in the window, per platform.
+
+    Coverage-check input: the ground truth of on-chain mech traffic
+    for the window, straight from the marketplace subgraph without any
+    parsedRequest / tool filter. Compared against the unfiltered lake
+    ID set below to prove no on-chain request is missing from the
+    lake.
+
+    :param since_ts: unix seconds, inclusive lower bound.
+    :param until_ts: unix seconds, exclusive upper bound.
+    :return: platform name → set of on-chain request_ids for that platform.
+    """
+    # pylint: disable=import-outside-toplevel
+    from benchmark.datasets import fetch_production as fp
+
+    platforms = [
+        ("omen", fp.MECH_MARKETPLACE_GNOSIS_URL),
+        ("polymarket", fp.MECH_MARKETPLACE_POLYGON_URL),
+    ]
+    ids_by_platform: dict[str, set[str]] = {}
+    for platform, marketplace_url in platforms:
+        log.info(
+            "pulling marketplace request_ids: platform=%s window=[%s, %s)",
+            platform,
+            since_ts,
+            until_ts,
+        )
+        ids_by_platform[platform] = fp.fetch_all_delivery_request_ids(
+            marketplace_url, since_ts, timestamp_lt=until_ts
+        )
+    return ids_by_platform
+
+
+def _pull_lake_request_ids_unfiltered(since: datetime, until: datetime) -> set[str]:
+    """Fetch every lake request_id in the window regardless of resolution.
+
+    Coverage-check counterpart to :func:`_pull_marketplace_request_ids`.
+    Includes pending rows and off-chain rows, because the coverage
+    question is "is this on-chain request in the lake at all?", not
+    "did mech-analytics finish scoring it?".
+
+    :param since: timezone-aware datetime, inclusive lower bound.
+    :param until: timezone-aware datetime, exclusive upper bound.
+    :return: set of request_ids the lake has for the window.
+    """
+    # pylint: disable=import-outside-toplevel
+    from benchmark.mech_analytics_client import iter_scored_rows
+
+    log.info(
+        "pulling lake request_ids (unfiltered) since=%s until=%s",
+        since.isoformat(),
+        until.isoformat(),
+    )
+    return {
+        row["request_id"]
+        for row in iter_scored_rows(since=since, until=until, resolved=None)
+        if row.get("request_id")
+    }
 
 
 # --------------------------------------------------------------------------- #
@@ -566,6 +647,137 @@ def _section(title: str) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Coverage check                                                              #
+# --------------------------------------------------------------------------- #
+
+
+def _report_coverage_check(
+    marketplace_ids_by_platform: dict[str, set[str]],
+    lake_ids: set[str],
+) -> tuple[int, dict[str, list[str]]]:
+    """Coverage check: prove every on-chain request is in the lake.
+
+    For each platform, computes the set of request_ids the marketplace
+    subgraph knows about but the lake does not. Prints a per-platform
+    breakdown and returns the total gap size plus the per-platform ID
+    lists so the caller can put the full lists in the JSON artifact
+    and act on the gate.
+
+    :param marketplace_ids_by_platform: output of
+        :func:`_pull_marketplace_request_ids`.
+    :param lake_ids: output of :func:`_pull_lake_request_ids_unfiltered`.
+    :return: tuple of (total_missing_count, per-platform missing lists).
+    """
+    _section("Coverage check (marketplace subgraph → mech-analytics lake)")
+    missing_by_platform: dict[str, list[str]] = {}
+    total_missing = 0
+    for platform, marketplace_ids in marketplace_ids_by_platform.items():
+        missing = sorted(marketplace_ids - lake_ids)
+        missing_by_platform[platform] = missing
+        total_missing += len(missing)
+        marker = "✓" if not missing else "✗"
+        print(
+            f"  {platform}: marketplace={len(marketplace_ids):>7}  "
+            f"missing_from_lake={len(missing):>5}  {marker}"
+        )
+    print(f"  lake (all chains, incl. off-chain): {len(lake_ids):>7}")
+    print(
+        f"  total missing from lake:            {total_missing:>7}  "
+        f"{'✓' if total_missing == 0 else '✗'}"
+    )
+    if total_missing:
+        print()
+        print("  These on-chain request_ids are not in the mech-analytics lake.")
+        print("  Check ``mech_migration_failures`` on the predict-api DB for each")
+        print("  ID to see if it's a known-loss backfill failure")
+        print("  (parsed_request_null, unhandled_type_prompt, etc.).")
+        print()
+        for platform, missing in missing_by_platform.items():
+            if not missing:
+                continue
+            print(f"  {platform} — first 20 of {len(missing)}:")
+            for rid in missing[:20]:
+                print(f"    {rid}")
+            print("    (full list in the .json artifact)")
+    return total_missing, missing_by_platform
+
+
+# --------------------------------------------------------------------------- #
+# Report artifact writers                                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _git_sha() -> str:
+    """Return the current git commit SHA, or ``unknown`` if git isn't
+    available (e.g. running inside a stripped-down container).
+    """
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],
+                stderr=subprocess.DEVNULL,
+                cwd=Path(__file__).resolve().parent,
+            )
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _print_metadata(
+    since: datetime, until: datetime, mech_analytics_url: str
+) -> dict[str, Any]:
+    """Print the run's provenance header and return the same fields as a
+    dict for the JSON artifact.
+
+    Every artifact this script writes needs to be dated and attributable
+    so a reviewer months later can tell whether a report is still
+    current — which mech-analytics version it verified, which script
+    commit produced it, when it ran.
+    """
+    metadata = {
+        "run_at_utc": datetime.now(timezone.utc).isoformat(),
+        "script_git_sha": _git_sha(),
+        "mech_analytics_url": mech_analytics_url,
+        "window": {
+            "since": since.isoformat(),
+            "until": until.isoformat(),
+        },
+    }
+    print("=== Run metadata ===")
+    for line in (
+        f"  run_at (UTC):        {metadata['run_at_utc']}",
+        f"  script git SHA:      {metadata['script_git_sha']}",
+        f"  mech-analytics URL:  {metadata['mech_analytics_url']}",
+        f"  window:              {since.isoformat()} → {until.isoformat()}",
+    ):
+        print(line)
+    return metadata
+
+
+def _write_report_files(
+    output_dir: Path,
+    window_slug: str,
+    human_report: str,
+    json_data: dict[str, Any],
+) -> None:
+    """Write the human report and structured JSON to ``output_dir``.
+
+    A K8s Job mounts a PVC or emptyDir at ``output_dir``; a reviewer or
+    a follow-up step can then read the ``.md`` for the human summary
+    and the ``.json`` for full ID lists and machine consumption.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    md_path = output_dir / f"{window_slug}.md"
+    json_path = output_dir / f"{window_slug}.json"
+    md_path.write_text(human_report)
+    json_path.write_text(json.dumps(json_data, indent=2, default=str))
+    print(f"\nwrote {md_path}")
+    print(f"wrote {json_path}")
+
+
+# --------------------------------------------------------------------------- #
 # CLI                                                                         #
 # --------------------------------------------------------------------------- #
 
@@ -595,6 +807,16 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=0.02,
         help="max outcome_mismatch / resolved_both to accept parity (default 0.02)",
     )
+    p.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help=(
+            "if set, write <window>.md and <window>.json report artifacts to "
+            "this directory in addition to printing to stdout. "
+            "Intended for K8s Job runs that publish reports to a PVC."
+        ),
+    )
     p.add_argument("-v", "--verbose", action="store_true")
     return p.parse_args(argv)
 
@@ -617,13 +839,35 @@ def _compute_window(args: argparse.Namespace) -> tuple[datetime, datetime]:
     return since, until
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    """Run all reconciliation checks and print the report to stdout.
+class _Tee:
+    """Duplicate every ``print`` to the real stdout and a StringIO buffer.
+
+    Lets ``main`` emit its report live to the console (for local runs
+    and K8s pod logs) while also capturing the full text for the
+    ``--output-dir`` report artifact.
+    """
+
+    def __init__(self, buffer: io.StringIO) -> None:
+        self._buffer = buffer
+        self._stdout = sys.__stdout__
+
+    def write(self, s: str) -> int:
+        self._stdout.write(s)
+        return self._buffer.write(s)
+
+    def flush(self) -> None:
+        self._stdout.flush()
+
+
+def main(
+    argv: Sequence[str] | None = None,
+) -> int:  # pylint: disable=too-many-locals,too-many-statements
+    """Run coverage + parity checks and emit a report to stdout (+ file).
 
     :param argv: optional CLI argument override; defaults to ``sys.argv``.
-    :return: 0 on parity within thresholds; 2 on min-row guard trip;
-        3 on divergence above --min-overlap-fraction /
-        --max-outcome-mismatch-fraction.
+    :return: exit code — 0 pass; 2 min-row guard trip; 3 parity
+        divergence above thresholds; 4 coverage gap
+        (on-chain requests missing from the lake).
     """
     args = _parse_args(argv)
     logging.basicConfig(
@@ -631,81 +875,150 @@ def main(argv: Sequence[str] | None = None) -> int:
         format="%(asctime)s %(name)s %(levelname)s %(message)s",
     )
     since, until = _compute_window(args)
-    print(f"window: {since.isoformat()} to {until.isoformat()} (excl. trailing 24h)")
 
-    since_ts = int(since.timestamp())
-    until_ts = int(until.timestamp())
+    # Tee stdout so the human-readable report can also be written to
+    # ``--output-dir`` at the end without a second pass.
+    report_buffer = io.StringIO()
+    sys.stdout = _Tee(report_buffer)  # type: ignore[assignment]
+    started_at = time.monotonic()
+    exit_code = 0
+    metadata: dict[str, Any] = {}
+    coverage_summary: dict[str, Any] = {}
+    parity_summary: dict[str, Any] = {}
+    try:
+        mech_analytics_url = os.environ.get("MECH_ANALYTICS_URL", "<unset>")
+        metadata = _print_metadata(since, until, mech_analytics_url)
 
-    mp_rows, deliver_to_request_by_platform = _pull_mech_predict_rows(
-        since_ts, until_ts
-    )
-    lake_rows = _pull_lake_rows(since, until)
+        since_ts = int(since.timestamp())
+        until_ts = int(until.timestamp())
 
-    # Min-row guard: fail loud on either side coming back thin.
-    if len(mp_rows) < args.min_rows or len(lake_rows) < args.min_rows:
-        print()
+        # --- Coverage check (fast-fail: if the lake is missing on-chain
+        # requests, parity on the overlap doesn't rescue that).
+        marketplace_ids_by_platform = _pull_marketplace_request_ids(since_ts, until_ts)
+        lake_ids_unfiltered = _pull_lake_request_ids_unfiltered(since, until)
+        total_missing, missing_by_platform = _report_coverage_check(
+            marketplace_ids_by_platform, lake_ids_unfiltered
+        )
+        coverage_summary = {
+            "marketplace_ids_by_platform_count": {
+                p: len(v) for p, v in marketplace_ids_by_platform.items()
+            },
+            "lake_ids_unfiltered_count": len(lake_ids_unfiltered),
+            "missing_from_lake_by_platform": missing_by_platform,
+            "total_missing": total_missing,
+        }
+
+        # --- Parity check on the resolved intersection.
+        mp_rows, deliver_to_request_by_platform = _pull_mech_predict_rows(
+            since_ts, until_ts
+        )
+        lake_rows = _pull_lake_rows(since, until)
+
+        if len(mp_rows) < args.min_rows or len(lake_rows) < args.min_rows:
+            print()
+            print(
+                f"FAIL: min-row guard tripped "
+                f"(mech-predict={len(mp_rows)}, lake={len(lake_rows)}, "
+                f"threshold={args.min_rows})"
+            )
+            print(
+                "Refusing to report parity on a vacuous window. "
+                "Extend the window, check the endpoints, or lower --min-rows."
+            )
+            exit_code = 2
+            return exit_code
+
+        print(f"mech-predict rows: {len(mp_rows)}   lake rows: {len(lake_rows)}")
+
+        intersection, only_mp, only_lake = _report_row_set_overlap(mp_rows, lake_rows)
+        resolved_both, outcome_mismatch = _report_final_outcome_diff(
+            mp_rows, lake_rows, intersection
+        )
+        _report_market_id_diff(mp_rows, lake_rows, intersection)
+        _report_dedup_granularity(mp_rows, deliver_to_request_by_platform)
+        _report_null_provenance(lake_rows)
+        _report_per_tool_aggregate(mp_rows, lake_rows, intersection)
+
+        # --- Verdict.
+        _section("Verdict")
+        mp_ids_size = len(intersection) + len(only_mp)
+        lake_ids_size = len(intersection) + len(only_lake)
+        overlap_denom = min(mp_ids_size, lake_ids_size)
+        overlap_fraction = len(intersection) / overlap_denom if overlap_denom else 0.0
+        mismatch_fraction = outcome_mismatch / resolved_both if resolved_both else 0.0
+        print(f"  coverage: missing_from_lake={total_missing} " f"(threshold == 0)")
         print(
-            f"FAIL: min-row guard tripped "
-            f"(mech-predict={len(mp_rows)}, lake={len(lake_rows)}, "
-            f"threshold={args.min_rows})"
+            f"  overlap:  {len(intersection)} / {overlap_denom} = "
+            f"{overlap_fraction:.4f}  (threshold >= {args.min_overlap_fraction})"
         )
         print(
-            "Refusing to report parity on a vacuous window. "
-            "Extend the window, check the endpoints, or lower --min-rows."
+            f"  outcome:  {outcome_mismatch} / {resolved_both} = "
+            f"{mismatch_fraction:.4f}  (threshold <= {args.max_outcome_mismatch_fraction})"
         )
-        return 2
+        parity_summary = {
+            "mp_rows": len(mp_rows),
+            "lake_rows_resolved": len(lake_rows),
+            "intersection": len(intersection),
+            "only_mp": len(only_mp),
+            "only_lake": len(only_lake),
+            "outcome_mismatch": outcome_mismatch,
+            "resolved_both": resolved_both,
+            "overlap_fraction": overlap_fraction,
+            "mismatch_fraction": mismatch_fraction,
+        }
 
-    print(f"mech-predict rows: {len(mp_rows)}   " f"lake rows: {len(lake_rows)}")
+        # Coverage failure takes precedence — an incomplete lake means
+        # even a perfect parity number is describing an incomplete
+        # picture. Reviewer needs to know the gap first.
+        if total_missing > 0:
+            print()
+            print(
+                f"FAIL (coverage): {total_missing} on-chain request_ids "
+                f"are missing from the lake."
+            )
+            exit_code = 4
+            return exit_code
 
-    intersection, only_mp, only_lake = _report_row_set_overlap(mp_rows, lake_rows)
-    resolved_both, outcome_mismatch = _report_final_outcome_diff(
-        mp_rows, lake_rows, intersection
-    )
-    _report_market_id_diff(mp_rows, lake_rows, intersection)
-    _report_dedup_granularity(mp_rows, deliver_to_request_by_platform)
-    _report_null_provenance(lake_rows)
-    _report_per_tool_aggregate(mp_rows, lake_rows, intersection)
-
-    print()
-    _section("Divergence gate")
-    # Denominator is a set size to match the numerator (also a set size).
-    # Row counts would under-report on the two conditions this script
-    # explicitly measures elsewhere: rows without request_id (WARN in
-    # _report_row_set_overlap) and multi-deliver-per-request (class 4a
-    # in _report_dedup_granularity).
-    mp_ids_size = len(intersection) + len(only_mp)
-    lake_ids_size = len(intersection) + len(only_lake)
-    overlap_denom = min(mp_ids_size, lake_ids_size)
-    overlap_fraction = len(intersection) / overlap_denom if overlap_denom else 0.0
-    mismatch_fraction = outcome_mismatch / resolved_both if resolved_both else 0.0
-    print(
-        f"  overlap: {len(intersection)} / {overlap_denom} = "
-        f"{overlap_fraction:.4f}  (threshold >= {args.min_overlap_fraction})"
-    )
-    print(
-        f"  outcome mismatch: {outcome_mismatch} / {resolved_both} = "
-        f"{mismatch_fraction:.4f}  (threshold <= {args.max_outcome_mismatch_fraction})"
-    )
-    failures: list[str] = []
-    if overlap_fraction < args.min_overlap_fraction:
-        failures.append(
-            f"overlap_fraction {overlap_fraction:.4f} < "
-            f"min_overlap_fraction {args.min_overlap_fraction}"
-        )
-    if mismatch_fraction > args.max_outcome_mismatch_fraction:
-        failures.append(
-            f"outcome_mismatch_fraction {mismatch_fraction:.4f} > "
-            f"max_outcome_mismatch_fraction {args.max_outcome_mismatch_fraction}"
-        )
-    if failures:
+        failures: list[str] = []
+        if overlap_fraction < args.min_overlap_fraction:
+            failures.append(
+                f"overlap_fraction {overlap_fraction:.4f} < "
+                f"min_overlap_fraction {args.min_overlap_fraction}"
+            )
+        if mismatch_fraction > args.max_outcome_mismatch_fraction:
+            failures.append(
+                f"outcome_mismatch_fraction {mismatch_fraction:.4f} > "
+                f"max_outcome_mismatch_fraction {args.max_outcome_mismatch_fraction}"
+            )
+        if failures:
+            print()
+            print("FAIL (parity): divergence exceeds thresholds:")
+            for reason in failures:
+                print(f"  - {reason}")
+            exit_code = 3
+            return exit_code
         print()
-        print("FAIL: divergence exceeds thresholds:")
-        for reason in failures:
-            print(f"  - {reason}")
-        return 3
-    print()
-    print("PASS: divergence within thresholds")
-    return 0
+        print("PASS: coverage complete, parity within thresholds")
+        return exit_code
+    finally:
+        elapsed_s = time.monotonic() - started_at
+        print(f"\nwall time: {elapsed_s:.1f}s")
+        sys.stdout = sys.__stdout__  # type: ignore[assignment]
+        if args.output_dir:
+            window_slug = f"{since.date().isoformat()}_to_{until.date().isoformat()}"
+            json_data = {
+                "metadata": {**metadata, "wall_time_s": round(elapsed_s, 1)},
+                "coverage": coverage_summary,
+                "parity": parity_summary,
+                "verdict": "PASS" if exit_code == 0 else "FAIL",
+                "exit_code": exit_code,
+            }
+            _write_report_files(
+                Path(args.output_dir),
+                window_slug,
+                report_buffer.getvalue(),
+                json_data,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/verify_migration_swap.py
+++ b/scripts/verify_migration_swap.py
@@ -710,10 +710,15 @@ def _report_coverage_check(
 def _git_sha() -> str:
     """Return the current git commit SHA, or ``unknown`` if git isn't
     available (e.g. running inside a stripped-down container).
+
+    ``git`` is resolved via PATH deliberately: hardcoding an absolute
+    path would be brittle across environments (Linux/macOS/CI/Docker
+    all put git in different locations) and the argv is a fixed literal
+    that never accepts user input.
     """
     try:
         return (
-            subprocess.check_output(
+            subprocess.check_output(  # nosec B603 B607
                 ["git", "rev-parse", "HEAD"],
                 stderr=subprocess.DEVNULL,
                 cwd=Path(__file__).resolve().parent,


### PR DESCRIPTION
## Summary

Adds coverage check and K8s-Job runtime to the mech-analytics parity verification script, so infra can produce proof-quality reports for the mech-predict cutover without local machines in the loop.

Three things ship together:

1. **Coverage check** in `scripts/verify_migration_swap.py`. Proves every on-chain `request_id` the marketplace subgraph knows about is present in the mech-analytics lake, regardless of resolution status or whether mech-predict's parser would currently use it. Fails with exit code 4 if any on-chain request is missing.
2. **`Dockerfile.verify`** — narrow image (python:3.13-slim + uv + just the `benchmark/` tree and the script). Entry point invokes the script via `uv run`. Non-root runtime. Infra mounts `/reports` for `--output-dir`.
3. **`publish-verify-image.yaml`** — publishes `valory/mech-predict-verify:<version>` on release (tag stripped of leading `v` to match `release.yaml` convention). Release-only trigger.

## What the script now does per run

- **Coverage phase.** Pulls every delivery `request_id` from the marketplace subgraph for the window (new helper `fetch_all_delivery_request_ids`, raw ID set with no parsedRequest gate). Pulls every lake `request_id` for the window via `/v1/data/scored-rows` unfiltered. Diffs. Reports the count and full ID list. First 20 in markdown, complete list in JSON.
- **Parity phase.** On the resolved intersection: `final_outcome`, `market_id`, per-tool `brier` / `directional_accuracy`. Same shape as before.
- **Verdict.** Coverage failure blocks the run first. Then the parity threshold gate.
- **`--output-dir`.** When set, tees the human report to `<since>_to_<until>.md` and structured data to `<since>_to_<until>.json`. Default is stdout only.
- **Metadata header.** Every report carries run timestamp UTC, script git SHA, mech-analytics URL, window bounds, wall time.

## Exit codes

- `0` — coverage complete, parity within thresholds
- `2` — min-row guard tripped (window too thin)
- `3` — parity divergence exceeds thresholds
- `4` — coverage gap (at least one on-chain request_id missing from lake, new)

## `resolved_before` / `timestamp_lt` bounds (folded in)

`fetch_omen_resolved`, `fetch_polymarket_resolved`, `fetch_deliveries`, and `process_platform` now accept an optional upper bound on the resolution / delivery timestamp. Without it, verifying older windows means enumerating the subgraph from the window start all the way to now (~150k+ bets for a Feb 2026 window, several hours). With the bound each window finishes in 5-8 min against a live subgraph.

## Runtime contract (K8s Job side)

- Image: `valory/mech-predict-verify:<version>` after the next release
- Env: `MECH_ANALYTICS_URL`, plus subgraph URLs per the script docstring (`OMEN_SUBGRAPH_URL` etc.)
- Mount: `/reports` PVC for `--output-dir` artifacts
- Exit codes as above

Example Job spec Marc can start from:

```yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: parity-check-jul
spec:
  template:
    spec:
      containers:
      - name: parity
        image: valory/mech-predict-verify:<version>
        args:
        - "--since"
        - "2026-07-01T00:00:00+00:00"
        - "--until"
        - "2026-07-04T00:00:00+00:00"
        - "--output-dir"
        - "/reports"
        env:
        - name: MECH_ANALYTICS_URL
          value: "https://mech-analytics-api.autonolas.tech"
        - name: OMEN_SUBGRAPH_URL
          valueFrom:
            secretKeyRef:
              name: parity-secrets
              key: OMEN_SUBGRAPH_URL
        volumeMounts:
        - name: reports
          mountPath: /reports
      volumes:
      - name: reports
        persistentVolumeClaim:
          claimName: parity-reports
      restartPolicy: Never
```

## Test plan

- [x] `py_compile` clean on both changed files
- [x] `black --check`, `isort --check-only` clean
- [x] `bandit` — B607 partial-path finding on the `git rev-parse` call fixed with inline nosec + rationale
- [x] `--help` renders with new `--output-dir` flag documented
- [x] All new helpers (`_Tee`, `_git_sha`, `_print_metadata`, `_report_coverage_check`, `_pull_marketplace_request_ids`, `_pull_lake_request_ids_unfiltered`, `_write_report_files`, `fetch_all_delivery_request_ids`) importable
- [ ] Cut a release tag, verify `valory/mech-predict-verify:<version>` lands on Docker Hub
- [ ] Infra runs the K8s Job against a recent 3-day window with `--output-dir`, artifacts land in the PVC and contain the coverage section
- [ ] Run against a window known to have a coverage gap, verify exit code 4 and the missing-ID list in the artifact

## Backwards compatibility

No CLI arg removed, no default changed, no existing exit code repurposed. Existing local invocations (no `--output-dir`) behave identically except that the report now includes a metadata header and a coverage-check section before the parity output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)