### PR TITLE
benchmark: preflight tool registration; a zero-scored run fails the workflow

### DIFF
--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -162,6 +162,37 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      # F14: fail in seconds on a config the replay step would only reject
+      # minutes later. Registration is knowable the moment the command parses;
+      # the 2026-08-04 full_search run spent 6m32s and 301 IPFS fetches
+      # discovering an unregistered baseline at the replay step (302 identical
+      # warnings in between). Schema resolution raises here too, by name, so a
+      # present-but-unusable PredictionResult is caught before any download.
+      - name: Preflight tool registration
+        env:
+          TOOL: ${{ steps.parse.outputs.tool }}
+          CANDIDATE_TOOL: ${{ steps.parse.outputs.candidate_tool }}
+        run: |
+          uv run python -c '
+          import sys
+          from benchmark.tools import TOOL_REGISTRY
+          from benchmark.prompt_replay import _get_structured_output_schema
+
+          tool, candidate = sys.argv[1], sys.argv[2] or sys.argv[1]
+          missing = sorted({n for n in (tool, candidate) if n not in TOOL_REGISTRY})
+          if missing:
+              print(
+                  f"::error::not registered in benchmark/tools.py "
+                  f"TOOL_REGISTRY: {missing}. Add a ToolSpec entry (same "
+                  f"family as the parent). Registered: {sorted(TOOL_REGISTRY)}"
+              )
+              sys.exit(1)
+          # Raises ValueError naming tool+module on a present-but-unusable
+          # schema; returns None for plain-prompt tools, which is fine.
+          _get_structured_output_schema(candidate)
+          print(f"preflight ok: tool={tool} candidate={candidate}")
+          ' "$TOOL" "$CANDIDATE_TOOL"
+
       # Download latest production log from flywheel
       - name: Download production log
         uses: dawidd6/action-download-artifact@09f2f74827fd3a8607589e5ad7f9398816f540fe  # v3

--- a/.github/workflows/benchmark_replay.yaml
+++ b/.github/workflows/benchmark_replay.yaml
@@ -162,36 +162,13 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
-      # F14: fail in seconds on a config the replay step would only reject
-      # minutes later. Registration is knowable the moment the command parses;
-      # the 2026-08-04 full_search run spent 6m32s and 301 IPFS fetches
-      # discovering an unregistered baseline at the replay step (302 identical
-      # warnings in between). Schema resolution raises here too, by name, so a
-      # present-but-unusable PredictionResult is caught before any download.
+      # Preflight: catch unregistered tools / bad schemas before any IPFS
+      # fetches. Lives in benchmark/preflight.py so lint + tests cover it.
       - name: Preflight tool registration
         env:
           TOOL: ${{ steps.parse.outputs.tool }}
           CANDIDATE_TOOL: ${{ steps.parse.outputs.candidate_tool }}
-        run: |
-          uv run python -c '
-          import sys
-          from benchmark.tools import TOOL_REGISTRY
-          from benchmark.prompt_replay import _get_structured_output_schema
-
-          tool, candidate = sys.argv[1], sys.argv[2] or sys.argv[1]
-          missing = sorted({n for n in (tool, candidate) if n not in TOOL_REGISTRY})
-          if missing:
-              print(
-                  f"::error::not registered in benchmark/tools.py "
-                  f"TOOL_REGISTRY: {missing}. Add a ToolSpec entry (same "
-                  f"family as the parent). Registered: {sorted(TOOL_REGISTRY)}"
-              )
-              sys.exit(1)
-          # Raises ValueError naming tool+module on a present-but-unusable
-          # schema; returns None for plain-prompt tools, which is fine.
-          _get_structured_output_schema(candidate)
-          print(f"preflight ok: tool={tool} candidate={candidate}")
-          ' "$TOOL" "$CANDIDATE_TOOL"
+        run: uv run python -m benchmark.preflight "$TOOL" "$CANDIDATE_TOOL"
 
       # Download latest production log from flywheel
       - name: Download production log

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -41,6 +41,15 @@ MAX_FAILURE_BODIES_IN_COMMENT = 5
 MAX_FAILURE_BODY_CHARS = 600
 
 
+def _format_breakdown(breakdown: dict[str, int]) -> str:
+    """Render the parse-status buckets in their fixed, diffable order.
+
+    :param breakdown: counts per ``PARSE_STATUS_BUCKETS`` entry.
+    :return: ``"valid=3, missing_fields=0, ..."``.
+    """
+    return ", ".join(f"{k}={breakdown[k]}" for k in PARSE_STATUS_BUCKETS)
+
+
 def _compute_parse_reliability(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Summarise parse reliability from ``prediction_parse_status`` values.
 
@@ -338,7 +347,7 @@ def _format_reliability_block(
     # line count short.
     if c_valid < c_total:
         bd = c_rel["breakdown"]
-        breakdown_str = ", ".join(f"{k}={bd[k]}" for k in PARSE_STATUS_BUCKETS)
+        breakdown_str = _format_breakdown(bd)
         lines.append(f"  - Breakdown: {breakdown_str}")
 
     if filter_stats is not None and filter_stats.get("source") == "tournament":
@@ -654,22 +663,20 @@ def main() -> None:
     # deleting the signal the health block exists to carry.
     candidate_metrics["parse_reliability"] = _compute_parse_reliability(candidate_rows)
 
-    # A run that scored nothing is a FAILURE, not a result. Keyed on the
-    # PAIRED count, not on row counts: a tournament-fallback run legitimately
-    # has zero production rows and still scores, while the 2026-08-04 v5 run
-    # had 300 candidate rows -- all malformed -- and exited green with a
-    # published verdict. #420 made the rendering honest ("Computed on 0
-    # markets"); this makes the exit code honest too, so the run goes red,
-    # the incomplete-benchmark notice fires, and no verdict is published.
+    # n==0 scored pairs = nothing to verdict; exit nonzero so no report is
+    # published and the incomplete-benchmark notice fires. Keyed on the PAIRED
+    # count because it is the one number that means "scorable": zero can come
+    # from candidate parse failures OR from null p_yes on either arm.
+    # Tournament-fallback runs arrive here with a synthesized NON-empty
+    # baseline arm (the tournament p_yes is copied per market upstream in
+    # replay()), so they pass because they genuinely have pairs -- the
+    # empty-baseline exit above never sees them empty.
     if candidate_metrics["n"] == 0:
         rel = candidate_metrics["parse_reliability"]
-        breakdown = ", ".join(
-            f"{k}={rel['breakdown'][k]}" for k in PARSE_STATUS_BUCKETS
-        )
         print(
-            f"ERROR: 0 of {rel['total']} candidate responses were usable "
-            f"({breakdown}); refusing to publish a verdict computed on "
-            "nothing.",
+            f"ERROR: 0 scored pairs from {rel['total']} candidate rows "
+            f"(candidate parse: {_format_breakdown(rel['breakdown'])}); "
+            "refusing to publish a verdict computed on nothing.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/benchmark/ci_replay.py
+++ b/benchmark/ci_replay.py
@@ -654,6 +654,26 @@ def main() -> None:
     # deleting the signal the health block exists to carry.
     candidate_metrics["parse_reliability"] = _compute_parse_reliability(candidate_rows)
 
+    # A run that scored nothing is a FAILURE, not a result. Keyed on the
+    # PAIRED count, not on row counts: a tournament-fallback run legitimately
+    # has zero production rows and still scores, while the 2026-08-04 v5 run
+    # had 300 candidate rows -- all malformed -- and exited green with a
+    # published verdict. #420 made the rendering honest ("Computed on 0
+    # markets"); this makes the exit code honest too, so the run goes red,
+    # the incomplete-benchmark notice fires, and no verdict is published.
+    if candidate_metrics["n"] == 0:
+        rel = candidate_metrics["parse_reliability"]
+        breakdown = ", ".join(
+            f"{k}={rel['breakdown'][k]}" for k in PARSE_STATUS_BUCKETS
+        )
+        print(
+            f"ERROR: 0 of {rel['total']} candidate responses were usable "
+            f"({breakdown}); refusing to publish a verdict computed on "
+            "nothing.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # Infer tool from data
     tool = baseline_rows[0].get("tool_name", "unknown")
 

--- a/benchmark/preflight.py
+++ b/benchmark/preflight.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Benchmark preflight: fail a misconfigured run before anything is spent.
+
+Invoked by ``benchmark_replay.yaml`` right after dependency install and
+before the log download / tournament fetch / enrich stages. Lives here as a
+real module -- not a snippet inside the workflow YAML -- so the same lint,
+type and test gates that cover the code it protects cover the guard itself.
+
+Failures print GitHub Actions ``::error::`` annotations, so both failure
+modes (unregistered name, unusable schema) surface identically on the run
+summary instead of one being a bare traceback in the log.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from benchmark.prompt_replay import _get_structured_output_schema
+from benchmark.tools import TOOL_REGISTRY
+
+
+def main(argv: list[str]) -> int:
+    """Validate the requested tool pairing against the registry.
+
+    :param argv: ``[tool, candidate_tool]``; an empty candidate means an
+        in-place run (candidate defaults to the tool itself).
+    :return: process exit code -- 0 when the pairing is replayable, 1 when
+        the run would be doomed and must not proceed to the download stages.
+    """
+    if len(argv) < 1 or not argv[0]:
+        print("::error::preflight called without a tool name")
+        return 1
+    tool = argv[0]
+    candidate = argv[1] if len(argv) > 1 and argv[1] else tool
+
+    missing = sorted({name for name in (tool, candidate) if name not in TOOL_REGISTRY})
+    if missing:
+        print(
+            f"::error::not registered in benchmark/tools.py TOOL_REGISTRY: "
+            f"{missing}. Add a ToolSpec entry (same family as the parent). "
+            f"Registered: {sorted(TOOL_REGISTRY)}"
+        )
+        return 1
+
+    try:
+        # Raises ValueError naming tool+module on a present-but-unusable
+        # schema; returns None for plain-prompt tools, which is fine.
+        _get_structured_output_schema(candidate)
+    except (ValueError, ImportError) as exc:
+        print(f"::error::{exc}")
+        return 1
+
+    print(f"preflight ok: tool={tool} candidate={candidate}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -819,10 +819,51 @@ class TestMainRowGuards:
             ],
         )
         assert code == 1
-        err = capsys.readouterr().err
-        assert "0 of 3 candidate responses were usable" in err
-        assert "malformed=3" in err
-        assert "refusing to publish" in err.lower()
+        captured = capsys.readouterr()
+        assert "0 scored pairs from 3 candidate rows" in captured.err
+        assert "malformed=3" in captured.err
+        assert "refusing to publish" in captured.err.lower()
+        # The harm on 2026-08-04 was a PUBLISHED verdict, not the exit code:
+        # main() renders the report to stdout before posting, so an empty
+        # stdout is what pins "no verdict escaped". A refactor moving the
+        # guard below the render would fail here.
+        assert captured.out == "", "a verdict was published despite the guard"
+
+    def test_tournament_fallback_shape_still_exits_zero(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """The guard's exemption for tournament-fallback runs is executable.
+
+        The fallback synthesizes a NON-empty baseline arm (tournament p_yes
+        per market) and candidate rows that pair normally; keying the guard
+        on the paired count is what lets those runs pass. If pair_arms or the
+        fallback shape ever drifts and zeroes n on tournament data, this
+        flips green runs red -- this test makes that loud.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        cand = [{**_row("valid"), "question_text": f"Q{i}?"} for i in range(3)]
+        # Tournament flavour: the sidecar next to candidate.jsonl marks the
+        # rows as tournament-sourced, which the report renders as
+        # "Baseline (tourn)".
+        stats = {
+            "source": "tournament",
+            "accepted": 3,
+            "rejected": {},
+            "no_row_id": 0,
+            "production_attempt": {"accepted": 0, "rejected": {}},
+            "fallback_reason": "0 production rows",
+        }
+        (tmp_path / "filter_stats.json").write_text(json.dumps(stats), encoding="utf-8")
+        code = self._run(tmp_path, monkeypatch, cand)
+        out = capsys.readouterr().out
+        assert code == 0, "tournament-shaped run went red"
+        assert "tourn" in out, "report did not render the tournament label"
 
     def test_populated_candidate_renders(
         self,

--- a/benchmark/tests/test_ci_replay.py
+++ b/benchmark/tests/test_ci_replay.py
@@ -788,6 +788,42 @@ class TestMainRowGuards:
         assert code == 1
         assert "No candidate rows" in capsys.readouterr().err
 
+    def test_all_malformed_candidate_fails_the_run(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A run that scored nothing must exit nonzero, not publish a verdict.
+
+        The 2026-08-04 v5 run had 300 candidate rows -- every one malformed --
+        and exited green with a posted report. The rendering was already made
+        honest ("Computed on 0 markets"); this pins the exit code, which is
+        what makes the run go red and the incomplete-benchmark notice fire.
+        Keyed on the PAIRED count so a tournament-fallback run (zero
+        production rows, real scored pairs) is untouched.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        code = self._run(
+            tmp_path,
+            monkeypatch,
+            [
+                {
+                    **_row("malformed", p_yes=None),
+                    "question_text": f"Q{i}?",
+                }
+                for i in range(3)
+            ],
+        )
+        assert code == 1
+        err = capsys.readouterr().err
+        assert "0 of 3 candidate responses were usable" in err
+        assert "malformed=3" in err
+        assert "refusing to publish" in err.lower()
+
     def test_populated_candidate_renders(
         self,
         tmp_path: Path,

--- a/benchmark/tests/test_preflight.py
+++ b/benchmark/tests/test_preflight.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+#
+#   Copyright 2026 Valory AG
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# ------------------------------------------------------------------------------
+"""Tests for the workflow preflight.
+
+The preflight used to live as a Python snippet inside benchmark_replay.yaml,
+where no linter, type checker or test could see it — the guard against silent
+misconfiguration was itself unguarded. These tests are the point of the
+extraction: every branch of the module is pinned.
+"""
+
+import sys
+import types
+
+import pytest
+from benchmark import preflight
+from benchmark.preflight import main
+from benchmark.tools import TOOL_REGISTRY
+
+
+class TestPreflight:
+    """Every exit path of the preflight, driven as the workflow drives it."""
+
+    def test_registered_pairing_passes(self, capsys: pytest.CaptureFixture) -> None:
+        """A registered baseline with a registered structured candidate: 0."""
+        assert main(["superforcaster", "superforcaster-polymarket-v4"]) == 0
+        assert "preflight ok" in capsys.readouterr().out
+
+    def test_empty_candidate_defaults_to_tool(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """In-place runs pass an empty candidate; it must not fail the check."""
+        assert main(["superforcaster_full_search", ""]) == 0
+        out = capsys.readouterr().out
+        assert "candidate=superforcaster_full_search" in out
+
+    def test_unregistered_tool_fails_with_annotation(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """An unregistered name exits 1 with a ::error:: annotation.
+
+        The annotation is load-bearing: it is what surfaces on the Actions
+        run summary instead of a bare traceback in the log.
+
+        :param capsys: pytest capsys fixture.
+        """
+        assert main(["no-such-tool", ""]) == 1
+        out = capsys.readouterr().out
+        assert out.startswith("::error::")
+        assert "no-such-tool" in out
+        assert "TOOL_REGISTRY" in out
+
+    def test_unregistered_candidate_behind_registered_baseline_fails(
+        self, capsys: pytest.CaptureFixture
+    ) -> None:
+        """The candidate is validated too, not just the baseline."""
+        assert main(["superforcaster", "no-such-candidate"]) == 1
+        assert "no-such-candidate" in capsys.readouterr().out
+
+    def test_missing_argument_fails(self, capsys: pytest.CaptureFixture) -> None:
+        """No tool argument at all is a hard error, not a crash."""
+        assert main([]) == 1
+        assert "::error::" in capsys.readouterr().out
+
+    def test_malformed_schema_fails_with_annotation(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """A present-but-unusable schema annotates instead of raising bare.
+
+        This is the asymmetry fix: the registry-missing branch already
+        annotated, while a schema ValueError previously escaped bare.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        bad = types.ModuleType("preflight_bad_module")
+        bad.PredictionResult = object  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "preflight_bad_module", bad)
+        monkeypatch.setitem(
+            TOOL_REGISTRY,
+            "preflight-bad-tool",
+            type(TOOL_REGISTRY["superforcaster"])(
+                module="preflight_bad_module", family="superforcaster"
+            ),
+        )
+        assert main(["superforcaster", "preflight-bad-tool"]) == 1
+        out = capsys.readouterr().out
+        assert out.startswith("::error::")
+        assert "preflight-bad-tool" in out
+
+    def test_module_entrypoint_matches_workflow_invocation(self) -> None:
+        """Pin the ``python -m benchmark.preflight`` contract the workflow uses."""
+        assert hasattr(preflight, "main")
+        assert callable(preflight.main)


### PR DESCRIPTION
## Why

Two failure modes from the 2026-08-04 agent benchmark runs, both structural:

1. **Slow failure.** A `/benchmark` for a tool absent from `TOOL_REGISTRY` spent **6m32s and 301 IPFS fetches** before dying at the replay step — the condition was knowable one second after the command parsed, and was in fact logged as a warning **302 times** on the way down.
2. **Silent failure.** A candidate that parsed **0 of 300** responses still exited green and published a report. An earlier change made the *rendering* honest ("Computed on 0 markets"); the exit code stayed 0, so the run read as success, and the PR's one benchmark grant was consumed by a non-result.

## What changed

**Preflight step** (workflow, right after `Install dependencies`, before any download): both tool names checked against `TOOL_REGISTRY`, and the candidate's structured-output schema resolved — a present-but-unusable `PredictionResult` raises by tool and module name. Misconfiguration now fails in seconds with the registered set in the error message.

**Zero-scored guard** (`ci_replay.main`): if the paired count is 0, print the parse breakdown to stderr and exit 1 — no verdict is published, the run goes red, and the existing *incomplete-benchmark* notice fires. Keyed on the **paired** count deliberately: a tournament-fallback run legitimately has zero production rows and real scored pairs, and passes untouched.

## Verification

- New test drives `main()` with an all-malformed candidate arm: exit 1, breakdown on stderr, no report — and fails with the guard removed (verified).
- Preflight snippet exercised against the live registry for both outcomes: unregistered name → exit 1 naming the entries; registered tool + resolvable schema → exit 0.
- 1516 tests pass; black / isort / flake8 / darglint green; mypy and pylint no new findings; workflow YAML parses.

## Scope

One workflow step + ~20 lines in `ci_replay.py` + one test. Budget-refund on incomplete runs (the agent-skills half of this failure class) is deliberately separate — different repo, different mechanism.