### PR TITLE
fix(benchmark): warn on partial ROI groups corruption; pin the log-format call site

### DIFF
--- a/benchmark/notify_slack.py
+++ b/benchmark/notify_slack.py
@@ -516,7 +516,17 @@ def main() -> None:
     log.info("Done.")
 
 
-if __name__ == "__main__":
-    # The level prefix is load-bearing, not decoration -- see the constant.
+def _configure_logging() -> None:
+    """Configure the entry-point logger.
+
+    Lives outside the ``__main__`` guard so the call itself is reachable by a
+    test: the level prefix is the fix (see ``_LEVEL_PREFIX_FORMAT``), and a
+    guard-only call site cannot be executed by the suite, so dropping the
+    ``format`` argument would silently restore the unfilterable log.
+    """
     logging.basicConfig(level=logging.INFO, format=_LEVEL_PREFIX_FORMAT)
+
+
+if __name__ == "__main__":
+    _configure_logging()
     main()

--- a/benchmark/roi_slack.py
+++ b/benchmark/roi_slack.py
@@ -427,24 +427,27 @@ def build_roi_section(results_path: Path, platform: str) -> str | None:
             type(groups).__name__,
         )
         return None
+    # Report EVERY dropped entry, not just an all-garbage list. A partially
+    # truncated write (process killed mid-write, one entry replaced by an error
+    # placeholder) leaves valid groups beside the garbage, so it renders a
+    # normal-looking table with silently missing rows -- the more realistic
+    # corruption shape, and the one an all-or-nothing check cannot see.
+    malformed = [group for group in groups if not isinstance(group, dict)]
+    if malformed:
+        log.warning(
+            "%d of %d ROI 'groups' entries are not objects (first bad is %s); "
+            "the roi_sim write is likely truncated or schema-drifted -- "
+            "dropping them.",
+            len(malformed),
+            len(groups),
+            type(malformed[0]).__name__,
+        )
     platform_groups = [
         group
         for group in groups
         if isinstance(group, dict) and group.get("platform") == platform
     ]
     if not platform_groups:
-        # "No data for this platform yet" is legitimate and silent. A non-empty
-        # groups list that yields no dicts at all is not: that is a truncated or
-        # schema-drifted roi_sim write wearing the same silence. Separate the
-        # two so the second cannot hide behind the first.
-        if groups and not any(isinstance(group, dict) for group in groups):
-            log.warning(
-                "ROI results carry %d 'groups' entries but none are objects "
-                "(first is %s); the roi_sim write is likely truncated or "
-                "schema-drifted -- skipping the section.",
-                len(groups),
-                type(groups[0]).__name__,
-            )
         return None
 
     # Forward-compatible deployment filter: groups explicitly marked

--- a/benchmark/tests/test_notify_slack.py
+++ b/benchmark/tests/test_notify_slack.py
@@ -28,6 +28,7 @@ from urllib.error import HTTPError
 from urllib.request import Request
 
 import pytest
+from benchmark import notify_slack
 from benchmark.analyze import PLATFORM_LABELS, ROLLING_WINDOW_DAYS
 from benchmark.notify_slack import (
     _LEVEL_PREFIX_FORMAT,
@@ -155,6 +156,28 @@ class TestBuildSystemPrompt:
 
 class TestLogFormat:
     """The flywheel log format keeps WARNING distinguishable from INFO."""
+
+    def test_configure_logging_passes_the_prefix_format(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The CALL SITE is pinned, not just the constant's value.
+
+        Reverting `format=_LEVEL_PREFIX_FORMAT` at the call site while leaving
+        the constant intact left the whole suite green, so the line that
+        actually fixes the flywheel log was unprotected -- a refactor or merge
+        dropping the argument would silently restore the unfilterable log.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        """
+        captured: dict[str, Any] = {}
+
+        def fake_basic_config(**kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
+        notify_slack._configure_logging()
+        assert captured["format"] == _LEVEL_PREFIX_FORMAT
+        assert captured["level"] == logging.INFO
 
     def test_level_is_recoverable_from_a_rendered_line(self) -> None:
         """A WARNING and an INFO with the same text render differently.

--- a/benchmark/tests/test_notify_slack.py
+++ b/benchmark/tests/test_notify_slack.py
@@ -31,9 +31,9 @@ import pytest
 from benchmark.analyze import PLATFORM_LABELS, ROLLING_WINDOW_DAYS
 from benchmark.notify_slack import (
     _LEVEL_PREFIX_FORMAT,
-    _configure_logging,
     _build_system_prompt,
     _compute_top_k,
+    _configure_logging,
     _count_eligible_tools,
     _infer_platform_label,
     _main_window_label,

--- a/benchmark/tests/test_notify_slack.py
+++ b/benchmark/tests/test_notify_slack.py
@@ -28,10 +28,10 @@ from urllib.error import HTTPError
 from urllib.request import Request
 
 import pytest
-from benchmark import notify_slack
 from benchmark.analyze import PLATFORM_LABELS, ROLLING_WINDOW_DAYS
 from benchmark.notify_slack import (
     _LEVEL_PREFIX_FORMAT,
+    _configure_logging,
     _build_system_prompt,
     _compute_top_k,
     _count_eligible_tools,
@@ -175,7 +175,7 @@ class TestLogFormat:
             captured.update(kwargs)
 
         monkeypatch.setattr(logging, "basicConfig", fake_basic_config)
-        notify_slack._configure_logging()
+        _configure_logging()
         assert captured["format"] == _LEVEL_PREFIX_FORMAT
         assert captured["level"] == logging.INFO
 

--- a/benchmark/tests/test_roi_slack.py
+++ b/benchmark/tests/test_roi_slack.py
@@ -1269,7 +1269,7 @@ class TestRoiSectionFreshness:
         )
         with caplog.at_level(logging.WARNING):
             assert build_roi_section(path, "omen") is None
-        assert "none are objects" in caplog.text
+        assert "2 of 2 ROI 'groups' entries are not objects" in caplog.text
 
         # Contrast: a well-formed group for ANOTHER platform is the legitimate
         # quiet case -- same None, no warning.
@@ -1281,6 +1281,35 @@ class TestRoiSectionFreshness:
         with caplog.at_level(logging.WARNING):
             assert build_roi_section(path, "omen") is None
         assert not caplog.records
+
+    def test_mixed_corruption_warns_and_still_renders(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Garbage beside valid groups warns; the valid rows still render.
+
+        The realistic corruption shape: a write killed part-way leaves valid
+        entries next to placeholders. The table then looks normal with rows
+        silently missing, which an all-or-nothing check cannot see.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param caplog: pytest caplog fixture.
+        """
+        path = tmp_path / "roi_results.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "as_of": datetime.now(timezone.utc).date().isoformat(),
+                    "window_days": 90,
+                    "groups": [_group(tool="alpha"), "truncated-entry", None],
+                }
+            ),
+            encoding="utf-8",
+        )
+        with caplog.at_level(logging.WARNING):
+            section = build_roi_section(path, "omen")
+        assert section is not None
+        assert "alpha" in section
+        assert "2 of 3" in caplog.text
 
     def test_absent_timestamp_is_quiet(
         self, tmp_path: Path, caplog: pytest.LogCaptureFixture


### PR DESCRIPTION
Follow-up to #403 — the two `[Important, non-blocking]` findings @OjusWiZard raised alongside his approval, held back there so the push would not dismiss the two approvals.

### 1. Partial `groups` corruption passed silently

The warning added in #403 fired only when **every** entry was garbage (`not any(isinstance(...))`). One valid group beside a truncated entry rendered a normal-looking section with rows silently dropped — the more realistic corruption shape (a write killed part-way), and exactly the "looks like no data" silence the check existed to eliminate.

Now every non-object entry is counted and reported, and the valid rows still render:

```
WARNING: 2 of 3 ROI 'groups' entries are not objects (first bad is str); the
roi_sim write is likely truncated or schema-drifted -- dropping them.
```

### 2. The log-format fix was unpinned at the call site

`TestLogFormat` pinned what `_LEVEL_PREFIX_FORMAT` *contains*, not that it reaches `basicConfig`. Reproduced the reviewer's mutation: reverting `format=` at the `__main__` call site while leaving the constant intact left **all 170 tests green** — so the line that actually makes WARNING greppable in the flywheel log could regress via any refactor that drops the argument.

Extracted `_configure_logging()` (outside the `__main__` guard, so a test can reach it) and pinned the kwargs that arrive at `logging.basicConfig`.

This is the third instance in this PR series of a test driving a helper while the call site is reverted — the pattern recorded on #420. Both fixes here are mutation-tested against precisely the reversion demonstrated in review:

| mutation | result |
|---|---|
| revert `format=` at the call site, keep the constant | `test_configure_logging_passes_the_prefix_format` fails |
| restore the all-or-nothing groups rule | `test_mixed_corruption_warns_and_still_renders` fails |

172 tests green; `black` + `isort` clean against the repo's own configs.
