### PR TITLE
benchmark: preflight annotates all import-time failures

### DIFF
--- a/benchmark/preflight.py
+++ b/benchmark/preflight.py
@@ -63,8 +63,12 @@ def main(argv: list[str]) -> int:
         # Raises ValueError naming tool+module on a present-but-unusable
         # schema; returns None for plain-prompt tools, which is fine.
         _get_structured_output_schema(candidate)
-    except (ValueError, ImportError) as exc:
-        print(f"::error::{exc}")
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        # Deliberately broad: import_module propagates WHATEVER the tool's
+        # top-level code raises (RuntimeError, NameError, SyntaxError from a
+        # bad merge), and this module's entire contract is "annotate, never
+        # traceback". A narrow tuple here let exactly those escape bare.
+        print(f"::error::{type(exc).__name__}: {exc}")
         return 1
 
     print(f"preflight ok: tool={tool} candidate={candidate}")

--- a/benchmark/tests/test_preflight.py
+++ b/benchmark/tests/test_preflight.py
@@ -26,6 +26,7 @@ extraction: every branch of the module is pinned.
 
 import sys
 import types
+from pathlib import Path
 
 import pytest
 from benchmark import preflight
@@ -102,6 +103,61 @@ class TestPreflight:
         out = capsys.readouterr().out
         assert out.startswith("::error::")
         assert "preflight-bad-tool" in out
+
+    def test_import_crashing_module_annotates_not_tracebacks(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture,
+    ) -> None:
+        """A tool whose module raises at import must annotate, not traceback.
+
+        A module broken by a bad merge raises whatever its top-level code
+        hits (RuntimeError, NameError, SyntaxError) -- none of which the old
+        (ValueError, ImportError) tuple covered, so exactly the
+        misconfiguration class this preflight exists for escaped as the bare
+        traceback the docstring promises it prevents.
+
+        :param tmp_path: pytest tmp_path fixture.
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        crasher = "preflight_import_crasher"
+        (tmp_path / f"{crasher}.py").write_text(
+            'raise RuntimeError("module-level explosion")\n', encoding="utf-8"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+        monkeypatch.setitem(
+            TOOL_REGISTRY,
+            "preflight-crash-tool",
+            type(TOOL_REGISTRY["superforcaster"])(
+                module=crasher, family="superforcaster"
+            ),
+        )
+        assert main(["superforcaster", "preflight-crash-tool"]) == 1
+        out = capsys.readouterr().out
+        assert out.startswith("::error::"), f"escaped bare: {out[:80]!r}"
+        assert "RuntimeError" in out and "module-level explosion" in out
+
+    def test_import_error_annotates(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """The plain-ImportError branch (missing dependency) is pinned too.
+
+        :param monkeypatch: pytest monkeypatch fixture.
+        :param capsys: pytest capsys fixture.
+        """
+        monkeypatch.setitem(
+            TOOL_REGISTRY,
+            "preflight-missing-dep-tool",
+            type(TOOL_REGISTRY["superforcaster"])(
+                module="no_such_module_anywhere_xyz", family="superforcaster"
+            ),
+        )
+        assert main(["superforcaster", "preflight-missing-dep-tool"]) == 1
+        out = capsys.readouterr().out
+        assert out.startswith("::error::")
+        assert "ModuleNotFoundError" in out or "ImportError" in out
 
     def test_module_entrypoint_matches_workflow_invocation(self) -> None:
         """Pin the ``python -m benchmark.preflight`` contract the workflow uses."""


### PR DESCRIPTION
## Why

Post-approval finding on #432 (thread on `benchmark/preflight.py`): the module docstring promises every failure surfaces as a `::error::` annotation, but `except (ValueError, ImportError)` doesn't cover a tool module that **raises at import** — `importlib.import_module` propagates whatever the top-level code hits (`RuntimeError`, `NameError`, `SyntaxError` from a bad merge). That's exactly the misconfiguration class the preflight exists to catch, and it was the one case still escaping as the bare traceback the docstring says it prevents. Fails closed either way (the run still goes red); this is annotation quality.

## What changed

- `except Exception` — deliberately broad, documented, lint-disabled at the line: a guard whose entire contract is "annotate, never traceback" is the textbook place for one. The annotation now includes the exception type.
- Both previously-unpinned branches tested: a real module raising at import (asserts `::error::RuntimeError: module-level explosion`, and fails with the narrow tuple restored — verified), and the missing-dependency `ImportError` branch.

## Verification

1540 tests pass; the widened catch is mutation-verified; black/isort/flake8/darglint green, mypy no new errors, pylint clean on touched files.