### PR TITLE
hotfix: use error column not reason in known-loss query

### DIFF
--- a/benchmark/tests/test_verify_migration_swap.py
+++ b/benchmark/tests/test_verify_migration_swap.py
@@ -27,6 +27,7 @@ the artifact contract.
 
 from __future__ import annotations
 
+import inspect
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -1071,3 +1072,24 @@ class TestReportCoverageCheckDirect:
         data = json.loads(artifacts[0].read_text())
         assert data["verdict"] == "ERROR"
         assert data["exit_code"] != 0
+
+    def test_known_loss_query_targets_the_error_column_not_reason(self) -> None:
+        """The predict-api ``mech_migration_failures`` schema is
+        ``(id, chain_id, request_id, cid, error, attempted_at)`` — the
+        reason category lives in the ``error`` column, not ``reason``.
+        The v0.21.17 prod run crashed with
+        ``psycopg.errors.UndefinedColumn: column "reason" does not exist``
+        because the query was mis-named against the docs. Pinning the
+        SQL text keeps this from recurring.
+        """
+        # pylint: disable-next=protected-access
+        source = inspect.getsource(vms._pull_known_loss_failures)
+        assert "FROM mech_migration_failures" in source
+        assert "AND error = ANY(" in source, (
+            "known-loss query must filter on the ``error`` column; the DB "
+            "schema does not have a ``reason`` column"
+        )
+        assert "AND reason = ANY(" not in source, (
+            "``reason`` is the wrong column name — see the v0.21.17 prod "
+            'crash (UndefinedColumn: column "reason" does not exist)'
+        )

--- a/scripts/verify_migration_swap.py
+++ b/scripts/verify_migration_swap.py
@@ -155,7 +155,7 @@ _KNOWN_LOSS_REASONS: tuple[str, ...] = (
 
 # Per-query statement timeout for the predict-api pull. The table is
 # ~1.16M rows in prod, small in absolute terms, and the query has
-# ``WHERE request_id IS NOT NULL AND reason IN (...)`` on it — but a
+# ``WHERE request_id IS NOT NULL AND error IN (...)`` on it — but a
 # missing index, a replica lag spike, or a lock contention burst
 # turns the documented "few seconds" into an unbounded hang with
 # only K8s ``activeDeadlineSeconds`` to stop it. Bound it here so
@@ -436,10 +436,15 @@ def _pull_known_loss_failures(predict_api_url: str) -> dict[str, set[str]]:
         options=connect_options,
     ) as conn:
         with conn.cursor() as cur:
+            # The DB column is named ``error`` (per predict-api's schema:
+            # ``id, chain_id, request_id, cid, error, attempted_at``). We
+            # refer to the values as "reasons" in Python — matching how
+            # predict-api's own logs and this repo's docstrings describe
+            # them — but the SQL column is ``error``.
             cur.execute(
                 "SELECT chain_id, request_id FROM mech_migration_failures "
                 "WHERE request_id IS NOT NULL "
-                "AND reason = ANY(%(reasons)s)",
+                "AND error = ANY(%(reasons)s)",
                 {"reasons": list(_KNOWN_LOSS_REASONS)},
             )
             for chain_id, request_id in cur:


### PR DESCRIPTION
## Summary

v0.21.17 crashed in production after 5800s of work with:

```
psycopg.errors.UndefinedColumn: column "reason" does not exist
```

Predict-api's ``mech_migration_failures`` schema is
``(id, chain_id, request_id, cid, error, attempted_at)``. The reason
category is stored in the ``error`` column, not ``reason``. Everywhere else on the Python side we call these values "reasons" (matches how predict-api's own logs describe them and how Ojus / Benny suggested it in the round-1 review), but the SQL column name is different.

## Fix

- ``AND error = ANY(%(reasons)s)`` in ``_pull_known_loss_failures``
- Inline comment above the query pinning the naming split
- New regression test ``test_known_loss_query_targets_the_error_column_not_reason`` uses ``inspect.getsource`` to flip red if anyone puts ``reason`` back

## Verification

Ran the corrected query against the live predict-api DB:

| chain | rows |
|---|---|
| 100 (Gnosis / omen) | 1,145,119 |
| 8453 (Base) | 13,863 |
| 137 (Polygon / polymarket) | 4 |

Matches the ~1.15M chain-100 known-loss ceiling we had from earlier back-of-envelope work.

## Post-merge

Cut v0.21.18 immediately so infra can re-run. Same env / args / mount as the v0.21.17 message; nothing else changes.

## Test plan

- [x] ``pytest benchmark/tests/test_verify_migration_swap.py`` — 26/26
- [x] ``tomte tox -e black-check`` clean
- [x] Query verified against prod DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)