### PR TITLE
chore(deps): bump mech v0.34.7 -> v0.34.8

### DIFF
--- a/packages/packages.json
+++ b/packages/packages.json
@@ -27,8 +27,8 @@
         "custom/valory/finetuned_prediction/0.1.0": "bafybeiclpkn4sqvri7k5aiklt5fm6hnt3tgo4qxtrkzxe4fwzfs2plgbk4",
         "custom/valory/propose_question/0.1.0": "bafybeif2dmjftef7pnixwnutn42tdaxbbr77anl5ixsv6kwsxnk7sm6fni",
         "custom/valory/superforcaster_polymarket_v4/0.1.0": "bafybeieuzna7fsv4iwz7gvqpvkurfdskd2tul6b4asjg4dcsp4oieic6ti",
-        "agent/valory/mech_predict/0.1.0": "bafybeieotzpw4sfglsc4irqqeccdzfunqwhrxkb7a34waja64w24q3apfy",
-        "service/valory/mech_predict/0.1.0": "bafybeib74rmksx7u5swxbdql5odyelhdvyyiqh5k2juix4hwukdk5mcvku"
+        "agent/valory/mech_predict/0.1.0": "bafybeifswcmwxb4t5t72723fhpiab3orvncqijlugznpuhjlduwr7uj2eq",
+        "service/valory/mech_predict/0.1.0": "bafybeiaf2sbbe2i3o7qsnlpbnz3tza3pgd633zjzsc3snrhxxd6syup4gm"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -69,8 +69,8 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
         "skill/valory/delivery_rate_abci/0.1.0": "bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m",
-        "skill/valory/mech_abci/0.1.0": "bafybeiafeyknnrcbnba5vkw42tdmsxk5wt4sey2ohlao4hmjzrqadws6ay",
-        "skill/valory/task_execution/0.1.0": "bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm",
-        "skill/valory/task_submission_abci/0.1.0": "bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq"
+        "skill/valory/mech_abci/0.1.0": "bafybeidkugsxm66kr6vguonbpt2idh5anqgnc6mvakq452g57fi27t4ere",
+        "skill/valory/task_execution/0.1.0": "bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api",
+        "skill/valory/task_submission_abci/0.1.0": "bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu"
     }
 }

--- a/packages/valory/agents/mech_predict/aea-config.yaml
+++ b/packages/valory/agents/mech_predict/aea-config.yaml
@@ -42,12 +42,12 @@ skills:
 - valory/abstract_abci:0.1.0:bafybeie5et43th2nta76cd3kpm3fmurd7oyzk3qxim76octvt56m6r2poi
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/contract_subscription:0.1.0:bafybeiey3zrdef6qcspojfbi2qmzc7cdxrwljmu6cnfxqr7okwfimyjrey
-- valory/mech_abci:0.1.0:bafybeiafeyknnrcbnba5vkw42tdmsxk5wt4sey2ohlao4hmjzrqadws6ay
+- valory/mech_abci:0.1.0:bafybeidkugsxm66kr6vguonbpt2idh5anqgnc6mvakq452g57fi27t4ere
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/delivery_rate_abci:0.1.0:bafybeifjiazvf3qhr2264i55u4tlvmyf6ztgak2ndqolujt4kw6jiy7l3m
-- valory/task_execution:0.1.0:bafybeia55nqej54xx7gq2uktfmt2jmzjx2ko2ndt576sepvtab6wf452dm
-- valory/task_submission_abci:0.1.0:bafybeicbn5nm5phrmjrzx2q3cgehfzbodqgbkkrxdbtmqnbkhi42cgznuq
+- valory/task_execution:0.1.0:bafybeidkfnjo25dkytddterwbfrjv4bxr7tou6lnhzn4dbqhpfm7z34api
+- valory/task_submission_abci:0.1.0:bafybeifvlavnxhbvs6rnajxt7qh5jkekt7ja2vlrowm4qffltqzlqxhvsu
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/websocket_client:0.1.0:bafybeiht2ify5vkseeulutzjwkw5vcmhcwtun2o5ehn6hya6uz4eanua2m

--- a/packages/valory/services/mech_predict/service.yaml
+++ b/packages/valory/services/mech_predict/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifogoiwjqlb3nk2o6bbybr4safi4bfv4va7a4rq7ptse6ps7ep4zm
 fingerprint_ignore_patterns: []
-agent: valory/mech_predict:0.1.0:bafybeieotzpw4sfglsc4irqqeccdzfunqwhrxkb7a34waja64w24q3apfy
+agent: valory/mech_predict:0.1.0:bafybeifswcmwxb4t5t72723fhpiab3orvncqijlugznpuhjlduwr7uj2eq
 number_of_agents: 1
 deployment:
   agent:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ pytest_targets_extra = ["benchmark/tests"]
 # tomte auto-prepends valory-xyz/open-autonomy@... and open-aea@...
 # from pyproject pins, so only the non-PyPI mech upstream needs listing.
 upstream_pins = [
-    "valory-xyz/mech@v0.34.7",
+    "valory-xyz/mech@v0.34.8",
     "valory-xyz/kv-store@v0.7.1",
 ]
 tomte_dep_pin = " @ git+https://github.com/valory-xyz/tomte.git@v0.7.0"


### PR DESCRIPTION
## Summary

Pins upstream mech to [v0.34.8](https://github.com/valory-xyz/mech/releases/tag/v0.34.8).

Three third-party skill hashes bumped (\`mech_abci\`, \`task_execution\`, \`task_submission_abci\`); \`autonomy packages lock\` cascaded the \`mech_predict\` agent and service hashes.

## Verified locally

- \`autonomy packages lock --check\` — OK