### PR TITLE
chore(deps): bump mech v0.34.5 -> v0.34.6

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -27,8 +27,8 @@
         "custom/valory/finetuned_prediction/0.1.0": "bafybeiclpkn4sqvri7k5aiklt5fm6hnt3tgo4qxtrkzxe4fwzfs2plgbk4",
         "custom/valory/propose_question/0.1.0": "bafybeif2dmjftef7pnixwnutn42tdaxbbr77anl5ixsv6kwsxnk7sm6fni",
         "custom/valory/superforcaster_polymarket_v4/0.1.0": "bafybeieuzna7fsv4iwz7gvqpvkurfdskd2tul6b4asjg4dcsp4oieic6ti",
-        "agent/valory/mech_predict/0.1.0": "bafybeiemdd5z4rhtmay7pgfblbedbfv7ojvj5dml2py27mstjrzlyq6zc4",
-        "service/valory/mech_predict/0.1.0": "bafybeidi2nzk4yfjysazqvjs3hoki3viduxmap2rdh3q3ndxrhuxy7haku"
+        "agent/valory/mech_predict/0.1.0": "bafybeif6xzgwyfg53juq4tebkg5qmkoclf6o3zjzz3sjypb3dj37ezi24q",
+        "service/valory/mech_predict/0.1.0": "bafybeid7msd2op3hv54lbbyipstyn6hf4yh4qa5nuylqsyo67kp4zb54ni"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -69,8 +69,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm",
-        "skill/valory/task_execution/0.1.0": "bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve"
+        "skill/valory/mech_abci/0.1.0": "bafybeicdhperwghzemntlzc3evrpnlvbuzjw3bmrsstmpfiwynwyxn7bz4",
+        "skill/valory/task_execution/0.1.0": "bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a"
     }
 }

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -42,12 +42,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
-- valory/mech_abci:0.1.0:bafybeigfubl4qqto3oimy4tsxclg3wpgn3ixee7veietoiifhb5sgkzidm
+- valory/mech_abci:0.1.0:bafybeicdhperwghzemntlzc3evrpnlvbuzjw3bmrsstmpfiwynwyxn7bz4
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/task_execution:0.1.0:bafybeie63xevn4p7phvpswadq7lbsr6qvtxkhdmcmoyqtdlzvjvcpfjdza
-- valory/task_submission_abci:0.1.0:bafybeiesn6mgvjl53lbqigqoq3z2n2f5f6siyv6g445x6c2muu4dgsfdve
+- valory/task_execution:0.1.0:bafybeiduw74ltjr6utxsb3ojfyxmgtght2x7yxovvcm7cmuaj7dlrgsxfy
+- valory/task_submission_abci:0.1.0:bafybeie4pmlwxrvhj3icrmodoiucjx3cqizdeo7v7wnrc56c2v7cs5tk6a
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeiemdd5z4rhtmay7pgfblbedbfv7ojvj5dml2py27mstjrzlyq6zc4
+agent: valory/mech_predict:0.1.0:bafybeif6xzgwyfg53juq4tebkg5qmkoclf6o3zjzz3sjypb3dj37ezi24q
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ pytest_targets_extra = ["benchmark/tests"]
 # tomte auto-prepends valory-xyz/open-autonomy@... and open-aea@...
 # from pyproject pins, so only the non-PyPI mech upstream needs listing.
 upstream_pins = [
-    "valory-xyz/mech@v0.34.5",
+    "valory-xyz/mech@v0.34.6",
     "valory-xyz/kv-store@v0.7.1",
 ]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"


### PR DESCRIPTION
## Summary

- Bumps mech to [v0.34.6](https://github.com/valory-xyz/mech/releases/tag/v0.34.6) — the 402 asset-address auto-derive from mech PR #477.
- Three third-party skill hashes updated: `mech_abci`, `task_execution`, `task_submission_abci`. `autonomy packages lock` cascaded the `mech_predict` agent + service hashes.

## What v0.34.6 brings

- The mech's 402 challenge now reads the balance tracker's on-chain `token()` at build time (cached per tracker address; transient RPC failures do not poison the cache). Removes the dead `payment_type_to_asset_address` map primitive.
- Token-payment mechs (Polygon USDC, Optimism USDC) now report the correct ERC-20 asset in the 402 body instead of falling back to native `0x0000...0000`, so mech-interact's asset-match guard admits the deposit as intended.

## Test plan

- [x] `autonomy packages sync --update-packages` — three third-party skills pulled from IPFS
- [x] `autonomy packages lock` — no drift after re-lock
- [x] `tomte tox -e check-hash -e check-packages -e check-dependencies` — all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)