### PR TITLE
fix(verify): pad marketplace request_ids to 32 bytes before coverage set diff

### DIFF
--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -1293,6 +1293,13 @@ def _pad_request_id(rid: str) -> str:
     be silently reshaped into ``"0x...req_in"`` and defeat the point
     of a readable stub; a real producer sending non-hex IDs is also
     left alone rather than reshaped into something equally wrong.
+
+    :param rid: request_id as returned by the marketplace subgraph.
+        Expected 66-char ``0x``-prefixed hex, but ``64-65`` chars
+        appear on the fraction of IDs whose leading byte has zero
+        nibbles.
+    :return: the same value padded to 66 chars if it decodes as
+        hex, otherwise returned unchanged.
     """
     if not rid.startswith("0x"):
         return rid

--- a/benchmark/datasets/fetch_production.py
+++ b/benchmark/datasets/fetch_production.py
@@ -1268,6 +1268,42 @@ DELIVER_REQUEST_IDS_QUERY = """
 _DELIVERY_LAG_ENVELOPE_S = 7 * 24 * 60 * 60
 
 
+def _pad_request_id(rid: str) -> str:
+    """Left-pad the hex body of a marketplace request_id to 32 bytes.
+
+    graph-node returns ``Bytes32`` fields with leading-zero-stripped
+    hex for a subset of rows — measured at ~5% of
+    ``Deliver.request.id`` on marketplace-gnosis — while the
+    mech-analytics lake stores every ``request_id`` in its full
+    66-character padded form. Without normalisation, the coverage
+    check's ``marketplace_ids - lake_ids`` set subtraction reports
+    every stripped ID as "missing from lake" even when the underlying
+    request is in fact in the lake, and the false-positive rate
+    dominates the real coverage signal (~93% of one recent run's
+    "missing" list were truncated hex strings whose padded form
+    resolved to an actual lake row).
+
+    Normalising here (on ingest into the marketplace-side set) rather
+    than at every comparison site keeps the invariant local: everything
+    in ``request_ids`` is in the same 66-char shape as the lake before
+    any set operation touches it.
+
+    Non-hex bodies are returned unchanged. Test fixtures use semantic
+    placeholders (``"0xreq_in"``, ``"0xreq_1"``) that would otherwise
+    be silently reshaped into ``"0x...req_in"`` and defeat the point
+    of a readable stub; a real producer sending non-hex IDs is also
+    left alone rather than reshaped into something equally wrong.
+    """
+    if not rid.startswith("0x"):
+        return rid
+    body = rid[2:]
+    try:
+        int(body, 16)
+    except ValueError:
+        return rid
+    return "0x" + body.zfill(64)
+
+
 def fetch_all_delivery_request_ids(
     marketplace_url: str,
     request_ts_gt: int,
@@ -1397,7 +1433,7 @@ def fetch_all_delivery_request_ids(
                 dropped_no_rid += 1
                 continue
             if request_ts_gt < req_ts < request_ts_lt:
-                request_ids.add(rid)
+                request_ids.add(_pad_request_id(rid))
 
         log.info(
             "  fetched %d delivers (running set size %d)", len(page), len(request_ids)

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -45,6 +45,7 @@ from benchmark.datasets.fetch_production import (
     _match_and_build,
     _match_delivery,
     _migrate_legacy_log,
+    _pad_request_id,
     _parse_request_context,
     _should_defer_unparsed,
     append_rows,
@@ -2289,6 +2290,67 @@ class _FakeMarketplaceSubgraph:
         return {"delivers": page}
 
 
+class TestPadRequestId:
+    """Verify the leading-zero normalisation on marketplace request IDs.
+
+    graph-node strips leading zeros from some ``Bytes32`` hex values,
+    so ``Deliver.request.id`` comes back at 64-65 chars for the subset
+    of IDs whose first byte contains zero nibbles, while the
+    mech-analytics lake stores every ``request_id`` at the full 66-char
+    padded form. ``_pad_request_id`` normalises both shapes to the
+    same string before the coverage check does set subtraction, so a
+    truncated ID and its padded twin collapse to one comparison unit.
+    Non-hex placeholders pass through untouched so a semantic test
+    fixture (``"0xreq_in"``) isn't silently reshaped into
+    ``"0x...req_in"``.
+    """
+
+    def test_pads_65_char_hex_to_66(self) -> None:
+        """65-char hex (1 leading zero stripped) → padded to 66 chars."""
+        # Modal production case (87% of the artifact's truncated missing IDs).
+        rid = "0x" + "8a0a16555a31f51eaca13f4984e7445e100ab3151dc0123de09520fa10129e0"
+        padded = (
+            "0x0" + "8a0a16555a31f51eaca13f4984e7445e100ab3151dc0123de09520fa10129e0"
+        )
+
+        assert _pad_request_id(rid) == padded
+        assert len(_pad_request_id(rid)) == 66
+
+    def test_pads_64_char_hex_to_66(self) -> None:
+        """64-char hex (2 leading zeros stripped) → padded to 66 chars."""
+        rid = "0x" + "2debc48c4622fe81215da0cdb87caea1f2578b0bbda8879656cc72e4bda896"
+        padded = (
+            "0x00" + "2debc48c4622fe81215da0cdb87caea1f2578b0bbda8879656cc72e4bda896"
+        )
+
+        assert _pad_request_id(rid) == padded
+        assert len(_pad_request_id(rid)) == 66
+
+    def test_already_full_length_passes_through_unchanged(self) -> None:
+        """Idempotence: a full-length hex ID is returned byte-identical."""
+        rid = "0x" + "5df6b8c116b6ffc0e25d6374337bcb030ab2be2bcbdd98733ac7479acd752c68"
+
+        assert _pad_request_id(rid) == rid
+
+    def test_uppercase_hex_preserved(self) -> None:
+        """Case-preservation: EIP-55-style mixed hex is not case-mangled."""
+        rid = "0x" + "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+        assert len(rid) == 66
+        assert _pad_request_id(rid) == rid
+
+    def test_non_hex_body_returned_unchanged(self) -> None:
+        """Semantic placeholders like ``"0xreq_in"`` must pass through unchanged."""
+        for fixture in ("0xreq_in", "0xreq_1", "0xdeliver", "0xreq_ok"):
+            assert (
+                _pad_request_id(fixture) == fixture
+            ), f"non-hex fixture {fixture!r} was mutated by the padder"
+
+    def test_missing_0x_prefix_returned_unchanged(self) -> None:
+        """Inputs without a ``0x`` prefix are out of remit and returned as-is."""
+        assert _pad_request_id("abcdef") == "abcdef"
+        assert _pad_request_id("") == ""
+
+
 class TestFetchAllDeliveryRequestIds:
     """Coverage-side enumeration with cursor pagination.
 
@@ -2317,6 +2379,62 @@ class TestFetchAllDeliveryRequestIds:
             "blockTimestamp": str(delivery_ts),
             "request": request,
         }
+
+    def test_truncated_subgraph_request_id_is_padded_in_the_result_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Truncated ``Deliver.request.id`` values must be padded on ingest.
+
+        graph-node strips leading zeros from some ``Bytes32`` hex
+        values, and the mech-analytics lake stores every
+        ``request_id`` in its full 66-char padded form. The coverage
+        check compares the two sets by string equality, so a
+        truncated ID and its padded twin must collapse to the same
+        string on the way into ``request_ids`` — otherwise every
+        stripped ID is a false-positive "missing from lake" hit
+        (measured at ~5% of ``Deliver.request.id`` on marketplace-
+        gnosis, which dominated 93% of one recent run's missing
+        list). Sole tap that keeps the invariant local: normalise on
+        ingest, not at every comparison site.
+        """
+        # pylint: disable-next=import-outside-toplevel
+        from benchmark.datasets import fetch_production as fp
+
+        request_ts_gt = 1_700_000_000
+        request_ts_lt = 1_700_100_000
+        truncated = (
+            "0x" + "8a0a16555a31f51eaca13f4984e7445e100ab3151dc0123de09520fa10129e0"
+        )
+        padded = (
+            "0x0" + "8a0a16555a31f51eaca13f4984e7445e100ab3151dc0123de09520fa10129e0"
+        )
+        assert len(truncated) == 65 and len(padded) == 66
+        rows = [
+            self._deliver(
+                "0xd_trunc",
+                delivery_ts=request_ts_gt + 500,
+                request_id=truncated,
+                request_ts=request_ts_gt + 100,
+            ),
+        ]
+        fake = _FakeMarketplaceSubgraph(rows)
+        monkeypatch.setattr(fp, "_post_graphql", fake)
+
+        ids, dropped = fp.fetch_all_delivery_request_ids(
+            "http://marketplace",
+            request_ts_gt=request_ts_gt,
+            request_ts_lt=request_ts_lt,
+        )
+
+        assert ids == {
+            padded
+        }, f"expected the padded form in the result set, got {ids!r}"
+        assert truncated not in ids, (
+            "the truncated hex form must not appear in the result set — "
+            "it would produce a false-positive 'missing from lake' hit "
+            "on every string-comparison"
+        )
+        assert dropped == 0
 
     def test_single_page_sweep_filters_client_side_on_request_time(
         self, monkeypatch: pytest.MonkeyPatch

--- a/benchmark/tests/test_fetch_production.py
+++ b/benchmark/tests/test_fetch_production.py
@@ -2396,6 +2396,9 @@ class TestFetchAllDeliveryRequestIds:
         gnosis, which dominated 93% of one recent run's missing
         list). Sole tap that keeps the invariant local: normalise on
         ingest, not at every comparison site.
+
+        :param monkeypatch: pytest fixture used to swap the module's
+            ``_post_graphql`` for a fake subgraph.
         """
         # pylint: disable-next=import-outside-toplevel
         from benchmark.datasets import fetch_production as fp


### PR DESCRIPTION
## Summary

The mech-predict-verify coverage check has been reporting hundreds of thousands of "missing from lake" IDs. Investigation shows **~93% of those "missing" IDs are false positives** caused by a graph-node representation quirk: `Deliver.request.id` on marketplace-gnosis is returned with leading zeros stripped for ~5% of rows, while the mech-analytics lake stores every `request_id` at the full 66-char padded form. Since the coverage check compares by string equality, every stripped ID guarantees a "missing" hit even when the underlying request IS in the lake.

## Evidence

**Length histogram of the 507,344 "missing" IDs from the most recent verify run** (`autonolas-marketplace/2023-05-16_to_2026-08-02 (3).json`):

| length | count | share |
|---|---|---|
| 66 chars (well-formed) | 36,130 | 7.1% |
| 65 chars (1 leading zero stripped) | 441,782 | 87.1% |
| 64 chars (2 stripped) | 27,653 | 5.5% |
| 63 chars | 1,660 | 0.3% |
| 60-62 chars | 119 | <0.1% |

**Direct verification against the live subgraph:**
- Sampled 200 recent `delivers`: 11 (5.5%) had `request.id` returned at <66 chars
- Sampled 200 recent `requests`: 200/200 returned at 66 chars (the `Request` entity's own `id` is padded; only the nested `Deliver.request.id` isn't)

**Direct verification against the mech-analytics lake:**
- Took all 11 truncated IDs, padded each to 66 chars via `_pad_request_id`, queried `/v1/data/scored-rows` in a narrow window around each request's `blockTimestamp` from the subgraph
- **11/11 resolved to a real lake row.** Zero misses.

**Lake shape confirmed:**
- 5000-row sample of `/v1/data/scored-rows`: 100% of `request_id` values are 66 chars (0x + 64 hex).

Extrapolating: 5.5% × 9.82M omen deliveries = ~540k expected truncated total, vs 471k observed truncated missing. Same order of magnitude, consistent with the theory that every truncated subgraph ID is a false-positive miss.

## Change

`fetch_all_delivery_request_ids` in `benchmark/datasets/fetch_production.py` now runs every `request.id` from the subgraph through a new `_pad_request_id` helper before adding it to the coverage set. The helper:

- Left-pads the hex body to 32 bytes (`zfill(64)` — no-op if the body is already 64 chars, so already-padded IDs pass through unchanged)
- Preserves case (EIP-55-style mixed hex isn't reshaped)
- Returns non-hex bodies unchanged (test fixtures using semantic placeholders like `"0xreq_in"` slip through without being silently reshaped, and any future producer that ever sends a non-hex ID is left alone rather than turned into something equally wrong)

Applied at a single tap point on ingest into `request_ids` rather than at every downstream comparison site — keeps the invariant local, every set operation sees one shape.

## Expected impact on next verify run

The current 507,344 "missing" count would drop to at most 36,130 (the well-formed subset). If the remaining well-formed IDs are backfill lag or known-loss upstream, running verify with `--predict-api-url` would subtract those and reveal the actual coverage gap (likely near zero).

## Test plan

- [x] `TestPadRequestId` — 6 cases: 65-char and 64-char hex both pad to 66, already-66 passes through unchanged, uppercase hex case-preserved, non-hex placeholders returned as-is, no-`0x`-prefix inputs returned as-is.
- [x] `TestFetchAllDeliveryRequestIds::test_truncated_subgraph_request_id_is_padded_in_the_result_set` — integration test flowing a truncated ID through `fetch_all_delivery_request_ids` and asserting the padded form lands in `ids` and the truncated form does not.
- [x] Zero pre-existing tests changed.
- [x] Full benchmark suite: 1638 pass.
- [x] `tomte tox -e black-check -e isort-check -e flake8 -e mypy -e pylint` all clean on the two touched files (pylint 9.99/10 for the whole tree, unchanged).
- [ ] Post-merge: on next verify run, confirm coverage "missing" count drops from ~507k to <40k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)