### PR TITLE
fix(tests): make the widen-sample fixture dates relative to now (main is red)

### DIFF
--- a/benchmark/tests/test_tool_improvement_triage.py
+++ b/benchmark/tests/test_tool_improvement_triage.py
@@ -2692,13 +2692,22 @@ class TestMainWidenSampleDispatch:
             json.dumps(prev)
         )
         (results_dir / "scores_polymarket.json").write_text(json.dumps(cur))
+        # Dates are relative to now, NOT hard-coded: the count window applies
+        # a rolling COUNT_WINDOW_MAX_AGE_DAYS cap measured from the current
+        # time, so fixed 2026-06-* rows silently aged out of it and this test
+        # began failing on a date with no code change (2026-08-11).
+        newest = datetime.now(timezone.utc) - timedelta(days=8)
         rows = [
-            _cw_row(f"2026-06-{d:02d}T00:00:00Z", 0.5, True, row_id=f"r{d}")
-            for d in range(20, 28)
+            _cw_row(
+                (newest - timedelta(days=offset)).strftime("%Y-%m-%dT00:00:00Z"),
+                0.5,
+                True,
+                row_id=f"r{offset}",
+            )
+            for offset in range(8)
         ]
-        (logs_dir / "production_log_2026_06_28.jsonl").write_text(
-            "\n".join(json.dumps(r) for r in rows)
-        )
+        log_name = f"production_log_{newest:%Y_%m_%d}.jsonl"
+        (logs_dir / log_name).write_text("\n".join(json.dumps(r) for r in rows))
 
     def _run(
         self,


### PR DESCRIPTION
## The problem

`test_widen_note_created_with_deployment_review_label` fails on `main` as of today, with no code change behind it.

The fixture writes its production-log rows at a hard-coded `2026-06-20 … 2026-06-27`. The code under test drops rows older than a **rolling** cap measured from the real clock:

```python
COUNT_WINDOW_MAX_AGE_DAYS = 45
cutoff = now - timedelta(days=45)
```

Fixed dates against a moving cutoff have a guaranteed expiry date. It arrived this morning:

| CI ran | cutoff (`now - 45d`) | fixture rows `06-20 … 06-27` | result |
|---|---|---|---|
| 2026-08-10 23:10 UTC | 2026-06-26 | 2 rows survive -> widen issue created | pass |
| 2026-08-11 09:15 UTC | 2026-06-27 | 0 rows survive -> nothing created | **`assert 0 == 1`** |

## Why it is worth a standalone PR

It fails on `main`, so it reddens **every** PR opened from today. And the test matrix runs fail-fast: the one expired fixture cancels the other 14 test jobs, so their results are hidden too. On the run that surfaced this, the first red was an unrelated TLS error on the 3.14 runner and the suite never executed at all — a single expired fixture makes "CI is red" carry no information about the change under review.

## The change

Derive the dates from `now`, keeping the rows well inside the window, and name the log file from the newest row so the loader still finds it.

```python
newest = datetime.now(timezone.utc) - timedelta(days=8)
rows = [_cw_row((newest - timedelta(days=offset)).strftime("%Y-%m-%dT00:00:00Z"), ...)
        for offset in range(8)]
log_name = f"production_log_{newest:%Y_%m_%d}.jsonl"
```

What the test asserts is unchanged — only when its inputs are dated.

## Verification

- `benchmark/tests/test_tool_improvement_triage.py`: **171 passed**.
- Both directions checked against today's clock: reverting to the hard-coded dates **fails**, the relative dates **pass**. The fix is load-bearing, not incidental.
- Linters clean via the CI gate (`black-check`, `isort-check`, `flake8`, `mypy`, `pylint`, `darglint`) — no findings in the changed file.

