### PR TITLE
chore(deps): bump mech v0.34.3 -> v0.34.4

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -27,8 +27,8 @@
         "custom/valory/finetuned_prediction/0.1.0": "bafybeiclpkn4sqvri7k5aiklt5fm6hnt3tgo4qxtrkzxe4fwzfs2plgbk4",
         "custom/valory/propose_question/0.1.0": "bafybeif2dmjftef7pnixwnutn42tdaxbbr77anl5ixsv6kwsxnk7sm6fni",
         "custom/valory/superforcaster_polymarket_v4/0.1.0": "bafybeieuzna7fsv4iwz7gvqpvkurfdskd2tul6b4asjg4dcsp4oieic6ti",
-        "agent/valory/mech_predict/0.1.0": "bafybeiasxdmd4jrh47qwxx6yig2dnb4me6lhgvhca2ixzfpn3dg4oormne",
-        "service/valory/mech_predict/0.1.0": "bafybeihmx6ywz2pl4s7kz3ksvtvcbzyeasuph6ehtu7ouhabmlgp7vaufu"
+        "agent/valory/mech_predict/0.1.0": "bafybeigh5foumkg6mpf72krbsnk25gdcag3pbu4f7o7ebnuyothr7bzksi",
+        "service/valory/mech_predict/0.1.0": "bafybeig3v5itjfedek2g67busgxgmwvisquxuodhe63r6lr2xozojuu7la"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -69,8 +69,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e",
-        "skill/valory/mech_abci/0.1.0": "bafybeigdwb6lsnj46goll73qzkeqcyffpv7sixf5oqwlfthl43htsybjia",
-        "skill/valory/task_execution/0.1.0": "bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu"
+        "skill/valory/mech_abci/0.1.0": "bafybeiatph3obd4vomjsft7civq7iukue5c3q63t44cghvrfghca65aoma",
+        "skill/valory/task_execution/0.1.0": "bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a"
     }
 }

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -42,12 +42,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeicqlkmfpttw4hbbaakr6xos62rd6ytjwkyzlfli4xpvl5yqcycf6q
-- valory/mech_abci:0.1.0:bafybeigdwb6lsnj46goll73qzkeqcyffpv7sixf5oqwlfthl43htsybjia
+- valory/mech_abci:0.1.0:bafybeiatph3obd4vomjsft7civq7iukue5c3q63t44cghvrfghca65aoma
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeiathwdfpcfqbipqbkslv6j22q5cvov4n3czmehzij3czrhdnlg42e
-- valory/task_execution:0.1.0:bafybeiba6ar75dz6ih36u6vwt3ksnvcibgxvxrq2ktedcp2b6rmvew563y
-- valory/task_submission_abci:0.1.0:bafybeic3clyx66kfa3tdktzqiitr2kv5yk6qmqy6cuerumopweiigksabu
+- valory/task_execution:0.1.0:bafybeiblzdymhr6gps5be7eemrgaqwu45hzmd5rsugpkldutjumwl2gkqm
+- valory/task_submission_abci:0.1.0:bafybeicm4kt4zaznkb3vtdl3wz574j5xpqpo4gn2zwpaezpt4tqx2cj36a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeid6oyycsrvk4duftffs5mrfgmcepibt3qe4om3kfzhwhilfq3ynay

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeiasxdmd4jrh47qwxx6yig2dnb4me6lhgvhca2ixzfpn3dg4oormne
+agent: valory/mech_predict:0.1.0:bafybeigh5foumkg6mpf72krbsnk25gdcag3pbu4f7o7ebnuyothr7bzksi
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ pytest_targets_extra = ["benchmark/tests"]
 # tomte auto-prepends valory-xyz/open-autonomy@... and open-aea@...
 # from pyproject pins, so only the non-PyPI mech upstream needs listing.
 upstream_pins = [
-    "valory-xyz/mech@v0.34.3",
+    "valory-xyz/mech@v0.34.4",
     "valory-xyz/kv-store@v0.7.1",
 ]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"


### PR DESCRIPTION
## Summary

Picks up the offchain requestId int/str keying fix from [mech PR #474](https://github.com/valory-xyz/mech/pull/474) (v0.34.4), which closed the `TaskPoolingRound` crash on mixed-type `request_ids` across a pooling batch.

Three third-party mech skill hashes bumped:
- `skill/valory/task_execution/0.1.0`
- `skill/valory/task_submission_abci/0.1.0`
- `skill/valory/mech_abci/0.1.0`

Plus:
- `upstream_pins` in pyproject.toml: `valory-xyz/mech@v0.34.3` → `v0.34.4`
- `autonomy packages lock` cascaded the `mech_predict` agent and service hashes

## Test plan

- [x] `autonomy packages sync` clean (all three skills re-fetched from new hashes)
- [x] `autonomy packages lock` completes, agent + service hashes cascade
- [x] `tomte tox -e check-third-party-hashes` passes against `valory-xyz/mech@v0.34.4`
- [x] `tomte tox -p -e check-hash -e check-packages -e check-dependencies -e check-doc-hashes` passes locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)